### PR TITLE
Added R code and dialog for Compare Columns

### DIFF
--- a/instat/clsRSyntax.vb
+++ b/instat/clsRSyntax.vb
@@ -410,7 +410,7 @@ Public Class RSyntax
     End Function
 
     Public Function ContainsCode(clsRCode As RCodeStructure) As Boolean
-        Return (clsBaseFunction IsNot Nothing AndAlso clsBaseFunction.Equals(clsRCode)) OrElse (clsBaseOperator.Equals(clsRCode) AndAlso clsBaseOperator.Equals(clsRCode)) OrElse BeforeCodesContain(clsRCode) OrElse AfterCodesContain(clsRCode)
+        Return (clsBaseFunction IsNot Nothing AndAlso clsBaseFunction.Equals(clsRCode)) OrElse (clsBaseOperator IsNot Nothing AndAlso clsBaseOperator.Equals(clsRCode) AndAlso clsBaseOperator.Equals(clsRCode)) OrElse BeforeCodesContain(clsRCode) OrElse AfterCodesContain(clsRCode)
     End Function
 
     Public Function ContainsFunctionName(strFunctionName As String) As Boolean

--- a/instat/dlgCompareColumns.Designer.vb
+++ b/instat/dlgCompareColumns.Designer.vb
@@ -1,9 +1,9 @@
-﻿<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()> _
+﻿<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()>
 Partial Class dlgCompareColumns
     Inherits System.Windows.Forms.Form
 
     'Form overrides dispose to clean up the component list.
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Protected Overrides Sub Dispose(ByVal disposing As Boolean)
         Try
             If disposing AndAlso components IsNot Nothing Then
@@ -20,21 +20,164 @@ Partial Class dlgCompareColumns
     'NOTE: The following procedure is required by the Windows Form Designer
     'It can be modified using the Windows Form Designer.  
     'Do not modify it using the code editor.
-    <System.Diagnostics.DebuggerStepThrough()> _
+    <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
         Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(dlgCompareColumns))
+        Me.lblFirstColumn = New System.Windows.Forms.Label()
+        Me.lblSecondColumn = New System.Windows.Forms.Label()
+        Me.grpComparisions = New System.Windows.Forms.GroupBox()
+        Me.ucrSaveLogical = New instat.ucrSave()
+        Me.ucrChkSort = New instat.ucrCheck()
+        Me.ucrChkUnique = New instat.ucrCheck()
+        Me.ucrChkAllValues = New instat.ucrCheck()
+        Me.ucrChkUnion = New instat.ucrCheck()
+        Me.ucrChkIntersection = New instat.ucrCheck()
+        Me.ucrChkSecondNotFirst = New instat.ucrCheck()
+        Me.ucrChkFirstNotSecond = New instat.ucrCheck()
+        Me.ucrBase = New instat.ucrButtons()
+        Me.ucrReceiverSecond = New instat.ucrReceiverSingle()
+        Me.ucrReceiverFirst = New instat.ucrReceiverSingle()
+        Me.ucrSelectorCompareColumns = New instat.ucrSelectorByDataFrameAddRemove()
+        Me.grpComparisions.SuspendLayout()
         Me.SuspendLayout()
