### PR TITLE
Picsagraphs

### DIFF
--- a/instat/dlgPICSARainfall.vb
+++ b/instat/dlgPICSARainfall.vb
@@ -43,6 +43,8 @@ Public Class dlgPICSARainfall
     Private clsFactorLevels As New RFunction
     Private FactorLevel As RDotNet.SymbolicExpression
 
+    Private clsDatePeriodOperator As New ROperator
+
     Private clsMeanFunction As New RFunction
     Private clsMedianFunction As New RFunction
     Private clsLowerTercileFunction As New RFunction
@@ -157,6 +159,8 @@ Public Class dlgPICSARainfall
         clsGeomHlineUpperTercile = New RFunction
         clsGeomHlineAesUpperTercile = New RFunction
         clsUpperTercileFunction = New RFunction
+
+        clsDatePeriodOperator = New ROperator
 
         clsAsDate = New RFunction
         clsAsNumeric = New RFunction
@@ -318,6 +322,10 @@ Public Class dlgPICSARainfall
         clsAsDate.SetRCommand("as.Date")
         clsAsDate.AddParameter("origin", Chr(34) & "2015-12-31" & Chr(34), iPosition:=1)
 
+        clsDatePeriodOperator.SetOperation(" ")
+        clsDatePeriodOperator.bSpaceAroundOperation = False
+        clsDatePeriodOperator.bToScriptAsRString = True
+
         clsAsNumeric.SetRCommand("as.numeric")
         clsAsNumericX.SetRCommand("as.numeric")
 
@@ -372,7 +380,7 @@ Public Class dlgPICSARainfall
 
     'add more functions 
     Private Sub cmdPICSAOptions_Click(sender As Object, e As EventArgs) Handles cmdPICSAOptions.Click
-        sdgPICSARainfallGraph.SetRCode(clsNewOperator:=ucrBase.clsRsyntax.clsBaseOperator, dctNewThemeFunctions:=dctThemeFunctions, clsNewLabsFunction:=clsLabsFunction, clsNewThemeFunction:=clsThemeFunction, clsNewXScaleContinuousFunction:=clsXScalecontinuousFunction, clsNewYScaleContinuousFunction:=clsYScalecontinuousFunction, clsNewGeomhlineMean:=clsGeomHlineMean, clsNewGeomhlineMedian:=clsGeomHlineMedian, clsNewGeomhlineLowerTercile:=clsGeomHlineLowerTercile, clsNewGeomhlineUpperTercile:=clsGeomHlineUpperTercile, clsNewXLabsFunction:=clsXLabsFunction, clsNewYLabsFunction:=clsYLabsFunction, clsNewRaesFunction:=clsRaesFunction, clsNewAsDate:=clsAsDate, clsNewAsNumeric:=clsAsNumeric, clsNewYScaleDateFunction:=clsYScaleDateFunction, bReset:=bResetSubdialog)
+        sdgPICSARainfallGraph.SetRCode(clsNewOperator:=ucrBase.clsRsyntax.clsBaseOperator, dctNewThemeFunctions:=dctThemeFunctions, clsNewLabsFunction:=clsLabsFunction, clsNewThemeFunction:=clsThemeFunction, clsNewXScaleContinuousFunction:=clsXScalecontinuousFunction, clsNewYScaleContinuousFunction:=clsYScalecontinuousFunction, clsNewGeomhlineMean:=clsGeomHlineMean, clsNewGeomhlineMedian:=clsGeomHlineMedian, clsNewGeomhlineLowerTercile:=clsGeomHlineLowerTercile, clsNewGeomhlineUpperTercile:=clsGeomHlineUpperTercile, clsNewXLabsFunction:=clsXLabsFunction, clsNewYLabsFunction:=clsYLabsFunction, clsNewRaesFunction:=clsRaesFunction, clsNewAsDate:=clsAsDate, clsNewAsNumeric:=clsAsNumeric, clsNewYScaleDateFunction:=clsYScaleDateFunction, clsNewDatePeriodOperator:=clsDatePeriodOperator, bReset:=bResetSubdialog)
         sdgPICSARainfallGraph.ShowDialog()
         bResetSubdialog = False
     End Sub

