### PR TITLE
Create Survival Object dialog

### DIFF
--- a/instat/dlgSurvivalObject.Designer.vb
+++ b/instat/dlgSurvivalObject.Designer.vb
@@ -32,6 +32,7 @@ Partial Class dlgSurvivalObject
         Me.rdoCounting = New System.Windows.Forms.RadioButton()
         Me.rdoMstate = New System.Windows.Forms.RadioButton()
         Me.rdoInterval2 = New System.Windows.Forms.RadioButton()
+        Me.ucrInputOrigin = New instat.ucrInputTextBox()
         Me.ucrPnlType = New instat.UcrPanel()
         Me.ucrSaveObject = New instat.ucrSave()
         Me.ucrReceiverEvent = New instat.ucrReceiverSingle()
@@ -39,7 +40,10 @@ Partial Class dlgSurvivalObject
         Me.ucrReceiverTime1 = New instat.ucrReceiverSingle()
         Me.ucrSelectorFitObject = New instat.ucrSelectorByDataFrameAddRemove()
         Me.ucrBase = New instat.ucrButtons()
-        Me.ucrInputOrigin = New instat.ucrInputTextBox()
+        Me.ucrChkModifyEvent = New instat.ucrCheck()
+        Me.ucrModifyEventNumeric = New instat.ucrInputTextBox()
+        Me.lblSelectLevels = New System.Windows.Forms.Label()
+        Me.ucrModifyEventFactor = New instat.ucrFactor()
         Me.SuspendLayout()
         '
         'lblEntryTime
@@ -68,7 +72,7 @@ Partial Class dlgSurvivalObject
         '
         'lblOrigin
         '
-        Me.lblOrigin.Location = New System.Drawing.Point(281, 201)
+        Me.lblOrigin.Location = New System.Drawing.Point(281, 213)
         Me.lblOrigin.Name = "lblOrigin"
         Me.lblOrigin.Size = New System.Drawing.Size(83, 15)
         Me.lblOrigin.TabIndex = 9
@@ -176,6 +180,16 @@ Partial Class dlgSurvivalObject
         Me.rdoInterval2.TextAlign = System.Drawing.ContentAlignment.MiddleRight
         Me.rdoInterval2.UseVisualStyleBackColor = True
         '
+        'ucrInputOrigin
+        '
+        Me.ucrInputOrigin.AddQuotesIfUnrecognised = True
+        Me.ucrInputOrigin.IsMultiline = False
+        Me.ucrInputOrigin.IsReadOnly = False
+        Me.ucrInputOrigin.Location = New System.Drawing.Point(281, 231)
+        Me.ucrInputOrigin.Name = "ucrInputOrigin"
+        Me.ucrInputOrigin.Size = New System.Drawing.Size(73, 21)
+        Me.ucrInputOrigin.TabIndex = 21
+        '
         'ucrPnlType
         '
         Me.ucrPnlType.Location = New System.Drawing.Point(0, 10)
@@ -244,21 +258,55 @@ Partial Class dlgSurvivalObject
         Me.ucrBase.Size = New System.Drawing.Size(410, 52)
         Me.ucrBase.TabIndex = 12
         '
-        'ucrInputOrigin
+        'ucrChkModifyEvent
         '
-        Me.ucrInputOrigin.AddQuotesIfUnrecognised = True
-        Me.ucrInputOrigin.IsMultiline = False
-        Me.ucrInputOrigin.IsReadOnly = False
-        Me.ucrInputOrigin.Location = New System.Drawing.Point(281, 219)
-        Me.ucrInputOrigin.Name = "ucrInputOrigin"
-        Me.ucrInputOrigin.Size = New System.Drawing.Size(73, 21)
-        Me.ucrInputOrigin.TabIndex = 21
+        Me.ucrChkModifyEvent.Checked = False
+        Me.ucrChkModifyEvent.Location = New System.Drawing.Point(319, 193)
+        Me.ucrChkModifyEvent.Name = "ucrChkModifyEvent"
+        Me.ucrChkModifyEvent.Size = New System.Drawing.Size(100, 20)
+        Me.ucrChkModifyEvent.TabIndex = 22
+        '
+        'ucrModifyEventNumeric
+        '
+        Me.ucrModifyEventNumeric.AddQuotesIfUnrecognised = True
+        Me.ucrModifyEventNumeric.IsMultiline = False
+        Me.ucrModifyEventNumeric.IsReadOnly = False
+        Me.ucrModifyEventNumeric.Location = New System.Drawing.Point(440, 213)
+        Me.ucrModifyEventNumeric.Name = "ucrModifyEventNumeric"
+        Me.ucrModifyEventNumeric.Size = New System.Drawing.Size(120, 26)
+        Me.ucrModifyEventNumeric.TabIndex = 25
+        '
+        'lblSelectLevels
+        '
+        Me.lblSelectLevels.AutoSize = True
+        Me.lblSelectLevels.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.lblSelectLevels.Location = New System.Drawing.Point(439, 197)
+        Me.lblSelectLevels.Name = "lblSelectLevels"
+        Me.lblSelectLevels.Size = New System.Drawing.Size(176, 13)
+        Me.lblSelectLevels.TabIndex = 24
+        Me.lblSelectLevels.Text = "Event occurs when variable equals:"
+        '
+        'ucrModifyEventFactor
+        '
+        Me.ucrModifyEventFactor.AutoSize = True
+        Me.ucrModifyEventFactor.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
+        Me.ucrModifyEventFactor.clsReceiver = Nothing
+        Me.ucrModifyEventFactor.Location = New System.Drawing.Point(440, 213)
+        Me.ucrModifyEventFactor.Name = "ucrModifyEventFactor"
+        Me.ucrModifyEventFactor.shtCurrSheet = Nothing
+        Me.ucrModifyEventFactor.Size = New System.Drawing.Size(197, 116)
+        Me.ucrModifyEventFactor.TabIndex = 23
+        Me.ucrModifyEventFactor.ucrChkLevels = Nothing
         '
         'dlgSurvivalObject
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
-        Me.ClientSize = New System.Drawing.Size(431, 334)
+        Me.ClientSize = New System.Drawing.Size(646, 339)
+        Me.Controls.Add(Me.ucrModifyEventNumeric)
+        Me.Controls.Add(Me.lblSelectLevels)
+        Me.Controls.Add(Me.ucrModifyEventFactor)
+        Me.Controls.Add(Me.ucrChkModifyEvent)
         Me.Controls.Add(Me.ucrInputOrigin)
         Me.Controls.Add(Me.rdoMstate)
         Me.Controls.Add(Me.rdoInterval2)
