### PR TITLE
Implementing use of labels and levels in dialogs with factor grids

### DIFF
--- a/instat/clsRLink.vb
+++ b/instat/clsRLink.vb
@@ -748,6 +748,18 @@ Public Class RLink
         Return strDataType
     End Function
 
+    Public Function GetColumnType(strDataName As String, strColumnName As String) As String
+        Dim strDataType As String
+        Dim clsGetColumnType As New RFunction
+
+        clsGetColumnType.SetRCommand(strInstatDataObject & "$get_variables_metadata")
+        clsGetColumnType.AddParameter("data_name", Chr(34) & strDataName & Chr(34))
+        clsGetColumnType.AddParameter("column", Chr(34) & strColumnName & Chr(34))
+        clsGetColumnType.AddParameter("property", Chr(34) & "class" & Chr(34))
+        strDataType = RunInternalScriptGetValue(clsGetColumnType.ToScript()).AsCharacter(0)
+        Return strDataType
+    End Function
+
     Public Function MakeValidText(strText As String) As String
         Dim strOut As String
         Dim clsMakeNames As New RFunction
@@ -804,5 +816,19 @@ Public Class RLink
         clsIsBinary.AddParameter("x", clsRFunctionParameter:=clsGetColumn)
         bIsBinary = RunInternalScriptGetValue(clsIsBinary.ToScript()).AsLogical(0)
         Return bIsBinary
+    End Function
+
+    Public Function IsVariablesMetadata(strDataName As String, strProperty As String, Optional strColumn As String = "") As Boolean
+        Dim clsIsVarMetadata As New RFunction
+        Dim bIsVarMetadata As Boolean
+
+        clsIsVarMetadata.SetRCommand(strInstatDataObject & "$is_variables_metadata")
+        clsIsVarMetadata.AddParameter("data_name", Chr(34) & strDataName & Chr(34))
+        If strColumn <> "" Then
+            clsIsVarMetadata.AddParameter("column", Chr(34) & strColumn & Chr(34))
+        End If
+        clsIsVarMetadata.AddParameter("property", Chr(34) & strProperty & Chr(34))
+        bIsVarMetadata = RunInternalScriptGetValue(clsIsVarMetadata.ToScript()).AsLogical(0)
+        Return bIsVarMetadata
     End Function
 End Class

--- a/instat/dlgLabels.Designer.vb
+++ b/instat/dlgLabels.Designer.vb
@@ -28,6 +28,7 @@ Partial Class dlgLabels
         Me.ucrSelectorForLabels = New instat.ucrSelectorByDataFrameAddRemove()
         Me.ucrBase = New instat.ucrButtons()
         Me.cmdAddLevel = New System.Windows.Forms.Button()
+        Me.ucrChkAddLevels = New instat.ucrCheck()
         Me.SuspendLayout()
         '
         'lblFactor
@@ -42,12 +43,15 @@ Partial Class dlgLabels
         '
         'ucrReceiverLabels
         '
+        Me.ucrReceiverLabels.frmParent = Me
         Me.ucrReceiverLabels.Location = New System.Drawing.Point(256, 37)
         Me.ucrReceiverLabels.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverLabels.Name = "ucrReceiverLabels"
         Me.ucrReceiverLabels.Selector = Nothing
         Me.ucrReceiverLabels.Size = New System.Drawing.Size(106, 26)
+        Me.ucrReceiverLabels.strNcFilePath = ""
         Me.ucrReceiverLabels.TabIndex = 4
+        Me.ucrReceiverLabels.ucrSelector = Nothing
         '
         'ucrFactorLabels
         '
@@ -86,11 +90,20 @@ Partial Class dlgLabels
         Me.cmdAddLevel.Text = "Add Level"
         Me.cmdAddLevel.UseVisualStyleBackColor = True
         '
+        'ucrChkAddLevels
+        '
+        Me.ucrChkAddLevels.Checked = False
+        Me.ucrChkAddLevels.Location = New System.Drawing.Point(344, 245)
+        Me.ucrChkAddLevels.Name = "ucrChkAddLevels"
+        Me.ucrChkAddLevels.Size = New System.Drawing.Size(100, 20)
+        Me.ucrChkAddLevels.TabIndex = 6
+        '
         'dlgLabels
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
         Me.ClientSize = New System.Drawing.Size(533, 332)
