### PR TITLE
Dlg Jitter Bug Fix on change of data frames

### DIFF
--- a/instat/dlgJitter.vb
+++ b/instat/dlgJitter.vb
@@ -146,7 +146,7 @@ Public Class dlgJitter
         clsRunif.AddParameter("n", ucrSelectorForJitter.ucrAvailableDataFrames.iDataFrameLength)
     End Sub
 
-    Private Sub ucrSelectorForJitter_DataFrameChanged() Handles ucrSelectorForJitter.DataFrameChanged
+    Private Sub ucrSelectorForJitter_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrSelectorForJitter.ControlValueChanged
         LengthOfDataset()
     End Sub
 End Class


### PR DESCRIPTION
@africanmathsinitiative/developers  this is ready for review
The parameter `n` could be updated wgen you changed from one data frame to the other.
![image](https://cloud.githubusercontent.com/assets/20383893/26110728/d616a0ee-3a5b-11e7-9feb-b03a11f794f8.png)