--- a/instat/sdgPICSARainfallGraph.Designer.vb
+++ b/instat/sdgPICSARainfallGraph.Designer.vb
@@ -71,6 +71,9 @@ Partial Class sdgPICSARainfallGraph
         Me.ucrInputXTo = New instat.ucrInputTextBox()
         Me.ucrNudXAxisAngle = New instat.ucrNud()
         Me.grpYAxisLabels = New System.Windows.Forms.GroupBox()
+        Me.ucrNudDateBreakNumber = New instat.ucrNud()
+        Me.ucrInputDateBreakTime = New instat.ucrInputComboBox()
+        Me.ucrChkSpecifyDateBreaks = New instat.ucrCheck()
         Me.ucrInputLabelForDays = New instat.ucrInputComboBox()
         Me.ucrNudYAxisAngle = New instat.ucrNud()
         Me.ucrChkLabelForDays = New instat.ucrCheck()
@@ -500,6 +503,9 @@ Partial Class sdgPICSARainfallGraph
         '
         'grpYAxisLabels
         '
+        Me.grpYAxisLabels.Controls.Add(Me.ucrNudDateBreakNumber)
+        Me.grpYAxisLabels.Controls.Add(Me.ucrInputDateBreakTime)
+        Me.grpYAxisLabels.Controls.Add(Me.ucrChkSpecifyDateBreaks)
         Me.grpYAxisLabels.Controls.Add(Me.ucrInputLabelForDays)
         Me.grpYAxisLabels.Controls.Add(Me.ucrNudYAxisAngle)
         Me.grpYAxisLabels.Controls.Add(Me.ucrChkLabelForDays)
@@ -516,6 +522,29 @@ Partial Class sdgPICSARainfallGraph
         resources.ApplyResources(Me.grpYAxisLabels, "grpYAxisLabels")
         Me.grpYAxisLabels.Name = "grpYAxisLabels"
         Me.grpYAxisLabels.TabStop = False
+        '
+        'ucrNudDateBreakNumber
+        '
+        Me.ucrNudDateBreakNumber.DecimalPlaces = New Decimal(New Integer() {0, 0, 0, 0})
+        Me.ucrNudDateBreakNumber.Increment = New Decimal(New Integer() {1, 0, 0, 0})
+        resources.ApplyResources(Me.ucrNudDateBreakNumber, "ucrNudDateBreakNumber")
+        Me.ucrNudDateBreakNumber.Maximum = New Decimal(New Integer() {100, 0, 0, 0})
+        Me.ucrNudDateBreakNumber.Minimum = New Decimal(New Integer() {0, 0, 0, 0})
+        Me.ucrNudDateBreakNumber.Name = "ucrNudDateBreakNumber"
+        Me.ucrNudDateBreakNumber.Value = New Decimal(New Integer() {0, 0, 0, 0})
+        '
+        'ucrInputDateBreakTime
+        '
+        Me.ucrInputDateBreakTime.AddQuotesIfUnrecognised = True
+        Me.ucrInputDateBreakTime.IsReadOnly = False
+        resources.ApplyResources(Me.ucrInputDateBreakTime, "ucrInputDateBreakTime")
+        Me.ucrInputDateBreakTime.Name = "ucrInputDateBreakTime"
+        '
+        'ucrChkSpecifyDateBreaks
+        '
+        Me.ucrChkSpecifyDateBreaks.Checked = False
+        resources.ApplyResources(Me.ucrChkSpecifyDateBreaks, "ucrChkSpecifyDateBreaks")
+        Me.ucrChkSpecifyDateBreaks.Name = "ucrChkSpecifyDateBreaks"
         '
         'ucrInputLabelForDays
         '
@@ -1016,4 +1045,7 @@ Partial Class sdgPICSARainfallGraph
     Friend WithEvents Label1 As Label
     Friend WithEvents lblXAxisTitleSize As Label
     Friend WithEvents ucrChkXAxisAngle As ucrCheck
+    Friend WithEvents ucrChkSpecifyDateBreaks As ucrCheck
+    Friend WithEvents ucrNudDateBreakNumber As ucrNud
+    Friend WithEvents ucrInputDateBreakTime As ucrInputComboBox
 End Class

