### PR TITLE
Allowing all data types in the selector of Random Subset dialog

### DIFF
--- a/instat/dlgRandomSubsets.vb
+++ b/instat/dlgRandomSubsets.vb
@@ -38,7 +38,6 @@ Public Class dlgRandomSubsets
         ucrReceiverSubsets.SetParameterIsRFunction()
         ucrReceiverSubsets.Selector = ucrSelectorRandomSubsets
         ucrReceiverSubsets.SetMeAsReceiver()
-        ucrReceiverSubsets.SetIncludedDataTypes({"numeric"})
 
         'Replace checkbox
         ucrChkWithReplacement.SetParameter(New RParameter("replace", 1))


### PR DESCRIPTION
@dannyparsons I have allowed all data types now. fixes #3089