### PR TITLE
Dialog sizes and alignment fixes

### DIFF
--- a/instat/dlgCalculator.designer.vb
+++ b/instat/dlgCalculator.designer.vb
@@ -60,7 +60,7 @@ Partial Class dlgCalculator
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
-        Me.ClientSize = New System.Drawing.Size(456, 396)
+        Me.ClientSize = New System.Drawing.Size(494, 396)
         Me.Controls.Add(Me.ucrBase)
         Me.Controls.Add(Me.ucrCalc)
         Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow

--- a/instat/dlgCalculator.vb
+++ b/instat/dlgCalculator.vb
@@ -24,11 +24,13 @@ Public Class dlgCalculator
     Dim clsDetach As New RFunction
     Public bFirstLoad As Boolean = True
     Public iHelpCalcID As Integer
+    Private iBasicWidth As Integer
 
     Private Sub dlgCalculator_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
+            iBasicWidth = Me.Width
             SetDefaults()
             bFirstLoad = False
         Else
@@ -132,21 +134,21 @@ Public Class dlgCalculator
     Private Sub CalculationsOptions()
         Select Case ucrCalc.ucrInputCalOptions.GetText
             Case "Maths"
-                Me.Size = New System.Drawing.Size(680, 435)
+                Me.Size = New System.Drawing.Size(iBasicWidth * 1.33, Me.Height)
             Case "Logical and Symbols"
-                Me.Size = New System.Drawing.Size(627, 435)
+                Me.Size = New System.Drawing.Size(iBasicWidth * 1.23, Me.Height)
             Case "Statistics"
-                Me.Size = New System.Drawing.Size(588, 435)
+                Me.Size = New System.Drawing.Size(iBasicWidth * 1.15, Me.Height)
             Case "Strings (Character Columns)"
-                Me.Size = New System.Drawing.Size(630, 435)
+                Me.Size = New System.Drawing.Size(iBasicWidth * 1.24, Me.Height)
             Case "Probability"
-                Me.Size = New System.Drawing.Size(810, 435)
+                Me.Size = New System.Drawing.Size(iBasicWidth * 1.59, Me.Height)
             Case "Dates"
-                Me.Size = New System.Drawing.Size(660, 435)
+                Me.Size = New System.Drawing.Size(iBasicWidth * 1.3, Me.Height)
             Case "Rows"
-                Me.Size = New System.Drawing.Size(615, 435)
+                Me.Size = New System.Drawing.Size(iBasicWidth * 1.21, Me.Height)
             Case Else
-                Me.Size = New System.Drawing.Size(510, 435)
+                Me.Size = New System.Drawing.Size(iBasicWidth, Me.Height)
         End Select
     End Sub
 

--- a/instat/dlgContrasts.vb
+++ b/instat/dlgContrasts.vb
@@ -24,6 +24,7 @@ Public Class dlgContrasts
     Public bFirstLoad As Boolean = True
     Public bReset As Boolean = True
     Public clsNlevels, clsFactorColumn, clsContractMatrix, clsSetContrast As New RFunction
+    Private iFullWidth As Integer
 
     Public Sub New()
 
@@ -37,6 +38,7 @@ Public Class dlgContrasts
         grdCurrSheet = grdLayoutForContrasts.CurrentWorksheet
         grdCurrSheet.SetSettings(WorksheetSettings.Edit_DragSelectionToMoveCells, False)
         grdCurrSheet.SelectionForwardDirection = SelectionForwardDirection.Down
+        iFullWidth = Me.Width
     End Sub
 
     Private Sub dlgContrasts_Load(sender As Object, e As EventArgs) Handles MyBase.Load
@@ -149,7 +151,7 @@ Public Class dlgContrasts
 
     Private Sub SetGridDimensions()
         If Not ucrReceiverForContrasts.IsEmpty AndAlso ucrInputContrastName.GetText = "User Defined" Then
-            Me.Size = New System.Drawing.Size(440 + grdLayoutForContrasts.Width, 294)
+            Me.Size = New Size(iFullWidth, Me.Height)
             clsFactorColumn.AddParameter("col_name", ucrReceiverForContrasts.GetVariableNames())
             clsFactorColumn.AddParameter("data_name", Chr(34) & ucrSelectorForContrast.ucrAvailableDataFrames.cboAvailableDataFrames.SelectedItem & Chr(34))
             clsNlevels.AddParameter("x", clsRFunctionParameter:=clsFactorColumn)
@@ -157,7 +159,7 @@ Public Class dlgContrasts
             grdCurrSheet.Columns = grdCurrSheet.Rows - 1
             grdLayoutForContrasts.Enabled = True
         Else
-            Me.Size = New System.Drawing.Size(435, 294)
+            Me.Size = New Size(iFullWidth / 1.86, Me.Height)
             clsFactorColumn.RemoveParameterByName("col_name")
             clsNlevels.RemoveParameterByName("x")
             grdLayoutForContrasts.Enabled = False

--- a/instat/dlgDisplayDailyData.Designer.vb
+++ b/instat/dlgDisplayDailyData.Designer.vb
@@ -47,13 +47,13 @@ Partial Class dlgDisplayDailyData
         Me.lblDayOfTheYear = New System.Windows.Forms.Label()
         Me.lblYaxisUpper = New System.Windows.Forms.Label()
         Me.grpGraph = New System.Windows.Forms.GroupBox()
+        Me.ucrInputRugColour = New instat.ucrInputComboBox()
         Me.lblRugColor = New System.Windows.Forms.Label()
+        Me.ucrInputBarColour = New instat.ucrInputComboBox()
         Me.lblBarColour = New System.Windows.Forms.Label()
