### PR TITLE
Delete Rows - factors

### DIFF
--- a/instat/static/InstatObject/R/data_object_R6.R
+++ b/instat/static/InstatObject/R/data_object_R6.R
@@ -948,6 +948,7 @@ DataSheet$set("public", "remove_rows_in_data", function(row_names) {
   #since it removes column attributes
   self$set_data(dplyr::slice(curr_data, -rows_to_remove))
   self$append_to_changes(list(Removed_row, row_names))
+  self$add_defaults_variables_metadata(self$get_column_names())
   self$data_changed <- TRUE
 }
 )


### PR DESCRIPTION
fixes  #5325
Whenever the rows were deleted. The factor columns would lose the variable names in the metadata - to NA. They would therefore disappear (factor columns).
@africanmathsinitiative/developers ready for review