+        Me.Controls.Add(Me.ucrChkAddLevels)
         Me.Controls.Add(Me.cmdAddLevel)
         Me.Controls.Add(Me.ucrReceiverLabels)
         Me.Controls.Add(Me.lblFactor)
@@ -115,4 +128,5 @@ Partial Class dlgLabels
     Friend WithEvents lblFactor As Label
     Friend WithEvents ucrReceiverLabels As ucrReceiverSingle
     Friend WithEvents cmdAddLevel As Button
+    Friend WithEvents ucrChkAddLevels As ucrCheck
 End Class

--- a/instat/dlgLabels.vb
+++ b/instat/dlgLabels.vb
@@ -39,12 +39,11 @@ Public Class dlgLabels
     End Sub
 
     Private Sub TestOKEnabled()
-        If Not ucrReceiverLabels.IsEmpty() AndAlso ucrFactorLabels.IsColumnComplete("Labels") AndAlso ucrFactorLabels.IsColumnComplete("Levels") Then
+        If Not ucrReceiverLabels.IsEmpty() AndAlso ucrFactorLabels.IsColumnComplete("Labels") AndAlso (ucrChkAddLevels.Visible AndAlso Not ucrChkAddLevels.Checked OrElse (ucrFactorLabels.IsColumnComplete("Levels"))) Then
             ucrBase.OKEnabled(True)
         Else
             ucrBase.OKEnabled(False)
         End If
-
     End Sub
 
     Private Sub SetDefaults()
@@ -63,6 +62,7 @@ Public Class dlgLabels
         ucrFactorLabels.SetAsViewerOnly()
         ucrFactorLabels.AddEditableColumns({"Labels", "Levels"})
         ucrFactorLabels.SetIsGridColumn("Labels")
+        ucrFactorLabels.SetLevelsCheckbox(ucrChkAddLevels)
 
         ucrReceiverLabels.SetParameter(New RParameter("col_name", 1))
         ucrReceiverLabels.SetParameterIsString()
@@ -72,6 +72,8 @@ Public Class dlgLabels
 
         ucrSelectorForLabels.SetParameter(New RParameter("data_name", 0))
         ucrSelectorForLabels.SetParameterIsString()
+
+        ucrChkAddLevels.SetText("Add Levels")
     End Sub
 
     Private Sub ucrBase_ClickReset(sender As Object, e As EventArgs) Handles ucrBase.ClickReset
@@ -88,5 +90,14 @@ Public Class dlgLabels
     Private Sub ucrReceiverLabels_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrReceiverLabels.ControlContentsChanged, ucrFactorLabels.ControlContentsChanged
         cmdAddLevel.Enabled = ucrFactorLabels.grdFactorData.Visible
         TestOKEnabled()
+    End Sub
+
+    'TODO modify factor control to be able to manage two parameters from different columns
+    Private Sub ucrFactorLabels_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrFactorLabels.ControlValueChanged, ucrChkAddLevels.ControlValueChanged
+        If (ucrChkAddLevels.Checked OrElse Not ucrChkAddLevels.Visible) AndAlso ucrFactorLabels.IsColumnComplete("Levels") Then
+            clsViewLabels.AddParameter("new_levels", strParameterValue:=ucrFactorLabels.GetColumnInFactorSheet("Levels", bWithQuotes:=False))
+        Else
+            clsViewLabels.RemoveParameterByName("new_levels")
+        End If
     End Sub
 End Class

--- a/instat/dlgLabels.vb
+++ b/instat/dlgLabels.vb
@@ -15,10 +15,12 @@
 ' along with this program.  If not, see <http://www.gnu.org/licenses/>.
 Imports instat
 Imports instat.Translations
+
 Public Class dlgLabels
     Private bFirstLoad As Boolean = True
     Private bReset As Boolean = True
     Private clsViewLabels As New RFunction
+
     Private Sub dlgLabels_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         If bFirstLoad Then
             InitialiseDialog()
@@ -37,7 +39,7 @@ Public Class dlgLabels
     End Sub
 
     Private Sub TestOKEnabled()
