### PR TITLE
Changing Select File to Browse

### DIFF
--- a/instat/dlgExportGraphAsImage.Designer.vb
+++ b/instat/dlgExportGraphAsImage.Designer.vb
@@ -46,7 +46,7 @@ Partial Class dlgExportGraphAsImage
         Me.cmdBrowse.Name = "cmdBrowse"
         Me.cmdBrowse.Size = New System.Drawing.Size(75, 23)
         Me.cmdBrowse.TabIndex = 4
-        Me.cmdBrowse.Text = "Browse..."
+        Me.cmdBrowse.Text = "Browse"
         Me.cmdBrowse.UseVisualStyleBackColor = True
         '
         'ucrSelectedGraphReceiver

--- a/instat/dlgExportRObjects.Designer.vb
+++ b/instat/dlgExportRObjects.Designer.vb
@@ -93,7 +93,7 @@ Partial Class dlgExportRObjects
         Me.cmdBrowse.Name = "cmdBrowse"
         Me.cmdBrowse.Size = New System.Drawing.Size(62, 23)
         Me.cmdBrowse.TabIndex = 5
-        Me.cmdBrowse.Text = "Browse..."
+        Me.cmdBrowse.Text = "Browse"
         Me.cmdBrowse.UseVisualStyleBackColor = True
         '
         'dlgExportRObjects

--- a/instat/dlgExportRWorkspace.Designer.vb
+++ b/instat/dlgExportRWorkspace.Designer.vb
@@ -41,7 +41,7 @@ Partial Class dlgExportRWorkspace
         Me.cmdBrowse.Name = "cmdBrowse"
         Me.cmdBrowse.Size = New System.Drawing.Size(62, 23)
         Me.cmdBrowse.TabIndex = 9
-        Me.cmdBrowse.Text = "Browse..."
+        Me.cmdBrowse.Text = "Browse"
         Me.cmdBrowse.UseVisualStyleBackColor = True
         '
         'lblExport

--- a/instat/dlgFromLibrary.Designer.vb
+++ b/instat/dlgFromLibrary.Designer.vb
@@ -42,7 +42,7 @@ Partial Class dlgFromLibrary
         Me.cmdLibraryCollection.Name = "cmdLibraryCollection"
         Me.cmdLibraryCollection.Size = New System.Drawing.Size(142, 23)
         Me.cmdLibraryCollection.TabIndex = 2
-        Me.cmdLibraryCollection.Text = "Load file"
+        Me.cmdLibraryCollection.Text = "Browse"
         Me.cmdLibraryCollection.UseVisualStyleBackColor = True
         '
         'lstCollection

--- a/instat/dlgImportDataset.Designer.vb
+++ b/instat/dlgImportDataset.Designer.vb
@@ -236,8 +236,8 @@ Partial Class dlgImportDataset
         Me.cmdOpenDataSet.Name = "cmdOpenDataSet"
         Me.cmdOpenDataSet.Size = New System.Drawing.Size(66, 23)
         Me.cmdOpenDataSet.TabIndex = 33
-        Me.cmdOpenDataSet.Tag = "select_file"
-        Me.cmdOpenDataSet.Text = "Select File"
+        Me.cmdOpenDataSet.Tag = "browse"
+        Me.cmdOpenDataSet.Text = "Browse"
         Me.cmdOpenDataSet.UseVisualStyleBackColor = True
         '
         'grpCSV

--- a/instat/dlgOpenSST.Designer.vb
+++ b/instat/dlgOpenSST.Designer.vb
@@ -55,8 +55,8 @@ Partial Class dlgOpenSST
         Me.cmdOpenDataSet.Name = "cmdOpenDataSet"
         Me.cmdOpenDataSet.Size = New System.Drawing.Size(66, 23)
         Me.cmdOpenDataSet.TabIndex = 2
-        Me.cmdOpenDataSet.Tag = "select_file"
-        Me.cmdOpenDataSet.Text = "Select File"
+        Me.cmdOpenDataSet.Tag = "Browse"
+        Me.cmdOpenDataSet.Text = "Browse"
         Me.cmdOpenDataSet.UseVisualStyleBackColor = True
         '
         'lblFileOpenPath


### PR DESCRIPTION
Here I have changed Select File to Browse
Or removed the ellipsis from Browse. According to the Windows documentation we shouldn't use an ellipsis on Browse as the word "Browse" already implies a new window.

@dannyparsons this is ready to review

Fixes #2974 