+        Me.ucrNudUpperYaxis = New instat.ucrNud()
         Me.lblFactorby = New System.Windows.Forms.Label()
         Me.ucrReceiverFactorby = New instat.ucrReceiverMultiple()
-        Me.ucrInputRugColour = New instat.ucrInputComboBox()
-        Me.ucrInputBarColour = New instat.ucrInputComboBox()
-        Me.ucrNudUpperYaxis = New instat.ucrNud()
         Me.ucrReceiverElements = New instat.ucrReceiverMultiple()
         Me.ucrReceiverYear = New instat.ucrReceiverSingle()
         Me.ucrReceiverDayOfYear = New instat.ucrReceiverSingle()
@@ -96,7 +96,7 @@ Partial Class dlgDisplayDailyData
         Me.rdoGraph.Size = New System.Drawing.Size(100, 28)
         Me.rdoGraph.TabIndex = 2
         Me.rdoGraph.Text = "Graph"
-        Me.rdoGraph.TextAlign = System.Drawing.ContentAlignment.TopCenter
+        Me.rdoGraph.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
         Me.rdoGraph.UseVisualStyleBackColor = True
         '
         'lblStation
@@ -168,6 +168,15 @@ Partial Class dlgDisplayDailyData
         Me.grpGraph.TabStop = False
         Me.grpGraph.Text = "Graph"
         '
+        'ucrInputRugColour
+        '
+        Me.ucrInputRugColour.AddQuotesIfUnrecognised = True
+        Me.ucrInputRugColour.IsReadOnly = False
+        Me.ucrInputRugColour.Location = New System.Drawing.Point(83, 70)
+        Me.ucrInputRugColour.Name = "ucrInputRugColour"
+        Me.ucrInputRugColour.Size = New System.Drawing.Size(73, 21)
+        Me.ucrInputRugColour.TabIndex = 9
+        '
         'lblRugColor
         '
         Me.lblRugColor.AutoSize = True
@@ -177,6 +186,15 @@ Partial Class dlgDisplayDailyData
         Me.lblRugColor.TabIndex = 8
         Me.lblRugColor.Text = "Rug Color:"
         '
+        'ucrInputBarColour
+        '
+        Me.ucrInputBarColour.AddQuotesIfUnrecognised = True
+        Me.ucrInputBarColour.IsReadOnly = False
+        Me.ucrInputBarColour.Location = New System.Drawing.Point(83, 43)
+        Me.ucrInputBarColour.Name = "ucrInputBarColour"
+        Me.ucrInputBarColour.Size = New System.Drawing.Size(73, 21)
+        Me.ucrInputBarColour.TabIndex = 7
+        '
         'lblBarColour
         '
         Me.lblBarColour.AutoSize = True
@@ -185,6 +203,19 @@ Partial Class dlgDisplayDailyData
         Me.lblBarColour.Size = New System.Drawing.Size(59, 13)
         Me.lblBarColour.TabIndex = 6
         Me.lblBarColour.Text = "Bar Colour:"
+        '
+        'ucrNudUpperYaxis
+        '
+        Me.ucrNudUpperYaxis.DecimalPlaces = New Decimal(New Integer() {0, 0, 0, 0})
+        Me.ucrNudUpperYaxis.Increment = New Decimal(New Integer() {1, 0, 0, 0})
+        Me.ucrNudUpperYaxis.Location = New System.Drawing.Point(83, 13)
+        Me.ucrNudUpperYaxis.Margin = New System.Windows.Forms.Padding(4)
+        Me.ucrNudUpperYaxis.Maximum = New Decimal(New Integer() {100, 0, 0, 0})
+        Me.ucrNudUpperYaxis.Minimum = New Decimal(New Integer() {0, 0, 0, 0})
+        Me.ucrNudUpperYaxis.Name = "ucrNudUpperYaxis"
+        Me.ucrNudUpperYaxis.Size = New System.Drawing.Size(50, 23)
+        Me.ucrNudUpperYaxis.TabIndex = 3
+        Me.ucrNudUpperYaxis.Value = New Decimal(New Integer() {0, 0, 0, 0})
         '
         'lblFactorby
         '
@@ -206,37 +237,6 @@ Partial Class dlgDisplayDailyData
         Me.ucrReceiverFactorby.strNcFilePath = ""
         Me.ucrReceiverFactorby.TabIndex = 17
         Me.ucrReceiverFactorby.ucrSelector = Nothing
-        '
-        'ucrInputRugColour
-        '
-        Me.ucrInputRugColour.AddQuotesIfUnrecognised = True
-        Me.ucrInputRugColour.IsReadOnly = False
-        Me.ucrInputRugColour.Location = New System.Drawing.Point(83, 70)
-        Me.ucrInputRugColour.Name = "ucrInputRugColour"
-        Me.ucrInputRugColour.Size = New System.Drawing.Size(73, 21)
-        Me.ucrInputRugColour.TabIndex = 9
-        '
-        'ucrInputBarColour
-        '
-        Me.ucrInputBarColour.AddQuotesIfUnrecognised = True
-        Me.ucrInputBarColour.IsReadOnly = False
-        Me.ucrInputBarColour.Location = New System.Drawing.Point(83, 43)
-        Me.ucrInputBarColour.Name = "ucrInputBarColour"
-        Me.ucrInputBarColour.Size = New System.Drawing.Size(73, 21)
-        Me.ucrInputBarColour.TabIndex = 7
-        '
-        'ucrNudUpperYaxis
-        '
-        Me.ucrNudUpperYaxis.DecimalPlaces = New Decimal(New Integer() {0, 0, 0, 0})
-        Me.ucrNudUpperYaxis.Increment = New Decimal(New Integer() {1, 0, 0, 0})
-        Me.ucrNudUpperYaxis.Location = New System.Drawing.Point(83, 13)
-        Me.ucrNudUpperYaxis.Margin = New System.Windows.Forms.Padding(4)
-        Me.ucrNudUpperYaxis.Maximum = New Decimal(New Integer() {100, 0, 0, 0})
-        Me.ucrNudUpperYaxis.Minimum = New Decimal(New Integer() {0, 0, 0, 0})
-        Me.ucrNudUpperYaxis.Name = "ucrNudUpperYaxis"
-        Me.ucrNudUpperYaxis.Size = New System.Drawing.Size(50, 23)
-        Me.ucrNudUpperYaxis.TabIndex = 3
-        Me.ucrNudUpperYaxis.Value = New Decimal(New Integer() {0, 0, 0, 0})
         '
         'ucrReceiverElements
         '