@@ -284,6 +332,7 @@ Partial Class dlgSurvivalObject
         Me.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen
         Me.Text = "Create Survival Object"
         Me.ResumeLayout(False)
+        Me.PerformLayout()
 
     End Sub
     Friend WithEvents ucrReceiverTime2 As ucrReceiverSingle
@@ -304,4 +353,8 @@ Partial Class dlgSurvivalObject
     Friend WithEvents rdoRight As RadioButton
     Friend WithEvents ucrPnlType As UcrPanel
     Friend WithEvents ucrInputOrigin As ucrInputTextBox
+    Friend WithEvents ucrChkModifyEvent As ucrCheck
+    Friend WithEvents ucrModifyEventNumeric As ucrInputTextBox
+    Friend WithEvents lblSelectLevels As Label
+    Friend WithEvents ucrModifyEventFactor As ucrFactor
 End Class

--- a/instat/dlgSurvivalObject.Designer.vb
+++ b/instat/dlgSurvivalObject.Designer.vb
@@ -1,9 +1,9 @@
-﻿<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()> _
+﻿<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()>
 Partial Class dlgSurvivalObject
     Inherits System.Windows.Forms.Form
 
     'Form overrides dispose to clean up the component list.
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Protected Overrides Sub Dispose(ByVal disposing As Boolean)
         Try
             If disposing AndAlso components IsNot Nothing Then
@@ -20,15 +20,263 @@ Partial Class dlgSurvivalObject
     'NOTE: The following procedure is required by the Windows Form Designer
     'It can be modified using the Windows Form Designer.  
     'Do not modify it using the code editor.
-    <System.Diagnostics.DebuggerStepThrough()> _
+    <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
+        Me.lblEntryTime = New System.Windows.Forms.Label()
+        Me.lblExitTime2 = New System.Windows.Forms.Label()
+        Me.lblEvent = New System.Windows.Forms.Label()
+        Me.lblOrigin = New System.Windows.Forms.Label()
+        Me.rdoRight = New System.Windows.Forms.RadioButton()
+        Me.rdoLeft = New System.Windows.Forms.RadioButton()
+        Me.rdoInterval = New System.Windows.Forms.RadioButton()
+        Me.rdoCounting = New System.Windows.Forms.RadioButton()
+        Me.rdoMstate = New System.Windows.Forms.RadioButton()
+        Me.rdoInterval2 = New System.Windows.Forms.RadioButton()
+        Me.ucrPnlType = New instat.UcrPanel()
+        Me.ucrSaveObject = New instat.ucrSave()
+        Me.ucrReceiverEvent = New instat.ucrReceiverSingle()
+        Me.ucrReceiverTime2 = New instat.ucrReceiverSingle()
+        Me.ucrReceiverTime1 = New instat.ucrReceiverSingle()
+        Me.ucrSelectorFitObject = New instat.ucrSelectorByDataFrameAddRemove()
+        Me.ucrBase = New instat.ucrButtons()
+        Me.ucrInputOrigin = New instat.ucrInputTextBox()
         Me.SuspendLayout()
