### PR TITLE
Transform split bug fix

### DIFF
--- a/instat/dlgConvertColumns.Designer.vb
+++ b/instat/dlgConvertColumns.Designer.vb
@@ -231,6 +231,7 @@ Partial Class dlgConvertColumns
         Me.ucrReceiverColumnsToConvert.Name = "ucrReceiverColumnsToConvert"
         Me.ucrReceiverColumnsToConvert.Selector = Nothing
         Me.ucrReceiverColumnsToConvert.Size = New System.Drawing.Size(120, 100)
+        Me.ucrReceiverColumnsToConvert.strNcFilePath = ""
         Me.ucrReceiverColumnsToConvert.TabIndex = 2
         Me.ucrReceiverColumnsToConvert.ucrSelector = Nothing
         '

--- a/instat/dlgConvertColumns.vb
+++ b/instat/dlgConvertColumns.vb
@@ -130,14 +130,6 @@ Public Class dlgConvertColumns
         End If
     End Sub
 
-    Private Sub ucrChkSpecifyDecimalsToDisplay_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrChkSpecifyDecimalsToDisplay.ControlValueChanged
-        If ucrChkSpecifyDecimalsToDisplay.Checked Then
-            ucrReceiverColumnsToConvert.SetDataType("numeric")
-        Else
-            ucrReceiverColumnsToConvert.SetIncludedDataTypes({"integer", "numeric", "character", "ordered", "factor"})
-        End If
-    End Sub
-
     Private Sub Controls_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrReceiverColumnsToConvert.ControlContentsChanged, ucrPnlConvertTo.ControlContentsChanged, ucrNudDisplayDecimals.ControlContentsChanged, ucrChkSpecifyDecimalsToDisplay.ControlContentsChanged
         TestOKEnabled()
     End Sub

--- a/instat/dlgTransformText.vb
+++ b/instat/dlgTransformText.vb
@@ -26,6 +26,8 @@ Public Class dlgTransformText
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
+        Else
+            ReopenDialog()
         End If
         If bReset Then
             SetDefaults()
@@ -36,6 +38,9 @@ Public Class dlgTransformText
     End Sub
 
     Private Sub InitialiseDialog()
+        Dim dctInputPad As New Dictionary(Of String, String)
+        Dim dctInputSeparator As New Dictionary(Of String, String)
+
         ucrBase.iHelpTopicID = 343
         ucrBase.clsRsyntax.bUseBaseFunction = True
 
@@ -78,7 +83,6 @@ Public Class dlgTransformText
         ucrPnlOperation.AddToLinkedControls(ucrNudWidth, {rdoPad}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
 
         'ucrInputPad
-        Dim dctInputPad As New Dictionary(Of String, String)
         ucrInputPad.SetParameter(New RParameter("pad", 3))
         dctInputPad.Add("Space ( )", Chr(34) & " " & Chr(34))
         dctInputPad.Add("Hash #", Chr(34) & "#" & Chr(34))
@@ -88,6 +92,7 @@ Public Class dlgTransformText
         ucrInputPad.SetItems(dctInputPad)
         ucrInputPad.SetLinkedDisplayControl(lblPad)
         ucrInputPad.SetRDefault(Chr(34) & " " & Chr(34))
+        ucrInputPad.bAllowNonConditionValues = True
 
         'ucrNudWidth
         ucrNudWidth.SetParameter(New RParameter("width", 1))
@@ -139,7 +144,6 @@ Public Class dlgTransformText
         ucrChkLastOr.AddParameterIsRFunctionCondition(True, "start", True)
 
         ' ucrInputSeparator
-        Dim dctInputSeparator As New Dictionary(Of String, String)
         ucrInputSeparator.SetParameter(New RParameter("sep", 3))
         dctInputSeparator.Add("Space ( )", "fixed(" & Chr(34) & " " & Chr(34) & ")")
         dctInputSeparator.Add("Colon :", Chr(34) & ":" & Chr(34))
@@ -148,6 +152,7 @@ Public Class dlgTransformText
         ucrInputSeparator.SetItems(dctInputSeparator)
         ucrInputSeparator.SetLinkedDisplayControl(lblSeparator)
         ucrInputSeparator.SetRDefault("fixed(" & Chr(34) & " " & Chr(34) & ")")
+        ucrInputSeparator.bAllowNonConditionValues = True
 
         'rdoSubstring
         ucrPnlOperation.AddToLinkedControls(ucrNudFrom, {rdoSubstring}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
@@ -278,6 +283,11 @@ Public Class dlgTransformText
         SetDefaults()
         SetRCodeForControls(True)
         TestOkEnabled()
+    End Sub
+
+    Private Sub ReopenDialog() ' This is temporary while reopening the dialog can cause a developer error if the user changes a value in the ucrInput
+        ucrInputPad.bAllowNonConditionValues = True
+        ucrInputSeparator.bAllowNonConditionValues = True
     End Sub
 
     Private Sub NewDefaultName()


### PR DESCRIPTION
@dannyparsons this is ready to review
I've addressed the issue of the developer error when reopening when a ucrInput has a different value inputted from specified in Initialise()