+        '
+        'lblFirstColumn
+        '
+        resources.ApplyResources(Me.lblFirstColumn, "lblFirstColumn")
+        Me.lblFirstColumn.Name = "lblFirstColumn"
+        '
+        'lblSecondColumn
+        '
+        resources.ApplyResources(Me.lblSecondColumn, "lblSecondColumn")
+        Me.lblSecondColumn.Name = "lblSecondColumn"
+        '
+        'grpComparisions
+        '
+        Me.grpComparisions.Controls.Add(Me.ucrChkAllValues)
+        Me.grpComparisions.Controls.Add(Me.ucrChkUnion)
+        Me.grpComparisions.Controls.Add(Me.ucrChkIntersection)
+        Me.grpComparisions.Controls.Add(Me.ucrChkSecondNotFirst)
+        Me.grpComparisions.Controls.Add(Me.ucrChkFirstNotSecond)
+        resources.ApplyResources(Me.grpComparisions, "grpComparisions")
+        Me.grpComparisions.Name = "grpComparisions"
+        Me.grpComparisions.TabStop = False
+        '
+        'ucrSaveLogical
+        '
+        resources.ApplyResources(Me.ucrSaveLogical, "ucrSaveLogical")
+        Me.ucrSaveLogical.Name = "ucrSaveLogical"
+        '
+        'ucrChkSort
+        '
+        Me.ucrChkSort.Checked = False
+        resources.ApplyResources(Me.ucrChkSort, "ucrChkSort")
+        Me.ucrChkSort.Name = "ucrChkSort"
+        '
+        'ucrChkUnique
+        '
+        Me.ucrChkUnique.Checked = False
+        resources.ApplyResources(Me.ucrChkUnique, "ucrChkUnique")
+        Me.ucrChkUnique.Name = "ucrChkUnique"
+        '
+        'ucrChkAllValues
+        '
+        Me.ucrChkAllValues.Checked = False
+        resources.ApplyResources(Me.ucrChkAllValues, "ucrChkAllValues")
+        Me.ucrChkAllValues.Name = "ucrChkAllValues"
+        '
+        'ucrChkUnion
+        '
+        Me.ucrChkUnion.Checked = False
+        resources.ApplyResources(Me.ucrChkUnion, "ucrChkUnion")
+        Me.ucrChkUnion.Name = "ucrChkUnion"
+        '
+        'ucrChkIntersection
+        '
+        Me.ucrChkIntersection.Checked = False
+        resources.ApplyResources(Me.ucrChkIntersection, "ucrChkIntersection")
+        Me.ucrChkIntersection.Name = "ucrChkIntersection"
+        '
+        'ucrChkSecondNotFirst
+        '
+        Me.ucrChkSecondNotFirst.Checked = False
+        resources.ApplyResources(Me.ucrChkSecondNotFirst, "ucrChkSecondNotFirst")
+        Me.ucrChkSecondNotFirst.Name = "ucrChkSecondNotFirst"
+        '
+        'ucrChkFirstNotSecond
+        '
+        Me.ucrChkFirstNotSecond.Checked = False
+        resources.ApplyResources(Me.ucrChkFirstNotSecond, "ucrChkFirstNotSecond")
+        Me.ucrChkFirstNotSecond.Name = "ucrChkFirstNotSecond"
+        '
+        'ucrBase
+        '
+        resources.ApplyResources(Me.ucrBase, "ucrBase")
+        Me.ucrBase.Name = "ucrBase"
+        '
+        'ucrReceiverSecond
+        '
+        Me.ucrReceiverSecond.frmParent = Me
+        resources.ApplyResources(Me.ucrReceiverSecond, "ucrReceiverSecond")
+        Me.ucrReceiverSecond.Name = "ucrReceiverSecond"
+        Me.ucrReceiverSecond.Selector = Nothing
+        Me.ucrReceiverSecond.strNcFilePath = ""
+        Me.ucrReceiverSecond.ucrSelector = Nothing
+        '
+        'ucrReceiverFirst
+        '
+        Me.ucrReceiverFirst.frmParent = Me
+        resources.ApplyResources(Me.ucrReceiverFirst, "ucrReceiverFirst")
+        Me.ucrReceiverFirst.Name = "ucrReceiverFirst"
+        Me.ucrReceiverFirst.Selector = Nothing
+        Me.ucrReceiverFirst.strNcFilePath = ""
+        Me.ucrReceiverFirst.ucrSelector = Nothing
+        '
+        'ucrSelectorCompareColumns
+        '
+        Me.ucrSelectorCompareColumns.bDropUnusedFilterLevels = False
+        Me.ucrSelectorCompareColumns.bShowHiddenColumns = False
+        Me.ucrSelectorCompareColumns.bUseCurrentFilter = True
+        resources.ApplyResources(Me.ucrSelectorCompareColumns, "ucrSelectorCompareColumns")
+        Me.ucrSelectorCompareColumns.Name = "ucrSelectorCompareColumns"
         '
         'dlgCompareColumns
         '
         resources.ApplyResources(Me, "$this")
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.Controls.Add(Me.ucrSaveLogical)
+        Me.Controls.Add(Me.ucrChkSort)
+        Me.Controls.Add(Me.ucrChkUnique)
+        Me.Controls.Add(Me.grpComparisions)
+        Me.Controls.Add(Me.ucrBase)
+        Me.Controls.Add(Me.lblSecondColumn)
+        Me.Controls.Add(Me.lblFirstColumn)
+        Me.Controls.Add(Me.ucrReceiverSecond)
+        Me.Controls.Add(Me.ucrReceiverFirst)
+        Me.Controls.Add(Me.ucrSelectorCompareColumns)
         Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow
         Me.MaximizeBox = False
         Me.MinimizeBox = False
         Me.Name = "dlgCompareColumns"
         Me.ShowIcon = False
+        Me.grpComparisions.ResumeLayout(False)
         Me.ResumeLayout(False)
+        Me.PerformLayout()
 
     End Sub
