### PR TITLE
Runtime Warnings

### DIFF
--- a/instat/instat.vbproj
+++ b/instat/instat.vbproj
@@ -117,7 +117,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="UIAutomationProvider" />
     <Reference Include="unvell.ReoGrid, Version=2.0.1.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>


### PR DESCRIPTION
@dannyparsons  Removed the System.Net.Http reference.
Was not used anywhere. A simple google shows that its no longer in .Net framework by default.
@africanmathsinitiative/developers  this is ready for review
