### PR TITLE
Adding Cut/Copy/Paste for the script window 

### DIFF
--- a/instat/ucrScript.Designer.vb
+++ b/instat/ucrScript.Designer.vb
@@ -46,12 +46,12 @@ Partial Class ucrScript
         Me.mnuOpenScriptFromFile = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuSaveScript = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuClearContents = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuCopy = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuCut = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuPaste = New System.Windows.Forms.ToolStripMenuItem()
         Me.cmdRun = New System.Windows.Forms.Button()
         Me.lblHeader = New System.Windows.Forms.Label()
         Me.tlpTableContainer = New System.Windows.Forms.TableLayoutPanel()
-        Me.CopyToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.CutToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.PasteToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuContextScript.SuspendLayout()
         Me.tlpTableContainer.SuspendLayout()
         Me.SuspendLayout()
@@ -70,9 +70,9 @@ Partial Class ucrScript
         '
         'mnuContextScript
         '
-        Me.mnuContextScript.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuRunSelectedText, Me.mnuOpenScript, Me.mnuOpenScriptFromFile, Me.mnuSaveScript, Me.mnuClearContents, Me.CopyToolStripMenuItem, Me.CutToolStripMenuItem, Me.PasteToolStripMenuItem})
+        Me.mnuContextScript.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuRunSelectedText, Me.mnuOpenScript, Me.mnuOpenScriptFromFile, Me.mnuSaveScript, Me.mnuClearContents, Me.mnuCopy, Me.mnuCut, Me.mnuPaste})
         Me.mnuContextScript.Name = "mnuContextLogFile"
-        Me.mnuContextScript.Size = New System.Drawing.Size(254, 202)
+        Me.mnuContextScript.Size = New System.Drawing.Size(254, 180)
         '
         'mnuRunSelectedText
         '
@@ -103,6 +103,24 @@ Partial Class ucrScript
         Me.mnuClearContents.Name = "mnuClearContents"
         Me.mnuClearContents.Size = New System.Drawing.Size(253, 22)
         Me.mnuClearContents.Text = "Clear Script"
+        '
+        'mnuCopy
+        '
+        Me.mnuCopy.Name = "mnuCopy"
+        Me.mnuCopy.Size = New System.Drawing.Size(253, 22)
+        Me.mnuCopy.Text = "Copy"
+        '
+        'mnuCut
+        '
+        Me.mnuCut.Name = "mnuCut"
+        Me.mnuCut.Size = New System.Drawing.Size(253, 22)
+        Me.mnuCut.Text = "Cut"
+        '
+        'mnuPaste
+        '
+        Me.mnuPaste.Name = "mnuPaste"
+        Me.mnuPaste.Size = New System.Drawing.Size(253, 22)
+        Me.mnuPaste.Text = "Paste"
         '
         'cmdRun
         '
@@ -145,24 +163,6 @@ Partial Class ucrScript
         Me.tlpTableContainer.Size = New System.Drawing.Size(411, 314)
         Me.tlpTableContainer.TabIndex = 9
         '
-        'CopyToolStripMenuItem
-        '
-        Me.CopyToolStripMenuItem.Name = "CopyToolStripMenuItem"
-        Me.CopyToolStripMenuItem.Size = New System.Drawing.Size(253, 22)
-        Me.CopyToolStripMenuItem.Text = "Copy"
-        '
-        'CutToolStripMenuItem
-        '
-        Me.CutToolStripMenuItem.Name = "CutToolStripMenuItem"
-        Me.CutToolStripMenuItem.Size = New System.Drawing.Size(253, 22)
-        Me.CutToolStripMenuItem.Text = "Cut"
-        '
-        'PasteToolStripMenuItem
-        '
-        Me.PasteToolStripMenuItem.Name = "PasteToolStripMenuItem"
-        Me.PasteToolStripMenuItem.Size = New System.Drawing.Size(253, 22)
-        Me.PasteToolStripMenuItem.Text = "Paste"
-        '
         'ucrScript
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
@@ -188,7 +188,7 @@ Partial Class ucrScript
     Friend WithEvents mnuOpenScript As ToolStripMenuItem
     Friend WithEvents mnuSaveScript As ToolStripMenuItem
     Friend WithEvents mnuOpenScriptFromFile As ToolStripMenuItem
-    Friend WithEvents CopyToolStripMenuItem As ToolStripMenuItem
-    Friend WithEvents CutToolStripMenuItem As ToolStripMenuItem
-    Friend WithEvents PasteToolStripMenuItem As ToolStripMenuItem
+    Friend WithEvents mnuCopy As ToolStripMenuItem
+    Friend WithEvents mnuCut As ToolStripMenuItem
+    Friend WithEvents mnuPaste As ToolStripMenuItem
 End Class

