### PR TITLE
Added functionality to select columns from different data frames on the same dialog

### DIFF
--- a/instat/clsRLink.vb
+++ b/instat/clsRLink.vb
@@ -245,6 +245,29 @@ Public Class RLink
         Return lstDataFrameNames
     End Function
 
+    Public Function GetLinkedToDataFrameNames(strDataName As String, Optional bIncludeSelf As Boolean = False) As List(Of String)
+        Dim chrDataFrameNames As CharacterVector = Nothing
+        Dim lstDataFrameNames As New List(Of String)
+        Dim clsGetDataNames As New RFunction
+        Dim expNames As SymbolicExpression
+
+        clsGetDataNames.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_linked_to_data_name")
+        clsGetDataNames.AddParameter("from_data_frame", Chr(34) & strDataName & Chr(34), iPosition:=0)
+        If bIncludeSelf Then
+            clsGetDataNames.AddParameter("include_self", "TRUE", iPosition:=2)
+        Else
+            clsGetDataNames.AddParameter("include_self", "FALSE", iPosition:=2)
+        End If
+        If bInstatObjectExists Then
+            expNames = RunInternalScriptGetValue(clsGetDataNames.ToScript(), bSilent:=True)
+            If expNames IsNot Nothing AndAlso Not expNames.Type = Internals.SymbolicExpressionType.Null Then
+                chrDataFrameNames = expNames.AsCharacter
+                lstDataFrameNames.AddRange(chrDataFrameNames)
+            End If
+        End If
+        Return lstDataFrameNames
+    End Function
+
     Public Function GetColumnNames(strDataFrameName As String) As List(Of String)
         Dim chrCurrColumns As CharacterVector = Nothing
         Dim lstCurrColumns As New List(Of String)

--- a/instat/sdgCalculationsSummmary.vb
+++ b/instat/sdgCalculationsSummmary.vb
@@ -61,7 +61,7 @@ Public Class sdgCalculationsSummmary
 
         ucrManipulations.lstAvailableData.View = View.List
 
-        ucrCalcSummary.ucrReceiverForCalculation.bResetWhenSelectorResets = False
+        ucrCalcSummary.ucrReceiverForCalculation.bResetWhenSelectorDataFrameChanges = False
 
         'temp until working
         ucrCalcSummary.chkSaveResultInto.Visible = False

--- a/instat/sdgCalculationsSummmary.vb
+++ b/instat/sdgCalculationsSummmary.vb
@@ -61,7 +61,7 @@ Public Class sdgCalculationsSummmary
 
         ucrManipulations.lstAvailableData.View = View.List
 
-        ucrCalcSummary.ucrReceiverForCalculation.bResetWhenSelectorDataFrameChanges = False
+        ucrCalcSummary.ucrReceiverForCalculation.bAttachedToPrimaryDataFrame = False
 
         'temp until working
         ucrCalcSummary.chkSaveResultInto.Visible = False

--- a/instat/static/InstatObject/R/Backend_Components/link.R
+++ b/instat/static/InstatObject/R/Backend_Components/link.R
@@ -188,23 +188,26 @@ instat_object$set("public", "link_exists_from_by_to", function(first_data_frame,
 }
 )
 