+        '
+        'lblEntryTime
+        '
+        Me.lblEntryTime.Location = New System.Drawing.Point(281, 60)
+        Me.lblEntryTime.Name = "lblEntryTime"
+        Me.lblEntryTime.Size = New System.Drawing.Size(83, 15)
+        Me.lblEntryTime.TabIndex = 1
+        Me.lblEntryTime.Text = "Entry Time:"
+        '
+        'lblExitTime2
+        '
+        Me.lblExitTime2.Location = New System.Drawing.Point(281, 107)
+        Me.lblExitTime2.Name = "lblExitTime2"
+        Me.lblExitTime2.Size = New System.Drawing.Size(83, 15)
+        Me.lblExitTime2.TabIndex = 3
+        Me.lblExitTime2.Text = "Exit Time:"
+        '
+        'lblEvent
+        '
+        Me.lblEvent.Location = New System.Drawing.Point(281, 154)
+        Me.lblEvent.Name = "lblEvent"
+        Me.lblEvent.Size = New System.Drawing.Size(83, 15)
+        Me.lblEvent.TabIndex = 5
+        Me.lblEvent.Text = "Event:"
+        '
+        'lblOrigin
+        '
+        Me.lblOrigin.Location = New System.Drawing.Point(281, 201)
+        Me.lblOrigin.Name = "lblOrigin"
+        Me.lblOrigin.Size = New System.Drawing.Size(83, 15)
+        Me.lblOrigin.TabIndex = 9
+        Me.lblOrigin.Text = "Origin:"
+        '
+        'rdoRight
+        '
+        Me.rdoRight.Appearance = System.Windows.Forms.Appearance.Button
+        Me.rdoRight.FlatAppearance.BorderColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoRight.FlatAppearance.BorderSize = 2
+        Me.rdoRight.FlatAppearance.CheckedBackColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoRight.FlatStyle = System.Windows.Forms.FlatStyle.Flat
+        Me.rdoRight.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.rdoRight.Location = New System.Drawing.Point(7, 14)
+        Me.rdoRight.Name = "rdoRight"
+        Me.rdoRight.Size = New System.Drawing.Size(71, 27)
+        Me.rdoRight.TabIndex = 14
+        Me.rdoRight.TabStop = True
+        Me.rdoRight.Text = "Right"
+        Me.rdoRight.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
+        Me.rdoRight.UseVisualStyleBackColor = True
+        '
+        'rdoLeft
+        '
+        Me.rdoLeft.Appearance = System.Windows.Forms.Appearance.Button
+        Me.rdoLeft.FlatAppearance.BorderColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoLeft.FlatAppearance.BorderSize = 2
+        Me.rdoLeft.FlatAppearance.CheckedBackColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoLeft.FlatStyle = System.Windows.Forms.FlatStyle.Flat
+        Me.rdoLeft.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.rdoLeft.Location = New System.Drawing.Point(76, 14)
+        Me.rdoLeft.Name = "rdoLeft"
+        Me.rdoLeft.Size = New System.Drawing.Size(71, 27)
+        Me.rdoLeft.TabIndex = 16
+        Me.rdoLeft.TabStop = True
+        Me.rdoLeft.Text = "Left"
+        Me.rdoLeft.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
+        Me.rdoLeft.UseVisualStyleBackColor = True
+        '
+        'rdoInterval
+        '
+        Me.rdoInterval.Appearance = System.Windows.Forms.Appearance.Button
+        Me.rdoInterval.FlatAppearance.BorderColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoInterval.FlatAppearance.BorderSize = 2
+        Me.rdoInterval.FlatAppearance.CheckedBackColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoInterval.FlatStyle = System.Windows.Forms.FlatStyle.Flat
+        Me.rdoInterval.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.rdoInterval.Location = New System.Drawing.Point(214, 14)
+        Me.rdoInterval.Name = "rdoInterval"
+        Me.rdoInterval.Size = New System.Drawing.Size(71, 27)
+        Me.rdoInterval.TabIndex = 18
+        Me.rdoInterval.TabStop = True
+        Me.rdoInterval.Text = "Interval"
+        Me.rdoInterval.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
+        Me.rdoInterval.UseVisualStyleBackColor = True
+        '
+        'rdoCounting
+        '
+        Me.rdoCounting.Appearance = System.Windows.Forms.Appearance.Button
+        Me.rdoCounting.FlatAppearance.BorderColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoCounting.FlatAppearance.BorderSize = 2
+        Me.rdoCounting.FlatAppearance.CheckedBackColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoCounting.FlatStyle = System.Windows.Forms.FlatStyle.Flat
+        Me.rdoCounting.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.rdoCounting.Location = New System.Drawing.Point(145, 14)
+        Me.rdoCounting.Name = "rdoCounting"
+        Me.rdoCounting.Size = New System.Drawing.Size(71, 27)
+        Me.rdoCounting.TabIndex = 17
+        Me.rdoCounting.TabStop = True
+        Me.rdoCounting.Text = "Counting Process"
+        Me.rdoCounting.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
+        Me.rdoCounting.UseVisualStyleBackColor = True
+        '
+        'rdoMstate
+        '
+        Me.rdoMstate.Appearance = System.Windows.Forms.Appearance.Button
+        Me.rdoMstate.FlatAppearance.BorderColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoMstate.FlatAppearance.BorderSize = 2
+        Me.rdoMstate.FlatAppearance.CheckedBackColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoMstate.FlatStyle = System.Windows.Forms.FlatStyle.Flat
+        Me.rdoMstate.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.rdoMstate.Location = New System.Drawing.Point(352, 14)
+        Me.rdoMstate.Name = "rdoMstate"
+        Me.rdoMstate.Size = New System.Drawing.Size(71, 27)
+        Me.rdoMstate.TabIndex = 20
+        Me.rdoMstate.TabStop = True
+        Me.rdoMstate.Text = "Multistate"
+        Me.rdoMstate.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
+        Me.rdoMstate.UseVisualStyleBackColor = True
+        '
+        'rdoInterval2
+        '
+        Me.rdoInterval2.Appearance = System.Windows.Forms.Appearance.Button
+        Me.rdoInterval2.FlatAppearance.BorderColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoInterval2.FlatAppearance.BorderSize = 2
+        Me.rdoInterval2.FlatAppearance.CheckedBackColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoInterval2.FlatStyle = System.Windows.Forms.FlatStyle.Flat
+        Me.rdoInterval2.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.rdoInterval2.Location = New System.Drawing.Point(283, 14)
+        Me.rdoInterval2.Name = "rdoInterval2"
+        Me.rdoInterval2.Size = New System.Drawing.Size(71, 27)
+        Me.rdoInterval2.TabIndex = 19
+        Me.rdoInterval2.TabStop = True
+        Me.rdoInterval2.Text = "Interval2"
+        Me.rdoInterval2.TextAlign = System.Drawing.ContentAlignment.MiddleRight
+        Me.rdoInterval2.UseVisualStyleBackColor = True
+        '
+        'ucrPnlType
+        '
+        Me.ucrPnlType.Location = New System.Drawing.Point(0, 10)
+        Me.ucrPnlType.Name = "ucrPnlType"
+        Me.ucrPnlType.Size = New System.Drawing.Size(437, 36)
+        Me.ucrPnlType.TabIndex = 13
+        '
+        'ucrSaveObject
+        '
+        Me.ucrSaveObject.Location = New System.Drawing.Point(10, 247)
+        Me.ucrSaveObject.Name = "ucrSaveObject"
+        Me.ucrSaveObject.Size = New System.Drawing.Size(266, 24)
+        Me.ucrSaveObject.TabIndex = 11
+        '
+        'ucrReceiverEvent
+        '
+        Me.ucrReceiverEvent.frmParent = Me
+        Me.ucrReceiverEvent.Location = New System.Drawing.Point(281, 170)
+        Me.ucrReceiverEvent.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrReceiverEvent.Name = "ucrReceiverEvent"
+        Me.ucrReceiverEvent.Selector = Nothing
+        Me.ucrReceiverEvent.Size = New System.Drawing.Size(120, 20)
+        Me.ucrReceiverEvent.strNcFilePath = ""
+        Me.ucrReceiverEvent.TabIndex = 6
+        Me.ucrReceiverEvent.ucrSelector = Nothing
+        '
+        'ucrReceiverTime2
+        '
+        Me.ucrReceiverTime2.frmParent = Me
+        Me.ucrReceiverTime2.Location = New System.Drawing.Point(281, 123)
+        Me.ucrReceiverTime2.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrReceiverTime2.Name = "ucrReceiverTime2"
+        Me.ucrReceiverTime2.Selector = Nothing
+        Me.ucrReceiverTime2.Size = New System.Drawing.Size(120, 20)
+        Me.ucrReceiverTime2.strNcFilePath = ""
+        Me.ucrReceiverTime2.TabIndex = 4
+        Me.ucrReceiverTime2.ucrSelector = Nothing
+        '
+        'ucrReceiverTime1
+        '
+        Me.ucrReceiverTime1.frmParent = Me
+        Me.ucrReceiverTime1.Location = New System.Drawing.Point(281, 76)
+        Me.ucrReceiverTime1.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrReceiverTime1.Name = "ucrReceiverTime1"
+        Me.ucrReceiverTime1.Selector = Nothing
+        Me.ucrReceiverTime1.Size = New System.Drawing.Size(120, 20)
+        Me.ucrReceiverTime1.strNcFilePath = ""
+        Me.ucrReceiverTime1.TabIndex = 2
+        Me.ucrReceiverTime1.ucrSelector = Nothing
+        '
+        'ucrSelectorFitObject
+        '
+        Me.ucrSelectorFitObject.bDropUnusedFilterLevels = False
+        Me.ucrSelectorFitObject.bShowHiddenColumns = False
+        Me.ucrSelectorFitObject.bUseCurrentFilter = True
+        Me.ucrSelectorFitObject.Location = New System.Drawing.Point(9, 49)
+        Me.ucrSelectorFitObject.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrSelectorFitObject.Name = "ucrSelectorFitObject"
+        Me.ucrSelectorFitObject.Size = New System.Drawing.Size(210, 180)
+        Me.ucrSelectorFitObject.TabIndex = 0
+        '
+        'ucrBase
+        '
+        Me.ucrBase.Location = New System.Drawing.Point(9, 277)
+        Me.ucrBase.Name = "ucrBase"
+        Me.ucrBase.Size = New System.Drawing.Size(410, 52)
+        Me.ucrBase.TabIndex = 12
+        '
+        'ucrInputOrigin
+        '
+        Me.ucrInputOrigin.AddQuotesIfUnrecognised = True
+        Me.ucrInputOrigin.IsMultiline = False
+        Me.ucrInputOrigin.IsReadOnly = False
+        Me.ucrInputOrigin.Location = New System.Drawing.Point(281, 219)
+        Me.ucrInputOrigin.Name = "ucrInputOrigin"
+        Me.ucrInputOrigin.Size = New System.Drawing.Size(73, 21)
+        Me.ucrInputOrigin.TabIndex = 21
         '
         'dlgSurvivalObject
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
-        Me.ClientSize = New System.Drawing.Size(462, 372)
+        Me.ClientSize = New System.Drawing.Size(431, 334)
+        Me.Controls.Add(Me.ucrInputOrigin)
+        Me.Controls.Add(Me.rdoMstate)
+        Me.Controls.Add(Me.rdoInterval2)
+        Me.Controls.Add(Me.rdoInterval)
+        Me.Controls.Add(Me.rdoCounting)
+        Me.Controls.Add(Me.rdoLeft)
+        Me.Controls.Add(Me.rdoRight)
+        Me.Controls.Add(Me.ucrPnlType)
+        Me.Controls.Add(Me.ucrSaveObject)
+        Me.Controls.Add(Me.lblOrigin)
+        Me.Controls.Add(Me.lblEvent)
+        Me.Controls.Add(Me.lblExitTime2)
+        Me.Controls.Add(Me.ucrReceiverEvent)
+        Me.Controls.Add(Me.lblEntryTime)
+        Me.Controls.Add(Me.ucrReceiverTime2)
+        Me.Controls.Add(Me.ucrReceiverTime1)
+        Me.Controls.Add(Me.ucrSelectorFitObject)
+        Me.Controls.Add(Me.ucrBase)
         Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow
         Me.MaximizeBox = False
         Me.MinimizeBox = False