+
+    Friend WithEvents ucrSelectorCompareColumns As ucrSelectorByDataFrameAddRemove
+    Friend WithEvents ucrReceiverFirst As ucrReceiverSingle
+    Friend WithEvents lblSecondColumn As Label
+    Friend WithEvents lblFirstColumn As Label
+    Friend WithEvents ucrReceiverSecond As ucrReceiverSingle
+    Friend WithEvents ucrBase As ucrButtons
+    Friend WithEvents ucrChkUnique As ucrCheck
+    Friend WithEvents grpComparisions As GroupBox
+    Friend WithEvents ucrChkSort As ucrCheck
+    Friend WithEvents ucrChkFirstNotSecond As ucrCheck
+    Friend WithEvents ucrChkSecondNotFirst As ucrCheck
+    Friend WithEvents ucrChkIntersection As ucrCheck
+    Friend WithEvents ucrChkUnion As ucrCheck
+    Friend WithEvents ucrChkAllValues As ucrCheck
+    Friend WithEvents ucrSaveLogical As ucrSave
 End Class

--- a/instat/dlgCompareColumns.resx
+++ b/instat/dlgCompareColumns.resx
@@ -117,17 +117,342 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="lblFirstColumn.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="lblFirstColumn.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="lblFirstColumn.Location" type="System.Drawing.Point, System.Drawing">
+    <value>270, 27</value>
+  </data>
+  <data name="lblFirstColumn.Size" type="System.Drawing.Size, System.Drawing">
+    <value>67, 13</value>
+  </data>
+  <data name="lblFirstColumn.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="lblFirstColumn.Text" xml:space="preserve">
+    <value>First Column:</value>
+  </data>
+  <data name="&gt;&gt;lblFirstColumn.Name" xml:space="preserve">
+    <value>lblFirstColumn</value>
+  </data>
+  <data name="&gt;&gt;lblFirstColumn.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblFirstColumn.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;lblFirstColumn.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="lblSecondColumn.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblSecondColumn.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblSecondColumn.Location" type="System.Drawing.Point, System.Drawing">
+    <value>270, 100</value>
+  </data>
+  <data name="lblSecondColumn.Size" type="System.Drawing.Size, System.Drawing">
+    <value>85, 13</value>
+  </data>
+  <data name="lblSecondColumn.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="lblSecondColumn.Text" xml:space="preserve">
+    <value>Second Column:</value>
+  </data>
+  <data name="&gt;&gt;lblSecondColumn.Name" xml:space="preserve">
+    <value>lblSecondColumn</value>
+  </data>
+  <data name="&gt;&gt;lblSecondColumn.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblSecondColumn.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;lblSecondColumn.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="ucrChkAllValues.Location" type="System.Drawing.Point, System.Drawing">
+    <value>11, 127</value>
+  </data>
+  <data name="ucrChkAllValues.Size" type="System.Drawing.Size, System.Drawing">
+    <value>210, 20</value>
+  </data>
+  <data name="ucrChkAllValues.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;ucrChkAllValues.Name" xml:space="preserve">
+    <value>ucrChkAllValues</value>
+  </data>
+  <data name="&gt;&gt;ucrChkAllValues.Type" xml:space="preserve">
+    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrChkAllValues.Parent" xml:space="preserve">
+    <value>grpComparisions</value>
+  </data>
+  <data name="&gt;&gt;ucrChkAllValues.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="ucrChkUnion.Location" type="System.Drawing.Point, System.Drawing">
+    <value>11, 101</value>
+  </data>
+  <data name="ucrChkUnion.Size" type="System.Drawing.Size, System.Drawing">
+    <value>210, 20</value>
+  </data>
+  <data name="ucrChkUnion.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;ucrChkUnion.Name" xml:space="preserve">
+    <value>ucrChkUnion</value>
+  </data>
+  <data name="&gt;&gt;ucrChkUnion.Type" xml:space="preserve">
+    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrChkUnion.Parent" xml:space="preserve">
+    <value>grpComparisions</value>
+  </data>
+  <data name="&gt;&gt;ucrChkUnion.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="ucrChkIntersection.Location" type="System.Drawing.Point, System.Drawing">
+    <value>11, 75</value>
+  </data>
+  <data name="ucrChkIntersection.Size" type="System.Drawing.Size, System.Drawing">
+    <value>210, 20</value>
+  </data>
+  <data name="ucrChkIntersection.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;ucrChkIntersection.Name" xml:space="preserve">
+    <value>ucrChkIntersection</value>
+  </data>
+  <data name="&gt;&gt;ucrChkIntersection.Type" xml:space="preserve">
+    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrChkIntersection.Parent" xml:space="preserve">
+    <value>grpComparisions</value>
+  </data>
+  <data name="&gt;&gt;ucrChkIntersection.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="ucrChkSecondNotFirst.Location" type="System.Drawing.Point, System.Drawing">
+    <value>11, 49</value>
+  </data>
+  <data name="ucrChkSecondNotFirst.Size" type="System.Drawing.Size, System.Drawing">
+    <value>210, 20</value>
+  </data>
+  <data name="ucrChkSecondNotFirst.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;ucrChkSecondNotFirst.Name" xml:space="preserve">
+    <value>ucrChkSecondNotFirst</value>
+  </data>
+  <data name="&gt;&gt;ucrChkSecondNotFirst.Type" xml:space="preserve">
+    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrChkSecondNotFirst.Parent" xml:space="preserve">
+    <value>grpComparisions</value>
+  </data>
+  <data name="&gt;&gt;ucrChkSecondNotFirst.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="ucrChkFirstNotSecond.Location" type="System.Drawing.Point, System.Drawing">
+    <value>11, 23</value>
+  </data>
+  <data name="ucrChkFirstNotSecond.Size" type="System.Drawing.Size, System.Drawing">
+    <value>210, 20</value>
+  </data>
+  <data name="ucrChkFirstNotSecond.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;ucrChkFirstNotSecond.Name" xml:space="preserve">
+    <value>ucrChkFirstNotSecond</value>
+  </data>
+  <data name="&gt;&gt;ucrChkFirstNotSecond.Type" xml:space="preserve">
+    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrChkFirstNotSecond.Parent" xml:space="preserve">
+    <value>grpComparisions</value>
+  </data>
+  <data name="&gt;&gt;ucrChkFirstNotSecond.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="grpComparisions.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 241</value>
+  </data>
+  <data name="grpComparisions.Size" type="System.Drawing.Size, System.Drawing">
+    <value>271, 154</value>
+  </data>
+  <data name="grpComparisions.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="grpComparisions.Text" xml:space="preserve">
+    <value>Comparisons to Display:</value>
+  </data>
+  <data name="&gt;&gt;grpComparisions.Name" xml:space="preserve">
+    <value>grpComparisions</value>
+  </data>
+  <data name="&gt;&gt;grpComparisions.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;grpComparisions.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;grpComparisions.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="ucrSaveLogical.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 412</value>
+  </data>
+  <data name="ucrSaveLogical.Size" type="System.Drawing.Size, System.Drawing">
+    <value>396, 24</value>
+  </data>
+  <data name="ucrSaveLogical.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;ucrSaveLogical.Name" xml:space="preserve">
+    <value>ucrSaveLogical</value>
+  </data>
+  <data name="&gt;&gt;ucrSaveLogical.Type" xml:space="preserve">
+    <value>instat.ucrSave, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrSaveLogical.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrSaveLogical.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="ucrChkSort.Location" type="System.Drawing.Point, System.Drawing">
+    <value>270, 204</value>
+  </data>
+  <data name="ucrChkSort.Size" type="System.Drawing.Size, System.Drawing">
+    <value>115, 20</value>
+  </data>
+  <data name="ucrChkSort.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;ucrChkSort.Name" xml:space="preserve">
+    <value>ucrChkSort</value>
+  </data>
+  <data name="&gt;&gt;ucrChkSort.Type" xml:space="preserve">
+    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrChkSort.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrChkSort.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="ucrChkUnique.Location" type="System.Drawing.Point, System.Drawing">
+    <value>21, 204</value>
+  </data>
+  <data name="ucrChkUnique.Size" type="System.Drawing.Size, System.Drawing">
+    <value>210, 20</value>
+  </data>
+  <data name="ucrChkUnique.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;ucrChkUnique.Name" xml:space="preserve">
+    <value>ucrChkUnique</value>
+  </data>
+  <data name="&gt;&gt;ucrChkUnique.Type" xml:space="preserve">
+    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrChkUnique.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrChkUnique.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="ucrBase.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 452</value>
+  </data>
+  <data name="ucrBase.Size" type="System.Drawing.Size, System.Drawing">
+    <value>410, 52</value>
+  </data>
+  <data name="ucrBase.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;ucrBase.Name" xml:space="preserve">
+    <value>ucrBase</value>
+  </data>
+  <data name="&gt;&gt;ucrBase.Type" xml:space="preserve">
+    <value>instat.ucrButtons, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrBase.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrBase.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>6, 13</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>800, 450</value>
+    <value>418, 512</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="ucrReceiverFirst.Location" type="System.Drawing.Point, System.Drawing">
+    <value>270, 43</value>
+  </data>
+  <data name="ucrReceiverFirst.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="ucrReceiverFirst.Size" type="System.Drawing.Size, System.Drawing">
+    <value>120, 20</value>
+  </data>
+  <data name="ucrReceiverFirst.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverFirst.Name" xml:space="preserve">
+    <value>ucrReceiverFirst</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverFirst.Type" xml:space="preserve">
+    <value>instat.ucrReceiverSingle, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverFirst.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverFirst.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="ucrSelectorCompareColumns.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 10</value>
+  </data>
+  <data name="ucrSelectorCompareColumns.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="ucrSelectorCompareColumns.Size" type="System.Drawing.Size, System.Drawing">
+    <value>210, 180</value>
+  </data>
+  <data name="ucrSelectorCompareColumns.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;ucrSelectorCompareColumns.Name" xml:space="preserve">
+    <value>ucrSelectorCompareColumns</value>
+  </data>
+  <data name="&gt;&gt;ucrSelectorCompareColumns.Type" xml:space="preserve">
+    <value>instat.ucrSelectorByDataFrameAddRemove, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrSelectorCompareColumns.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrSelectorCompareColumns.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="$this.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterScreen</value>
   </data>