--- a/instat/dlgOpenNetCDF.vb
+++ b/instat/dlgOpenNetCDF.vb
@@ -35,6 +35,7 @@ Public Class dlgOpenNetCDF
     Private strLong As String
     Private bCloseFile As Boolean = False
     Private strFileAssignName As String = "nc"
+    Private iExpandedWidth As Integer
 
     Public Sub New()
         ' This call is required by the designer.
@@ -43,6 +44,7 @@ Public Class dlgOpenNetCDF
         bComponentsInitialised = True
         bStartOpenDialog = True
         ucrInputDataName.bAutoChangeOnLeave = True
+        iExpandedWidth = Me.Width
     End Sub
 
     Private Sub dlgOpenNetCDF_Load(sender As Object, e As EventArgs) Handles MyBase.Load
@@ -94,9 +96,6 @@ Public Class dlgOpenNetCDF
         clsNcCloseFunction = New RFunction
         clsRFileDetails = New RFunction
 
-        Me.Size = New Size(434, 256)
-        cmdDetails.Text = "Show Details >>"
-        bShowDetails = True
         strShort = ""
         strMedium = ""
         strLong = ""
@@ -126,6 +125,9 @@ Public Class dlgOpenNetCDF
         ucrBase.clsRsyntax.SetBaseRFunction(clsImportNetcdfFunction)
         ucrBase.clsRsyntax.AddToAfterCodes(clsNcCloseFunction, iPosition:=0)
         bResetSubdialog = True
+
+        bShowDetails = False
+        SetDialogSize()
     End Sub
 
     Private Sub SetRCodeForControls(bReset As Boolean)
@@ -198,12 +200,16 @@ Public Class dlgOpenNetCDF
     End Sub
 
     Private Sub cmdDetails_Click(sender As Object, e As EventArgs) Handles cmdDetails.Click
+        SetDialogSize()
+    End Sub
+
+    Private Sub SetDialogSize()
         bShowDetails = Not bShowDetails
         If Not bShowDetails Then
-            Me.Size = New Size(777, 256)
+            Me.Size = New Size(iExpandedWidth, Me.Height)
             cmdDetails.Text = "Hide Details <<"
         Else
-            Me.Size = New Size(434, 256)
+            Me.Size = New Size(iExpandedWidth / 1.8, Me.Height)
             cmdDetails.Text = "Show Details >>"
         End If
     End Sub

--- a/instat/dlgStringHandling.vb
+++ b/instat/dlgStringHandling.vb
@@ -19,10 +19,13 @@ Public Class dlgStringHandling
     Private bFirstload As Boolean = True
     Private bReset As Boolean = True
     Private clsCountFunction, clsExtractFunction, clsDetectFunction, clsLocateFunction, clsReplaceFunction, clsReplaceAllFunction, clsFixedFunction, clsRegexFunction As New RFunction
+    Private iFullWidth As Integer
+
     Private Sub dlgStringHandling_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         If bFirstload Then
             InitialiseDialog()
             bFirstload = False
+            iFullWidth = Me.Width
         End If
         If bReset Then
             SetDefaults()
@@ -280,10 +283,10 @@ Public Class dlgStringHandling
     Private Sub ChangeSize()
         If rdoRegex.Checked Then
             grpRegex.Visible = True
-            Me.Size = New Size(685, 390)
+            Me.Size = New Size(iFullWidth, Me.Height)
         Else
             grpRegex.Visible = False
-            Me.Size = New Size(437, 390)
+            Me.Size = New Size(iFullWidth / 1.57, Me.Height)
         End If
     End Sub
 

--- a/instat/dlgThreeVariableFrequencies.Designer.vb
+++ b/instat/dlgThreeVariableFrequencies.Designer.vb
@@ -192,7 +192,7 @@ Partial Class dlgThreeVariableFrequencies
         Me.grpFreqTypeTable.Controls.Add(Me.ucrChkCount)
         Me.grpFreqTypeTable.Controls.Add(Me.ucrChkColumn)
         Me.grpFreqTypeTable.Controls.Add(Me.ucrChkCell)
-        Me.grpFreqTypeTable.Location = New System.Drawing.Point(274, 255)
+        Me.grpFreqTypeTable.Location = New System.Drawing.Point(260, 261)
         Me.grpFreqTypeTable.Name = "grpFreqTypeTable"
         Me.grpFreqTypeTable.Size = New System.Drawing.Size(121, 111)
         Me.grpFreqTypeTable.TabIndex = 13
@@ -247,7 +247,7 @@ Partial Class dlgThreeVariableFrequencies
         Me.grpFreqTypeGraph.Controls.Add(Me.rdoRow)
         Me.grpFreqTypeGraph.Controls.Add(Me.rdoCell)
         Me.grpFreqTypeGraph.Controls.Add(Me.ucrPnlFreqType)