--- a/instat/sdgPICSARainfallGraph.resx
+++ b/instat/sdgPICSARainfallGraph.resx
@@ -148,7 +148,7 @@
     <value>grpYAxisLabels</value>
   </data>
   <data name="&gt;&gt;lblYInStepsOf.ZOrder" xml:space="preserve">
-    <value>11</value>
+    <value>14</value>
   </data>
   <data name="lblYFrom.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -178,7 +178,7 @@
     <value>grpYAxisLabels</value>
   </data>
   <data name="&gt;&gt;lblYFrom.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>10</value>
   </data>
   <data name="lblYTo.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -208,7 +208,7 @@
     <value>grpYAxisLabels</value>
   </data>
   <data name="&gt;&gt;lblYTo.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>13</value>
   </data>
   <data name="lblXTo.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1263,6 +1263,69 @@
   <data name="&gt;&gt;grpXAxisLabels.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
+  <data name="ucrNudDateBreakNumber.Location" type="System.Drawing.Point, System.Drawing">
+    <value>357, 56</value>
+  </data>
+  <data name="ucrNudDateBreakNumber.Size" type="System.Drawing.Size, System.Drawing">
+    <value>50, 20</value>
+  </data>
+  <data name="ucrNudDateBreakNumber.TabIndex" type="System.Int32, mscorlib">
+    <value>36</value>
+  </data>
+  <data name="&gt;&gt;ucrNudDateBreakNumber.Name" xml:space="preserve">
+    <value>ucrNudDateBreakNumber</value>
+  </data>
+  <data name="&gt;&gt;ucrNudDateBreakNumber.Type" xml:space="preserve">
+    <value>instat.ucrNud, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrNudDateBreakNumber.Parent" xml:space="preserve">
+    <value>grpYAxisLabels</value>
+  </data>
+  <data name="&gt;&gt;ucrNudDateBreakNumber.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="ucrInputDateBreakTime.Location" type="System.Drawing.Point, System.Drawing">
+    <value>414, 55</value>
+  </data>
+  <data name="ucrInputDateBreakTime.Size" type="System.Drawing.Size, System.Drawing">
+    <value>70, 21</value>
+  </data>
+  <data name="ucrInputDateBreakTime.TabIndex" type="System.Int32, mscorlib">
+    <value>35</value>
+  </data>
+  <data name="&gt;&gt;ucrInputDateBreakTime.Name" xml:space="preserve">
+    <value>ucrInputDateBreakTime</value>
+  </data>
+  <data name="&gt;&gt;ucrInputDateBreakTime.Type" xml:space="preserve">
+    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrInputDateBreakTime.Parent" xml:space="preserve">
+    <value>grpYAxisLabels</value>
+  </data>
+  <data name="&gt;&gt;ucrInputDateBreakTime.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="ucrChkSpecifyDateBreaks.Location" type="System.Drawing.Point, System.Drawing">
+    <value>251, 55</value>
+  </data>
+  <data name="ucrChkSpecifyDateBreaks.Size" type="System.Drawing.Size, System.Drawing">
+    <value>100, 20</value>
+  </data>
+  <data name="ucrChkSpecifyDateBreaks.TabIndex" type="System.Int32, mscorlib">
+    <value>34</value>
+  </data>
+  <data name="&gt;&gt;ucrChkSpecifyDateBreaks.Name" xml:space="preserve">
+    <value>ucrChkSpecifyDateBreaks</value>
+  </data>
+  <data name="&gt;&gt;ucrChkSpecifyDateBreaks.Type" xml:space="preserve">
+    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrChkSpecifyDateBreaks.Parent" xml:space="preserve">
+    <value>grpYAxisLabels</value>
+  </data>
+  <data name="&gt;&gt;ucrChkSpecifyDateBreaks.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
   <data name="ucrInputLabelForDays.Location" type="System.Drawing.Point, System.Drawing">
     <value>126, 55</value>
   </data>
@@ -1282,7 +1345,7 @@
     <value>grpYAxisLabels</value>
   </data>
   <data name="&gt;&gt;ucrInputLabelForDays.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>3</value>
   </data>
   <data name="ucrNudYAxisAngle.Location" type="System.Drawing.Point, System.Drawing">
     <value>126, 89</value>