@@ -139,5 +464,29 @@
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
     <value>System.Windows.Forms.Form, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="ucrReceiverSecond.Location" type="System.Drawing.Point, System.Drawing">
+    <value>270, 113</value>
+  </data>
+  <data name="ucrReceiverSecond.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="ucrReceiverSecond.Size" type="System.Drawing.Size, System.Drawing">
+    <value>120, 20</value>
+  </data>
+  <data name="ucrReceiverSecond.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverSecond.Name" xml:space="preserve">
+    <value>ucrReceiverSecond</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverSecond.Type" xml:space="preserve">
+    <value>instat.ucrReceiverSingle, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverSecond.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverSecond.ZOrder" xml:space="preserve">
+    <value>7</value>
   </data>
 </root>

--- a/instat/dlgCompareColumns.vb
+++ b/instat/dlgCompareColumns.vb
@@ -14,7 +14,6 @@
 ' You should have received a copy of the GNU General Public License 
 ' along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-Imports instat
 Imports instat.Translations
 
 Public Class dlgCompareColumns

--- a/instat/dlgCompareColumns.vb
+++ b/instat/dlgCompareColumns.vb
@@ -86,6 +86,8 @@ Public Class dlgCompareColumns
         ucrSaveLogical.SetCheckBoxText("Save logical values for second column")
         ucrSaveLogical.SetSaveTypeAsColumn()
         ucrSaveLogical.SetIsTextBox()