-        Me.grpFreqTypeGraph.Location = New System.Drawing.Point(398, 255)
+        Me.grpFreqTypeGraph.Location = New System.Drawing.Point(384, 261)
         Me.grpFreqTypeGraph.Name = "grpFreqTypeGraph"
         Me.grpFreqTypeGraph.Size = New System.Drawing.Size(121, 111)
         Me.grpFreqTypeGraph.TabIndex = 14
@@ -294,6 +294,7 @@ Partial Class dlgThreeVariableFrequencies
         Me.ucrReceiverGroupBy2nd.Name = "ucrReceiverGroupBy2nd"
         Me.ucrReceiverGroupBy2nd.Selector = Nothing
         Me.ucrReceiverGroupBy2nd.Size = New System.Drawing.Size(121, 20)
+        Me.ucrReceiverGroupBy2nd.strNcFilePath = ""
         Me.ucrReceiverGroupBy2nd.TabIndex = 12
         Me.ucrReceiverGroupBy2nd.ucrSelector = Nothing
         '
@@ -305,6 +306,7 @@ Partial Class dlgThreeVariableFrequencies
         Me.ucrReceiverGroupsBy1st.Name = "ucrReceiverGroupsBy1st"
         Me.ucrReceiverGroupsBy1st.Selector = Nothing
         Me.ucrReceiverGroupsBy1st.Size = New System.Drawing.Size(121, 20)
+        Me.ucrReceiverGroupsBy1st.strNcFilePath = ""
         Me.ucrReceiverGroupsBy1st.TabIndex = 10
         Me.ucrReceiverGroupsBy1st.ucrSelector = Nothing
         '
@@ -316,6 +318,7 @@ Partial Class dlgThreeVariableFrequencies
         Me.ucrReceiverWeights.Name = "ucrReceiverWeights"
         Me.ucrReceiverWeights.Selector = Nothing
         Me.ucrReceiverWeights.Size = New System.Drawing.Size(128, 20)
+        Me.ucrReceiverWeights.strNcFilePath = ""
         Me.ucrReceiverWeights.TabIndex = 17
         Me.ucrReceiverWeights.ucrSelector = Nothing
         '
@@ -335,6 +338,7 @@ Partial Class dlgThreeVariableFrequencies
         Me.ucrReceiverColumnFactor.Name = "ucrReceiverColumnFactor"
         Me.ucrReceiverColumnFactor.Selector = Nothing
         Me.ucrReceiverColumnFactor.Size = New System.Drawing.Size(121, 20)
+        Me.ucrReceiverColumnFactor.strNcFilePath = ""
         Me.ucrReceiverColumnFactor.TabIndex = 8
         Me.ucrReceiverColumnFactor.ucrSelector = Nothing
         '
@@ -346,6 +350,7 @@ Partial Class dlgThreeVariableFrequencies
         Me.ucrReceiverRowFactor.Name = "ucrReceiverRowFactor"
         Me.ucrReceiverRowFactor.Selector = Nothing
         Me.ucrReceiverRowFactor.Size = New System.Drawing.Size(121, 20)
+        Me.ucrReceiverRowFactor.strNcFilePath = ""
         Me.ucrReceiverRowFactor.TabIndex = 6
         Me.ucrReceiverRowFactor.ucrSelector = Nothing
         '
@@ -385,7 +390,7 @@ Partial Class dlgThreeVariableFrequencies
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
-        Me.ClientSize = New System.Drawing.Size(521, 453)
+        Me.ClientSize = New System.Drawing.Size(509, 453)
         Me.Controls.Add(Me.ucrSaveGraph)
         Me.Controls.Add(Me.rdoBoth)
         Me.Controls.Add(Me.ucrReceiverGroupBy2nd)

--- a/instat/dlgThreeVariableFrequencies.vb
+++ b/instat/dlgThreeVariableFrequencies.vb
@@ -22,11 +22,15 @@ Public Class dlgThreeVariableFrequencies
     Private clsSjTab, clsSelect, clsSjPlot, clsGroupBy, clsGridArrange As New RFunction
     Private clsTableBaseOperator, clsGraphBaseOperator As New ROperator
     Private clsCurrBaseCode As RCodeStructure
+    Private iMaxWidth As Integer
+    Private iMaxGraphGroupX As Integer
 
     Private Sub dlgThreeVariableFrequencies_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
+            iMaxWidth = Me.Width
+            iMaxGraphGroupX = grpFreqTypeGraph.Location.X
             bFirstLoad = False
         End If
         If bReset Then
@@ -253,7 +257,6 @@ Public Class dlgThreeVariableFrequencies
         TestOkEnabled()
     End Sub
 
-
     Private Sub SetBaseFunction()
         If rdoTable.Checked OrElse rdoBoth.Checked Then
             ucrBase.clsRsyntax.SetBaseROperator(clsTableBaseOperator)
@@ -296,13 +299,11 @@ Public Class dlgThreeVariableFrequencies
 
     Private Sub ChangeLocation()
         If rdoBoth.Checked Then
-            grpFreqTypeTable.Location = New Point(260, 261)
-            grpFreqTypeGraph.Location = New Point(384, 261)
-            Me.Size = New Size(525, 492)
+            grpFreqTypeGraph.Location = New Point(iMaxGraphGroupX, grpFreqTypeGraph.Location.Y)
+            Me.Size = New Size(iMaxWidth, Me.Height)
         Else
-            grpFreqTypeTable.Location = New Point(260, 261)
-            grpFreqTypeGraph.Location = New Point(260, 261)
-            Me.Size = New Size(431, 492)
+            grpFreqTypeGraph.Location = New Point(iMaxGraphGroupX / 1.48, grpFreqTypeGraph.Location.Y)
+            Me.Size = New Size(iMaxWidth / 1.22, Me.Height)
         End If
     End Sub
 