@@ -1303,13 +1366,13 @@
     <value>grpYAxisLabels</value>
   </data>
   <data name="&gt;&gt;ucrNudYAxisAngle.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>4</value>
   </data>
   <data name="ucrChkLabelForDays.Location" type="System.Drawing.Point, System.Drawing">
     <value>6, 55</value>
   </data>
   <data name="ucrChkLabelForDays.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 20</value>
+    <value>111, 20</value>
   </data>
   <data name="ucrChkLabelForDays.TabIndex" type="System.Int32, mscorlib">
     <value>31</value>
@@ -1324,13 +1387,13 @@
     <value>grpYAxisLabels</value>
   </data>
   <data name="&gt;&gt;ucrChkLabelForDays.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>5</value>
   </data>
   <data name="ucrChkYAxisAngle.Location" type="System.Drawing.Point, System.Drawing">
     <value>6, 89</value>
   </data>
   <data name="ucrChkYAxisAngle.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 20</value>
+    <value>111, 20</value>
   </data>
   <data name="ucrChkYAxisAngle.TabIndex" type="System.Int32, mscorlib">
     <value>32</value>
@@ -1345,7 +1408,7 @@
     <value>grpYAxisLabels</value>
   </data>
   <data name="&gt;&gt;ucrChkYAxisAngle.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>6</value>
   </data>
   <data name="ucrChkYAxisLabelSize.Location" type="System.Drawing.Point, System.Drawing">
     <value>251, 89</value>
@@ -1366,13 +1429,13 @@
     <value>grpYAxisLabels</value>
   </data>
   <data name="&gt;&gt;ucrChkYAxisLabelSize.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>7</value>
   </data>
   <data name="ucrChkSpecifyYAxisTickMarks.Location" type="System.Drawing.Point, System.Drawing">
     <value>6, 21</value>
   </data>
   <data name="ucrChkSpecifyYAxisTickMarks.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 20</value>
+    <value>111, 20</value>
   </data>
   <data name="ucrChkSpecifyYAxisTickMarks.TabIndex" type="System.Int32, mscorlib">
     <value>29</value>
@@ -1387,7 +1450,7 @@
     <value>grpYAxisLabels</value>
   </data>
   <data name="&gt;&gt;ucrChkSpecifyYAxisTickMarks.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>8</value>
   </data>
   <data name="ucrInputYFrom.Location" type="System.Drawing.Point, System.Drawing">
     <value>160, 21</value>
@@ -1408,7 +1471,7 @@
     <value>grpYAxisLabels</value>
   </data>
   <data name="&gt;&gt;ucrInputYFrom.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>9</value>
   </data>
   <data name="ucrNudYAxisLabelSize.Location" type="System.Drawing.Point, System.Drawing">
     <value>357, 89</value>
@@ -1429,7 +1492,7 @@
     <value>grpYAxisLabels</value>
   </data>
   <data name="&gt;&gt;ucrNudYAxisLabelSize.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>11</value>
   </data>
   <data name="ucrInputYTo.Location" type="System.Drawing.Point, System.Drawing">
     <value>275, 21</value>
@@ -1450,7 +1513,7 @@
     <value>grpYAxisLabels</value>
   </data>
   <data name="&gt;&gt;ucrInputYTo.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>12</value>
   </data>
   <data name="ucrInputYInStepsOf.Location" type="System.Drawing.Point, System.Drawing">
     <value>434, 21</value>
@@ -1471,7 +1534,7 @@
     <value>grpYAxisLabels</value>
   </data>
   <data name="&gt;&gt;ucrInputYInStepsOf.ZOrder" xml:space="preserve">
-    <value>12</value>
+    <value>15</value>
   </data>
   <data name="grpYAxisLabels.Location" type="System.Drawing.Point, System.Drawing">
     <value>6, 120</value>


### PR DESCRIPTION
@maxwellfundi @rdstern thanks for testing, please check the latest version:

- added `na.rm` to summary functions for hlines
- hline checkboxes reset correctly
- hline labels checkboxes disabled as not yet implemented
- y axis label blank by default to prevent strange auto label when plotting dates
- x axis angle displays 90 by default correctly
- panel border colour linked correctly
- added option to specify date breaks