### PR TITLE
changed use of defined climatic variables

### DIFF
--- a/instat/dlgPICSARainfall.vb
+++ b/instat/dlgPICSARainfall.vb
@@ -136,7 +136,6 @@ Public Class dlgPICSARainfall
         ucrReceiverX.SetParameterIsString()
         ucrReceiverX.Selector = ucrSelectorPICSARainfall
         ucrReceiverX.SetClimaticType("year")
-        ucrReceiverX.strSelectorHeading = "Year Variables"
         ucrReceiverX.bAutoFill = True
         ucrReceiverX.bWithQuotes = False
 

--- a/instat/ucrReceiverSingle.vb
+++ b/instat/ucrReceiverSingle.vb
@@ -20,7 +20,6 @@ Public Class ucrReceiverSingle
     Dim strDataFrameName As String
     Public strCurrDataType As String
     Public Event WithMeSelectionChanged(ucrChangedReceiver As ucrReceiverSingle)
-    Public bAutoFill As Boolean = False
     'We have not added this to multiple receiver because we have no case yet that we want not to print graph
     Public bPrintGraph As Boolean = True
     'If True variable will be assigned to e.g. DF.x instead of x (where DF is strDataFrameName and x is receiver value)
@@ -306,20 +305,6 @@ Public Class ucrReceiverSingle
 
     Private Sub Selector_DataFrameChanged() Handles ucrSelector.DataFrameChanged
         CheckAutoFill()
-    End Sub
-
-    Public Sub CheckAutoFill()
-
-        'TODO When there are receivers with bAttachedToPrimaryDataFrame = False
-        '     don't always want to autofill when dataframe is changed.
-        '     Something like AndAlso Selector.CurrentReceiver.bAttachedToPrimaryDataFrame
-        '     except always want to autofill when resetting regardless of current receiver
-        If bAutoFill AndAlso Selector IsNot Nothing AndAlso (Selector.CurrentReceiver Is Nothing OrElse Selector.CurrentReceiver.bAttachedToPrimaryDataFrame) Then
-            SetMeAsReceiver()
-            If Selector.lstAvailableVariable.Items.Count = 1 Then
-                Add(Selector.lstAvailableVariable.Items(0).Text, Selector.strCurrentDataFrame)
-            End If
-        End If
     End Sub
 
     Private Sub ParentForm_Shown()


### PR DESCRIPTION
@africanmathsinitiative/developers this is ready for review.

Implements the suggestion in #5428. Climatic dialogs should autofill the same as before but will now also display full list of variables, not just the climatic defined ones. In particular, climatic dialogs are usable without defining.

It might be sensible for someone to take over this branch and make the necessary changes on the climatic dialogs to fully test this. 
See the required changes to climatic dialogs here: https://github.com/africanmathsinitiative/R-Instat/issues/5428#issuecomment-516462624
Some thought is needed to get the correct restrictions on the receivers now.

Still to do is implement autofilling of multiple items in a multiple receiver. I suggest this is for a separate pull request.