-instat_object$set("public", "get_linked_to_data_name", function(from_data_frame, link_pairs) {
+instat_object$set("public", "get_linked_to_data_name", function(from_data_frame, link_cols, include_self = FALSE) {
+  out <- c()
   for(curr_link in private$.links) {
     if(curr_link$from_data_frame == from_data_frame) {
       for(curr_link_pairs in curr_link$link_columns) {
-        if(length(link_pairs) == length(curr_link_pairs) && setequal(link_pairs, names(curr_link_pairs))) {
-          return(curr_link$to_data_frame)
+        if(length(link_cols) == length(curr_link_pairs) && setequal(link_cols, names(curr_link_pairs))) {
+          out <- c(out, curr_link$to_data_frame)
         }
       }
     }
   }
-  return("")
+  return(out)
 }
 )
 
 instat_object$set("public", "get_linked_to_definition", function(from_data_frame, link_pairs) {
   to_data_name <- self$get_linked_to_data_name(from_data_frame, link_pairs)
-  if(to_data_name != "") {
+  if(length(to_data_name) > 0) {
+    # TODO what happens if there is more than 1?
+    to_data_name <- to_data_name[1]
     curr_link <- self$get_link_between(from_data_frame, to_data_name)
     for(curr_link in private$.links) {
       for(curr_link_pairs in curr_link$link_columns) {

--- a/instat/static/InstatObject/R/Backend_Components/link.R
+++ b/instat/static/InstatObject/R/Backend_Components/link.R
@@ -188,18 +188,25 @@ instat_object$set("public", "link_exists_from_by_to", function(first_data_frame,
 }
 )
 
-instat_object$set("public", "get_linked_to_data_name", function(from_data_frame, link_cols, include_self = FALSE) {
+instat_object$set("public", "get_linked_to_data_name", function(from_data_frame, link_cols = c(), include_self = FALSE) {
   out <- c()
   for(curr_link in private$.links) {
     if(curr_link$from_data_frame == from_data_frame) {
-      for(curr_link_pairs in curr_link$link_columns) {
-        if(length(link_cols) == length(curr_link_pairs) && setequal(link_cols, names(curr_link_pairs))) {
+      if(length(link_cols) == 0) {
+        if(curr_link$to_data_frame != from_data_frame || (curr_link$to_data_frame == from_data_frame && include_self)) {
           out <- c(out, curr_link$to_data_frame)
+        }
+      }
+      else {
+        for(curr_link_pairs in curr_link$link_columns) {
+          if(length(link_cols) == length(curr_link_pairs) && setequal(link_cols, names(curr_link_pairs))) {
+            out <- c(out, curr_link$to_data_frame)
+          }
         }
       }
     }
   }
-  return(out)
+  return(unique(out))
 }
 )
 

--- a/instat/static/InstatObject/R/Backend_Components/summary_functions.R
+++ b/instat/static/InstatObject/R/Backend_Components/summary_functions.R
@@ -46,7 +46,8 @@ instat_object$set("public", "append_summaries_to_data_object", function(out, dat
   
   exists = FALSE
   if(self$link_exists_from(data_name, factors)) {
-    summary_name <- self$get_linked_to_data_name(data_name, factors)
+    #TODO what happens if there is more than 1?
+    summary_name <- self$get_linked_to_data_name(data_name, factors)[1]
     summary_obj <- self$get_data_objects(summary_name)
     exists <- TRUE
   }

--- a/instat/static/InstatObject/R/instat_object_R6.R
+++ b/instat/static/InstatObject/R/instat_object_R6.R
@@ -1104,7 +1104,8 @@ instat_object$set("public","create_factor_data_frame", function(data_name, facto
       factor_named <- factor
       names(factor_named) <- factor
       curr_factor_df_name <- self$get_linked_to_data_name(data_name, factor_named)
-      self$delete_dataframe(curr_factor_df_name)
+      # TODO what if there is more than 1?
+      if(length(curr_factor_df_name) > 0) self$delete_dataframe(curr_factor_df_name[1])
     }
     else {
       warning("replace = FALSE so no action will be taken.")
@@ -1255,7 +1256,7 @@ instat_object$set("public", "add_single_climdex_index", function(data_name, indi
     ind_data <- data.frame(factor(names(indices)), indices, row.names = NULL)
     names(ind_data) <- c(year, index_name)
     linked_data_name <- self$get_linked_to_data_name(data_name, year)
-    if(linked_data_name == "") {
+    if(length(linked_data_name) == 0) {
       data_list = list(ind_data)
       new_data_name <- paste(data_name, "by", year, sep = "_")
       new_data_name <- next_default_item(prefix = new_data_name , existing_names = self$get_data_names(), include_index = FALSE)
@@ -1267,6 +1268,8 @@ instat_object$set("public", "add_single_climdex_index", function(data_name, indi
       self$add_link(from_data_frame = data_name, to_data_frame = new_data_name, link_pairs = key_list, type = keyed_link_label)
     }
     else {
+      # TODO what if there are multiple?
+      linked_data_name <- linked_data_name[1]
       year_col_name_linked <- self$get_equivalent_columns(from_data_name = data_name, to_data_name = linked_data_name, columns = year)
       by <- year
       names(by) <- year_col_name_linked
@@ -1289,7 +1292,7 @@ instat_object$set("public", "add_single_climdex_index", function(data_name, indi
     names(ind_data) <- c(year, month, index_name)
     ind_data[[month]] <- as.numeric(ind_data[[month]])
     linked_data_name <- self$get_linked_to_data_name(data_name, c(year, month))
-    if(linked_data_name == "") {
+    if(length(linked_data_name) == 0) {
       data_list = list(ind_data)
       new_data_name <- paste(data_name, "by", year, month, sep = "_")
       new_data_name <- next_default_item(prefix = new_data_name , existing_names = self$get_data_names(), include_index = FALSE)
@@ -1301,6 +1304,8 @@ instat_object$set("public", "add_single_climdex_index", function(data_name, indi
       self$add_link(from_data_frame = data_name, to_data_frame = new_data_name, link_pairs = key_list, type = keyed_link_label)
     }
     else {
+      # TODO what if there are multiple?
+      linked_data_name <- linked_data_name[1]
       year_col_name_linked <- self$get_equivalent_columns(from_data_name = data_name, to_data_name = linked_data_name, columns = year)
       month_col_name_linked <- self$get_equivalent_columns(from_data_name = data_name, to_data_name = linked_data_name, columns = month)
       by <- c(year, month)

--- a/instat/ucrReceiver.vb
+++ b/instat/ucrReceiver.vb
@@ -335,7 +335,8 @@ Public Class ucrReceiver
     End Sub
 
     Private Sub ucrSelector_DataFrameChanged() Handles ucrSelector.DataFrameChanged
-        If bAttachedToPrimaryDataFrame Then
+        'TODO This is possibly an expensive check, there may be more efficient ways of checking if this is the current receiver
+        If ucrSelector IsNot Nothing AndAlso ucrSelector.CurrentReceiver IsNot Nothing AndAlso (ucrSelector.CurrentReceiver.bAttachedToPrimaryDataFrame OrElse ucrSelector.CurrentReceiver.Equals(Me)) Then
             Selector_ResetAll()
         End If
     End Sub

--- a/instat/ucrReceiver.vb
+++ b/instat/ucrReceiver.vb
@@ -49,9 +49,9 @@ Public Class ucrReceiver
     'Should columns be forced as a data frame object when bParameterIsRFunction = True
     Public bForceAsDataFrame As Boolean = False
 
-    'Currently no distinction in between selector resetting and data frame changed
-    'Need option to not reset receiver when data frame changed e.g. calculations dialog
-    Public bResetWhenSelectorResets As Boolean = True
+    ' If True then this receiver can only contain a column from the selector's primary data frame
+    ' and this receiver can set the selector's primary data frame (when current receiver), resetting all other receivers
+    Public bAttachedToPrimaryDataFrame As Boolean = True
 
     Public Sub New()
         ' This call is required by the designer.
@@ -331,8 +331,12 @@ Public Class ucrReceiver
     End Sub
 
     Protected Overridable Sub Selector_ResetAll() Handles ucrSelector.ResetReceivers
-        If bResetWhenSelectorResets Then
-            Clear()
+        Clear()
+    End Sub
+
+    Private Sub ucrSelector_DataFrameChanged() Handles ucrSelector.DataFrameChanged
+        If bAttachedToPrimaryDataFrame Then
+            Selector_ResetAll()
         End If
     End Sub
 
@@ -488,4 +492,8 @@ Public Class ucrReceiver
     Public Overridable Sub SetTextColour(clrNew As Color)
 
     End Sub
+
+    Public Overridable Function GetItemsDataFrames() As List(Of String)
+        Return New List(Of String)
+    End Function
 End Class

--- a/instat/ucrReceiverMultiple.vb
+++ b/instat/ucrReceiverMultiple.vb
@@ -460,4 +460,8 @@ Public Class ucrReceiverMultiple
     Private Sub ucrReceiverMultiple_SelectionChanged(sender As Object, e As EventArgs) Handles Me.SelectionChanged
         CheckSingleType()
     End Sub
+
+    Public Overrides Function GetItemsDataFrames() As List(Of String)
+        Return GetCurrGroupNames()
+    End Function
 End Class

--- a/instat/ucrReceiverSingle.vb
+++ b/instat/ucrReceiverSingle.vb
@@ -325,4 +325,8 @@ Public Class ucrReceiverSingle
     Public Overrides Sub SetTextColour(clrNew As Color)
         txtReceiverSingle.ForeColor = clrNew
     End Sub
+
+    Public Overrides Function GetItemsDataFrames() As List(Of String)
+        Return New List(Of String)({strDataFrameName})
+    End Function
 End Class

--- a/instat/ucrSelector.vb
+++ b/instat/ucrSelector.vb
@@ -26,6 +26,10 @@ Public Class ucrSelector
     Public bFirstLoad As Boolean
     Public bIncludeOverall As Boolean
     Public strCurrentDataFrame As String
+    ' If a dialog has receivers which can have columns from multiple data frames
+    ' there may be a primary data frame which some receivers must be from.
+    ' Other receivers may only allow columns from data frames linked to the primary data frame
+    Public strPrimaryDataFrame As String
     Public lstIncludedMetadataProperties As List(Of KeyValuePair(Of String, String()))
     Public lstExcludedMetadataProperties As List(Of KeyValuePair(Of String, String()))
     Private strType As String
@@ -36,6 +40,8 @@ Public Class ucrSelector
     'Usually False as the parameter comes from the data frame selector
     Public bHasOwnParameter As Boolean = False
     Private clsGgplotOperator As ROperator = Nothing
+
+    Protected bSilentDataFrameChange As Boolean = False
 
     Public Sub New()
         ' This call is required by the designer.
@@ -67,8 +73,14 @@ Public Class ucrSelector
     End Sub
 
     Protected Sub OnDataFrameChanged()
-        RaiseEvent DataFrameChanged()
-        ClearGgplotOptions()
+        If bSilentDataFrameChange Then
+            bSilentDataFrameChange = False
+        Else
+            RaiseEvent DataFrameChanged()
+            If CurrentReceiver.bAttachedToPrimaryDataFrame Then
+                ClearGgplotOptions()
+            End If
+        End If
     End Sub
 
     Protected Sub ClearGgplotOptions()
@@ -126,12 +138,25 @@ Public Class ucrSelector
     End Sub
 
     Public Sub SetCurrentReceiver(conReceiver As ucrReceiver)
+        Dim lstReceiverDataFrames As List(Of String)
+
         If CurrentReceiver IsNot Nothing Then
             CurrentReceiver.RemoveColor()
         End If
         If conReceiver IsNot Nothing Then
             CurrentReceiver = conReceiver
             CurrentReceiver.SetColor()
+            If Not CurrentReceiver.IsEmpty Then
+                lstReceiverDataFrames = CurrentReceiver.GetItemsDataFrames()
+                If lstReceiverDataFrames.Count = 1 AndAlso lstReceiverDataFrames(0) <> "" AndAlso lstReceiverDataFrames(0) <> strCurrentDataFrame Then
+                    SetDataframe(lstReceiverDataFrames(0), bSilent:=True)
+                End If
+            ElseIf CurrentReceiver.bAttachedToPrimaryDataFrame Then
+                If strPrimaryDataFrame <> "" AndAlso strPrimaryDataFrame <> strCurrentDataFrame Then
+                    SetDataframe(strPrimaryDataFrame, bSilent:=True)
+                End If
+            End If
+            'TODO possibly move this to avoid repetition loading list
             LoadList()
             If (TypeOf CurrentReceiver Is ucrReceiverSingle) Then
                 'lstAvailableVariable.SelectionMode = SelectionMode.One
@@ -399,5 +424,9 @@ Public Class ucrSelector
 
     Public Sub SetGgplotFunction(clsNewGgplotFunction As ROperator)
         clsGgplotOperator = clsNewGgplotFunction
+    End Sub
+
+    Public Overridable Sub SetDataframe(strNewDataFrame As String, Optional bEnableDataframe As Boolean = True, Optional bSilent As Boolean = False)
+
     End Sub
 End Class

--- a/instat/ucrSelector.vb
+++ b/instat/ucrSelector.vb
@@ -77,7 +77,7 @@ Public Class ucrSelector
             bSilentDataFrameChange = False
         Else
             RaiseEvent DataFrameChanged()
-            If CurrentReceiver.bAttachedToPrimaryDataFrame Then
+            If CurrentReceiver IsNot Nothing AndAlso CurrentReceiver.bAttachedToPrimaryDataFrame Then
                 ClearGgplotOptions()
             End If
         End If

--- a/instat/ucrSelectorByDataFrame.vb
+++ b/instat/ucrSelectorByDataFrame.vb
@@ -30,7 +30,6 @@ Public Class ucrSelectorByDataFrame
         strCurrentDataFrame = ucrAvailableDataFrames.cboAvailableDataFrames.Text
         LoadList()
         If strPrevDataFrame <> ucrAvailableDataFrames.cboAvailableDataFrames.Text Then
-            OnResetReceivers()
             OnDataFrameChanged()
         End If
     End Sub
@@ -50,7 +49,8 @@ Public Class ucrSelectorByDataFrame
         LoadList()
     End Sub
 
-    Public Sub SetDataframe(strDataframe As String, Optional bEnableDataframe As Boolean = True)
+    Public Overrides Sub SetDataframe(strDataframe As String, Optional bEnableDataframe As Boolean = True, Optional bSilent As Boolean = False)
+        bSilentDataFrameChange = bSilent
         ucrAvailableDataFrames.SetDataframe(strDataframe, bEnableDataframe)
     End Sub
 

--- a/instat/ucrSelectorByDataFrame.vb
+++ b/instat/ucrSelectorByDataFrame.vb
@@ -28,6 +28,9 @@ Public Class ucrSelectorByDataFrame
 
     Private Sub ucrAvailableDataFrames_DataFrameChanged(sender As Object, e As EventArgs, strPrevDataFrame As String) Handles ucrAvailableDataFrames.DataFrameChanged
         strCurrentDataFrame = ucrAvailableDataFrames.cboAvailableDataFrames.Text
+        If CurrentReceiver IsNot Nothing AndAlso CurrentReceiver.bAttachedToPrimaryDataFrame Then
+            strPrimaryDataFrame = strCurrentDataFrame
+        End If
         LoadList()
         If strPrevDataFrame <> ucrAvailableDataFrames.cboAvailableDataFrames.Text Then
             OnDataFrameChanged()


### PR DESCRIPTION
@africanmathsinitiative/developers there are changes to some main user controls here but the functionality of dialogs should not be affected. The new functionality is used when `bAttachedToPrimaryDataFrame = False` for a receiver, the default is `True`. Currently only `sdgCalculationsSummmary.vb` has such a receiver.
This will be common on climatic dialogs soon e.g. to select the start day from a linked data frame.