--- a/instat/ucrScript.Designer.vb
+++ b/instat/ucrScript.Designer.vb
@@ -49,6 +49,9 @@ Partial Class ucrScript
         Me.cmdRun = New System.Windows.Forms.Button()
         Me.lblHeader = New System.Windows.Forms.Label()
         Me.tlpTableContainer = New System.Windows.Forms.TableLayoutPanel()
+        Me.CopyToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.CutToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.PasteToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuContextScript.SuspendLayout()
         Me.tlpTableContainer.SuspendLayout()
         Me.SuspendLayout()
@@ -67,9 +70,9 @@ Partial Class ucrScript
         '
         'mnuContextScript
         '
-        Me.mnuContextScript.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuRunSelectedText, Me.mnuOpenScript, Me.mnuOpenScriptFromFile, Me.mnuSaveScript, Me.mnuClearContents})
+        Me.mnuContextScript.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuRunSelectedText, Me.mnuOpenScript, Me.mnuOpenScriptFromFile, Me.mnuSaveScript, Me.mnuClearContents, Me.CopyToolStripMenuItem, Me.CutToolStripMenuItem, Me.PasteToolStripMenuItem})
         Me.mnuContextScript.Name = "mnuContextLogFile"
-        Me.mnuContextScript.Size = New System.Drawing.Size(254, 136)
+        Me.mnuContextScript.Size = New System.Drawing.Size(254, 202)
         '
         'mnuRunSelectedText
         '
@@ -142,6 +145,24 @@ Partial Class ucrScript
         Me.tlpTableContainer.Size = New System.Drawing.Size(411, 314)
         Me.tlpTableContainer.TabIndex = 9
         '
+        'CopyToolStripMenuItem
+        '
+        Me.CopyToolStripMenuItem.Name = "CopyToolStripMenuItem"
+        Me.CopyToolStripMenuItem.Size = New System.Drawing.Size(253, 22)
+        Me.CopyToolStripMenuItem.Text = "Copy"
+        '
+        'CutToolStripMenuItem
+        '
+        Me.CutToolStripMenuItem.Name = "CutToolStripMenuItem"
+        Me.CutToolStripMenuItem.Size = New System.Drawing.Size(253, 22)
+        Me.CutToolStripMenuItem.Text = "Cut"
+        '
+        'PasteToolStripMenuItem
+        '
+        Me.PasteToolStripMenuItem.Name = "PasteToolStripMenuItem"
+        Me.PasteToolStripMenuItem.Size = New System.Drawing.Size(253, 22)
+        Me.PasteToolStripMenuItem.Text = "Paste"
+        '
         'ucrScript
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
@@ -167,4 +188,7 @@ Partial Class ucrScript
     Friend WithEvents mnuOpenScript As ToolStripMenuItem
     Friend WithEvents mnuSaveScript As ToolStripMenuItem
     Friend WithEvents mnuOpenScriptFromFile As ToolStripMenuItem
+    Friend WithEvents CopyToolStripMenuItem As ToolStripMenuItem
+    Friend WithEvents CutToolStripMenuItem As ToolStripMenuItem
+    Friend WithEvents PasteToolStripMenuItem As ToolStripMenuItem
 End Class

--- a/instat/ucrScript.vb
+++ b/instat/ucrScript.vb
@@ -142,4 +142,24 @@ Public Class ucrScript
     Private Sub mnuPaste_Click(sender As Object, e As EventArgs) Handles mnuPaste.Click
         txtScript.Text = Clipboard.GetText()
     End Sub
+
+    Private Sub EnableCopyCut()
+        If txtScript.SelectionLength > 0 Then
+            mnuCopy.Enabled = True
+            mnuCut.Enabled = True
+            mnuRunSelectedText.Enabled = True
+        Else
+            mnuCopy.Enabled = False
+            mnuCut.Enabled = False
+            mnuRunSelectedText.Enabled = False
+        End If
+    End Sub
+
+    Private Sub ucrScript_Load(sender As Object, e As EventArgs) Handles Me.Load
+        EnableCopyCut()
+    End Sub
+
+    Private Sub txtScript_MouseUp(sender As Object, e As EventArgs) Handles txtScript.MouseUp, txtScript.KeyUp
+        EnableCopyCut()
+    End Sub
 End Class

--- a/instat/ucrScript.vb
+++ b/instat/ucrScript.vb
@@ -129,7 +129,17 @@ Public Class ucrScript
         End Using
     End Sub
 
-    Private Sub PasteToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles PasteToolStripMenuItem.Click
+    Private Sub mnuCopy_Click(sender As Object, e As EventArgs) Handles mnuCopy.Click
+        Clipboard.SetText(txtScript.SelectedText)
+    End Sub
 