--- a/instat/dlgTransformText.vb
+++ b/instat/dlgTransformText.vb
@@ -21,11 +21,19 @@ Public Class dlgTransformText
     Private bReset As Boolean = True
     Private clsConvertFunction, clsLengthFunction, clsPadFunction, clsTrimFunction, clsWordsFunction, clsSubstringFunction As New RFunction
     Private bRCodeSet As Boolean = True
+    Private iFullHeight As Integer
+    Private igrpParameterFullHeight As Integer
+    Private iBaseMaxY As Integer
+    Private iNewColMaxY As Integer
 
     Private Sub dlgTransformText_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
+            iFullHeight = Me.Height
+            igrpParameterFullHeight = grpParameters.Height
+            iBaseMaxY = ucrBase.Location.Y
+            iNewColMaxY = ucrNewColName.Location.Y
             bFirstLoad = False
         End If
         If bReset Then
@@ -174,7 +182,6 @@ Public Class dlgTransformText
         ucrNewColName.SetSaveTypeAsColumn()
         ucrNewColName.SetDataFrameSelector(ucrSelectorForTransformText.ucrAvailableDataFrames)
         ucrNewColName.SetLabelText("Column Name:")
-        DialogSize()
     End Sub
 
     Private Sub SetDefaults()
@@ -242,6 +249,7 @@ Public Class dlgTransformText
         ucrNudTo.SetRCode(clsSubstringFunction, bReset)
 
         bRCodeSet = True
+        DialogSize()
     End Sub
 
     Private Sub TestOkEnabled()
@@ -297,33 +305,33 @@ Public Class dlgTransformText
     Private Sub DialogSize()
         If rdoConvertCase.Checked OrElse rdoTrim.Checked Then
             grpParameters.Visible = True
-            grpParameters.Size = New Size(397, 57)
-            ucrNewColName.Location = New Point(10, 301)
-            ucrBase.Location = New Point(10, 326)
-            Me.Size = New Size(435, 422)
+            grpParameters.Size = New Size(grpParameters.Width, igrpParameterFullHeight / 3.04)
+            ucrNewColName.Location = New Point(ucrNewColName.Location.X, iNewColMaxY / 1.39)
+            ucrBase.Location = New Point(ucrBase.Location.X, iBaseMaxY / 1.36)
+            Me.Size = New Size(Me.Width, iFullHeight / 1.27)
         ElseIf rdoLength.Checked Then
             grpParameters.Visible = False
-            ucrNewColName.Location = New Point(10, 237)
-            ucrBase.Location = New Point(10, 262)
-            Me.Size = New Size(435, 357)
+            ucrNewColName.Location = New Point(ucrNewColName.Location.X, iNewColMaxY / 1.76)
+            ucrBase.Location = New Point(ucrBase.Location.X, iBaseMaxY / 1.69)
+            Me.Size = New Size(Me.Width, iFullHeight / 1.5)
         ElseIf rdoSubstring.Checked Then
             grpParameters.Visible = True
-            grpParameters.Size = New Size(397, 81)
-            ucrNewColName.Location = New Point(10, 327)
-            ucrBase.Location = New Point(10, 352)
-            Me.Size = New Size(435, 448)
+            grpParameters.Size = New Size(grpParameters.Width, igrpParameterFullHeight / 2.14)
+            ucrNewColName.Location = New Point(ucrNewColName.Location.X, iNewColMaxY / 1.28)
+            ucrBase.Location = New Point(ucrBase.Location.X, iBaseMaxY / 1.26)
+            Me.Size = New Size(Me.Width, iFullHeight / 1.2)
         ElseIf rdoPad.Checked Then
             grpParameters.Visible = True
-            grpParameters.Size = New Size(397, 121)
-            ucrNewColName.Location = New Point(10, 365)
-            ucrBase.Location = New Point(10, 390)
-            Me.Size = New Size(435, 486)
+            grpParameters.Size = New Size(grpParameters.Width, igrpParameterFullHeight / 1.43)
+            ucrNewColName.Location = New Point(ucrNewColName.Location.X, iNewColMaxY / 1.14)
+            ucrBase.Location = New Point(ucrBase.Location.X, iBaseMaxY / 1.13)
+            Me.Size = New Size(Me.Width, iFullHeight / 1.1)
         Else
             grpParameters.Visible = True
-            grpParameters.Size = New Size(397, 173)
-            ucrNewColName.Location = New Point(10, 417)
-            ucrBase.Location = New Point(10, 442)
-            Me.Size = New Size(435, 537)
+            grpParameters.Size = New Size(grpParameters.Width, igrpParameterFullHeight)
+            ucrNewColName.Location = New Point(ucrBase.Location.X, iNewColMaxY)
+            ucrBase.Location = New Point(ucrBase.Location.X, iBaseMaxY)
+            Me.Size = New Size(Me.Width, iFullHeight)
         End If
     End Sub
 

--- a/instat/dlgTwoWayFrequencies.Designer.vb
+++ b/instat/dlgTwoWayFrequencies.Designer.vb
@@ -106,7 +106,6 @@ Partial Class dlgTwoWayFrequencies
         '
         Me.rdoGraph.Appearance = System.Windows.Forms.Appearance.Button
         Me.rdoGraph.BackgroundImageLayout = System.Windows.Forms.ImageLayout.None
-        Me.rdoGraph.CheckAlign = System.Drawing.ContentAlignment.MiddleCenter
         Me.rdoGraph.FlatAppearance.BorderColor = System.Drawing.SystemColors.ActiveCaption
         Me.rdoGraph.FlatAppearance.BorderSize = 2
         Me.rdoGraph.FlatAppearance.CheckedBackColor = System.Drawing.SystemColors.ActiveCaption
