### PR TITLE
Dialog Backup Manager

### DIFF
--- a/instat/clsRLink.vb
+++ b/instat/clsRLink.vb
@@ -178,16 +178,34 @@ Public Class RLink
         Return RunInternalScript(clsLoadPackages.ToScript(), bSilent:=bSilent)
     End Function
 
-    Public Sub LoadInstatDataObjectFromFile(strFile As String, Optional strComment As String = "")
+    Public Sub LoadInstatDataObjectFromFile(strFile As String, Optional bKeepExisting As Boolean = False, Optional strComment As String = "")
+        ' Dim clsReadRDS As New RFunction
+        ' Dim strScript As String = ""
+        ' Dim strTemp As String = ""
+
+        ' clsReadRDS.SetRCommand("readRDS")
+        ' clsReadRDS.AddParameter("file", Chr(34) & strFile.Replace("\", "/") & Chr(34))
+        ' clsReadRDS.SetAssignTo(strInstatDataObject)
+        ' strTemp = clsReadRDS.ToScript(strScript)
+        ' RunScript(strScript, strComment:=strComment)
+        ' bInstatObjectExists = True
+
+        Dim clsImportRDS As New RFunction
         Dim clsReadRDS As New RFunction
         Dim strScript As String = ""
         Dim strTemp As String = ""
 
         clsReadRDS.SetRCommand("readRDS")
         clsReadRDS.AddParameter("file", Chr(34) & strFile.Replace("\", "/") & Chr(34))
-        clsReadRDS.SetAssignTo(strInstatDataObject)
-        strTemp = clsReadRDS.ToScript(strScript)
-        RunScript(strScript, strComment:=strComment)
+        clsReadRDS.SetAssignTo("new_RDS")
+
+        clsImportRDS.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$import_RDS")
+        clsImportRDS.AddParameter("data_RDS", clsRFunctionParameter:=clsReadRDS)
+        'This RFunction takes booleans in capitals hence ToUpper
+        clsImportRDS.AddParameter("keep_existing", bKeepExisting.ToString.ToUpper)
+
+        strTemp = clsImportRDS.ToScript(strScript)
+        RunScript(strScript & strTemp, strComment:=strComment)
         bInstatObjectExists = True
     End Sub
 

--- a/instat/clsRLink.vb
+++ b/instat/clsRLink.vb
@@ -179,17 +179,6 @@ Public Class RLink
     End Function
 
     Public Sub LoadInstatDataObjectFromFile(strFile As String, Optional bKeepExisting As Boolean = False, Optional strComment As String = "")
-        ' Dim clsReadRDS As New RFunction
-        ' Dim strScript As String = ""
-        ' Dim strTemp As String = ""
-
-        ' clsReadRDS.SetRCommand("readRDS")
-        ' clsReadRDS.AddParameter("file", Chr(34) & strFile.Replace("\", "/") & Chr(34))
-        ' clsReadRDS.SetAssignTo(strInstatDataObject)
-        ' strTemp = clsReadRDS.ToScript(strScript)
-        ' RunScript(strScript, strComment:=strComment)
-        ' bInstatObjectExists = True
-
         Dim clsImportRDS As New RFunction
         Dim clsReadRDS As New RFunction
         Dim strScript As String = ""
@@ -200,9 +189,9 @@ Public Class RLink
         clsReadRDS.SetAssignTo("new_RDS")
 
         clsImportRDS.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$import_RDS")
-        clsImportRDS.AddParameter("data_RDS", clsRFunctionParameter:=clsReadRDS)
+        clsImportRDS.AddParameter("data_RDS", clsRFunctionParameter:=clsReadRDS, iPosition:=0)
         'This RFunction takes booleans in capitals hence ToUpper
-        clsImportRDS.AddParameter("keep_existing", bKeepExisting.ToString.ToUpper)
+        clsImportRDS.AddParameter("keep_existing", bKeepExisting.ToString.ToUpper, iPosition:=1)
 
         strTemp = clsImportRDS.ToScript(strScript)
         RunScript(strScript & strTemp, strComment:=strComment)

--- a/instat/dlgBackupManager.Designer.vb
+++ b/instat/dlgBackupManager.Designer.vb
@@ -1,9 +1,9 @@
-﻿<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()> _
+﻿<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()>
 Partial Class dlgBackupManager
     Inherits System.Windows.Forms.Form
 
     'Form overrides dispose to clean up the component list.
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Protected Overrides Sub Dispose(ByVal disposing As Boolean)
         Try
             If disposing AndAlso components IsNot Nothing Then
@@ -20,23 +20,112 @@ Partial Class dlgBackupManager
     'NOTE: The following procedure is required by the Windows Form Designer
     'It can be modified using the Windows Form Designer.  
     'Do not modify it using the code editor.
-    <System.Diagnostics.DebuggerStepThrough()> _
+    <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
+        Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(dlgBackupManager))
+        Me.lblBackupHeader = New System.Windows.Forms.Label()
+        Me.ctrLstViewDataBackups = New System.Windows.Forms.ListView()
+        Me.ctrLstViewColName = CType(New System.Windows.Forms.ColumnHeader(), System.Windows.Forms.ColumnHeader)
+        Me.ctrLstViewColDate = CType(New System.Windows.Forms.ColumnHeader(), System.Windows.Forms.ColumnHeader)
+        Me.ctrLstViewSize = CType(New System.Windows.Forms.ColumnHeader(), System.Windows.Forms.ColumnHeader)
+        Me.cmdClose = New System.Windows.Forms.Button()
+        Me.cmdHelp = New System.Windows.Forms.Button()
+        Me.cmdDelete = New System.Windows.Forms.Button()
+        Me.cmdOpen = New System.Windows.Forms.Button()
+        Me.lblBackupMessage = New System.Windows.Forms.Label()
+        Me.cmdSave = New System.Windows.Forms.Button()
         Me.SuspendLayout()
+        '
+        'lblBackupHeader
+        '
+        resources.ApplyResources(Me.lblBackupHeader, "lblBackupHeader")
+        Me.lblBackupHeader.Name = "lblBackupHeader"
+        '
+        'ucrLstViewDataBackups
+        '
+        Me.ctrLstViewDataBackups.Columns.AddRange(New System.Windows.Forms.ColumnHeader() {Me.ctrLstViewColName, Me.ctrLstViewColDate, Me.ctrLstViewSize})
+        resources.ApplyResources(Me.ctrLstViewDataBackups, "ucrLstViewDataBackups")
+        Me.ctrLstViewDataBackups.Name = "ucrLstViewDataBackups"
+        Me.ctrLstViewDataBackups.UseCompatibleStateImageBehavior = False
+        Me.ctrLstViewDataBackups.View = System.Windows.Forms.View.Details
+        '
+        'ucrLstViewColName
+        '
+        resources.ApplyResources(Me.ctrLstViewColName, "ucrLstViewColName")
+        '
+        'ucrLstViewColDate
+        '
+        resources.ApplyResources(Me.ctrLstViewColDate, "ucrLstViewColDate")
+        '
+        'ucrLstViewSize
+        '
+        resources.ApplyResources(Me.ctrLstViewSize, "ucrLstViewSize")
+        '
+        'cmdClose
+        '
+        resources.ApplyResources(Me.cmdClose, "cmdClose")
+        Me.cmdClose.Name = "cmdClose"
+        Me.cmdClose.UseVisualStyleBackColor = True
+        '
+        'cmdHelp
+        '
+        resources.ApplyResources(Me.cmdHelp, "cmdHelp")
+        Me.cmdHelp.Name = "cmdHelp"
+        Me.cmdHelp.UseVisualStyleBackColor = True
+        '
+        'cmdDelete
+        '
+        resources.ApplyResources(Me.cmdDelete, "cmdDelete")
+        Me.cmdDelete.Name = "cmdDelete"
+        Me.cmdDelete.UseVisualStyleBackColor = True
+        '
+        'cmdOpen
+        '
+        resources.ApplyResources(Me.cmdOpen, "cmdOpen")
+        Me.cmdOpen.Name = "cmdOpen"
+        Me.cmdOpen.UseVisualStyleBackColor = True
+        '
+        'lblBackupMessage
+        '
+        resources.ApplyResources(Me.lblBackupMessage, "lblBackupMessage")
+        Me.lblBackupMessage.ForeColor = System.Drawing.SystemColors.Highlight
+        Me.lblBackupMessage.Name = "lblBackupMessage"
+        '
+        'cmdSave
+        '
+        resources.ApplyResources(Me.cmdSave, "cmdSave")
+        Me.cmdSave.Name = "cmdSave"
+        Me.cmdSave.UseVisualStyleBackColor = True
         '
         'dlgBackupManager
         '
-        Me.AutoScaleDimensions = New System.Drawing.SizeF(9.0!, 20.0!)
+        resources.ApplyResources(Me, "$this")
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
-        Me.ClientSize = New System.Drawing.Size(278, 244)
+        Me.Controls.Add(Me.cmdSave)
+        Me.Controls.Add(Me.cmdClose)
+        Me.Controls.Add(Me.ctrLstViewDataBackups)
+        Me.Controls.Add(Me.cmdHelp)
+        Me.Controls.Add(Me.lblBackupHeader)
+        Me.Controls.Add(Me.cmdDelete)
+        Me.Controls.Add(Me.lblBackupMessage)
+        Me.Controls.Add(Me.cmdOpen)
         Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow
         Me.MaximizeBox = False
         Me.MinimizeBox = False
         Me.Name = "dlgBackupManager"
-        Me.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen
-        Me.Tag = "Backup_Manager"
-        Me.Text = "Backup Manager"
         Me.ResumeLayout(False)
+        Me.PerformLayout()
 
     End Sub
+    Friend WithEvents lblBackupMessage As Label
+    Friend WithEvents lblBackupHeader As Label
+    Friend WithEvents ctrLstViewDataBackups As ListView
+    Friend WithEvents cmdClose As Button
+    Friend WithEvents cmdHelp As Button
+    Friend WithEvents cmdDelete As Button
+    Friend WithEvents cmdOpen As Button
+    Friend WithEvents ctrLstViewColName As ColumnHeader
+    Friend WithEvents ctrLstViewColDate As ColumnHeader
+    Friend WithEvents ctrLstViewSize As ColumnHeader
+    Friend WithEvents cmdSave As Button
 End Class

--- a/instat/dlgBackupManager.resx
+++ b/instat/dlgBackupManager.resx
@@ -117,4 +117,268 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="lblBackupHeader.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="lblBackupHeader.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 37</value>
+  </data>
+  <data name="lblBackupHeader.Size" type="System.Drawing.Size, System.Drawing">
+    <value>133, 20</value>
+  </data>
+  <data name="lblBackupHeader.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="lblBackupHeader.Text" xml:space="preserve">
+    <value>Backup versions :</value>
+  </data>
+  <data name="&gt;&gt;lblBackupHeader.Name" xml:space="preserve">
+    <value>lblBackupHeader</value>
+  </data>
+  <data name="&gt;&gt;lblBackupHeader.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblBackupHeader.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;lblBackupHeader.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="ucrLstViewDataBackups.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 63</value>
+  </data>
+  <data name="ucrLstViewDataBackups.Size" type="System.Drawing.Size, System.Drawing">
+    <value>413, 172</value>
+  </data>
+  <data name="ucrLstViewDataBackups.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;ucrLstViewDataBackups.Name" xml:space="preserve">
+    <value>ucrLstViewDataBackups</value>
+  </data>
+  <data name="&gt;&gt;ucrLstViewDataBackups.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ListView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;ucrLstViewDataBackups.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrLstViewDataBackups.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="ucrLstViewColName.Text" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="ucrLstViewColName.Width" type="System.Int32, mscorlib">
+    <value>158</value>
+  </data>
+  <data name="ucrLstViewColDate.Text" xml:space="preserve">
+    <value>Date modified</value>
+  </data>
+  <data name="ucrLstViewColDate.Width" type="System.Int32, mscorlib">
+    <value>152</value>
+  </data>
+  <data name="ucrLstViewSize.Text" xml:space="preserve">
+    <value>Size</value>
+  </data>
+  <data name="ucrLstViewSize.Width" type="System.Int32, mscorlib">
+    <value>96</value>
+  </data>
+  <data name="cmdClose.Location" type="System.Drawing.Point, System.Drawing">
+    <value>334, 239</value>
+  </data>
+  <data name="cmdClose.Size" type="System.Drawing.Size, System.Drawing">
+    <value>76, 30</value>
+  </data>
+  <data name="cmdClose.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="cmdClose.Text" xml:space="preserve">
+    <value>Close</value>
+  </data>
+  <data name="&gt;&gt;cmdClose.Name" xml:space="preserve">
+    <value>cmdClose</value>
+  </data>
+  <data name="&gt;&gt;cmdClose.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cmdClose.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;cmdClose.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="cmdHelp.Location" type="System.Drawing.Point, System.Drawing">
+    <value>252, 239</value>
+  </data>
+  <data name="cmdHelp.Size" type="System.Drawing.Size, System.Drawing">
+    <value>76, 30</value>
+  </data>
+  <data name="cmdHelp.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="cmdHelp.Text" xml:space="preserve">
+    <value>Help</value>
+  </data>
+  <data name="&gt;&gt;cmdHelp.Name" xml:space="preserve">
+    <value>cmdHelp</value>
+  </data>
+  <data name="&gt;&gt;cmdHelp.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cmdHelp.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;cmdHelp.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="cmdDelete.Location" type="System.Drawing.Point, System.Drawing">
+    <value>170, 239</value>
+  </data>
+  <data name="cmdDelete.Size" type="System.Drawing.Size, System.Drawing">
+    <value>76, 30</value>
+  </data>
+  <data name="cmdDelete.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="cmdDelete.Text" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="&gt;&gt;cmdDelete.Name" xml:space="preserve">
+    <value>cmdDelete</value>
+  </data>
+  <data name="&gt;&gt;cmdDelete.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cmdDelete.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;cmdDelete.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="cmdOpen.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cmdOpen.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 239</value>
+  </data>
+  <data name="cmdOpen.Size" type="System.Drawing.Size, System.Drawing">
+    <value>76, 30</value>
+  </data>
+  <data name="cmdOpen.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="cmdOpen.Text" xml:space="preserve">
+    <value>Open</value>
+  </data>
+  <data name="&gt;&gt;cmdOpen.Name" xml:space="preserve">
+    <value>cmdOpen</value>
+  </data>
+  <data name="&gt;&gt;cmdOpen.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cmdOpen.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;cmdOpen.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="lblBackupMessage.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblBackupMessage.Location" type="System.Drawing.Point, System.Drawing">
+    <value>5, 8</value>
+  </data>
+  <data name="lblBackupMessage.Size" type="System.Drawing.Size, System.Drawing">
+    <value>414, 20</value>
+  </data>
+  <data name="lblBackupMessage.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="lblBackupMessage.Text" xml:space="preserve">
+    <value>The backup versions come from periodic system backups.</value>
+  </data>
+  <data name="&gt;&gt;lblBackupMessage.Name" xml:space="preserve">
+    <value>lblBackupMessage</value>
+  </data>
+  <data name="&gt;&gt;lblBackupMessage.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblBackupMessage.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;lblBackupMessage.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="cmdSave.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cmdSave.Location" type="System.Drawing.Point, System.Drawing">
+    <value>88, 239</value>
+  </data>
+  <data name="cmdSave.Size" type="System.Drawing.Size, System.Drawing">
+    <value>76, 30</value>
+  </data>
+  <data name="cmdSave.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="cmdSave.Text" xml:space="preserve">
+    <value>Save</value>
+  </data>
+  <data name="&gt;&gt;cmdSave.Name" xml:space="preserve">
+    <value>cmdSave</value>
+  </data>
+  <data name="&gt;&gt;cmdSave.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cmdSave.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;cmdSave.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>9, 20</value>
+  </data>
+  <data name="$this.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>426, 274</value>
+  </data>
+  <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
+    <value>CenterScreen</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>Backup Manager</value>
+  </data>
+  <data name="&gt;&gt;ucrLstViewColName.Name" xml:space="preserve">
+    <value>ucrLstViewColName</value>
+  </data>
+  <data name="&gt;&gt;ucrLstViewColName.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;ucrLstViewColDate.Name" xml:space="preserve">
+    <value>ucrLstViewColDate</value>
+  </data>
+  <data name="&gt;&gt;ucrLstViewColDate.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;ucrLstViewSize.Name" xml:space="preserve">
+    <value>ucrLstViewSize</value>
+  </data>
+  <data name="&gt;&gt;ucrLstViewSize.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>dlgBackupManager</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Form, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
 </root>

--- a/instat/dlgBackupManager.vb
+++ b/instat/dlgBackupManager.vb
@@ -60,6 +60,11 @@ Public Class dlgBackupManager
 
     Private Sub ctrLstViewDataBackups_ItemSelectionChanged(sender As Object, e As ListViewItemSelectionChangedEventArgs) Handles ctrLstViewDataBackups.ItemSelectionChanged
         TestOk()
+        If ctrLstViewDataBackups.SelectedIndices.Count > 1 Then
+            'this is meant to restrict a user from attempting to open or save more than 1 file
+            cmdOpen.Enabled = False
+            cmdSave.Enabled = False
+        End If
     End Sub
 
     Private Sub cmdOpen_Click(sender As Object, e As EventArgs) Handles cmdOpen.Click
@@ -72,17 +77,13 @@ Public Class dlgBackupManager
             Return
         End If
 
-        If (ctrLstViewDataBackups.SelectedIndices.Count = 1) Then
-            'get the selected file path. To be used in opening the file name in form Main
-            strSelectedDataFilePath = strAutoSavedDataFilePaths(ctrLstViewDataBackups.SelectedIndices(0))
-            If strSelectedDataFilePath <> "" Then
-                'pass the selected file to the sub which will load the file to the instant object
-                frmMain.clsRLink.LoadInstatDataObjectFromFile(strSelectedDataFilePath, strComment:="Loading auto recovered data file")
-            End If
-        Else
-            'don't allow opening of more than 1 file at a time. NOTE in future this can be changed
-            MsgBox("You can only open one data file at a time")
+        'get the selected file path. To be used in opening the file name in form Main
+        strSelectedDataFilePath = strAutoSavedDataFilePaths(ctrLstViewDataBackups.SelectedIndices(0))
+        If strSelectedDataFilePath <> "" Then
+            'pass the selected file to the sub which will load the file to the instant object
+            frmMain.clsRLink.LoadInstatDataObjectFromFile(strSelectedDataFilePath, strComment:="Loading auto recovered data file")
         End If
+
         SetButtonStates(False)
         Close()
     End Sub
@@ -93,23 +94,16 @@ Public Class dlgBackupManager
             Return
         End If
 
-        'if its only one file that got selected then use the SaveFileDialog
-        If (ctrLstViewDataBackups.SelectedIndices.Count = 1) Then
-            Using dlgSave As New SaveFileDialog
-                dlgSave.Title = "Save Data File"
-                dlgSave.Filter = "RDS Data file (*.RDS)|*.RDS"
-                If dlgSave.ShowDialog() = DialogResult.OK Then
-                    'save the selected file
-                    SaveFile(strAutoSavedDataFilePaths(ctrLstViewDataBackups.SelectedIndices(0)), dlgSave.FileName)
-                    'display success message
-                    MsgBox("Data file successfully saved to " & dlgSave.FileName)
-                End If
-            End Using
-        Else
-            'don't allow saving of more than 1 file at a time
-            'NOTE in future this can be changed
-            MsgBox("You can only save one data file at a time")
-        End If
+        Using dlgSave As New SaveFileDialog
+            dlgSave.Title = "Save Data File"
+            dlgSave.Filter = "RDS Data file (*.RDS)|*.RDS"
+            If dlgSave.ShowDialog() = DialogResult.OK Then
+                'save the selected file
+                SaveFile(strAutoSavedDataFilePaths(ctrLstViewDataBackups.SelectedIndices(0)), dlgSave.FileName)
+                'display success message
+                MsgBox("Data file successfully saved to " & dlgSave.FileName)
+            End If
+        End Using
     End Sub
 
     Private Sub cmdDelete_Click(sender As Object, e As EventArgs) Handles cmdDelete.Click
@@ -132,7 +126,6 @@ Public Class dlgBackupManager
         LoadFilesInfo()
         'set the button states accordingly
         TestOk()
-
     End Sub
 
     Private Sub cmdHelp_Click(sender As Object, e As EventArgs) Handles cmdHelp.Click

--- a/instat/dlgBackupManager.vb
+++ b/instat/dlgBackupManager.vb
@@ -1,5 +1,209 @@
-﻿Public Class dlgBackupManager
+﻿' R- Instat
+' Copyright (C) 2015-2017
+'
+' This program is free software: you can redistribute it and/or modify
+' it under the terms of the GNU General Public License as published by
+' the Free Software Foundation, either version 3 of the License, or
+' (at your option) any later version.
+'
+' This program is distributed in the hope that it will be useful,
+' but WITHOUT ANY WARRANTY; without even the implied warranty of
+' MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+' GNU General Public License for more details.
+'
+' You should have received a copy of the GNU General Public License 
+' along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Imports instat.Translations
+Imports System.IO
+Public Class dlgBackupManager
+    Private strAutoSaveDataFolderPath As String 'holds the folder path for data files. Set by the parent form
+    Private strAutoSavedDataFilePaths As List(Of String) 'holds the file paths including the file name
+    Private strSelectedDataFilePath As String 'holds the selected file path
+
     Private Sub dlgBackupManager_Load(sender As Object, e As EventArgs) Handles MyBase.Load
+        autoTranslate(Me)
+        'Get the default Auto save Data Folder
+        strAutoSaveDataFolderPath = frmMain.strAutoSaveDataFolderPath
+        'set selected data file path to empty string
+        strSelectedDataFilePath = ""
+        LoadFilesInfo()
+        SetButtonStates(False)
+        'add to the list of last loaded forms
+        frmMain.clsRecentItems.addToMenu(Me)
+    End Sub
+
+    'loads the files info's into the listview
+    Private Sub LoadFilesInfo()
+        'clear any previous items
+        ctrLstViewDataBackups.Items.Clear()
+
+        'countercheck if the folder really exists then get all the file paths inside the folder
+        If Directory.Exists(strAutoSaveDataFolderPath) Then
+            strAutoSavedDataFilePaths = My.Computer.FileSystem.GetFiles(frmMain.strAutoSaveDataFolderPath).ToList
+        End If
+
+        'if there are files then loop thro to get their info
+        If strAutoSavedDataFilePaths IsNot Nothing AndAlso strAutoSavedDataFilePaths.Count > 0 Then
+            Dim autoSavedFileInfo As FileInfo
+            'Iterate through the path list add the file infos to the listview
+            For Each filePath As String In strAutoSavedDataFilePaths
+                'create a file info object from the file path, to get file information
+                autoSavedFileInfo = New FileInfo(filePath)
+                ' Create the listviewitem and initialise it with values for the 3 columns add it to the listview 
+                With autoSavedFileInfo
+                    ctrLstViewDataBackups.Items.Add(New ListViewItem(New String() { .Name, .LastWriteTime.ToString, GetConvertedFileSize(.Length)}))
+                End With
+            Next
+        End If
+    End Sub
+
+    Private Sub ctrLstViewDataBackups_ItemSelectionChanged(sender As Object, e As ListViewItemSelectionChangedEventArgs) Handles ctrLstViewDataBackups.ItemSelectionChanged
+        TestOk()
+    End Sub
+
+    Private Sub cmdOpen_Click(sender As Object, e As EventArgs) Handles cmdOpen.Click
+        If (Not TestOk()) Then
+            MsgBox("Select the file to open")
+            Return
+        End If
+
+        If MsgBox("Are you sure you want to open this data file?" & Environment.NewLine & "This will replace the current data.", MessageBoxButtons.YesNo, "Back up Manager") = MsgBoxResult.No Then
+            Return
+        End If
+
+        If (ctrLstViewDataBackups.SelectedIndices.Count = 1) Then
+            'get the selected file path. To be used in opening the file name in form Main
+            strSelectedDataFilePath = strAutoSavedDataFilePaths(ctrLstViewDataBackups.SelectedIndices(0))
+            If strSelectedDataFilePath <> "" Then
+                'pass the selected file to the sub which will load the file to the instant object
+                frmMain.clsRLink.LoadInstatDataObjectFromFile(strSelectedDataFilePath, strComment:="Loading auto recovered data file")
+            End If
+        Else
+            'don't allow opening of more than 1 file at a time. NOTE in future this can be changed
+            MsgBox("You can only open one data file at a time")
+        End If
+        SetButtonStates(False)
+        Close()
+    End Sub
+
+    Private Sub cmdSave_Click(sender As Object, e As EventArgs) Handles cmdSave.Click
+        If (Not TestOk()) Then
+            MsgBox("Select the file to save")
+            Return
+        End If
+
+        'if its only one file that got selected then use the SaveFileDialog
+        If (ctrLstViewDataBackups.SelectedIndices.Count = 1) Then
+            Using dlgSave As New SaveFileDialog
+                dlgSave.Title = "Save Data File"
+                dlgSave.Filter = "RDS Data file (*.RDS)|*.RDS"
+                If dlgSave.ShowDialog() = DialogResult.OK Then
+                    'save the selected file
+                    SaveFile(strAutoSavedDataFilePaths(ctrLstViewDataBackups.SelectedIndices(0)), dlgSave.FileName)
+                    'display success message
+                    MsgBox("Data file successfully saved to " & dlgSave.FileName)
+                End If
+            End Using
+        Else
+            'don't allow saving of more than 1 file at a time
+            'NOTE in future this can be changed
+            MsgBox("You can only save one data file at a time")
+        End If
+    End Sub
+
+    Private Sub cmdDelete_Click(sender As Object, e As EventArgs) Handles cmdDelete.Click
+        If (Not TestOk()) Then
+            MsgBox("Select the file to delete")
+            Return
+        End If
+
+        If MsgBox("Are you sure you want to delete this file?" & Environment.NewLine & "You cannot undo this action and all its data will be lost.", MessageBoxButtons.YesNo, "Back up Manager") = MsgBoxResult.No Then
+            Return
+        End If
+
+        'loop thro deleting the selected files
+        For i As Integer = 0 To ctrLstViewDataBackups.SelectedIndices.Count - 1
+            'delete the file
+            File.Delete(strAutoSavedDataFilePaths(ctrLstViewDataBackups.SelectedIndices(i)))
+        Next
+
+        'then reload file info's
+        LoadFilesInfo()
+        'set the button states accordingly
+        TestOk()
 
     End Sub
+
+    Private Sub cmdHelp_Click(sender As Object, e As EventArgs) Handles cmdHelp.Click
+        'the help Id for this dialog is not yet known. This is temporary
+        Dim iHelpTopicID As Integer = 0
+        If iHelpTopicID > 0 Then
+            Help.ShowHelp(Me.Parent, frmMain.strStaticPath & "\" & frmMain.strHelpFilePath, HelpNavigator.TopicId, iHelpTopicID.ToString())
+        Else
+            Help.ShowHelp(Me.Parent, frmMain.strStaticPath & "\" & frmMain.strHelpFilePath, HelpNavigator.TableOfContents)
+        End If
+    End Sub
+
+    Private Sub cmdClose_Click(sender As Object, e As EventArgs) Handles cmdClose.Click
+        strSelectedDataFilePath = ""
+        Close()
+    End Sub
+
+    'function to return bytes as KB,MB,GB,TB in a 2 dp string format
+    Public Function GetConvertedFileSize(lFileSize As ULong) As String
+        Try
+            'to hold the division result as a double for formatting
+            Dim doubleBytes As Double
+            Select Case lFileSize
+                Case Is >= 1099511627776
+                    doubleBytes = lFileSize / 1099511627776 'TB
+                    Return FormatNumber(doubleBytes, 2) & " TB"
+                Case 1073741824 To 1099511627775
+                    doubleBytes = lFileSize / 1073741824 'GB
+                    Return FormatNumber(doubleBytes, 2) & " GB"
+                Case 1048576 To 1073741823
+                    doubleBytes = lFileSize / 1048576 'MB
+                    Return FormatNumber(doubleBytes, 2) & " MB"
+                Case 1024 To 1048575
+                    doubleBytes = lFileSize / 1024 'KB
+                    Return FormatNumber(doubleBytes, 2) & " KB"
+                Case 0 To 1023
+                    doubleBytes = lFileSize ' bytes
+                    Return FormatNumber(doubleBytes, 2) & " bytes"
+                Case Else
+                    Return ""
+            End Select
+        Catch ex As Exception
+            Return ""
+        End Try
+    End Function
+
+    'serves 2 purposes. checks whether the open,save,delete operation are allowed and also sets the controls states
+    Private Function TestOk() As Boolean
+        If (ctrLstViewDataBackups.Items.Count > 0 AndAlso ctrLstViewDataBackups.SelectedIndices.Count > 0) Then
+            SetButtonStates(True)
+            Return True
+        Else
+            SetButtonStates(False)
+            Return False
+        End If
+    End Function
+
+    Private Sub SetButtonStates(bState As Boolean)
+        cmdSave.Enabled = bState
+        cmdOpen.Enabled = bState
+        cmdDelete.Enabled = bState
+    End Sub
+
+    'copies the file to the user destination location
+    Private Sub SaveFile(strSourceFileName As String, strDestFilename As String)
+        Try
+            File.Copy(strSourceFileName, strDestFilename, True)
+        Catch ex As Exception
+            MsgBox("Could not copy and/or delete data file." & Environment.NewLine & ex.Message, "Error copying/deleting file")
+        End Try
+    End Sub
+
+
 End Class

--- a/instat/dlgBackupManager.vb
+++ b/instat/dlgBackupManager.vb
@@ -60,11 +60,6 @@ Public Class dlgBackupManager
 
     Private Sub ctrLstViewDataBackups_ItemSelectionChanged(sender As Object, e As ListViewItemSelectionChangedEventArgs) Handles ctrLstViewDataBackups.ItemSelectionChanged
         TestOk()
-        If ctrLstViewDataBackups.SelectedIndices.Count > 1 Then
-            'this is meant to restrict a user from attempting to open or save more than 1 file
-            cmdOpen.Enabled = False
-            cmdSave.Enabled = False
-        End If
     End Sub
 
     Private Sub cmdOpen_Click(sender As Object, e As EventArgs) Handles cmdOpen.Click
@@ -175,18 +170,26 @@ Public Class dlgBackupManager
     'serves 2 purposes. checks whether the open,save,delete operation are allowed and also sets the controls states
     Private Function TestOk() As Boolean
         If (ctrLstViewDataBackups.Items.Count > 0 AndAlso ctrLstViewDataBackups.SelectedIndices.Count > 0) Then
-            SetButtonStates(True)
+            SetButtonStates(True, iSelectedIndices:=ctrLstViewDataBackups.SelectedIndices.Count)
             Return True
         Else
-            SetButtonStates(False)
+            SetButtonStates(False, iSelectedIndices:=ctrLstViewDataBackups.SelectedIndices.Count)
             Return False
         End If
     End Function
 
-    Private Sub SetButtonStates(bState As Boolean)
-        cmdSave.Enabled = bState
-        cmdOpen.Enabled = bState
-        cmdDelete.Enabled = bState
+    Private Sub SetButtonStates(bState As Boolean, Optional iSelectedIndices As Integer = 0)
+        'this is meant to restrict a user from attempting to open or save more than 1 file. Delete is allowed
+        If bState AndAlso iSelectedIndices > 1 Then
+            cmdOpen.Enabled = False
+            cmdSave.Enabled = False
+            cmdDelete.Enabled = bState
+        Else
+            cmdOpen.Enabled = bState
+            cmdSave.Enabled = bState
+            cmdDelete.Enabled = bState
+        End If
+
     End Sub
 
     'copies the file to the user destination location


### PR DESCRIPTION
Changes to the `clsRLink`, Subroutine `LoadInstatDataObjectFromFile` . 
@dannyparsons you can review the subroutine `LoadInstatDataObjectFromFile` .  I have commented out the original code statements so that you can compare the changes.

@africanmathsinitiative/developers we can have an interesting discussion on  `clsImportRDS.ToScript(strScript)` subroutine with @volloholic .

This is continuation of #4240