+    Private Sub mnuCut_Click(sender As Object, e As EventArgs) Handles mnuCut.Click
+        Clipboard.Clear()
+        Clipboard.SetText(txtScript.SelectedText)
+        txtScript.Text = ""
+    End Sub
+
+    Private Sub mnuPaste_Click(sender As Object, e As EventArgs) Handles mnuPaste.Click
+        txtScript.Text = Clipboard.GetText()
     End Sub
 End Class

--- a/instat/ucrScript.vb
+++ b/instat/ucrScript.vb
@@ -136,11 +136,29 @@ Public Class ucrScript
     Private Sub mnuCut_Click(sender As Object, e As EventArgs) Handles mnuCut.Click
         Clipboard.Clear()
         Clipboard.SetText(txtScript.Text)
-        txtScript.Text = ""
+        txtScript.SelectedText = ""
     End Sub
 
     Private Sub mnuPaste_Click(sender As Object, e As EventArgs) Handles mnuPaste.Click
-        txtScript.Text = Clipboard.GetText()
+        Dim msgPaste As DialogResult
+
+        If Clipboard.ContainsData(DataFormats.Text) Then
+            If txtScript.SelectionLength > 0 Then
+                msgPaste = MessageBox.Show("Are you sure you want to overwrite the selected text?", "Paste to Script Window", MessageBoxButtons.YesNo)
+                If msgPaste = DialogResult.Yes Then
+                    txtScript.SelectedText = Clipboard.GetText()
+                End If
+            Else
+                If txtScript.Text = "" Then
+                    txtScript.Text = Clipboard.GetText()
+                Else
+                    txtScript.SelectionStart = txtScript.TextLength
+
+                End If
+            End If
+        Else
+            MessageBox.Show("You can only paste text data on the script window?", "Paste to Script Window", MessageBoxButtons.OK)
+        End If
     End Sub
 
     Private Sub EnableCopyCut()

--- a/instat/ucrScript.vb
+++ b/instat/ucrScript.vb
@@ -130,12 +130,12 @@ Public Class ucrScript
     End Sub
 
     Private Sub mnuCopy_Click(sender As Object, e As EventArgs) Handles mnuCopy.Click
-        Clipboard.SetText(txtScript.SelectedText)
+        Clipboard.SetText(txtScript.Text)
     End Sub
 
     Private Sub mnuCut_Click(sender As Object, e As EventArgs) Handles mnuCut.Click
         Clipboard.Clear()
-        Clipboard.SetText(txtScript.SelectedText)
+        Clipboard.SetText(txtScript.Text)
         txtScript.Text = ""
     End Sub
 

--- a/instat/ucrScript.vb
+++ b/instat/ucrScript.vb
@@ -152,8 +152,8 @@ Public Class ucrScript
                 If txtScript.Text = "" Then
                     txtScript.Text = Clipboard.GetText()
                 Else
-                    txtScript.SelectionStart = txtScript.TextLength
-
+                    txtScript.SelectionStart = txtScript.TextLength & Environment.NewLine
+                    txtScript.AppendText(Clipboard.GetText)
                 End If
             End If
         Else

--- a/instat/ucrScript.vb
+++ b/instat/ucrScript.vb
@@ -157,9 +157,27 @@ Public Class ucrScript
 
     Private Sub ucrScript_Load(sender As Object, e As EventArgs) Handles Me.Load
         EnableCopyCut()
+        EnableMenusWhenScriptNotEmpty()
     End Sub
 
     Private Sub txtScript_MouseUp(sender As Object, e As EventArgs) Handles txtScript.MouseUp, txtScript.KeyUp
         EnableCopyCut()
+    End Sub
+
+    Private Sub txtScript_TextChanged(sender As Object, e As EventArgs) Handles txtScript.TextChanged
+        EnableMenusWhenScriptNotEmpty()
+    End Sub
+    Private Sub EnableMenusWhenScriptNotEmpty()
+        If txtScript.Text <> "" Then
+            cmdRun.Enabled = True
+            mnuOpenScript.Enabled = True
+            mnuClearContents.Enabled = True
+            mnuSaveScript.Enabled = True
+        Else
+            cmdRun.Enabled = False
+            mnuOpenScript.Enabled = False
+            mnuClearContents.Enabled = False
+            mnuSaveScript.Enabled = False
+        End If
     End Sub
 End Class

--- a/instat/ucrScript.vb
+++ b/instat/ucrScript.vb
@@ -129,4 +129,7 @@ Public Class ucrScript
         End Using
     End Sub
 
+    Private Sub PasteToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles PasteToolStripMenuItem.Click
+
+    End Sub
 End Class


### PR DESCRIPTION
@africanmathsinitiative/developers  this is ready for review. 

As of now, this copies/cuts the entire text in the script window. I wonder if we could include an option of copying/cutting  selected text. 

Fixes #4389 