@@ -117,7 +116,7 @@ Partial Class dlgTwoWayFrequencies
         Me.rdoGraph.Size = New System.Drawing.Size(100, 28)
         Me.rdoGraph.TabIndex = 2
         Me.rdoGraph.Text = "Graph"
-        Me.rdoGraph.TextAlign = System.Drawing.ContentAlignment.TopCenter
+        Me.rdoGraph.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
         Me.rdoGraph.UseVisualStyleBackColor = True
         '
         'grpFreqTypeTable
@@ -178,7 +177,6 @@ Partial Class dlgTwoWayFrequencies
         '
         Me.rdoBoth.Appearance = System.Windows.Forms.Appearance.Button
         Me.rdoBoth.BackgroundImageLayout = System.Windows.Forms.ImageLayout.None
-        Me.rdoBoth.CheckAlign = System.Drawing.ContentAlignment.MiddleCenter
         Me.rdoBoth.FlatAppearance.BorderColor = System.Drawing.SystemColors.ActiveCaption
         Me.rdoBoth.FlatAppearance.BorderSize = 2
         Me.rdoBoth.FlatAppearance.CheckedBackColor = System.Drawing.SystemColors.ActiveCaption
@@ -189,7 +187,7 @@ Partial Class dlgTwoWayFrequencies
         Me.rdoBoth.Size = New System.Drawing.Size(100, 28)
         Me.rdoBoth.TabIndex = 3
         Me.rdoBoth.Text = "Both"
-        Me.rdoBoth.TextAlign = System.Drawing.ContentAlignment.TopCenter
+        Me.rdoBoth.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
         Me.rdoBoth.UseVisualStyleBackColor = True
         '
         'grpFreqTypeGraph
@@ -305,6 +303,7 @@ Partial Class dlgTwoWayFrequencies
         Me.ucrReceiverWeights.Name = "ucrReceiverWeights"
         Me.ucrReceiverWeights.Selector = Nothing
         Me.ucrReceiverWeights.Size = New System.Drawing.Size(120, 20)
+        Me.ucrReceiverWeights.strNcFilePath = ""
         Me.ucrReceiverWeights.TabIndex = 13
         Me.ucrReceiverWeights.ucrSelector = Nothing
         '
@@ -316,6 +315,7 @@ Partial Class dlgTwoWayFrequencies
         Me.ucrReceiverColumnFactor.Name = "ucrReceiverColumnFactor"
         Me.ucrReceiverColumnFactor.Selector = Nothing
         Me.ucrReceiverColumnFactor.Size = New System.Drawing.Size(121, 20)
+        Me.ucrReceiverColumnFactor.strNcFilePath = ""
         Me.ucrReceiverColumnFactor.TabIndex = 8
         Me.ucrReceiverColumnFactor.ucrSelector = Nothing
         '
@@ -327,6 +327,7 @@ Partial Class dlgTwoWayFrequencies
         Me.ucrReceiverRowFactor.Name = "ucrReceiverRowFactor"
         Me.ucrReceiverRowFactor.Selector = Nothing
         Me.ucrReceiverRowFactor.Size = New System.Drawing.Size(121, 20)
+        Me.ucrReceiverRowFactor.strNcFilePath = ""
         Me.ucrReceiverRowFactor.TabIndex = 6
         Me.ucrReceiverRowFactor.ucrSelector = Nothing
         '

--- a/instat/dlgTwoWayFrequencies.vb
+++ b/instat/dlgTwoWayFrequencies.vb
@@ -23,12 +23,18 @@ Public Class dlgTwoWayFrequencies
     Public strDefaultDataFrame As String = ""
     Public strDefaultColumnVariable As String = ""
     Public strDefaultRowVariable As String = ""
+    Private iFullWidth As Integer
+    Private iGraphTypeMaxX As Integer
+    Private iTableTypeMaxX As Integer
 
     Private Sub dlgTwoWayFrequencies_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
+            iFullWidth = Me.Width
+            iGraphTypeMaxX = grpFreqTypeGraph.Location.X
+            iTableTypeMaxX = grpFreqTypeTable.Location.X
         End If
         If bReset Then
             SetDefaults()
@@ -37,14 +43,13 @@ Public Class dlgTwoWayFrequencies
         SetDefaultVariables()
         bReset = False
         'temp needed because of show/hiding bug
-        ChangeLocation()
+        SetLocations()
         TestOkEnabled()
     End Sub
 
     Private Sub InitialiseDialog()
         'HelpID
         ucrBase.iHelpTopicID = 415
-        Me.Size = New Size(426, 411)
         ucrReceiverColumnFactor.Selector = ucrSelectorTwoWayFrequencies
         ucrReceiverRowFactor.Selector = ucrSelectorTwoWayFrequencies
         ucrReceiverWeights.Selector = ucrSelectorTwoWayFrequencies
@@ -139,7 +144,6 @@ Public Class dlgTwoWayFrequencies
         ucrSaveGraph.SetIsComboBox()
         ucrSaveGraph.SetAssignToIfUncheckedValue("last_graph")
         ucrChkColumn.SetLinkedDisplayControl(grpFreqTypeTable)
-        ChangeLocation()
     End Sub
 
     Private Sub SetDefaults()
@@ -205,7 +209,7 @@ Public Class dlgTwoWayFrequencies
         ucrChkRow.SetRCode(clsSjTab, bReset)
         ucrChkCount.SetRCode(clsSjTab, bReset)
         ucrSaveGraph.SetRCode(clsSjPlot, bReset)
-
+        SetLocations()
     End Sub
 
     Private Sub SetDefaultVariables()