@@ -38,4 +286,22 @@ Partial Class dlgSurvivalObject
         Me.ResumeLayout(False)
 
     End Sub
+    Friend WithEvents ucrReceiverTime2 As ucrReceiverSingle
+    Friend WithEvents ucrReceiverTime1 As ucrReceiverSingle
+    Friend WithEvents ucrSelectorFitObject As ucrSelectorByDataFrameAddRemove
+    Friend WithEvents ucrBase As ucrButtons
+    Friend WithEvents ucrReceiverEvent As ucrReceiverSingle
+    Friend WithEvents ucrSaveObject As ucrSave
+    Friend WithEvents lblOrigin As Label
+    Friend WithEvents lblEvent As Label
+    Friend WithEvents lblExitTime2 As Label
+    Friend WithEvents lblEntryTime As Label
+    Friend WithEvents rdoMstate As RadioButton
+    Friend WithEvents rdoInterval2 As RadioButton
+    Friend WithEvents rdoInterval As RadioButton
+    Friend WithEvents rdoCounting As RadioButton
+    Friend WithEvents rdoLeft As RadioButton
+    Friend WithEvents rdoRight As RadioButton
+    Friend WithEvents ucrPnlType As UcrPanel
+    Friend WithEvents ucrInputOrigin As ucrInputTextBox
 End Class

--- a/instat/dlgSurvivalObject.vb
+++ b/instat/dlgSurvivalObject.vb
@@ -14,6 +14,7 @@
 ' You should have received a copy of the GNU General Public License 
 ' along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+Imports instat
 Imports instat.Translations
 Public Class dlgSurvivalObject
     Private bFirstLoad As Boolean = True
@@ -21,6 +22,10 @@ Public Class dlgSurvivalObject
     Private clsDefaultFunction As New RFunction
     Private clsRightLeftFunction As New RFunction
     Private clsStartEndFunction As New RFunction
+    Private clsModifyFunction As New RFunction
+    Private clsModifyOperation As New ROperator
+    Private clsModifyFunction2 As New RParameter
+    Private clsCFunction As New RFunction
 
     Private Sub dlgSurvivalObject_Load(sender As Object, e As EventArgs) Handles Me.Load
         autoTranslate(Me)
@@ -34,6 +39,7 @@ Public Class dlgSurvivalObject
         SetRCodeforControls(bReset)
         bReset = False
         TestOkEnabled()
+        DialogWidth()
     End Sub
 
     Private Sub InitialiseDialog()
@@ -78,7 +84,7 @@ Public Class dlgSurvivalObject
         ucrReceiverTime2.SetIncludedDataTypes({"numeric"})
         ucrReceiverTime2.SetLinkedDisplayControl(lblExitTime2)
 