+        ' This ensures the assign text is correctly cleared when resetting
+        ucrSaveLogical.bUpdateRCodeFromControl = False
     End Sub
 
     Private Sub SetDefaults()
@@ -96,6 +98,7 @@ Public Class dlgCompareColumns
 
         ucrSelectorCompareColumns.Reset()
         ucrReceiverFirst.SetMeAsReceiver()
+        ucrSaveLogical.Reset()
 
         clsCompareColumns.SetRCommand("compare_columns")
         clsYinXOperator.SetOperation("%in%")
@@ -121,14 +124,14 @@ Public Class dlgCompareColumns
     End Sub
 
     Private Sub TestOkEnabled()
-        If Not ucrReceiverFirst.IsEmpty AndAlso Not ucrReceiverSecond.IsEmpty Then
+        If Not ucrReceiverFirst.IsEmpty AndAlso Not ucrReceiverSecond.IsEmpty AndAlso ucrSaveLogical.IsComplete() Then
             ucrBase.OKEnabled(True)
         Else
             ucrBase.OKEnabled(False)
         End If
     End Sub
 
-    Private Sub Receivers_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrReceiverFirst.ControlContentsChanged, ucrReceiverSecond.ControlContentsChanged
+    Private Sub Controls_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrReceiverFirst.ControlContentsChanged, ucrReceiverSecond.ControlContentsChanged, ucrSaveLogical.ControlContentsChanged
         TestOkEnabled()
     End Sub
 
@@ -148,6 +151,16 @@ Public Class dlgCompareColumns
             ucrBase.clsRsyntax.AddToAfterCodes(clsYinXOperator, iPosition:=1)
         Else
             ucrBase.clsRsyntax.RemoveFromAfterCodes(clsYinXOperator)
+        End If
+    End Sub
+
+    Private Sub ucrReceiverFirst_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverFirst.ControlValueChanged
+        If Not ucrSaveLogical.bUserTyped Then
+            If ucrReceiverFirst.IsEmpty Then
+                ucrSaveLogical.SetName("")
+            Else
+                ucrSaveLogical.SetName("in_" & ucrReceiverFirst.GetVariableNames(False))
+            End If
         End If
     End Sub
 End Class