-        If Not ucrReceiverLabels.IsEmpty() AndAlso ucrFactorLabels.IsColumnComplete(0) Then
+        If Not ucrReceiverLabels.IsEmpty() AndAlso ucrFactorLabels.IsColumnComplete("Labels") AndAlso ucrFactorLabels.IsColumnComplete("Levels") Then
             ucrBase.OKEnabled(True)
         Else
             ucrBase.OKEnabled(False)
@@ -55,17 +57,18 @@ Public Class dlgLabels
 
     Private Sub InitialiseDialog()
         ucrBase.iHelpTopicID = 35
-        ucrReceiverLabels.Selector = ucrSelectorForLabels
-        ucrReceiverLabels.SetMeAsReceiver()
 
-        ucrReceiverLabels.SetIncludedDataTypes({"factor"})
+        ucrFactorLabels.SetParameter(New RParameter("new_labels", 2))
         ucrFactorLabels.SetReceiver(ucrReceiverLabels)
         ucrFactorLabels.SetAsViewerOnly()
-        ucrFactorLabels.AddEditableColumns({"Levels"})
+        ucrFactorLabels.AddEditableColumns({"Labels", "Levels"})
+        ucrFactorLabels.SetIsGridColumn("Labels")
 
-        ucrFactorLabels.SetParameter(New RParameter("new_levels", 2))
         ucrReceiverLabels.SetParameter(New RParameter("col_name", 1))
         ucrReceiverLabels.SetParameterIsString()
+        ucrReceiverLabels.Selector = ucrSelectorForLabels
+        ucrReceiverLabels.SetMeAsReceiver()
+        ucrReceiverLabels.SetIncludedDataTypes({"factor"})
 
         ucrSelectorForLabels.SetParameter(New RParameter("data_name", 0))
         ucrSelectorForLabels.SetParameterIsString()

--- a/instat/dlgLabels.vb
+++ b/instat/dlgLabels.vb
@@ -39,7 +39,7 @@ Public Class dlgLabels
     End Sub
 
     Private Sub TestOKEnabled()
-        If Not ucrReceiverLabels.IsEmpty() AndAlso ucrFactorLabels.IsColumnComplete("Labels") AndAlso (ucrChkAddLevels.Visible AndAlso Not ucrChkAddLevels.Checked OrElse (ucrFactorLabels.IsColumnComplete("Levels"))) Then
+        If Not ucrReceiverLabels.IsEmpty() AndAlso ucrFactorLabels.IsColumnComplete(ucrFactorLabels.strLabelsName) AndAlso (ucrChkAddLevels.Visible AndAlso Not ucrChkAddLevels.Checked OrElse (ucrFactorLabels.IsColumnComplete(ucrFactorLabels.strLevelsName))) Then
             ucrBase.OKEnabled(True)
         Else
             ucrBase.OKEnabled(False)
@@ -60,8 +60,8 @@ Public Class dlgLabels
         ucrFactorLabels.SetParameter(New RParameter("new_labels", 2))
         ucrFactorLabels.SetReceiver(ucrReceiverLabels)
         ucrFactorLabels.SetAsViewerOnly()
-        ucrFactorLabels.AddEditableColumns({"Labels", "Levels"})
-        ucrFactorLabels.SetIsGridColumn("Labels")
+        ucrFactorLabels.AddEditableColumns({ucrFactorLabels.strLevelsName, ucrFactorLabels.strLabelsName})
+        ucrFactorLabels.SetIsGridColumn(ucrFactorLabels.strLabelsName)
         ucrFactorLabels.SetLevelsCheckbox(ucrChkAddLevels)
 
         ucrReceiverLabels.SetParameter(New RParameter("col_name", 1))
@@ -94,8 +94,8 @@ Public Class dlgLabels
 
     'TODO modify factor control to be able to manage two parameters from different columns
     Private Sub ucrFactorLabels_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrFactorLabels.ControlValueChanged, ucrChkAddLevels.ControlValueChanged
