### PR TITLE
Clearing the previously selected columns on reopen in the sort dialog.

### DIFF
--- a/instat/dlgSort.Designer.vb
+++ b/instat/dlgSort.Designer.vb
@@ -125,6 +125,7 @@ Partial Class dlgSort
         '
         'ucrSelectForSort
         '
+        Me.ucrSelectForSort.bDropUnusedFilterLevels = False
         Me.ucrSelectForSort.bShowHiddenColumns = False
         Me.ucrSelectForSort.bUseCurrentFilter = True
         resources.ApplyResources(Me.ucrSelectForSort, "ucrSelectForSort")

--- a/instat/dlgSort.vb
+++ b/instat/dlgSort.vb
@@ -91,7 +91,7 @@ Public Class dlgSort
     End Sub
 
     Private Sub SetDefaultColumn()
-        ClearReceiver
+        ucrReceiverSort.Clear()
         ucrSelectForSort.ucrAvailableDataFrames.cboAvailableDataFrames.SelectedItem = strSelectedDataFrame
         ucrReceiverSort.Add(strSelectedColumn, strSelectedDataFrame)
         bUseSelectedColumn = False
@@ -119,10 +119,6 @@ Public Class dlgSort
 
     Private Sub CoreControls_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrReceiverSort.ControlContentsChanged
         TestOKEnabled()
-    End Sub
-
-    Private Sub ClearReceiver()
-        ucrReceiverSort.Clear()
     End Sub
 
 End Class

--- a/instat/dlgSort.vb
+++ b/instat/dlgSort.vb
@@ -38,7 +38,6 @@ Public Class dlgSort
         End If
         SetRCodeForControls(bReset)
         bReset = False
-        Reopen()
         If bUseSelectedColumn Then
             SetDefaultColumn()
         End If
@@ -92,6 +91,7 @@ Public Class dlgSort
     End Sub
 
     Private Sub SetDefaultColumn()
+        ClearReceiver
         ucrSelectForSort.ucrAvailableDataFrames.cboAvailableDataFrames.SelectedItem = strSelectedDataFrame
         ucrReceiverSort.Add(strSelectedColumn, strSelectedDataFrame)
         bUseSelectedColumn = False
@@ -121,7 +121,7 @@ Public Class dlgSort
         TestOKEnabled()
     End Sub
 
-    Private Sub Reopen()
+    Private Sub ClearReceiver()
         ucrReceiverSort.Clear()
     End Sub
 

--- a/instat/dlgSort.vb
+++ b/instat/dlgSort.vb
@@ -38,6 +38,7 @@ Public Class dlgSort
         End If
         SetRCodeForControls(bReset)
         bReset = False
+        Reopen()
         If bUseSelectedColumn Then
             SetDefaultColumn()
         End If
@@ -119,4 +120,9 @@ Public Class dlgSort
     Private Sub CoreControls_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrReceiverSort.ControlContentsChanged
         TestOKEnabled()
     End Sub
+
+    Private Sub Reopen()
+        ucrReceiverSort.Clear()
+    End Sub
+
 End Class


### PR DESCRIPTION
This fixes issue #5048. @africanmathsinitiative/developers this is ready for review.