--- a/instat/dlgCompareColumns.vb
+++ b/instat/dlgCompareColumns.vb
@@ -1,3 +1,153 @@
-﻿Public Class dlgCompareColumns
+﻿' R- Instat
+' Copyright (C) 2015-2017
+'
+' This program is free software: you can redistribute it and/or modify
+' it under the terms of the GNU General Public License as published by
+' the Free Software Foundation, either version 3 of the License, or
+' (at your option) any later version.
+'
+' This program is distributed in the hope that it will be useful,
+' but WITHOUT ANY WARRANTY; without even the implied warranty of
+' MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+' GNU General Public License for more details.
+'
+' You should have received a copy of the GNU General Public License 
+' along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+Imports instat
+Imports instat.Translations
+
+Public Class dlgCompareColumns
+
+    Private bFirstLoad As Boolean = True
+    Private bReset As Boolean = True
+    Private clsCompareColumns As New RFunction
+    Private clsYinXOperator As New ROperator
+
+    Private Sub dlgCompareColumns_Load(sender As Object, e As EventArgs) Handles Me.Load
+        If bFirstLoad Then
+            InitialiseDialog()
+            bFirstLoad = False
+        End If
+
+        If bReset Then
+            SetDefaults()
+        End If
+        SetRCodeForControls(bReset)
+        bReset = False
+        autoTranslate(Me)
+        TestOkEnabled()
+    End Sub
+
+    Private Sub InitialiseDialog()
+        ucrReceiverFirst.SetParameter(New RParameter("x", 0))
+        ucrReceiverFirst.Selector = ucrSelectorCompareColumns
+        ucrReceiverFirst.SetParameterIsRFunction()
+        ucrReceiverFirst.bAttachedToPrimaryDataFrame = False
+        ucrReceiverFirst.bOnlyLinkedToPrimaryDataFrames = False
+        ucrReceiverFirst.bIncludeDataFrameInAssignment = True
+
+        ucrReceiverSecond.SetParameter(New RParameter("y", 1))
+        ucrReceiverSecond.Selector = ucrSelectorCompareColumns
+        ucrReceiverSecond.SetParameterIsRFunction()
+        ucrReceiverSecond.bAttachedToPrimaryDataFrame = False
+        ucrReceiverSecond.bOnlyLinkedToPrimaryDataFrames = False
+        ucrReceiverSecond.bIncludeDataFrameInAssignment = True
+
+        ucrChkUnique.SetParameter(New RParameter("use_unique", 2), bNewChangeParameterValue:=True)
+        ucrChkUnique.SetText("Use unique values for comparison")
+        ucrChkUnique.SetRDefault("TRUE")
+
+        ucrChkSort.SetParameter(New RParameter("sort_values", 3), bNewChangeParameterValue:=True)
+        ucrChkSort.SetText("Sort values")
+        ucrChkSort.SetRDefault("TRUE")
+
+        ucrChkFirstNotSecond.SetParameter(New RParameter("firstnotsecond", 4), bNewChangeParameterValue:=True)
+        ucrChkFirstNotSecond.SetText("Values in first column not in second")
+        ucrChkFirstNotSecond.SetRDefault("TRUE")
+
+        ucrChkSecondNotFirst.SetParameter(New RParameter("secondnotfirst", 5), bNewChangeParameterValue:=True)
+        ucrChkSecondNotFirst.SetText("Values in second column not in first")
+        ucrChkSecondNotFirst.SetRDefault("TRUE")
+
+        ucrChkIntersection.SetParameter(New RParameter("display_intersection", 6), bNewChangeParameterValue:=True)
+        ucrChkIntersection.SetText("Values in both columns (intersection)")
+        ucrChkIntersection.SetRDefault("FALSE")
+
+        ucrChkUnion.SetParameter(New RParameter("display_union", 7), bNewChangeParameterValue:=True)
+        ucrChkUnion.SetText("Values in either column (union)")
+        ucrChkUnion.SetRDefault("FALSE")
+
+        ucrChkAllValues.SetParameter(New RParameter("display_values", 8), bNewChangeParameterValue:=True)
+        ucrChkAllValues.SetText("All values if columns are equal")
+        ucrChkAllValues.SetRDefault("TRUE")
+
+        ' Not setting data frame selector or prefix here because we need save control only linked to data frame of second selector which is not yet implemented
+        ucrSaveLogical.SetCheckBoxText("Save logical values for second column")
+        ucrSaveLogical.SetSaveTypeAsColumn()
+        ucrSaveLogical.SetIsTextBox()
+    End Sub
+
+    Private Sub SetDefaults()
+        clsCompareColumns = New RFunction
+        clsYinXOperator = New ROperator
+
+        ucrBase.clsRsyntax.ClearCodes()
+
+        ucrSelectorCompareColumns.Reset()
+        ucrReceiverFirst.SetMeAsReceiver()
+
+        clsCompareColumns.SetRCommand("compare_columns")
+        clsYinXOperator.SetOperation("%in%")
+        ucrBase.clsRsyntax.SetBaseRFunction(clsCompareColumns)
+        ucrBase.clsRsyntax.iCallType = 2
+    End Sub
+
+    Private Sub SetRCodeForControls(bReset As Boolean)
+        ucrReceiverFirst.AddAdditionalCodeParameterPair(clsYinXOperator, New RParameter("right", iNewPosition:=1), iAdditionalPairNo:=1)
+        ucrReceiverSecond.AddAdditionalCodeParameterPair(clsYinXOperator, New RParameter("left", iNewPosition:=0), iAdditionalPairNo:=1)
+
+        ucrReceiverFirst.SetRCode(clsCompareColumns, bReset)
+        ucrReceiverSecond.SetRCode(clsCompareColumns, bReset)
+        ucrChkUnique.SetRCode(clsCompareColumns, bReset)
+        ucrChkSort.SetRCode(clsCompareColumns, bReset)
+        ucrChkFirstNotSecond.SetRCode(clsCompareColumns, bReset)
+        ucrChkSecondNotFirst.SetRCode(clsCompareColumns, bReset)
+        ucrChkIntersection.SetRCode(clsCompareColumns, bReset)
+        ucrChkUnion.SetRCode(clsCompareColumns, bReset)
+        ucrChkAllValues.SetRCode(clsCompareColumns, bReset)
+
+        ucrSaveLogical.SetRCode(clsYinXOperator, bReset)
+    End Sub
+
+    Private Sub TestOkEnabled()
+        If Not ucrReceiverFirst.IsEmpty AndAlso Not ucrReceiverSecond.IsEmpty Then
+            ucrBase.OKEnabled(True)
+        Else
+            ucrBase.OKEnabled(False)
+        End If
+    End Sub
+
+    Private Sub Receivers_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrReceiverFirst.ControlContentsChanged, ucrReceiverSecond.ControlContentsChanged
+        TestOkEnabled()
+    End Sub
+
+    Private Sub ucrBase_ClickReset(sender As Object, e As EventArgs) Handles ucrBase.ClickReset
+        SetDefaults()
+        SetRCodeForControls(True)
+        TestOkEnabled()
+    End Sub
+
+    Private Sub ucrReceiverSecond_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverSecond.ControlValueChanged
+        ' Needs to be done manually because data frame name should only be the data frame name from the second receiver's variable.
+        ucrSaveLogical.SetGlobalDataName(ucrReceiverSecond.GetDataName())
+    End Sub
+
+    Private Sub ucrSaveLogical_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrSaveLogical.ControlValueChanged
+        If ucrSaveLogical.ucrChkSave.Checked Then
+            ucrBase.clsRsyntax.AddToAfterCodes(clsYinXOperator, iPosition:=1)
+        Else
+            ucrBase.clsRsyntax.RemoveFromAfterCodes(clsYinXOperator)
+        End If
+    End Sub
 End Class