-        If (ucrChkAddLevels.Checked OrElse Not ucrChkAddLevels.Visible) AndAlso ucrFactorLabels.IsColumnComplete("Levels") Then
-            clsViewLabels.AddParameter("new_levels", strParameterValue:=ucrFactorLabels.GetColumnInFactorSheet("Levels", bWithQuotes:=False))
+        If (ucrChkAddLevels.Checked OrElse Not ucrChkAddLevels.Visible) AndAlso ucrFactorLabels.IsColumnComplete(ucrFactorLabels.strLevelsName) Then
+            clsViewLabels.AddParameter("new_levels", strParameterValue:=ucrFactorLabels.GetColumnInFactorSheet(ucrFactorLabels.strLevelsName, bWithQuotes:=False))
         Else
             clsViewLabels.RemoveParameterByName("new_levels")
         End If

--- a/instat/dlgRecodeFactor.vb
+++ b/instat/dlgRecodeFactor.vb
@@ -32,13 +32,14 @@ Public Class dlgRecodeFactor
     End Sub
 
     Private Sub InitialiseDialog()
+        clsReplaceFunction = New RFunction
+
         ucrBase.clsRsyntax.SetFunction("revalue")
         ucrReceiverFactor.Selector = ucrSelectorForRecode
         ucrReceiverFactor.SetIncludedDataTypes({"factor"})
         ucrReceiverFactor.SetMeAsReceiver()
         ucrBase.iHelpTopicID = 37
 
-        clsReplaceFunction = New RFunction
         clsReplaceFunction.strRCommand = "c"
         ucrBase.clsRsyntax.AddParameter("replace", clsRFunctionParameter:=clsReplaceFunction)
 
@@ -49,7 +50,9 @@ Public Class dlgRecodeFactor
         ucrFactorGrid.SetReceiver(ucrReceiverFactor)
         ucrFactorGrid.SetAsViewerOnly()
         ucrFactorGrid.bIncludeCopyOfLevels = True
-        ucrFactorGrid.AddEditableColumns({"New Levels"})
+        ucrFactorGrid.AddEditableColumns({"New Label"})
+        ucrFactorGrid.SetIncludeLevels(False)
+
         ucrInputColumnName.SetValidationTypeAsRVariable()
     End Sub
 
@@ -66,7 +69,7 @@ Public Class dlgRecodeFactor
     End Sub
 
     Private Sub TestOKEnabled()
-        If Not ucrReceiverFactor.IsEmpty AndAlso ucrFactorGrid.IsColumnComplete(2) Then
+        If Not ucrReceiverFactor.IsEmpty AndAlso ucrFactorGrid.IsColumnComplete("New Label") Then
             ucrBase.OKEnabled(True)
         Else
             ucrBase.OKEnabled(False)
@@ -74,17 +77,17 @@ Public Class dlgRecodeFactor
     End Sub
 
     Private Sub ucrFactorGrid_GridContentChanged() Handles ucrFactorGrid.GridContentChanged
-        Dim strCurrentLevels As List(Of String)
-        Dim strNewLevels As List(Of String)
+        Dim strCurrentLabels As List(Of String)
+        Dim strNewLabels As List(Of String)
         Dim strReplace As String = ""
 
-        strCurrentLevels = ucrFactorGrid.GetColumnAsList(0, False)
-        strNewLevels = ucrFactorGrid.GetColumnAsList(2, True)
+        strCurrentLabels = ucrFactorGrid.GetColumnAsList(ucrFactorGrid.strLabelsName, False)
+        strNewLabels = ucrFactorGrid.GetColumnAsList("New Label", True)
         clsReplaceFunction.ClearParameters()
-        If ucrFactorGrid.IsColumnComplete(2) AndAlso strCurrentLevels.Count = strNewLevels.Count Then
-            For i = 0 To strCurrentLevels.Count - 1
+        If ucrFactorGrid.IsColumnComplete(ucrFactorGrid.strLabelsName) AndAlso strCurrentLabels.Count = strNewLabels.Count Then
+            For i = 0 To strCurrentLabels.Count - 1
                 ' Backtick needed for names of the vector incase the levels are not valid R names
-                clsReplaceFunction.AddParameter(Chr(96) & strCurrentLevels(i) & Chr(96), strNewLevels(i))
+                clsReplaceFunction.AddParameter(Chr(96) & strCurrentLabels(i) & Chr(96), strNewLabels(i))
             Next
         End If
         TestOKEnabled()