@@ -274,11 +278,11 @@ Public Class dlgTwoWayFrequencies
         TestOkEnabled()
     End Sub
 
-    Private Sub ChangeLocation()
+    Private Sub SetLocations()
         If rdoBoth.Checked Then
-            grpFreqTypeTable.Location = New Point(240, 166)
-            grpFreqTypeGraph.Location = New Point(358, 166)
-            Me.Size = New Size(496, 433)
+            grpFreqTypeTable.Location = New Point(iTableTypeMaxX / 1.1, grpFreqTypeTable.Location.Y)
+            grpFreqTypeGraph.Location = New Point(iGraphTypeMaxX, grpFreqTypeGraph.Location.Y)
+            Me.Size = New Size(iFullWidth, Me.Height)
         Else
             If rdoGraph.Checked Then
                 grpFreqTypeGraph.Show()
@@ -287,9 +291,9 @@ Public Class dlgTwoWayFrequencies
                 grpFreqTypeGraph.Hide()
                 grpFreqTypeTable.Show()
             End If
-            grpFreqTypeTable.Location = New Point(263, 166)
-            grpFreqTypeGraph.Location = New Point(263, 166)
-            Me.Size = New Size(437, 433)
+            grpFreqTypeTable.Location = New Point(iTableTypeMaxX, grpFreqTypeTable.Location.Y)
+            grpFreqTypeGraph.Location = New Point(iGraphTypeMaxX / 1.36, grpFreqTypeGraph.Location.Y)
+            Me.Size = New Size(iFullWidth / 1.13, Me.Height)
         End If
     End Sub
 
@@ -310,7 +314,7 @@ Public Class dlgTwoWayFrequencies
             ucrReceiverRowFactor.SetParameter(clsRowParam)
             ucrReceiverColumnFactor.SetParameter(clsColumnParam)
         End If
-        ChangeLocation()
+        SetLocations()
         SetBaseFunction()
     End Sub
 

--- a/instat/ucrCalculator.Designer.vb
+++ b/instat/ucrCalculator.Designer.vb
@@ -187,12 +187,15 @@ Partial Class ucrCalculator
         '
         'ucrReceiverForCalculation
         '
+        Me.ucrReceiverForCalculation.frmParent = Nothing
         Me.ucrReceiverForCalculation.Location = New System.Drawing.Point(87, 13)
         Me.ucrReceiverForCalculation.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.ucrReceiverForCalculation.Name = "ucrReceiverForCalculation"
         Me.ucrReceiverForCalculation.Selector = Nothing
         Me.ucrReceiverForCalculation.Size = New System.Drawing.Size(284, 28)
+        Me.ucrReceiverForCalculation.strNcFilePath = ""
         Me.ucrReceiverForCalculation.TabIndex = 120
+        Me.ucrReceiverForCalculation.ucrSelector = Nothing
         '
         'lblExpression
         '
@@ -207,6 +210,7 @@ Partial Class ucrCalculator
         '
         'ucrSaveResultInto
         '
+        Me.ucrSaveResultInto.AddQuotesIfUnrecognised = True
         Me.ucrSaveResultInto.IsReadOnly = False
         Me.ucrSaveResultInto.Location = New System.Drawing.Point(121, 286)
         Me.ucrSaveResultInto.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
@@ -227,6 +231,8 @@ Partial Class ucrCalculator
         '
         'ucrInputTryMessage
         '
+        Me.ucrInputTryMessage.AddQuotesIfUnrecognised = True
+        Me.ucrInputTryMessage.IsMultiline = False
         Me.ucrInputTryMessage.IsReadOnly = True
         Me.ucrInputTryMessage.Location = New System.Drawing.Point(93, 257)
         Me.ucrInputTryMessage.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
@@ -275,6 +281,7 @@ Partial Class ucrCalculator
         '
         'ucrInputCalOptions
         '
+        Me.ucrInputCalOptions.AddQuotesIfUnrecognised = True
         Me.ucrInputCalOptions.IsReadOnly = False
         Me.ucrInputCalOptions.Location = New System.Drawing.Point(226, 38)
         Me.ucrInputCalOptions.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
@@ -1741,7 +1748,7 @@ Partial Class ucrCalculator
         Me.Controls.Add(Me.ucrReceiverForCalculation)
         Me.Controls.Add(Me.lblExpression)
         Me.Name = "ucrCalculator"
-        Me.Size = New System.Drawing.Size(555, 322)
+        Me.Size = New System.Drawing.Size(491, 322)
         Me.grpBasic.ResumeLayout(False)
         Me.grpDates.ResumeLayout(False)
         Me.grpRows.ResumeLayout(False)

--- a/instat/ucrCalculator.vb
+++ b/instat/ucrCalculator.vb
@@ -24,6 +24,7 @@ Public Class ucrCalculator
     Public Event TryCommadClick()
     Public bFirstLoad As Boolean = True
     Public bControlsInitialised As Boolean = False
+    Private iBasicWidth As Integer
 
     Public Sub New()
 
@@ -32,6 +33,7 @@ Public Class ucrCalculator
 
         ' Add any initialization after the InitializeComponent() call.
         InitialiseControls()
+        iBasicWidth = Me.Width
     End Sub
 
     Private Sub ucrCalculator_Load(sender As Object, e As EventArgs) Handles Me.Load
@@ -172,7 +174,7 @@ Public Class ucrCalculator
                 grpProbabilty.Visible = False
                 grpRows.Visible = False
                 iHelpCalcID = 126
-                Me.Size = New System.Drawing.Size(659, 377)
+                Me.Size = New Size(iBasicWidth * 1.34, Me.Height)
             Case "Logical and Symbols"
                 grpDates.Visible = False
                 grpStatistics.Visible = False