--- a/instat/static/InstatObject/R/stand_alone_functions.R
+++ b/instat/static/InstatObject/R/stand_alone_functions.R
@@ -1044,3 +1044,44 @@ drop_unused_levels <- function(dat, columns) {
   }
   return(dat)
 }
+
+compare_columns <- function(x, y, use_unique = TRUE, sort_values = TRUE, firstnotsecond = TRUE, secondnotfirst = TRUE, display_intersection = FALSE, display_union = FALSE, display_values = TRUE) {
+  x_name <- deparse(substitute(x))
+  y_name <- deparse(substitute(y))
+  if(use_unique) {
+    x <- unique(x)
+    y <- unique(y)
+  }
+  if(sort_values) {
+    x <- sort(x)
+    y <- sort(y)
+  }
+  equal <- setequal(x, y)
+  cat(paste0("Columns contain all the same values: ", equal, "\n \n"))
+  if(equal) {
+    if(display_values) cat(paste0("Values: ", paste0("'", x, "'", collapse = ", "), "\n \n"))
+  }
+  if(!equal) {
+    cat("First column:", x_name, "\n \n")
+    cat("Second column:", y_name, "\n \n")
+    if(firstnotsecond) {
+      cat("Values in first not in second: ")
+      setd <- dplyr::setdiff(x, y)
+      if(length(setd) != 0) cat(paste0("'", setd, "'", collapse = ", "))
+      cat("\n \n")
+    }
+    if(secondnotfirst) {
+      cat("Values in second not in first: ")
+      setd <- dplyr::setdiff(y, x)
+      if(length(setd) != 0) cat(paste0("'", setd, "'", collapse = ", "))
+      cat("\n \n")
+    }
+    if(display_intersection) {
+      cat("Intersection (Values that appear in both columns):")
+      inter <- dplyr::intersect(x, y)
+      if(length(inter) != 0) cat(paste0("'", inter, "'", collapse = ", "))
+      cat("\n \n")
+    }
+    if(display_union) cat(paste0("Union (Values that appear in either column): ", paste0("'", dplyr::union(x, y), "'", collapse = ", ")))
+  }
+}