-        ucrReceiverEvent.SetParameter(New RParameter("event", 2))
+        ucrReceiverEvent.SetParameter(New RParameter("event", 0, bNewIncludeArgumentName:=False))
         ucrReceiverEvent.SetParameterIsRFunction()
         ucrReceiverEvent.Selector = ucrSelectorFitObject
         ucrReceiverEvent.SetIncludedDataTypes({"numeric"})
@@ -91,6 +97,35 @@ Public Class dlgSurvivalObject
         ucrInputOrigin.AddQuotesIfUnrecognised = False
         ucrInputOrigin.SetRDefault(0)
 
+        'ucrChk
+        ucrChkModifyEvent.SetText("Modify Event")
+        ' TODO: set up so we can add to linked controls
+        ' this can't currently be done (to my knowledge) because we need to specify if it is a factor or numeric
+        ' this is currently run manually in the Viewing modify options() sub
+
+        'ucrReceiverEvent.AddToLinkedControls(ucrModifyEventNumeric, {"numeric"}, bNewLinkedHideIfParameterMissing:=True)
+
+        'ucrChkModifyEvent.AddToLinkedControls(ucrModifyEventNumeric, {True}, bNewLinkedHideIfParameterMissing:=True)
+        'ucrChkModifyEvent.AddToLinkedControls(ucrModifyEventFactor, {True}, bNewLinkedHideIfParameterMissing:=True)
+
+        'ucrChkModifyEvent.AddParameterValuesCondition(False, "event", ucrReceiverEvent.GetVariables(), True)
+        ucrChkModifyEvent.AddParameterIsROperatorCondition(True, "%in%", True)
+        ucrChkModifyEvent.SetDefaultState(False)
+
+        'ucrInput
+        ucrModifyEventNumeric.SetParameter(New RParameter("x", bNewIncludeArgumentName:=False))
+        ucrModifyEventNumeric.SetValidationTypeAsNumericList(dcmMin:=Integer.MinValue,
+                                                             dcmMax:=Integer.MaxValue)
+        ucrModifyEventNumeric.SetLinkedDisplayControl(lblSelectLevels)
+        ucrModifyEventNumeric.AddQuotesIfUnrecognised = False
+
+        'ucrFactorLevels
+        ucrModifyEventFactor.SetParameter(New RParameter("y", bNewIncludeArgumentName:=False))
+        ucrModifyEventFactor.SetLinkedDisplayControl(lblSelectLevels)
+        ucrModifyEventFactor.SetReceiver(ucrReceiverEvent)
+        ucrModifyEventFactor.SetAsMultipleSelector()
+        ucrModifyEventFactor.SetIncludeLevels(False)
+
         ucrSaveObject.SetSaveTypeAsSurv()
         ucrSaveObject.SetDataFrameSelector(ucrSelectorFitObject.ucrAvailableDataFrames)
         ucrSaveObject.SetLabelText("Save Survival Object:")
@@ -102,6 +137,10 @@ Public Class dlgSurvivalObject
         clsDefaultFunction = New RFunction
         clsRightLeftFunction = New RFunction
         clsStartEndFunction = New RFunction
+        clsModifyFunction = New RFunction
+        clsModifyFunction2 = New RParameter
+        clsModifyOperation = New ROperator
+        clsCFunction = New RFunction
 
         ucrSelectorFitObject.Reset()
         ucrSaveObject.Reset()
@@ -113,30 +152,44 @@ Public Class dlgSurvivalObject
         clsStartEndFunction.SetPackageName("survival")
         clsStartEndFunction.SetRCommand("Surv")
 
+        ' TODO If I check several options in the factor dlg, then it runs c(c())
+        clsCFunction.SetRCommand("c")
+
+        clsModifyOperation.SetOperation("%in%")
+        clsModifyOperation.AddParameter(clsRFunctionParameter:=clsCFunction, iPosition:=1)
+
         clsDefaultFunction.SetRCommand("with")
         clsDefaultFunction.AddParameter("exp", clsRFunctionParameter:=clsRightLeftFunction)
+        ' TODO fix up the set assign to as currently it is always running surv()
         clsDefaultFunction.SetAssignTo(strTemp:="surv", strTempDataframe:=ucrSelectorFitObject.ucrAvailableDataFrames.cboAvailableDataFrames.Text, strTempSurv:="surv", bAssignToIsPrefix:=True)
 
         ucrBase.clsRsyntax.SetBaseRFunction(clsDefaultFunction)
+
+        DialogWidth()
+        ViewingModifyOptions()
     End Sub
 
     Private Sub SetRCodeforControls(bReset As Boolean)
         ucrReceiverTime2.AddAdditionalCodeParameterPair(clsStartEndFunction, New RParameter("time2", 1), iAdditionalPairNo:=1)
-        ucrReceiverEvent.AddAdditionalCodeParameterPair(clsStartEndFunction, New RParameter("event", 2), iAdditionalPairNo:=1)
+        'ucrReceiverEvent.AddAdditionalCodeParameterPair(clsStartEndFunction, New RParameter("event", 2), iAdditionalPairNo:=1)
+        'ucrReceiverEvent.AddAdditionalCodeParameterPair(clsRightLeftFunction, New RParameter("event", 2), iAdditionalPairNo:=2)
         ucrPnlType.AddAdditionalCodeParameterPair(clsStartEndFunction, New RParameter("type", 3), iAdditionalPairNo:=1)
 
         ucrSelectorFitObject.SetRCode(clsDefaultFunction, bReset)
         ucrReceiverTime1.SetRCode(clsStartEndFunction, bReset)
         ucrReceiverTime2.SetRCode(clsRightLeftFunction, bReset)
-        ucrReceiverEvent.SetRCode(clsRightLeftFunction, bReset)
         ucrPnlType.SetRCode(clsRightLeftFunction, bReset)
         ucrInputOrigin.SetRCode(clsStartEndFunction, bReset)
         ucrSaveObject.SetRCode(clsDefaultFunction, bReset)
+        ucrReceiverEvent.SetRCode(clsModifyOperation, bReset)
+
+        ucrModifyEventNumeric.SetRCode(clsCFunction, bReset)
+        ucrModifyEventFactor.SetRCode(clsCFunction, bReset)
     End Sub
 
     Private Sub TestOkEnabled()
 