@@ -181,7 +183,7 @@ Public Class ucrCalculator
                 grpBasic.Visible = True
                 grpStrings.Visible = False
                 iHelpCalcID = 127
-                Me.Size = New System.Drawing.Size(617, 377)
+                Me.Size = New Size(iBasicWidth * 1.26, Me.Height)
                 grpProbabilty.Visible = False
                 grpRows.Visible = False
             Case "Statistics"
@@ -191,7 +193,7 @@ Public Class ucrCalculator
                 grpMaths.Visible = False
                 grpBasic.Visible = True
                 iHelpCalcID = 128
-                Me.Size = New System.Drawing.Size(568, 377)
+                Me.Size = New Size(iBasicWidth * 1.16, Me.Height)
                 grpStrings.Visible = False
                 grpProbabilty.Visible = False
                 grpRows.Visible = False
@@ -205,7 +207,7 @@ Public Class ucrCalculator
                 grpProbabilty.Visible = False
                 grpRows.Visible = False
                 iHelpCalcID = 129
-                Me.Size = New System.Drawing.Size(610, 377)
+                Me.Size = New Size(iBasicWidth * 1.24, Me.Height)
             Case "Probability"
                 grpDates.Visible = False
                 grpProbabilty.Visible = True
@@ -216,7 +218,7 @@ Public Class ucrCalculator
                 grpBasic.Visible = True
                 grpRows.Visible = False
                 iHelpCalcID = 120
-                Me.Size = New System.Drawing.Size(779, 377)
+                Me.Size = New Size(iBasicWidth * 1.59, Me.Height)
             Case "Dates"
                 grpDates.Visible = True
                 grpProbabilty.Visible = False
@@ -227,7 +229,7 @@ Public Class ucrCalculator
                 grpBasic.Visible = True
                 grpRows.Visible = False
                 iHelpCalcID = 130
-                Me.Size = New System.Drawing.Size(639, 377)
+                Me.Size = New Size(iBasicWidth * 1.3, Me.Height)
             Case "Rows"
                 grpDates.Visible = False
                 grpProbabilty.Visible = False
@@ -237,10 +239,10 @@ Public Class ucrCalculator
                 grpMaths.Visible = False
                 grpStrings.Visible = False
                 grpRows.Visible = True
-                Me.Size = New System.Drawing.Size(595, 377)
+                Me.Size = New Size(iBasicWidth * 1.21, Me.Height)
             Case Else
                 grpDates.Visible = False
-                Me.Size = New System.Drawing.Size(491, 377)
+                Me.Size = New Size(iBasicWidth, Me.Height)
                 grpProbabilty.Visible = False
                 grpStatistics.Visible = False
                 grpBasic.Visible = True

--- a/instat/ucrDialogDisabled.Designer.vb
+++ b/instat/ucrDialogDisabled.Designer.vb
@@ -43,15 +43,13 @@ Partial Class ucrDialogDisabled
         '
         'lblDisabled
         '
-        Me.lblDisabled.Anchor = CType((((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Bottom) _
-            Or System.Windows.Forms.AnchorStyles.Left) _
-            Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
         Me.lblDisabled.BackColor = System.Drawing.SystemColors.GradientInactiveCaption
+        Me.lblDisabled.Dock = System.Windows.Forms.DockStyle.Fill
         Me.lblDisabled.Font = New System.Drawing.Font("Microsoft Sans Serif", 9.75!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
         Me.lblDisabled.ForeColor = System.Drawing.SystemColors.ControlText
         Me.lblDisabled.Location = New System.Drawing.Point(0, 0)
         Me.lblDisabled.Name = "lblDisabled"
-        Me.lblDisabled.Size = New System.Drawing.Size(241, 51)
+        Me.lblDisabled.Size = New System.Drawing.Size(240, 50)
         Me.lblDisabled.TabIndex = 0
         Me.lblDisabled.Text = "This dialog is not yet functioning. " & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "It is for viewing only." & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "OK cannot be enabl" &
     "ed." & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10)


### PR DESCRIPTION
@africanmathsinitiative/developers another interesting issue here related to displays on different screens. I noticed when testing on my machine some dialogs were very small and cut off most of the controls. I realised this was only on dialogs where the size changes depending on options e.g. calculator expands for different keyboards.

The reason these dialogs don't display correctly on some screens is that the size is set directly in the dialog code which is interpreted differently on different machines. So the solution is to not have fixed sizes set in the dialog but to make it proportionally bigger or smaller. It's easiest to see with an example. The next time someone has to do this, these are roughly the steps:

1. In the designer work out all the different sizes you want the dialog to be. Make a note of the different sizes.

2. Pick one size to be the "default" size, usually the size of the dialog with the default settings.

3. In the dialog code, create a variable for any size that varies e.g. in the calculator only the width varies. Then on first load, set the width variable to be the current width of the dialog. This is how you can have the default size stored without it being dependent on your machine. It could be different on different machines.

4. Work out the ratios of the other widths compared to your default width. And then when you need to change the size in the code set it as a proportion of your "default" width. e.g. in calculator the statistics keyboard is 15% wider than the default i.e. `iBasicWidth * 1.15`.

Although the default size variable will be the same the size in the designer, this is only on your machine, which is why using `Me.Width` is better than setting a fixed value.

This might sound more complicated than it is. The general rule is that we can't have sizes set to a fixed number in dialogs. Everything needs to be relative/proportional to something else. 
The exact same thing applies to locations if you need controls to move on the dialog.

The easiest is to look at an example, the calculator is a simple one. I will copy this message in an email to everyone so we have a reference for it the next time someone needs to do this.