--- a/instat/ucrReceiverSingle.vb
+++ b/instat/ucrReceiverSingle.vb
@@ -23,6 +23,9 @@ Public Class ucrReceiverSingle
     Public bAutoFill As Boolean = False
     'We have not added this to multiple receiver because we have no case yet that we want not to print graph
     Public bPrintGraph As Boolean = True
+    'If True variable will be assigned to e.g. DF.x instead of x (where DF is strDataFrameName and x is receiver value)
+    'This is useful e.g. to ensure uniqueness when a dialog uses multiple data frames
+    Public bIncludeDataFrameInAssignment As Boolean = False
 
     Public Sub New()
         ' This call is required by the designer.
@@ -222,7 +225,11 @@ Public Class ucrReceiverSingle
             End Select
 
             'TODO make this an option set in Options menu
-            clsGetVariablesFunc.SetAssignTo(txtReceiverSingle.Text)
+            If bIncludeDataFrameInAssignment AndAlso strDataFrameName <> "" Then
+                clsGetVariablesFunc.SetAssignTo(strDataFrameName & "." & txtReceiverSingle.Text)
+            Else
+                clsGetVariablesFunc.SetAssignTo(txtReceiverSingle.Text)
+            End If
             Return clsGetVariablesFunc
         Else
             Return clsGetVariablesFunc

--- a/instat/ucrSave.vb
+++ b/instat/ucrSave.vb
@@ -29,6 +29,7 @@ Public Class ucrSave
     Private bAssignToColumnWithoutNames As Boolean = False
     Private bInsertColumnBefore As Boolean = False
     Private strAssignToIfUnchecked As String = ""
+    Private strGlobalDataName As String = ""
 
     Private Sub ucrSave_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         If bFirstLoad Then
@@ -73,10 +74,16 @@ Public Class ucrSave
     End Sub
 
     Public Sub SetCheckBoxText(strText As String)
+        Dim g As Graphics = ucrChkSave.chkCheck.CreateGraphics
+        Dim s As SizeF
+
         ucrChkSave.SetText(strText)
         bShowLabel = False
         bShowCheckBox = True
         LabelOrCheckboxSettings()
+        ' "[box]" allows for a sufficient amount of space for the box of the checkbox
+        s = g.MeasureString(ucrChkSave.chkCheck.Text & "[box]", ucrChkSave.chkCheck.Font)
+        ucrChkSave.Width = Math.Max(100, s.Width)
     End Sub
 
     Public Sub SetIsComboBox()
@@ -265,6 +272,8 @@ Public Class ucrSave
                 Else
                     If ucrDataFrameSelector IsNot Nothing Then
                         strDataName = ucrDataFrameSelector.cboAvailableDataFrames.Text
+                    Else
+                        strDataName = strGlobalDataName
                     End If
                     If bShowCheckBox AndAlso Not ucrChkSave.Checked Then
                         strSaveName = strAssignToIfUnchecked
@@ -377,4 +386,9 @@ Public Class ucrSave
             Return ucrInputTextSave.bUserTyped
         End If
     End Function
+
+    Public Sub SetGlobalDataName(strNewGlobalDataName As String)
+        strGlobalDataName = strNewGlobalDataName
+        UpdateAssignTo()
+    End Sub
 End Class

--- a/instat/ucrSelector.vb
+++ b/instat/ucrSelector.vb
@@ -146,7 +146,7 @@ Public Class ucrSelector
         If conReceiver IsNot Nothing Then
             CurrentReceiver = conReceiver
             CurrentReceiver.SetColor()
-            SetPrimaryDataFrameOptions(strPrimaryDataFrame, Not CurrentReceiver.bAttachedToPrimaryDataFrame)
+            SetPrimaryDataFrameOptions(strPrimaryDataFrame, Not CurrentReceiver.bAttachedToPrimaryDataFrame AndAlso CurrentReceiver.bOnlyLinkedToPrimaryDataFrames)
             If Not CurrentReceiver.IsEmpty Then
                 lstReceiverDataFrames = CurrentReceiver.GetItemsDataFrames()
                 If lstReceiverDataFrames.Count = 1 AndAlso lstReceiverDataFrames(0) <> "" AndAlso lstReceiverDataFrames(0) <> strCurrentDataFrame Then


### PR DESCRIPTION
@africanmathsinitiative/developers this is ready for review. This is a new dialog for Prepare > Check Data (and the new Options by Context menu), useful for comparing the values in two columns before doing a merge to check the values match, so likely the two columns will be from different data frames. An example is comparing the values in the station columns of the three data frames in the Western Kenya data.

@shadrackkibet I have added to our functionality for getting columns from different data frames. It shouldn't affect how this works in existing climatic dialogs but please check.