-        If ucrReceiverTime2.IsEmpty() OrElse ucrReceiverEvent.IsEmpty() OrElse Not ucrSaveObject.IsComplete() Then
+        If ucrReceiverTime2.IsEmpty() OrElse ucrReceiverEvent.IsEmpty() OrElse Not ucrSaveObject.IsComplete() OrElse ((ucrReceiverEvent.strCurrDataType = "numeric" OrElse ucrReceiverEvent.strCurrDataType = "integer") AndAlso ucrChkModifyEvent.Checked AndAlso ucrModifyEventNumeric.GetText = "") OrElse (ucrReceiverEvent.strCurrDataType = "factor" AndAlso ucrChkModifyEvent.Checked AndAlso ucrModifyEventFactor.GetSelectedLevels = "") Then
             ucrBase.OKEnabled(False)
         Else
             If (rdoMstate.Checked OrElse rdoCounting.Checked OrElse rdoInterval.Checked OrElse rdoInterval2.Checked) AndAlso ucrReceiverTime1.IsEmpty() Then
@@ -150,14 +203,7 @@ Public Class dlgSurvivalObject
             End If
         End If
 
-        ' ucrsave cannot be empty
-
-        ' if right or left are clicked, then end and event cannot be empty
-
-        ' if one of the other four are clicked, then start or end have to be filled
-        '           ' if end is filled, then event must be filled 
-        '           ' if counting is selected, nud cannot be empty
-
+        ' TODO add chkbox stuff in here
     End Sub
 
     Private Sub ucrBase_ClickReset(sender As Object, e As EventArgs) Handles ucrBase.ClickReset
@@ -169,27 +215,92 @@ Public Class dlgSurvivalObject
     Private Sub ucrPnl_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrPnlType.ControlContentsChanged
         ' exp = clsRightLeftFunction if right or left censoring occurs
         ' otherwise exp = clsStartEndFunction if one Then Of the other four rdos are selected
+
         If rdoRight.Checked = True OrElse rdoLeft.Checked = True Then
             clsDefaultFunction.AddParameter("exp", clsRFunctionParameter:=clsRightLeftFunction)
         Else
             clsDefaultFunction.AddParameter("exp", clsRFunctionParameter:=clsStartEndFunction)
 
-            'If ucrReceiverTime1.SetMeAsReceiver Then ' TODO what is the correct code for this line?
-            'ucrReceiverTime2.SetMeAsReceiver()
-            'End If
+            '            If ucrReceiverTime1.focused Then ' TODO what is the correct code for this line?
+            '            ucrReceiverTime2.SetMeAsReceiver()
+            '        End If
+
         End If
 
         ' mstate allows factors
-        If rdoMstate.Checked = True OrElse rdoCounting.Checked = True Then
-            ucrReceiverEvent.SetIncludedDataTypes({"numeric", "factor"})
+        If rdoMstate.Checked OrElse rdoCounting.Checked Then
+            ' todo: why doesn't this line work?
+            ucrReceiverEvent.SetIncludedDataTypes({"factor", "numeric"})
         Else
             ucrReceiverEvent.SetIncludedDataTypes({"numeric"})
         End If
 
+        ViewingModifyOptions()
         TestOkEnabled()
     End Sub
 
-    Private Sub ucrCoreControls(ucrChangedControl As ucrCore) Handles ucrReceiverTime1.ControlContentsChanged, ucrReceiverTime2.ControlContentsChanged, ucrReceiverEvent.ControlContentsChanged, ucrSaveObject.ControlContentsChanged, ucrInputOrigin.ControlContentsChanged
+    Private Sub DialogWidth()
+        If ucrChkModifyEvent.Checked Then
+            Me.Size = New System.Drawing.Size(692, Me.Height)
+        Else
+            Me.Size = New System.Drawing.Size(448, Me.Height)
+        End If
+    End Sub
+
+    Private Sub ViewingModifyOptions()
+        If Not ucrReceiverEvent.IsEmpty Then
+            ucrChkModifyEvent.Enabled = True
+            If ucrChkModifyEvent.Checked Then
+                lblSelectLevels.Visible = True
+
+                clsRightLeftFunction.AddParameter("event", clsROperatorParameter:=clsModifyOperation, iPosition:=2)
+                clsStartEndFunction.AddParameter("event", clsROperatorParameter:=clsModifyOperation, iPosition:=2)
+
+                ' have to currently add these variables into the c() function manually
+                ' this is because the ucr that is added changed depending on the data type
+                ' and (to my knowledge) we can't yet do this in the automatic system
+                If ucrReceiverEvent.strCurrDataType = "numeric" OrElse ucrReceiverEvent.strCurrDataType = "integer" Then
+                    ucrModifyEventNumeric.Visible = True
+                    ucrModifyEventFactor.Visible = False
+                    clsCFunction.RemoveParameterByName("y")
+                    clsCFunction.AddParameter("x", ucrModifyEventNumeric.GetText(), bIncludeArgumentName:=False)
+                Else
+                    ' what if it is logic? Surely that should be treated in the "else" case
+                    ' does that work here?
+                    ucrModifyEventNumeric.Visible = False
+                    ucrModifyEventFactor.Visible = True
+                    clsCFunction.RemoveParameterByName("x")
+                    clsCFunction.AddParameter("y", ucrModifyEventFactor.GetSelectedLevels(), bIncludeArgumentName:=False)
+                End If
+            Else
+                lblSelectLevels.Visible = False
+                ucrModifyEventNumeric.Visible = False
+                ucrModifyEventFactor.Visible = False
+
+                clsCFunction.RemoveParameterByName("x")
+                clsCFunction.RemoveParameterByName("y")
+
+                clsRightLeftFunction.AddParameter("event", clsRFunctionParameter:=ucrReceiverEvent.GetVariables, iPosition:=2)
+                clsStartEndFunction.AddParameter("event", clsRFunctionParameter:=ucrReceiverEvent.GetVariables, iPosition:=2)
+            End If
+
+        Else
+            ucrChkModifyEvent.Enabled = False
+        End If
+    End Sub
+
+    Private Sub ucrChkModifyEvent_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrChkModifyEvent.ControlContentsChanged
+        DialogWidth()
+        TestOkEnabled()
+        ViewingModifyOptions()
+    End Sub
+
+    Private Sub ucrReceiverEventControl(ucrChangedControl As ucrCore) Handles ucrReceiverEvent.ControlContentsChanged
+        ViewingModifyOptions()
+        TestOkEnabled()
+    End Sub
+
+    Private Sub ucrCoreControls(ucrChangedControl As ucrCore) Handles ucrReceiverTime1.ControlContentsChanged, ucrReceiverTime2.ControlContentsChanged, ucrSaveObject.ControlContentsChanged, ucrInputOrigin.ControlContentsChanged, ucrModifyEventFactor.ControlContentsChanged, ucrModifyEventNumeric.ControlContentsChanged, ucrChkModifyEvent.ControlContentsChanged
         TestOkEnabled()
     End Sub
 End Class