--- a/instat/dlgReferenceLevel.vb
+++ b/instat/dlgReferenceLevel.vb
@@ -50,6 +50,7 @@ Public Class dlgReferenceLevel
         ucrFactorReferenceLevels.SetParameter(New RParameter("new_ref_level", 2))
         ucrFactorReferenceLevels.SetReceiver(ucrReceiverReferenceLevels)
         ucrFactorReferenceLevels.SetAsSingleSelector()
+        ucrFactorReferenceLevels.SetIncludeLevels(False)
     End Sub
 
     Private Sub SetDefaults()

--- a/instat/dlgRemoveUnusedLevels.vb
+++ b/instat/dlgRemoveUnusedLevels.vb
@@ -41,7 +41,9 @@ Public Class dlgRemoveUnusedLevels
         ucrReceiverFactorColumn.Selector = ucrSelectorFactorColumn
         ucrReceiverFactorColumn.SetMeAsReceiver()
         ucrReceiverFactorColumn.SetIncludedDataTypes({"factor"})
+
         ucrRemoveUnusedFactorLevels.SetReceiver(ucrReceiverFactorColumn)
+        ucrRemoveUnusedFactorLevels.SetIncludeLevels(False)
 
         'Set selector data frame
         ucrSelectorFactorColumn.SetParameter(New RParameter("data_name", 0))

--- a/instat/static/InstatObject/R/data_object_R6.R
+++ b/instat/static/InstatObject/R/data_object_R6.R
@@ -1124,7 +1124,7 @@ data_object$set("public", "set_factor_levels", function(col_name, new_labels, ne
   col_data <- self$get_columns_from_data(col_name, use_current_filter = FALSE)
   if(!is.factor(col_data)) stop(paste(col_name, "is not a factor."))
   old_labels <- levels(col_data)
-  if(length(new_labels) != length(old_labels)) stop("There must be at least as many new levels as current levels.")
+  if(length(new_labels) < length(old_labels)) stop("There must be at least as many new levels as current levels.")
   if(!missing(new_levels) && anyDuplicated(new_levels)) stop("new levels must be unique")
   # Must be private$data because setting an attribute
   levels(private$data[[col_name]]) <- new_labels
@@ -1136,10 +1136,10 @@ data_object$set("public", "set_factor_levels", function(col_name, new_labels, ne
   }
   else if(set_new_labels && self$is_variables_metadata(labels_label, col_name)) {
     labels_list <- self$get_variables_metadata(property = labels_label, column = col_name, direct_from_attributes = TRUE)
-    names(labels_list) <- as.character(new_levels[1:length(old_levels)])
-    if(length(new_levels) > length(old_levels)) {
-      extra_labels <- seq(from = max(labels_list) + 1, length.out = (length(new_levels) - length(old_levels)))
-      names(extra_labels) <- new_levels[!new_levels %in% names(labels_list)]
+    names(labels_list) <- as.character(new_labels[1:length(old_levels)])
+    if(length(new_labels) > length(old_lables)) {
+      extra_labels <- seq(from = max(labels_list) + 1, length.out = (length(new_labels) - length(old_levels)))
+      names(extra_labels) <- new_labels[!new_labels %in% names(labels_list)]
       labels_list <- c(labels_list, extra_labels)
     }
     self$append_to_variables_metadata(col_name, labels_label, labels_list)

--- a/instat/static/InstatObject/R/data_object_R6.R
+++ b/instat/static/InstatObject/R/data_object_R6.R
@@ -945,7 +945,7 @@ data_object$set("public", "get_factor_data_frame", function(col_name = "") {
   counts <- plyr::rename(counts, replace = c("col_data" = "Labels", "Freq" = "Counts"))
   counts[["Ord"]] <- 1:nrow(counts)
   if(self$is_variables_metadata(str = labels_label, col = col_name)) {
-    curr_levels <- names(self$get_variables_metadata(property = labels_label, column = col_name))
+    curr_levels <- as.vector(self$get_variables_metadata(property = labels_label, column = col_name, direct_from_attributes = TRUE))
   }
   else curr_levels <- counts[["Ord"]]
   counts[["Levels"]] <- curr_levels
@@ -1124,27 +1124,26 @@ data_object$set("public", "set_factor_levels", function(col_name, new_labels, ne
   col_data <- self$get_columns_from_data(col_name, use_current_filter = FALSE)
   if(!is.factor(col_data)) stop(paste(col_name, "is not a factor."))
   old_labels <- levels(col_data)
-  if(length(new_labels) < length(old_labels)) stop("There must be at least as many new levels as current levels.")
-  
+  if(length(new_labels) != length(old_labels)) stop("There must be at least as many new levels as current levels.")
+  if(!missing(new_levels) && anyDuplicated(new_levels)) stop("new levels must be unique")
   # Must be private$data because setting an attribute
   levels(private$data[[col_name]]) <- new_labels
   
   if(!missing(new_levels)) {
     labels_list <- new_levels
-    names(labels_list) <- new_levels
+    names(labels_list) <- new_labels
     self$append_to_variables_metadata(col_name, labels_label, labels_list)
   }
-  # Not sure this is needed now
-  # else if(set_new_labels && self$is_variables_metadata(labels_label, col_name)) {
-  #   labels_list <- self$get_variables_metadata(property = labels_label, column = col_name, direct_from_attributes = TRUE)
-  #   names(labels_list) <- as.character(new_levels[1:length(old_levels)])
-  #   if(length(new_levels) > length(old_levels)) {
-  #     extra_labels <- seq(from = max(labels_list) + 1, length.out = (length(new_levels) - length(old_levels)))
-  #     names(extra_labels) <- new_levels[!new_levels %in% names(labels_list)]
-  #     labels_list <- c(labels_list, extra_labels)
-  #   }
-  #   self$append_to_variables_metadata(col_name, labels_label, labels_list)
-  # }
+  else if(set_new_labels && self$is_variables_metadata(labels_label, col_name)) {
+    labels_list <- self$get_variables_metadata(property = labels_label, column = col_name, direct_from_attributes = TRUE)
+    names(labels_list) <- as.character(new_levels[1:length(old_levels)])
+    if(length(new_levels) > length(old_levels)) {
+      extra_labels <- seq(from = max(labels_list) + 1, length.out = (length(new_levels) - length(old_levels)))
+      names(extra_labels) <- new_levels[!new_levels %in% names(labels_list)]
+      labels_list <- c(labels_list, extra_labels)
+    }
+    self$append_to_variables_metadata(col_name, labels_label, labels_list)
+  }
   self$data_changed <- TRUE
   self$variables_metadata_changed <- TRUE
 } 

--- a/instat/static/InstatObject/R/data_object_R6.R
+++ b/instat/static/InstatObject/R/data_object_R6.R
@@ -937,15 +937,19 @@ data_object$set("public", "get_data_frame_length", function(use_current_filter =
 )
 
 data_object$set("public", "get_factor_data_frame", function(col_name = "") {
-  if(!(col_name %in% self$get_column_names())) {
-    stop(col_name, " is not a column in", get_metadata(data_name_label))
-  }
-  if(!(is.factor(self$get_columns_from_data(col_name, use_current_filter = FALSE)))){
-    stop(col_name, " is not a factor column")
-  }
+  if(!(col_name %in% self$get_column_names())) stop(col_name, " is not a column name,")
+  col_data <- self$get_columns_from_data(col_name, use_current_filter = FALSE)
+  if(!(is.factor(col_data))) stop(col_name, " is not a factor column")
   
-  counts <- as.data.frame(table(self$get_columns_from_data(col_name, use_current_filter = FALSE)))
-  counts <- plyr::rename(counts, replace = c("Var1" = "Levels", "Freq" = "Counts"))
+  counts <- as.data.frame(table(col_data))
+  counts <- plyr::rename(counts, replace = c("col_data" = "Labels", "Freq" = "Counts"))
+  counts[["Ord"]] <- 1:nrow(counts)
+  if(self$is_variables_metadata(str = labels_label, col = col_name)) {
+    curr_levels <- names(self$get_variables_metadata(property = labels_label, column = col_name))
+  }
+  else curr_levels <- counts[["Ord"]]
+  counts[["Levels"]] <- curr_levels
+  counts <- counts[c("Ord", "Labels", "Levels", "Counts")]
   return(counts)
 }
 )
@@ -1115,24 +1119,32 @@ data_object$set("public", "drop_unused_factor_levels", function(col_name) {
 } 
 )
 
-data_object$set("public", "set_factor_levels", function(col_name, new_levels, set_new_labels = TRUE) {
-  if(!col_name %in% self$get_column_names()) stop(paste(col_name,"not found in data."))
-  if(!is.factor(self$get_columns_from_data(col_name, use_current_filter = FALSE))) stop(paste(col_name,"is not a factor."))
-  old_levels <- levels(self$get_columns_from_data(col_name, use_current_filter = FALSE))
-  if(length(new_levels) < length(old_levels)) stop("There must be at least as many new levels as current levels.")
+data_object$set("public", "set_factor_levels", function(col_name, new_labels, new_levels, set_new_labels = TRUE) {
+  if(!col_name %in% self$get_column_names()) stop(paste(col_name, "not found in data."))
+  col_data <- self$get_columns_from_data(col_name, use_current_filter = FALSE)
+  if(!is.factor(col_data)) stop(paste(col_name, "is not a factor."))
+  old_labels <- levels(col_data)
+  if(length(new_labels) < length(old_labels)) stop("There must be at least as many new levels as current levels.")
   
   # Must be private$data because setting an attribute
-  levels(private$data[[col_name]]) <- new_levels
-  if(set_new_labels && self$is_variables_metadata(labels_label, col_name)) {
-    new_labels <- self$get_variables_metadata(property = labels_label, column = col_name, direct_from_attributes = TRUE)
-    names(new_labels) <- as.character(new_levels[1:length(old_levels)])
-    if(length(new_levels) > length(old_levels)) {
-      extra_labels <- seq(from = max(new_labels) + 1, length.out = (length(new_levels) - length(old_levels)))
-      names(extra_labels) <- new_levels[!new_levels %in% names(new_labels)]
-      new_labels <- c(new_labels, extra_labels)
-    }
-    self$append_to_variables_metadata(col_name, labels_label, new_labels)
+  levels(private$data[[col_name]]) <- new_labels
+  
+  if(!missing(new_levels)) {
+    labels_list <- new_levels
+    names(labels_list) <- new_levels
+    self$append_to_variables_metadata(col_name, labels_label, labels_list)
   }
+  # Not sure this is needed now
+  # else if(set_new_labels && self$is_variables_metadata(labels_label, col_name)) {
+  #   labels_list <- self$get_variables_metadata(property = labels_label, column = col_name, direct_from_attributes = TRUE)
+  #   names(labels_list) <- as.character(new_levels[1:length(old_levels)])
+  #   if(length(new_levels) > length(old_levels)) {
+  #     extra_labels <- seq(from = max(labels_list) + 1, length.out = (length(new_levels) - length(old_levels)))
+  #     names(extra_labels) <- new_levels[!new_levels %in% names(labels_list)]
+  #     labels_list <- c(labels_list, extra_labels)
+  #   }
+  #   self$append_to_variables_metadata(col_name, labels_label, labels_list)
+  # }
   self$data_changed <- TRUE
   self$variables_metadata_changed <- TRUE
 } 

--- a/instat/static/InstatObject/R/instat_object_R6.R
+++ b/instat/static/InstatObject/R/instat_object_R6.R
@@ -834,8 +834,8 @@ instat_object$set("public", "drop_unused_factor_levels", function(data_name, col
 } 
 )
 
-instat_object$set("public", "set_factor_levels", function(data_name, col_name, new_levels, set_new_labels = TRUE) {
-  self$get_data_objects(data_name)$set_factor_levels(col_name = col_name, new_levels = new_levels, set_new_labels = set_new_labels)
+instat_object$set("public", "set_factor_levels", function(data_name, col_name, new_labels, new_levels, set_new_labels = TRUE) {
+  self$get_data_objects(data_name)$set_factor_levels(col_name = col_name, new_labels = new_labels, new_levels = new_levels, set_new_labels = set_new_labels)
 } 
 )
 

--- a/instat/static/InstatObject/R/instat_object_R6.R
+++ b/instat/static/InstatObject/R/instat_object_R6.R
@@ -747,8 +747,8 @@ instat_object$set("public", "get_column_factor_levels", function(data_name,col_n
 } 
 )
 
-instat_object$set("public", "get_factor_data_frame", function(data_name,col_name = "") {
-  self$get_data_objects(data_name)$get_factor_data_frame(col_name)
+instat_object$set("public", "get_factor_data_frame", function(data_name, col_name = "", include_levels = TRUE) {
+  self$get_data_objects(data_name)$get_factor_data_frame(col_name = col_name, include_levels = include_levels)
 } 
 )
 

--- a/instat/ucrFactor.vb
+++ b/instat/ucrFactor.vb
@@ -64,6 +64,9 @@ Public Class ucrFactor
 
     Public Sub SetReceiver(clsNewReceiver As ucrReceiverSingle)
         clsReceiver = clsNewReceiver
+        If ucrChkLevels IsNot Nothing Then
+            ucrChkLevels.Enabled = Not clsReceiver.IsEmpty
+        End If
         RefreshFactorData()
     End Sub
 
@@ -186,7 +189,8 @@ Public Class ucrFactor
             ApplyColumnSettings()
             RaiseEvent GridContentChanged()
             If ucrChkLevels IsNot Nothing Then
-                ucrChkLevels.Visible = True
+                ucrChkLevels.Enabled = True
+                ucrChkLevels.Checked = False
             End If
             If Not bForceShowLevels Then
                 iLevelsCol = GetColumnIndex("Levels")
@@ -194,7 +198,8 @@ Public Class ucrFactor
                     bHasLevels = frmMain.clsRLink.IsVariablesMetadata(clsReceiver.GetDataName(), "labels", clsReceiver.GetVariableNames(False))
                     If bHasLevels Then
                         If ucrChkLevels IsNot Nothing Then
-                            ucrChkLevels.Visible = False
+                            ucrChkLevels.Enabled = False
+                            ucrChkLevels.Checked = True
                         End If
                     Else
                         shtCurrSheet.HideColumns(iLevelsCol, 1)
@@ -543,6 +548,9 @@ Public Class ucrFactor
 
     Public Sub SetLevelsCheckbox(ucrChkAddLevels As ucrCheck)
         ucrChkLevels = ucrChkAddLevels
+        If clsReceiver IsNot Nothing Then
+            ucrChkLevels.Enabled = Not clsReceiver.IsEmpty
+        End If
     End Sub
 
     Private Sub ucrChkLevels_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrChkLevels.ControlValueChanged
@@ -561,8 +569,8 @@ Public Class ucrFactor
     End Sub
 
     Private Sub clsReceiver_ControlValueChanged(ucrChangedControl As ucrCore) Handles clsReceiver.ControlValueChanged
-        If ucrChkLevels IsNot Nothing Then
-            ucrChkLevels.Enabled = Not clsReceiver.IsEmpty
+        If ucrChkLevels IsNot Nothing AndAlso clsReceiver.IsEmpty Then
+            ucrChkLevels.Enabled = False
         End If
     End Sub
 End Class

--- a/instat/ucrFilter.vb
+++ b/instat/ucrFilter.vb
@@ -62,6 +62,7 @@ Public Class ucrFilter
         ucrFilterOperation.SetItems({"==", "<", "<=", ">", ">=", "!="})
         ucrFactorLevels.SetAsMultipleSelector()
         ucrFactorLevels.SetReceiver(ucrFilterByReceiver)
+        ucrFactorLevels.SetIncludeLevels(False)
         clsFilterView.bForceIncludeOperation = False
         lstFilters.Columns.Add("Variable")
         lstFilters.Columns.Add("Condition")


### PR DESCRIPTION
The main change here is to include "levels" as well as "labels" for factors. Our new language uses 
"label" - a text value corresponding to each category of a factor
"level" - a number value corresponding to each category of a factor

So in levels/labels dialog you can now set a level and a label for each category or "level" (double meaning of level)
You can also just use labels if you don't care about levels

This has affected the following dialogs which use factor grids:
dlgLabels
dlgRecodeFactor
dlgReferenceLevel
dlgRemoveUnusedLevels
ucrFilter

Note that only labels dialog has visibly changed, as the others don't need to include the levels, but the code changes affect all of them so they need testing.

@Lunalo this builds on the changes from your branch. Can you review this? I suggest using efc data and other data so you have a mixture of data with and without existing labels list.