--- a/instat/dlgSurvivalObject.vb
+++ b/instat/dlgSurvivalObject.vb
@@ -13,6 +13,183 @@
 '
 ' You should have received a copy of the GNU General Public License 
 ' along with this program.  If not, see <http://www.gnu.org/licenses/>.
-Public Class dlgSurvivalObject
 
+Imports instat.Translations
+Public Class dlgSurvivalObject
+    Private bFirstLoad As Boolean = True
+    Private bReset As Boolean = True
+    Private clsDefaultFunction As New RFunction
+    Private clsRightLeftFunction As New RFunction
+    Private clsStartEndFunction As New RFunction
+
+    Private Sub dlgSurvivalObject_Load(sender As Object, e As EventArgs) Handles Me.Load
+        autoTranslate(Me)
+        If bFirstLoad Then
+            InitialiseDialog()
+            bFirstLoad = False
+        End If
+        If bReset Then
+            SetDefaults()
+        End If
+        SetRCodeforControls(bReset)
+        bReset = False
+        TestOkEnabled()
+    End Sub
+
+    Private Sub InitialiseDialog()
+        'ucrBase.iHelpTopicID = 
+
+        'ucrPnl
+        ucrPnlType.SetParameter(New RParameter("type", 3))
+        ucrPnlType.AddRadioButton(rdoRight, Chr(34) & "right" & Chr(34))
+        ucrPnlType.AddRadioButton(rdoLeft, Chr(34) & "left" & Chr(34))
+        ucrPnlType.AddRadioButton(rdoCounting, Chr(34) & "counting" & Chr(34))
+        ucrPnlType.AddRadioButton(rdoInterval, Chr(34) & "interval" & Chr(34))
+        ucrPnlType.AddRadioButton(rdoInterval2, Chr(34) & "interval2" & Chr(34))
+        ucrPnlType.AddRadioButton(rdoMstate, Chr(34) & "mstate" & Chr(34))
+        ucrPnlType.SetRDefault(Chr(34) & "right" & Chr(34))
+        ' Note that this is the default in R when the status is not a factor
+        ' if status is a factor, then mstate is the new default (and it runs mstate even if you type in type = "right" - and consequently does not work in places where right censored data usually works, such as coxph model
+        ' so the option "right" cannot be chosen if status is a factor
+
+        ' entry time always is time
+        ' exit time is time or time2 depending if rdoright, left are selected, or one of the other four are
+        ' attach to different classes for time and time2 to get around this
+
+        ucrPnlType.AddToLinkedControls(ucrReceiverTime1, {rdoCounting, rdoInterval, rdoInterval2, rdoMstate}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
+        ucrPnlType.AddToLinkedControls(ucrInputOrigin, {rdoCounting}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:=0)
+
+        'ucrSelector
+        ucrSelectorFitObject.SetParameter(New RParameter("data", 0))
+        ucrSelectorFitObject.SetParameterIsrfunction()
+
+        'ucrReceiver
+        ucrReceiverTime1.SetParameter(New RParameter("time", 0))
+        ucrReceiverTime1.SetParameterIsRFunction()
+        ucrReceiverTime1.Selector = ucrSelectorFitObject
+        ' allows numeric or logical, but not factor
+        ucrReceiverTime1.SetIncludedDataTypes({"numeric"})
+        ucrReceiverTime1.SetLinkedDisplayControl(lblEntryTime)
+
+        ucrReceiverTime2.SetParameter(New RParameter("time", 1))
+        ucrReceiverTime2.SetParameterIsRFunction()
+        ucrReceiverTime2.Selector = ucrSelectorFitObject
+        ucrReceiverTime2.SetMeAsReceiver()
+        ucrReceiverTime2.SetIncludedDataTypes({"numeric"})
+        ucrReceiverTime2.SetLinkedDisplayControl(lblExitTime2)
+
+        ucrReceiverEvent.SetParameter(New RParameter("event", 2))
+        ucrReceiverEvent.SetParameterIsRFunction()
+        ucrReceiverEvent.Selector = ucrSelectorFitObject
+        ucrReceiverEvent.SetIncludedDataTypes({"numeric"})
+
+        ' only display if counting is selected
+        ucrInputOrigin.SetParameter(New RParameter("origin", 4))
+        ucrInputOrigin.SetLinkedDisplayControl(lblOrigin)
+        ucrInputOrigin.SetValidationTypeAsNumeric(dcmMin:=Integer.MinValue,
+                                                  dcmMax:=Integer.MaxValue)
+        ucrInputOrigin.AddQuotesIfUnrecognised = False
+        ucrInputOrigin.SetRDefault(0)
+
+        ucrSaveObject.SetSaveTypeAsSurv()
+        ucrSaveObject.SetDataFrameSelector(ucrSelectorFitObject.ucrAvailableDataFrames)
+        ucrSaveObject.SetLabelText("Save Survival Object:")
+        ucrSaveObject.SetIsComboBox()
+        ucrSaveObject.SetAssignToBooleans(bTempAssignToIsPrefix:=True)
+    End Sub
+
+    Private Sub SetDefaults()
+        clsDefaultFunction = New RFunction
+        clsRightLeftFunction = New RFunction
+        clsStartEndFunction = New RFunction
+
+        ucrSelectorFitObject.Reset()
+        ucrSaveObject.Reset()
+
+        clsRightLeftFunction.SetPackageName("survival")
+        clsRightLeftFunction.SetRCommand("Surv")
+        clsRightLeftFunction.AddParameter("type", Chr(34) & "right" & Chr(34), iPosition:=3)
+
+        clsStartEndFunction.SetPackageName("survival")
+        clsStartEndFunction.SetRCommand("Surv")
+
+        clsDefaultFunction.SetRCommand("with")
+        clsDefaultFunction.AddParameter("exp", clsRFunctionParameter:=clsRightLeftFunction)
+        clsDefaultFunction.SetAssignTo(strTemp:="surv", strTempDataframe:=ucrSelectorFitObject.ucrAvailableDataFrames.cboAvailableDataFrames.Text, strTempSurv:="surv", bAssignToIsPrefix:=True)
+
+        ucrBase.clsRsyntax.SetBaseRFunction(clsDefaultFunction)
+    End Sub
+
+    Private Sub SetRCodeforControls(bReset As Boolean)
+        ucrReceiverTime2.AddAdditionalCodeParameterPair(clsStartEndFunction, New RParameter("time2", 1), iAdditionalPairNo:=1)
+        ucrReceiverEvent.AddAdditionalCodeParameterPair(clsStartEndFunction, New RParameter("event", 2), iAdditionalPairNo:=1)
+        ucrPnlType.AddAdditionalCodeParameterPair(clsStartEndFunction, New RParameter("type", 3), iAdditionalPairNo:=1)
+
+        ucrSelectorFitObject.SetRCode(clsDefaultFunction, bReset)
+        ucrReceiverTime1.SetRCode(clsStartEndFunction, bReset)
+        ucrReceiverTime2.SetRCode(clsRightLeftFunction, bReset)
+        ucrReceiverEvent.SetRCode(clsRightLeftFunction, bReset)
+        ucrPnlType.SetRCode(clsRightLeftFunction, bReset)
+        ucrInputOrigin.SetRCode(clsStartEndFunction, bReset)
+        ucrSaveObject.SetRCode(clsDefaultFunction, bReset)
+    End Sub
+
+    Private Sub TestOkEnabled()
+
+        If ucrReceiverTime2.IsEmpty() OrElse ucrReceiverEvent.IsEmpty() OrElse Not ucrSaveObject.IsComplete() Then
+            ucrBase.OKEnabled(False)
+        Else
+            If (rdoMstate.Checked OrElse rdoCounting.Checked OrElse rdoInterval.Checked OrElse rdoInterval2.Checked) AndAlso ucrReceiverTime1.IsEmpty() Then
+                ucrBase.OKEnabled(False)
+            Else
+                If rdoCounting.Checked AndAlso ucrInputOrigin.IsEmpty() Then
+                    ucrBase.OKEnabled(False)
+                Else
+                    ucrBase.OKEnabled(True)
+                End If
+            End If
+        End If
+
+        ' ucrsave cannot be empty
+
+        ' if right or left are clicked, then end and event cannot be empty
+
+        ' if one of the other four are clicked, then start or end have to be filled
+        '           ' if end is filled, then event must be filled 
+        '           ' if counting is selected, nud cannot be empty
+
+    End Sub
+
+    Private Sub ucrBase_ClickReset(sender As Object, e As EventArgs) Handles ucrBase.ClickReset
+        SetDefaults()
+        SetRCodeforControls(True)
+        TestOkEnabled()
+    End Sub
+
+    Private Sub ucrPnl_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrPnlType.ControlContentsChanged
+        ' exp = clsRightLeftFunction if right or left censoring occurs
+        ' otherwise exp = clsStartEndFunction if one Then Of the other four rdos are selected
+        If rdoRight.Checked = True OrElse rdoLeft.Checked = True Then
+            clsDefaultFunction.AddParameter("exp", clsRFunctionParameter:=clsRightLeftFunction)
+        Else
+            clsDefaultFunction.AddParameter("exp", clsRFunctionParameter:=clsStartEndFunction)
+
+            'If ucrReceiverTime1.SetMeAsReceiver Then ' TODO what is the correct code for this line?
+            'ucrReceiverTime2.SetMeAsReceiver()
+            'End If
+        End If
+
+        ' mstate allows factors
+        If rdoMstate.Checked = True OrElse rdoCounting.Checked = True Then
+            ucrReceiverEvent.SetIncludedDataTypes({"numeric", "factor"})
+        Else
+            ucrReceiverEvent.SetIncludedDataTypes({"numeric"})
+        End If
+
+        TestOkEnabled()
+    End Sub
+
+    Private Sub ucrCoreControls(ucrChangedControl As ucrCore) Handles ucrReceiverTime1.ControlContentsChanged, ucrReceiverTime2.ControlContentsChanged, ucrReceiverEvent.ControlContentsChanged, ucrSaveObject.ControlContentsChanged, ucrInputOrigin.ControlContentsChanged
+        TestOkEnabled()
+    End Sub
 End Class


### PR DESCRIPTION
Not ready for review.

Current issues
1. I set the ValidationTypeAsNumeric for an input, however, it still takes non-numeric values. I saw that this is an issue in other dialogs (such as climatic ones with threshold as an input). However, it is not an issue for the ValidationTypeAsNumericList option. @dannyparsons is this a known issue?
2. Changing the survival object name doesn't update in the code, it just keeps the default name. It is unclear if this is me coding it wrong in the dialog, or if this is an issue in the setup of the Surv object outside of the dialog. Something to explore.
3. Issue with logic columns for "interval" and "interval2" types in R. It claims to accept numeric or logical columns, however, if I put a logical column in, it throws an error. Need to look into this a little more.

```
library(survival)
data(cancer)
cancer$status.logic <- with(cancer,
                              ifelse(status == 1, TRUE, FALSE))
class(cancer$status.logic)
[1] logical
with(data=cancer, exp=survival::Surv(time = time,
                                        time2 = time,
                                        event = status.logic,
                                        type = "interval"))
Error in survival::Surv(time = time, time2 = time, event = status.logic,  : 
  Invalid status value, must be logical or numeric
```

4. (small one) work out how to say "if this receiver is currently selected then ..." for when we switch tabs and one receiver is no longer visible.
5. Work on changing the status indicator