### PR TITLE
New treemap dialog

### DIFF
--- a/instat/dlgTreemap.Designer.vb
+++ b/instat/dlgTreemap.Designer.vb
@@ -24,30 +24,30 @@ Partial Class dlgTreemap
     Private Sub InitializeComponent()
         Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(dlgTreemap))
         Me.lblLabel = New System.Windows.Forms.Label()
-        Me.ucrInputLabel = New instat.ucrInputComboBox()
-        Me.ucrSaveTreemap = New instat.ucrSave()
-        Me.ucrChkIsCurrency = New instat.ucrCheck()
         Me.rdoPrimary = New System.Windows.Forms.RadioButton()
         Me.rdoSummary = New System.Windows.Forms.RadioButton()
         Me.cmdOptions = New System.Windows.Forms.Button()
         Me.lblWeightBy = New System.Windows.Forms.Label()
         Me.lblIdentifier = New System.Windows.Forms.Label()
+        Me.lblSymbol = New System.Windows.Forms.Label()
+        Me.lblFill = New System.Windows.Forms.Label()
+        Me.grpOptions = New System.Windows.Forms.GroupBox()
+        Me.lblTextColour = New System.Windows.Forms.Label()
+        Me.lblTileColour = New System.Windows.Forms.Label()
+        Me.lblSummary = New System.Windows.Forms.Label()
+        Me.ucrInputSummary = New instat.ucrInputComboBox()
+        Me.ucrColourText = New instat.ucrColors()
+        Me.ucrColourTile = New instat.ucrColors()
+        Me.ucrReceiverFill = New instat.ucrReceiverSingle()
+        Me.ucrInputSymbol = New instat.ucrInputTextBox()
+        Me.ucrInputLabel = New instat.ucrInputComboBox()
+        Me.ucrSaveTreemap = New instat.ucrSave()
+        Me.ucrChkIsCurrency = New instat.ucrCheck()
         Me.ucrReceiverWeightBy = New instat.ucrReceiverSingle()
         Me.ucrReceiverIdentifier = New instat.ucrReceiverSingle()
         Me.ucrSelectorTreemap = New instat.ucrSelectorByDataFrameAddRemove()
         Me.ucrBase = New instat.ucrButtons()
         Me.ucrPnlDataType = New instat.UcrPanel()
-        Me.lblSymbol = New System.Windows.Forms.Label()
-        Me.ucrInputSymbol = New instat.ucrInputTextBox()
-        Me.lblFill = New System.Windows.Forms.Label()
-        Me.ucrReceiverFill = New instat.ucrReceiverSingle()
-        Me.grpOptions = New System.Windows.Forms.GroupBox()
-        Me.lblTextColour = New System.Windows.Forms.Label()
-        Me.ucrColourText = New instat.ucrColors()
-        Me.lblBoxColour = New System.Windows.Forms.Label()
-        Me.ucrColourBox = New instat.ucrColors()
-        Me.lblSummary = New System.Windows.Forms.Label()
-        Me.ucrInputSummary = New instat.ucrInputComboBox()
         Me.grpOptions.SuspendLayout()
         Me.SuspendLayout()
         '
@@ -55,24 +55,6 @@ Partial Class dlgTreemap
         '
         resources.ApplyResources(Me.lblLabel, "lblLabel")
         Me.lblLabel.Name = "lblLabel"
-        '
-        'ucrInputLabel
-        '
-        Me.ucrInputLabel.AddQuotesIfUnrecognised = True
-        Me.ucrInputLabel.IsReadOnly = False
-        resources.ApplyResources(Me.ucrInputLabel, "ucrInputLabel")
-        Me.ucrInputLabel.Name = "ucrInputLabel"
-        '
-        'ucrSaveTreemap
-        '
-        resources.ApplyResources(Me.ucrSaveTreemap, "ucrSaveTreemap")
-        Me.ucrSaveTreemap.Name = "ucrSaveTreemap"
-        '
-        'ucrChkIsCurrency
-        '
-        Me.ucrChkIsCurrency.Checked = False
-        resources.ApplyResources(Me.ucrChkIsCurrency, "ucrChkIsCurrency")
-        Me.ucrChkIsCurrency.Name = "ucrChkIsCurrency"
         '
         'rdoPrimary
         '
@@ -117,6 +99,98 @@ Partial Class dlgTreemap
         Me.lblIdentifier.Name = "lblIdentifier"
         Me.lblIdentifier.Tag = "Variable:"
         '
+        'lblSymbol
+        '
+        resources.ApplyResources(Me.lblSymbol, "lblSymbol")
+        Me.lblSymbol.Name = "lblSymbol"
+        '
+        'lblFill
+        '
+        resources.ApplyResources(Me.lblFill, "lblFill")
+        Me.lblFill.Name = "lblFill"
+        Me.lblFill.Tag = ""
+        '
+        'grpOptions
+        '
+        Me.grpOptions.Controls.Add(Me.lblTextColour)
+        Me.grpOptions.Controls.Add(Me.ucrColourText)
+        Me.grpOptions.Controls.Add(Me.lblTileColour)
+        Me.grpOptions.Controls.Add(Me.ucrColourTile)
+        resources.ApplyResources(Me.grpOptions, "grpOptions")
+        Me.grpOptions.Name = "grpOptions"
+        Me.grpOptions.TabStop = False
+        '
+        'lblTextColour
+        '
+        resources.ApplyResources(Me.lblTextColour, "lblTextColour")
+        Me.lblTextColour.Name = "lblTextColour"
+        '
+        'lblTileColour
+        '
+        resources.ApplyResources(Me.lblTileColour, "lblTileColour")
+        Me.lblTileColour.Name = "lblTileColour"
+        '
+        'lblSummary
+        '
+        resources.ApplyResources(Me.lblSummary, "lblSummary")
+        Me.lblSummary.Name = "lblSummary"
+        '
+        'ucrInputSummary
+        '
+        Me.ucrInputSummary.AddQuotesIfUnrecognised = True
+        Me.ucrInputSummary.IsReadOnly = False
+        resources.ApplyResources(Me.ucrInputSummary, "ucrInputSummary")
+        Me.ucrInputSummary.Name = "ucrInputSummary"
+        '
+        'ucrColourText
+        '
+        Me.ucrColourText.AddQuotesIfUnrecognised = True
+        Me.ucrColourText.IsReadOnly = False
+        resources.ApplyResources(Me.ucrColourText, "ucrColourText")
+        Me.ucrColourText.Name = "ucrColourText"
+        '
+        'ucrColourTile
+        '
+        Me.ucrColourTile.AddQuotesIfUnrecognised = True
+        Me.ucrColourTile.IsReadOnly = False
+        resources.ApplyResources(Me.ucrColourTile, "ucrColourTile")
+        Me.ucrColourTile.Name = "ucrColourTile"
+        '
+        'ucrReceiverFill
+        '
+        Me.ucrReceiverFill.frmParent = Me
+        resources.ApplyResources(Me.ucrReceiverFill, "ucrReceiverFill")
+        Me.ucrReceiverFill.Name = "ucrReceiverFill"
+        Me.ucrReceiverFill.Selector = Nothing
+        Me.ucrReceiverFill.strNcFilePath = ""
+        Me.ucrReceiverFill.ucrSelector = Nothing
+        '
+        'ucrInputSymbol
+        '
+        Me.ucrInputSymbol.AddQuotesIfUnrecognised = True
+        Me.ucrInputSymbol.IsMultiline = False
+        Me.ucrInputSymbol.IsReadOnly = False
+        resources.ApplyResources(Me.ucrInputSymbol, "ucrInputSymbol")
+        Me.ucrInputSymbol.Name = "ucrInputSymbol"
+        '
+        'ucrInputLabel
+        '
+        Me.ucrInputLabel.AddQuotesIfUnrecognised = True
+        Me.ucrInputLabel.IsReadOnly = False
+        resources.ApplyResources(Me.ucrInputLabel, "ucrInputLabel")
+        Me.ucrInputLabel.Name = "ucrInputLabel"
+        '
+        'ucrSaveTreemap
+        '
+        resources.ApplyResources(Me.ucrSaveTreemap, "ucrSaveTreemap")
+        Me.ucrSaveTreemap.Name = "ucrSaveTreemap"
+        '
+        'ucrChkIsCurrency
+        '
+        Me.ucrChkIsCurrency.Checked = False
+        resources.ApplyResources(Me.ucrChkIsCurrency, "ucrChkIsCurrency")
+        Me.ucrChkIsCurrency.Name = "ucrChkIsCurrency"
+        '
         'ucrReceiverWeightBy
         '
         Me.ucrReceiverWeightBy.frmParent = Me
@@ -152,80 +226,6 @@ Partial Class dlgTreemap
         '
         resources.ApplyResources(Me.ucrPnlDataType, "ucrPnlDataType")
         Me.ucrPnlDataType.Name = "ucrPnlDataType"
-        '
-        'lblSymbol
-        '
-        resources.ApplyResources(Me.lblSymbol, "lblSymbol")
-        Me.lblSymbol.Name = "lblSymbol"
-        '
-        'ucrInputSymbol
-        '
-        Me.ucrInputSymbol.AddQuotesIfUnrecognised = True
-        Me.ucrInputSymbol.IsMultiline = False
-        Me.ucrInputSymbol.IsReadOnly = False
-        resources.ApplyResources(Me.ucrInputSymbol, "ucrInputSymbol")
-        Me.ucrInputSymbol.Name = "ucrInputSymbol"
-        '
-        'lblFill
-        '
-        resources.ApplyResources(Me.lblFill, "lblFill")
-        Me.lblFill.Name = "lblFill"
-        Me.lblFill.Tag = ""
-        '
-        'ucrReceiverFill
-        '
-        Me.ucrReceiverFill.frmParent = Me
-        resources.ApplyResources(Me.ucrReceiverFill, "ucrReceiverFill")
-        Me.ucrReceiverFill.Name = "ucrReceiverFill"
-        Me.ucrReceiverFill.Selector = Nothing
-        Me.ucrReceiverFill.strNcFilePath = ""
-        Me.ucrReceiverFill.ucrSelector = Nothing
-        '
-        'grpOptions
-        '
-        Me.grpOptions.Controls.Add(Me.lblTextColour)
-        Me.grpOptions.Controls.Add(Me.ucrColourText)
-        Me.grpOptions.Controls.Add(Me.lblBoxColour)
-        Me.grpOptions.Controls.Add(Me.ucrColourBox)
-        resources.ApplyResources(Me.grpOptions, "grpOptions")
-        Me.grpOptions.Name = "grpOptions"
-        Me.grpOptions.TabStop = False
-        '
-        'lblTextColour
-        '
-        resources.ApplyResources(Me.lblTextColour, "lblTextColour")
-        Me.lblTextColour.Name = "lblTextColour"
-        '
-        'ucrColourText
-        '
-        Me.ucrColourText.AddQuotesIfUnrecognised = True
-        Me.ucrColourText.IsReadOnly = False
-        resources.ApplyResources(Me.ucrColourText, "ucrColourText")
-        Me.ucrColourText.Name = "ucrColourText"
-        '
-        'lblBoxColour
-        '
-        resources.ApplyResources(Me.lblBoxColour, "lblBoxColour")
-        Me.lblBoxColour.Name = "lblBoxColour"
-        '
-        'ucrColourBox
-        '
-        Me.ucrColourBox.AddQuotesIfUnrecognised = True
-        Me.ucrColourBox.IsReadOnly = False
-        resources.ApplyResources(Me.ucrColourBox, "ucrColourBox")
-        Me.ucrColourBox.Name = "ucrColourBox"
-        '
-        'lblSummary
-        '
-        resources.ApplyResources(Me.lblSummary, "lblSummary")
-        Me.lblSummary.Name = "lblSummary"
-        '
-        'ucrInputSummary
-        '
-        Me.ucrInputSummary.AddQuotesIfUnrecognised = True
-        Me.ucrInputSummary.IsReadOnly = False
-        resources.ApplyResources(Me.ucrInputSummary, "ucrInputSummary")
-        Me.ucrInputSummary.Name = "ucrInputSummary"
         '
         'dlgTreemap
         '
@@ -284,8 +284,8 @@ Partial Class dlgTreemap
     Friend WithEvents grpOptions As GroupBox
     Friend WithEvents lblTextColour As Label
     Friend WithEvents ucrColourText As ucrColors
-    Friend WithEvents lblBoxColour As Label
-    Friend WithEvents ucrColourBox As ucrColors
+    Friend WithEvents lblTileColour As Label
+    Friend WithEvents ucrColourTile As ucrColors
     Friend WithEvents lblSummary As Label
     Friend WithEvents ucrInputSummary As ucrInputComboBox
 End Class

--- a/instat/dlgTreemap.Designer.vb
+++ b/instat/dlgTreemap.Designer.vb
@@ -31,13 +31,11 @@ Partial Class dlgTreemap
         Me.rdoSummary = New System.Windows.Forms.RadioButton()
         Me.cmdOptions = New System.Windows.Forms.Button()
         Me.lblWeightBy = New System.Windows.Forms.Label()
-        Me.lblGroupByIdentifier = New System.Windows.Forms.Label()
+        Me.lblIdentifier = New System.Windows.Forms.Label()
         Me.ucrReceiverWeightBy = New instat.ucrReceiverSingle()
         Me.ucrReceiverIdentifier = New instat.ucrReceiverSingle()
         Me.ucrSelectorTreemap = New instat.ucrSelectorByDataFrameAddRemove()
         Me.ucrBase = New instat.ucrButtons()
-        Me.cmdBarChartOptions = New System.Windows.Forms.Button()
-        Me.cmdPieChartOptions = New System.Windows.Forms.Button()
         Me.ucrPnlDataType = New instat.UcrPanel()
         Me.lblSymbol = New System.Windows.Forms.Label()
         Me.ucrInputSymbol = New instat.ucrInputTextBox()
@@ -113,11 +111,11 @@ Partial Class dlgTreemap
         Me.lblWeightBy.Name = "lblWeightBy"
         Me.lblWeightBy.Tag = ""
         '
-        'lblGroupByIdentifier
+        'lblIdentifier
         '
-        resources.ApplyResources(Me.lblGroupByIdentifier, "lblGroupByIdentifier")
-        Me.lblGroupByIdentifier.Name = "lblGroupByIdentifier"
-        Me.lblGroupByIdentifier.Tag = "Variable:"
+        resources.ApplyResources(Me.lblIdentifier, "lblIdentifier")
+        Me.lblIdentifier.Name = "lblIdentifier"
+        Me.lblIdentifier.Tag = "Variable:"
         '
         'ucrReceiverWeightBy
         '
@@ -149,20 +147,6 @@ Partial Class dlgTreemap
         '
         resources.ApplyResources(Me.ucrBase, "ucrBase")
         Me.ucrBase.Name = "ucrBase"
-        '
-        'cmdBarChartOptions
-        '
-        resources.ApplyResources(Me.cmdBarChartOptions, "cmdBarChartOptions")
-        Me.cmdBarChartOptions.Name = "cmdBarChartOptions"
-        Me.cmdBarChartOptions.Tag = "Bar_Chart_Options"
-        Me.cmdBarChartOptions.UseVisualStyleBackColor = True
-        '
-        'cmdPieChartOptions
-        '
-        resources.ApplyResources(Me.cmdPieChartOptions, "cmdPieChartOptions")
-        Me.cmdPieChartOptions.Name = "cmdPieChartOptions"
-        Me.cmdPieChartOptions.Tag = "Pie_Chart_Options"
-        Me.cmdPieChartOptions.UseVisualStyleBackColor = True
         '
         'ucrPnlDataType
         '
@@ -262,13 +246,11 @@ Partial Class dlgTreemap
         Me.Controls.Add(Me.rdoSummary)
         Me.Controls.Add(Me.cmdOptions)
         Me.Controls.Add(Me.lblWeightBy)
-        Me.Controls.Add(Me.lblGroupByIdentifier)
+        Me.Controls.Add(Me.lblIdentifier)
         Me.Controls.Add(Me.ucrReceiverWeightBy)
         Me.Controls.Add(Me.ucrReceiverIdentifier)
         Me.Controls.Add(Me.ucrSelectorTreemap)
         Me.Controls.Add(Me.ucrBase)
-        Me.Controls.Add(Me.cmdBarChartOptions)
-        Me.Controls.Add(Me.cmdPieChartOptions)
         Me.Controls.Add(Me.ucrPnlDataType)
         Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow
         Me.MaximizeBox = False
@@ -289,13 +271,11 @@ Partial Class dlgTreemap
     Friend WithEvents rdoSummary As RadioButton
     Friend WithEvents cmdOptions As Button
     Friend WithEvents lblWeightBy As Label
-    Friend WithEvents lblGroupByIdentifier As Label
+    Friend WithEvents lblIdentifier As Label
     Friend WithEvents ucrReceiverWeightBy As ucrReceiverSingle
     Friend WithEvents ucrReceiverIdentifier As ucrReceiverSingle
     Friend WithEvents ucrSelectorTreemap As ucrSelectorByDataFrameAddRemove
     Friend WithEvents ucrBase As ucrButtons
-    Friend WithEvents cmdBarChartOptions As Button
-    Friend WithEvents cmdPieChartOptions As Button
     Friend WithEvents ucrPnlDataType As UcrPanel
     Friend WithEvents ucrInputSymbol As ucrInputTextBox
     Friend WithEvents lblSymbol As Label

--- a/instat/dlgTreemap.Designer.vb
+++ b/instat/dlgTreemap.Designer.vb
@@ -1,0 +1,311 @@
+﻿<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()> _
+Partial Class dlgTreemap
+    Inherits System.Windows.Forms.Form
+
+    'Form overrides dispose to clean up the component list.
+    <System.Diagnostics.DebuggerNonUserCode()> _
+    Protected Overrides Sub Dispose(ByVal disposing As Boolean)
+        Try
+            If disposing AndAlso components IsNot Nothing Then
+                components.Dispose()
+            End If
+        Finally
+            MyBase.Dispose(disposing)
+        End Try
+    End Sub
+
+    'Required by the Windows Form Designer
+    Private components As System.ComponentModel.IContainer
+
+    'NOTE: The following procedure is required by the Windows Form Designer
+    'It can be modified using the Windows Form Designer.  
+    'Do not modify it using the code editor.
+    <System.Diagnostics.DebuggerStepThrough()> _
+    Private Sub InitializeComponent()
+        Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(dlgTreemap))
+        Me.lblLabel = New System.Windows.Forms.Label()
+        Me.ucrInputLabel = New instat.ucrInputComboBox()
+        Me.ucrSaveTreemap = New instat.ucrSave()
+        Me.ucrChkIsCurrency = New instat.ucrCheck()
+        Me.rdoPrimary = New System.Windows.Forms.RadioButton()
+        Me.rdoSummary = New System.Windows.Forms.RadioButton()
+        Me.cmdOptions = New System.Windows.Forms.Button()
+        Me.lblWeightBy = New System.Windows.Forms.Label()
+        Me.lblGroupByIdentifier = New System.Windows.Forms.Label()
+        Me.ucrReceiverWeightBy = New instat.ucrReceiverSingle()
+        Me.ucrReceiverIdentifier = New instat.ucrReceiverSingle()
+        Me.ucrSelectorTreemap = New instat.ucrSelectorByDataFrameAddRemove()
+        Me.ucrBase = New instat.ucrButtons()
+        Me.cmdBarChartOptions = New System.Windows.Forms.Button()
+        Me.cmdPieChartOptions = New System.Windows.Forms.Button()
+        Me.ucrPnlDataType = New instat.UcrPanel()
+        Me.lblSymbol = New System.Windows.Forms.Label()
+        Me.ucrInputSymbol = New instat.ucrInputTextBox()
+        Me.lblFill = New System.Windows.Forms.Label()
+        Me.ucrReceiverFill = New instat.ucrReceiverSingle()
+        Me.grpOptions = New System.Windows.Forms.GroupBox()
+        Me.lblTextColour = New System.Windows.Forms.Label()
+        Me.ucrColourText = New instat.ucrColors()
+        Me.lblBoxColour = New System.Windows.Forms.Label()
+        Me.ucrColourBox = New instat.ucrColors()
+        Me.lblSummary = New System.Windows.Forms.Label()
+        Me.ucrInputSummary = New instat.ucrInputComboBox()
+        Me.grpOptions.SuspendLayout()
+        Me.SuspendLayout()
+        '
+        'lblLabel
+        '
+        resources.ApplyResources(Me.lblLabel, "lblLabel")
+        Me.lblLabel.Name = "lblLabel"
+        '
+        'ucrInputLabel
+        '
+        Me.ucrInputLabel.AddQuotesIfUnrecognised = True
+        Me.ucrInputLabel.IsReadOnly = False
+        resources.ApplyResources(Me.ucrInputLabel, "ucrInputLabel")
+        Me.ucrInputLabel.Name = "ucrInputLabel"
+        '
+        'ucrSaveTreemap
+        '
+        resources.ApplyResources(Me.ucrSaveTreemap, "ucrSaveTreemap")
+        Me.ucrSaveTreemap.Name = "ucrSaveTreemap"
+        '
+        'ucrChkIsCurrency
+        '
+        Me.ucrChkIsCurrency.Checked = False
+        resources.ApplyResources(Me.ucrChkIsCurrency, "ucrChkIsCurrency")
+        Me.ucrChkIsCurrency.Name = "ucrChkIsCurrency"
+        '
+        'rdoPrimary
+        '
+        resources.ApplyResources(Me.rdoPrimary, "rdoPrimary")
+        Me.rdoPrimary.BackColor = System.Drawing.SystemColors.Control
+        Me.rdoPrimary.FlatAppearance.BorderColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoPrimary.FlatAppearance.BorderSize = 2
+        Me.rdoPrimary.FlatAppearance.CheckedBackColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoPrimary.Name = "rdoPrimary"
+        Me.rdoPrimary.TabStop = True
+        Me.rdoPrimary.Tag = ""
+        Me.rdoPrimary.UseVisualStyleBackColor = False
+        '
+        'rdoSummary
+        '
+        resources.ApplyResources(Me.rdoSummary, "rdoSummary")
+        Me.rdoSummary.BackColor = System.Drawing.SystemColors.Control
+        Me.rdoSummary.FlatAppearance.BorderColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoSummary.FlatAppearance.BorderSize = 2
+        Me.rdoSummary.FlatAppearance.CheckedBackColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoSummary.Name = "rdoSummary"
+        Me.rdoSummary.TabStop = True
+        Me.rdoSummary.Tag = "Pie_Chart"
+        Me.rdoSummary.UseVisualStyleBackColor = False
+        '
+        'cmdOptions
+        '
+        resources.ApplyResources(Me.cmdOptions, "cmdOptions")
+        Me.cmdOptions.Name = "cmdOptions"
+        Me.cmdOptions.Tag = "Plot_Options..."
+        Me.cmdOptions.UseVisualStyleBackColor = True
+        '
+        'lblWeightBy
+        '
+        resources.ApplyResources(Me.lblWeightBy, "lblWeightBy")
+        Me.lblWeightBy.Name = "lblWeightBy"
+        Me.lblWeightBy.Tag = ""
+        '
+        'lblGroupByIdentifier
+        '
+        resources.ApplyResources(Me.lblGroupByIdentifier, "lblGroupByIdentifier")
+        Me.lblGroupByIdentifier.Name = "lblGroupByIdentifier"
+        Me.lblGroupByIdentifier.Tag = "Variable:"
+        '
+        'ucrReceiverWeightBy
+        '
+        Me.ucrReceiverWeightBy.frmParent = Me
+        resources.ApplyResources(Me.ucrReceiverWeightBy, "ucrReceiverWeightBy")
+        Me.ucrReceiverWeightBy.Name = "ucrReceiverWeightBy"
+        Me.ucrReceiverWeightBy.Selector = Nothing
+        Me.ucrReceiverWeightBy.strNcFilePath = ""
+        Me.ucrReceiverWeightBy.ucrSelector = Nothing
+        '
+        'ucrReceiverIdentifier
+        '
+        Me.ucrReceiverIdentifier.frmParent = Me
+        resources.ApplyResources(Me.ucrReceiverIdentifier, "ucrReceiverIdentifier")
+        Me.ucrReceiverIdentifier.Name = "ucrReceiverIdentifier"
+        Me.ucrReceiverIdentifier.Selector = Nothing
+        Me.ucrReceiverIdentifier.strNcFilePath = ""
+        Me.ucrReceiverIdentifier.ucrSelector = Nothing
+        '
+        'ucrSelectorTreemap
+        '
+        Me.ucrSelectorTreemap.bDropUnusedFilterLevels = False
+        Me.ucrSelectorTreemap.bShowHiddenColumns = False
+        Me.ucrSelectorTreemap.bUseCurrentFilter = True
+        resources.ApplyResources(Me.ucrSelectorTreemap, "ucrSelectorTreemap")
+        Me.ucrSelectorTreemap.Name = "ucrSelectorTreemap"
+        '
+        'ucrBase
+        '
+        resources.ApplyResources(Me.ucrBase, "ucrBase")
+        Me.ucrBase.Name = "ucrBase"
+        '
+        'cmdBarChartOptions
+        '
+        resources.ApplyResources(Me.cmdBarChartOptions, "cmdBarChartOptions")
+        Me.cmdBarChartOptions.Name = "cmdBarChartOptions"
+        Me.cmdBarChartOptions.Tag = "Bar_Chart_Options"
+        Me.cmdBarChartOptions.UseVisualStyleBackColor = True
+        '
+        'cmdPieChartOptions
+        '
+        resources.ApplyResources(Me.cmdPieChartOptions, "cmdPieChartOptions")
+        Me.cmdPieChartOptions.Name = "cmdPieChartOptions"
+        Me.cmdPieChartOptions.Tag = "Pie_Chart_Options"
+        Me.cmdPieChartOptions.UseVisualStyleBackColor = True
+        '
+        'ucrPnlDataType
+        '
+        resources.ApplyResources(Me.ucrPnlDataType, "ucrPnlDataType")
+        Me.ucrPnlDataType.Name = "ucrPnlDataType"
+        '
+        'lblSymbol
+        '
+        resources.ApplyResources(Me.lblSymbol, "lblSymbol")
+        Me.lblSymbol.Name = "lblSymbol"
+        '
+        'ucrInputSymbol
+        '
+        Me.ucrInputSymbol.AddQuotesIfUnrecognised = True
+        Me.ucrInputSymbol.IsMultiline = False
+        Me.ucrInputSymbol.IsReadOnly = False
+        resources.ApplyResources(Me.ucrInputSymbol, "ucrInputSymbol")
+        Me.ucrInputSymbol.Name = "ucrInputSymbol"
+        '
+        'lblFill
+        '
+        resources.ApplyResources(Me.lblFill, "lblFill")
+        Me.lblFill.Name = "lblFill"
+        Me.lblFill.Tag = ""
+        '
+        'ucrReceiverFill
+        '
+        Me.ucrReceiverFill.frmParent = Me
+        resources.ApplyResources(Me.ucrReceiverFill, "ucrReceiverFill")
+        Me.ucrReceiverFill.Name = "ucrReceiverFill"
+        Me.ucrReceiverFill.Selector = Nothing
+        Me.ucrReceiverFill.strNcFilePath = ""
+        Me.ucrReceiverFill.ucrSelector = Nothing
+        '
+        'grpOptions
+        '
+        Me.grpOptions.Controls.Add(Me.lblTextColour)
+        Me.grpOptions.Controls.Add(Me.ucrColourText)
+        Me.grpOptions.Controls.Add(Me.lblBoxColour)
+        Me.grpOptions.Controls.Add(Me.ucrColourBox)
+        resources.ApplyResources(Me.grpOptions, "grpOptions")
+        Me.grpOptions.Name = "grpOptions"
+        Me.grpOptions.TabStop = False
+        '
+        'lblTextColour
+        '
+        resources.ApplyResources(Me.lblTextColour, "lblTextColour")
+        Me.lblTextColour.Name = "lblTextColour"
+        '
+        'ucrColourText
+        '
+        Me.ucrColourText.AddQuotesIfUnrecognised = True
+        Me.ucrColourText.IsReadOnly = False
+        resources.ApplyResources(Me.ucrColourText, "ucrColourText")
+        Me.ucrColourText.Name = "ucrColourText"
+        '
+        'lblBoxColour
+        '
+        resources.ApplyResources(Me.lblBoxColour, "lblBoxColour")
+        Me.lblBoxColour.Name = "lblBoxColour"
+        '
+        'ucrColourBox
+        '
+        Me.ucrColourBox.AddQuotesIfUnrecognised = True
+        Me.ucrColourBox.IsReadOnly = False
+        resources.ApplyResources(Me.ucrColourBox, "ucrColourBox")
+        Me.ucrColourBox.Name = "ucrColourBox"
+        '
+        'lblSummary
+        '
+        resources.ApplyResources(Me.lblSummary, "lblSummary")
+        Me.lblSummary.Name = "lblSummary"
+        '
+        'ucrInputSummary
+        '
+        Me.ucrInputSummary.AddQuotesIfUnrecognised = True
+        Me.ucrInputSummary.IsReadOnly = False
+        resources.ApplyResources(Me.ucrInputSummary, "ucrInputSummary")
+        Me.ucrInputSummary.Name = "ucrInputSummary"
+        '
+        'dlgTreemap
+        '
+        resources.ApplyResources(Me, "$this")
+        Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.Controls.Add(Me.ucrInputSummary)
+        Me.Controls.Add(Me.lblSummary)
+        Me.Controls.Add(Me.grpOptions)
+        Me.Controls.Add(Me.lblFill)
+        Me.Controls.Add(Me.ucrReceiverFill)
+        Me.Controls.Add(Me.ucrInputSymbol)
+        Me.Controls.Add(Me.lblSymbol)
+        Me.Controls.Add(Me.lblLabel)
+        Me.Controls.Add(Me.ucrInputLabel)
+        Me.Controls.Add(Me.ucrSaveTreemap)
+        Me.Controls.Add(Me.ucrChkIsCurrency)
+        Me.Controls.Add(Me.rdoPrimary)
+        Me.Controls.Add(Me.rdoSummary)
+        Me.Controls.Add(Me.cmdOptions)
+        Me.Controls.Add(Me.lblWeightBy)
+        Me.Controls.Add(Me.lblGroupByIdentifier)
+        Me.Controls.Add(Me.ucrReceiverWeightBy)
+        Me.Controls.Add(Me.ucrReceiverIdentifier)
+        Me.Controls.Add(Me.ucrSelectorTreemap)
+        Me.Controls.Add(Me.ucrBase)
+        Me.Controls.Add(Me.cmdBarChartOptions)
+        Me.Controls.Add(Me.cmdPieChartOptions)
+        Me.Controls.Add(Me.ucrPnlDataType)
+        Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow
+        Me.MaximizeBox = False
+        Me.MinimizeBox = False
+        Me.Name = "dlgTreemap"
+        Me.grpOptions.ResumeLayout(False)
+        Me.grpOptions.PerformLayout()
+        Me.ResumeLayout(False)
+        Me.PerformLayout()
+
+    End Sub
+
+    Friend WithEvents lblLabel As Label
+    Friend WithEvents ucrInputLabel As ucrInputComboBox
+    Friend WithEvents ucrSaveTreemap As ucrSave
+    Friend WithEvents ucrChkIsCurrency As ucrCheck
+    Friend WithEvents rdoPrimary As RadioButton
+    Friend WithEvents rdoSummary As RadioButton
+    Friend WithEvents cmdOptions As Button
+    Friend WithEvents lblWeightBy As Label
+    Friend WithEvents lblGroupByIdentifier As Label
+    Friend WithEvents ucrReceiverWeightBy As ucrReceiverSingle
+    Friend WithEvents ucrReceiverIdentifier As ucrReceiverSingle
+    Friend WithEvents ucrSelectorTreemap As ucrSelectorByDataFrameAddRemove
+    Friend WithEvents ucrBase As ucrButtons
+    Friend WithEvents cmdBarChartOptions As Button
+    Friend WithEvents cmdPieChartOptions As Button
+    Friend WithEvents ucrPnlDataType As UcrPanel
+    Friend WithEvents ucrInputSymbol As ucrInputTextBox
+    Friend WithEvents lblSymbol As Label
+    Friend WithEvents lblFill As Label
+    Friend WithEvents ucrReceiverFill As ucrReceiverSingle
+    Friend WithEvents grpOptions As GroupBox
+    Friend WithEvents lblTextColour As Label
+    Friend WithEvents ucrColourText As ucrColors
+    Friend WithEvents lblBoxColour As Label
+    Friend WithEvents ucrColourBox As ucrColors
+    Friend WithEvents lblSummary As Label
+    Friend WithEvents ucrInputSummary As ucrInputComboBox
+End Class

--- a/instat/dlgTreemap.resx
+++ b/instat/dlgTreemap.resx
@@ -292,7 +292,7 @@
     <value>NoControl</value>
   </data>
   <data name="cmdOptions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 261</value>
+    <value>9, 232</value>
   </data>
   <data name="cmdOptions.Size" type="System.Drawing.Size, System.Drawing">
     <value>121, 25</value>
@@ -345,34 +345,34 @@
   <data name="&gt;&gt;lblWeightBy.ZOrder" xml:space="preserve">
     <value>14</value>
   </data>
-  <data name="lblGroupByIdentifier.AutoSize" type="System.Boolean, mscorlib">
+  <data name="lblIdentifier.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="lblGroupByIdentifier.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="lblIdentifier.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="lblGroupByIdentifier.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="lblIdentifier.Location" type="System.Drawing.Point, System.Drawing">
     <value>254, 61</value>
   </data>
-  <data name="lblGroupByIdentifier.Size" type="System.Drawing.Size, System.Drawing">
-    <value>54, 13</value>
+  <data name="lblIdentifier.Size" type="System.Drawing.Size, System.Drawing">
+    <value>50, 13</value>
   </data>
-  <data name="lblGroupByIdentifier.TabIndex" type="System.Int32, mscorlib">
+  <data name="lblIdentifier.TabIndex" type="System.Int32, mscorlib">
     <value>19</value>
   </data>
-  <data name="lblGroupByIdentifier.Text" xml:space="preserve">
-    <value>Group By:</value>
+  <data name="lblIdentifier.Text" xml:space="preserve">
+    <value>Identifier:</value>
   </data>
-  <data name="&gt;&gt;lblGroupByIdentifier.Name" xml:space="preserve">
-    <value>lblGroupByIdentifier</value>
+  <data name="&gt;&gt;lblIdentifier.Name" xml:space="preserve">
+    <value>lblIdentifier</value>
   </data>
-  <data name="&gt;&gt;lblGroupByIdentifier.Type" xml:space="preserve">
+  <data name="&gt;&gt;lblIdentifier.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;lblGroupByIdentifier.Parent" xml:space="preserve">
+  <data name="&gt;&gt;lblIdentifier.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;lblGroupByIdentifier.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;lblIdentifier.ZOrder" xml:space="preserve">
     <value>15</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
@@ -735,60 +735,6 @@
   <data name="&gt;&gt;ucrBase.ZOrder" xml:space="preserve">
     <value>19</value>
   </data>
-  <data name="cmdBarChartOptions.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="cmdBarChartOptions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 230</value>
-  </data>
-  <data name="cmdBarChartOptions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>121, 25</value>
-  </data>
-  <data name="cmdBarChartOptions.TabIndex" type="System.Int32, mscorlib">
-    <value>26</value>
-  </data>
-  <data name="cmdBarChartOptions.Text" xml:space="preserve">
-    <value>Bar Chart Options</value>
-  </data>
-  <data name="&gt;&gt;cmdBarChartOptions.Name" xml:space="preserve">
-    <value>cmdBarChartOptions</value>
-  </data>
-  <data name="&gt;&gt;cmdBarChartOptions.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cmdBarChartOptions.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;cmdBarChartOptions.ZOrder" xml:space="preserve">
-    <value>20</value>
-  </data>
-  <data name="cmdPieChartOptions.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="cmdPieChartOptions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 230</value>
-  </data>
-  <data name="cmdPieChartOptions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>121, 25</value>
-  </data>
-  <data name="cmdPieChartOptions.TabIndex" type="System.Int32, mscorlib">
-    <value>24</value>
-  </data>
-  <data name="cmdPieChartOptions.Text" xml:space="preserve">
-    <value>Pie Chart Options</value>
-  </data>
-  <data name="&gt;&gt;cmdPieChartOptions.Name" xml:space="preserve">
-    <value>cmdPieChartOptions</value>
-  </data>
-  <data name="&gt;&gt;cmdPieChartOptions.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cmdPieChartOptions.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;cmdPieChartOptions.ZOrder" xml:space="preserve">
-    <value>21</value>
-  </data>
   <data name="ucrPnlDataType.Location" type="System.Drawing.Point, System.Drawing">
     <value>86, 5</value>
   </data>
@@ -808,7 +754,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrPnlDataType.ZOrder" xml:space="preserve">
-    <value>22</value>
+    <value>20</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterScreen</value>

--- a/instat/dlgTreemap.resx
+++ b/instat/dlgTreemap.resx
@@ -1,0 +1,849 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="lblLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="lblLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="lblLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>251, 226</value>
+  </data>
+  <data name="lblLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>36, 13</value>
+  </data>
+  <data name="lblLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>23</value>
+  </data>
+  <data name="lblLabel.Text" xml:space="preserve">
+    <value>Label:</value>
+  </data>
+  <data name="&gt;&gt;lblLabel.Name" xml:space="preserve">
+    <value>lblLabel</value>
+  </data>
+  <data name="&gt;&gt;lblLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblLabel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;lblLabel.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="ucrInputLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>254, 244</value>
+  </data>
+  <data name="ucrInputLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>21, 17, 21, 17</value>
+  </data>
+  <data name="ucrInputLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>120, 21</value>
+  </data>
+  <data name="ucrInputLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>25</value>
+  </data>
+  <data name="&gt;&gt;ucrInputLabel.Name" xml:space="preserve">
+    <value>ucrInputLabel</value>
+  </data>
+  <data name="&gt;&gt;ucrInputLabel.Type" xml:space="preserve">
+    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrInputLabel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrInputLabel.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="ucrSaveTreemap.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 380</value>
+  </data>
+  <data name="ucrSaveTreemap.Size" type="System.Drawing.Size, System.Drawing">
+    <value>255, 24</value>
+  </data>
+  <data name="ucrSaveTreemap.TabIndex" type="System.Int32, mscorlib">
+    <value>29</value>
+  </data>
+  <data name="&gt;&gt;ucrSaveTreemap.Name" xml:space="preserve">
+    <value>ucrSaveTreemap</value>
+  </data>
+  <data name="&gt;&gt;ucrSaveTreemap.Type" xml:space="preserve">
+    <value>instat.ucrSave, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrSaveTreemap.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrSaveTreemap.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="ucrChkIsCurrency.Location" type="System.Drawing.Point, System.Drawing">
+    <value>254, 180</value>
+  </data>
+  <data name="ucrChkIsCurrency.Size" type="System.Drawing.Size, System.Drawing">
+    <value>82, 20</value>
+  </data>
+  <data name="ucrChkIsCurrency.TabIndex" type="System.Int32, mscorlib">
+    <value>28</value>
+  </data>
+  <data name="&gt;&gt;ucrChkIsCurrency.Name" xml:space="preserve">
+    <value>ucrChkIsCurrency</value>
+  </data>
+  <data name="&gt;&gt;ucrChkIsCurrency.Type" xml:space="preserve">
+    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrChkIsCurrency.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrChkIsCurrency.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="rdoPrimary.Appearance" type="System.Windows.Forms.Appearance, System.Windows.Forms">
+    <value>Button</value>
+  </data>
+  <data name="rdoPrimary.FlatStyle" type="System.Windows.Forms.FlatStyle, System.Windows.Forms">
+    <value>Flat</value>
+  </data>
+  <data name="rdoPrimary.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="rdoPrimary.Location" type="System.Drawing.Point, System.Drawing">
+    <value>97, 11</value>
+  </data>
+  <data name="rdoPrimary.Size" type="System.Drawing.Size, System.Drawing">
+    <value>110, 28</value>
+  </data>
+  <data name="rdoPrimary.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
+  </data>
+  <data name="rdoPrimary.Text" xml:space="preserve">
+    <value>Primary data</value>
+  </data>
+  <data name="rdoPrimary.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleCenter</value>
+  </data>
+  <data name="&gt;&gt;rdoPrimary.Name" xml:space="preserve">
+    <value>rdoPrimary</value>
+  </data>
+  <data name="&gt;&gt;rdoPrimary.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rdoPrimary.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;rdoPrimary.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="rdoSummary.Appearance" type="System.Windows.Forms.Appearance, System.Windows.Forms">
+    <value>Button</value>
+  </data>
+  <data name="rdoSummary.FlatStyle" type="System.Windows.Forms.FlatStyle, System.Windows.Forms">
+    <value>Flat</value>
+  </data>
+  <data name="rdoSummary.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="rdoSummary.Location" type="System.Drawing.Point, System.Drawing">
+    <value>205, 11</value>
+  </data>
+  <data name="rdoSummary.Size" type="System.Drawing.Size, System.Drawing">
+    <value>110, 28</value>
+  </data>
+  <data name="rdoSummary.TabIndex" type="System.Int32, mscorlib">
+    <value>17</value>
+  </data>
+  <data name="rdoSummary.Text" xml:space="preserve">
+    <value>Summary data</value>
+  </data>
+  <data name="rdoSummary.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleCenter</value>
+  </data>
+  <data name="&gt;&gt;rdoSummary.Name" xml:space="preserve">
+    <value>rdoSummary</value>
+  </data>
+  <data name="&gt;&gt;rdoSummary.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rdoSummary.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;rdoSummary.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="cmdOptions.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cmdOptions.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 261</value>
+  </data>
+  <data name="cmdOptions.Size" type="System.Drawing.Size, System.Drawing">
+    <value>121, 25</value>
+  </data>
+  <data name="cmdOptions.TabIndex" type="System.Int32, mscorlib">
+    <value>27</value>
+  </data>
+  <data name="cmdOptions.Text" xml:space="preserve">
+    <value>Options</value>
+  </data>
+  <data name="&gt;&gt;cmdOptions.Name" xml:space="preserve">
+    <value>cmdOptions</value>
+  </data>
+  <data name="&gt;&gt;cmdOptions.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cmdOptions.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;cmdOptions.ZOrder" xml:space="preserve">
+    <value>13</value>
+  </data>
+  <data name="lblWeightBy.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblWeightBy.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblWeightBy.Location" type="System.Drawing.Point, System.Drawing">
+    <value>254, 111</value>
+  </data>
+  <data name="lblWeightBy.Size" type="System.Drawing.Size, System.Drawing">
+    <value>107, 13</value>
+  </data>
+  <data name="lblWeightBy.TabIndex" type="System.Int32, mscorlib">
+    <value>21</value>
+  </data>
+  <data name="lblWeightBy.Text" xml:space="preserve">
+    <value>Weight By (Optional):</value>
+  </data>
+  <data name="&gt;&gt;lblWeightBy.Name" xml:space="preserve">
+    <value>lblWeightBy</value>
+  </data>
+  <data name="&gt;&gt;lblWeightBy.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblWeightBy.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;lblWeightBy.ZOrder" xml:space="preserve">
+    <value>14</value>
+  </data>
+  <data name="lblGroupByIdentifier.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblGroupByIdentifier.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblGroupByIdentifier.Location" type="System.Drawing.Point, System.Drawing">
+    <value>254, 61</value>
+  </data>
+  <data name="lblGroupByIdentifier.Size" type="System.Drawing.Size, System.Drawing">
+    <value>54, 13</value>
+  </data>
+  <data name="lblGroupByIdentifier.TabIndex" type="System.Int32, mscorlib">
+    <value>19</value>
+  </data>
+  <data name="lblGroupByIdentifier.Text" xml:space="preserve">
+    <value>Group By:</value>
+  </data>
+  <data name="&gt;&gt;lblGroupByIdentifier.Name" xml:space="preserve">
+    <value>lblGroupByIdentifier</value>
+  </data>
+  <data name="&gt;&gt;lblGroupByIdentifier.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblGroupByIdentifier.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;lblGroupByIdentifier.ZOrder" xml:space="preserve">
+    <value>15</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>418, 464</value>
+  </data>
+  <data name="ucrInputSummary.Location" type="System.Drawing.Point, System.Drawing">
+    <value>307, 154</value>
+  </data>
+  <data name="ucrInputSummary.Size" type="System.Drawing.Size, System.Drawing">
+    <value>67, 21</value>
+  </data>
+  <data name="ucrInputSummary.TabIndex" type="System.Int32, mscorlib">
+    <value>37</value>
+  </data>
+  <data name="&gt;&gt;ucrInputSummary.Name" xml:space="preserve">
+    <value>ucrInputSummary</value>
+  </data>
+  <data name="&gt;&gt;ucrInputSummary.Type" xml:space="preserve">
+    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrInputSummary.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrInputSummary.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="lblSummary.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblSummary.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblSummary.Location" type="System.Drawing.Point, System.Drawing">
+    <value>252, 156</value>
+  </data>
+  <data name="lblSummary.Size" type="System.Drawing.Size, System.Drawing">
+    <value>53, 13</value>
+  </data>
+  <data name="lblSummary.TabIndex" type="System.Int32, mscorlib">
+    <value>36</value>
+  </data>
+  <data name="lblSummary.Text" xml:space="preserve">
+    <value>Summary:</value>
+  </data>
+  <data name="&gt;&gt;lblSummary.Name" xml:space="preserve">
+    <value>lblSummary</value>
+  </data>
+  <data name="&gt;&gt;lblSummary.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblSummary.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;lblSummary.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="lblTextColour.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblTextColour.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblTextColour.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 54</value>
+  </data>
+  <data name="lblTextColour.Size" type="System.Drawing.Size, System.Drawing">
+    <value>63, 13</value>
+  </data>
+  <data name="lblTextColour.TabIndex" type="System.Int32, mscorlib">
+    <value>38</value>
+  </data>
+  <data name="lblTextColour.Text" xml:space="preserve">
+    <value>Text colour:</value>
+  </data>
+  <data name="&gt;&gt;lblTextColour.Name" xml:space="preserve">
+    <value>lblTextColour</value>
+  </data>
+  <data name="&gt;&gt;lblTextColour.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblTextColour.Parent" xml:space="preserve">
+    <value>grpOptions</value>
+  </data>
+  <data name="&gt;&gt;lblTextColour.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="ucrColourText.Location" type="System.Drawing.Point, System.Drawing">
+    <value>80, 52</value>
+  </data>
+  <data name="ucrColourText.Size" type="System.Drawing.Size, System.Drawing">
+    <value>137, 21</value>
+  </data>
+  <data name="ucrColourText.TabIndex" type="System.Int32, mscorlib">
+    <value>37</value>
+  </data>
+  <data name="&gt;&gt;ucrColourText.Name" xml:space="preserve">
+    <value>ucrColourText</value>
+  </data>
+  <data name="&gt;&gt;ucrColourText.Type" xml:space="preserve">
+    <value>instat.ucrColors, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrColourText.Parent" xml:space="preserve">
+    <value>grpOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrColourText.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="lblBoxColour.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblBoxColour.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblBoxColour.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 23</value>
+  </data>
+  <data name="lblBoxColour.Size" type="System.Drawing.Size, System.Drawing">
+    <value>60, 13</value>
+  </data>
+  <data name="lblBoxColour.TabIndex" type="System.Int32, mscorlib">
+    <value>36</value>
+  </data>
+  <data name="lblBoxColour.Text" xml:space="preserve">
+    <value>Box colour:</value>
+  </data>
+  <data name="&gt;&gt;lblBoxColour.Name" xml:space="preserve">
+    <value>lblBoxColour</value>
+  </data>
+  <data name="&gt;&gt;lblBoxColour.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblBoxColour.Parent" xml:space="preserve">
+    <value>grpOptions</value>
+  </data>
+  <data name="&gt;&gt;lblBoxColour.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="ucrColourBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>80, 21</value>
+  </data>
+  <data name="ucrColourBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>137, 21</value>
+  </data>
+  <data name="ucrColourBox.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;ucrColourBox.Name" xml:space="preserve">
+    <value>ucrColourBox</value>
+  </data>
+  <data name="&gt;&gt;ucrColourBox.Type" xml:space="preserve">
+    <value>instat.ucrColors, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrColourBox.Parent" xml:space="preserve">
+    <value>grpOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrColourBox.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="grpOptions.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 293</value>
+  </data>
+  <data name="grpOptions.Size" type="System.Drawing.Size, System.Drawing">
+    <value>230, 81</value>
+  </data>
+  <data name="grpOptions.TabIndex" type="System.Int32, mscorlib">
+    <value>35</value>
+  </data>
+  <data name="grpOptions.Text" xml:space="preserve">
+    <value>Options</value>
+  </data>
+  <data name="&gt;&gt;grpOptions.Name" xml:space="preserve">
+    <value>grpOptions</value>
+  </data>
+  <data name="&gt;&gt;grpOptions.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;grpOptions.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;grpOptions.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="lblFill.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblFill.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblFill.Location" type="System.Drawing.Point, System.Drawing">
+    <value>254, 277</value>
+  </data>
+  <data name="lblFill.Size" type="System.Drawing.Size, System.Drawing">
+    <value>22, 13</value>
+  </data>
+  <data name="lblFill.TabIndex" type="System.Int32, mscorlib">
+    <value>33</value>
+  </data>
+  <data name="lblFill.Text" xml:space="preserve">
+    <value>Fill:</value>
+  </data>
+  <data name="&gt;&gt;lblFill.Name" xml:space="preserve">
+    <value>lblFill</value>
+  </data>
+  <data name="&gt;&gt;lblFill.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblFill.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;lblFill.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="ucrReceiverFill.Location" type="System.Drawing.Point, System.Drawing">
+    <value>254, 292</value>
+  </data>
+  <data name="ucrReceiverFill.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="ucrReceiverFill.Size" type="System.Drawing.Size, System.Drawing">
+    <value>120, 20</value>
+  </data>
+  <data name="ucrReceiverFill.TabIndex" type="System.Int32, mscorlib">
+    <value>34</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverFill.Name" xml:space="preserve">
+    <value>ucrReceiverFill</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverFill.Type" xml:space="preserve">
+    <value>instat.ucrReceiverSingle, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverFill.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverFill.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="ucrInputSymbol.Location" type="System.Drawing.Point, System.Drawing">
+    <value>323, 201</value>
+  </data>
+  <data name="ucrInputSymbol.Size" type="System.Drawing.Size, System.Drawing">
+    <value>51, 21</value>
+  </data>
+  <data name="ucrInputSymbol.TabIndex" type="System.Int32, mscorlib">
+    <value>32</value>
+  </data>
+  <data name="&gt;&gt;ucrInputSymbol.Name" xml:space="preserve">
+    <value>ucrInputSymbol</value>
+  </data>
+  <data name="&gt;&gt;ucrInputSymbol.Type" xml:space="preserve">
+    <value>instat.ucrInputTextBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrInputSymbol.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrInputSymbol.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="lblSymbol.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblSymbol.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblSymbol.Location" type="System.Drawing.Point, System.Drawing">
+    <value>272, 203</value>
+  </data>
+  <data name="lblSymbol.Size" type="System.Drawing.Size, System.Drawing">
+    <value>44, 13</value>
+  </data>
+  <data name="lblSymbol.TabIndex" type="System.Int32, mscorlib">
+    <value>31</value>
+  </data>
+  <data name="lblSymbol.Text" xml:space="preserve">
+    <value>Symbol:</value>
+  </data>
+  <data name="&gt;&gt;lblSymbol.Name" xml:space="preserve">
+    <value>lblSymbol</value>
+  </data>
+  <data name="&gt;&gt;lblSymbol.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblSymbol.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;lblSymbol.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="ucrReceiverIdentifier.Location" type="System.Drawing.Point, System.Drawing">
+    <value>254, 76</value>
+  </data>
+  <data name="ucrReceiverIdentifier.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="ucrReceiverIdentifier.Size" type="System.Drawing.Size, System.Drawing">
+    <value>120, 20</value>
+  </data>
+  <data name="ucrReceiverIdentifier.TabIndex" type="System.Int32, mscorlib">
+    <value>20</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverIdentifier.Name" xml:space="preserve">
+    <value>ucrReceiverIdentifier</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverIdentifier.Type" xml:space="preserve">
+    <value>instat.ucrReceiverSingle, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverIdentifier.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverIdentifier.ZOrder" xml:space="preserve">
+    <value>17</value>
+  </data>
+  <data name="ucrSelectorTreemap.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 40</value>
+  </data>
+  <data name="ucrSelectorTreemap.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="ucrSelectorTreemap.Size" type="System.Drawing.Size, System.Drawing">
+    <value>210, 180</value>
+  </data>
+  <data name="ucrSelectorTreemap.TabIndex" type="System.Int32, mscorlib">
+    <value>18</value>
+  </data>
+  <data name="&gt;&gt;ucrSelectorTreemap.Name" xml:space="preserve">
+    <value>ucrSelectorTreemap</value>
+  </data>
+  <data name="&gt;&gt;ucrSelectorTreemap.Type" xml:space="preserve">
+    <value>instat.ucrSelectorByDataFrameAddRemove, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrSelectorTreemap.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrSelectorTreemap.ZOrder" xml:space="preserve">
+    <value>18</value>
+  </data>
+  <data name="ucrBase.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 410</value>
+  </data>
+  <data name="ucrBase.Size" type="System.Drawing.Size, System.Drawing">
+    <value>410, 52</value>
+  </data>
+  <data name="ucrBase.TabIndex" type="System.Int32, mscorlib">
+    <value>30</value>
+  </data>
+  <data name="&gt;&gt;ucrBase.Name" xml:space="preserve">
+    <value>ucrBase</value>
+  </data>
+  <data name="&gt;&gt;ucrBase.Type" xml:space="preserve">
+    <value>instat.ucrButtons, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrBase.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrBase.ZOrder" xml:space="preserve">
+    <value>19</value>
+  </data>
+  <data name="cmdBarChartOptions.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cmdBarChartOptions.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 230</value>
+  </data>
+  <data name="cmdBarChartOptions.Size" type="System.Drawing.Size, System.Drawing">
+    <value>121, 25</value>
+  </data>
+  <data name="cmdBarChartOptions.TabIndex" type="System.Int32, mscorlib">
+    <value>26</value>
+  </data>
+  <data name="cmdBarChartOptions.Text" xml:space="preserve">
+    <value>Bar Chart Options</value>
+  </data>
+  <data name="&gt;&gt;cmdBarChartOptions.Name" xml:space="preserve">
+    <value>cmdBarChartOptions</value>
+  </data>
+  <data name="&gt;&gt;cmdBarChartOptions.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cmdBarChartOptions.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;cmdBarChartOptions.ZOrder" xml:space="preserve">
+    <value>20</value>
+  </data>
+  <data name="cmdPieChartOptions.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cmdPieChartOptions.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 230</value>
+  </data>
+  <data name="cmdPieChartOptions.Size" type="System.Drawing.Size, System.Drawing">
+    <value>121, 25</value>
+  </data>
+  <data name="cmdPieChartOptions.TabIndex" type="System.Int32, mscorlib">
+    <value>24</value>
+  </data>
+  <data name="cmdPieChartOptions.Text" xml:space="preserve">
+    <value>Pie Chart Options</value>
+  </data>
+  <data name="&gt;&gt;cmdPieChartOptions.Name" xml:space="preserve">
+    <value>cmdPieChartOptions</value>
+  </data>
+  <data name="&gt;&gt;cmdPieChartOptions.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cmdPieChartOptions.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;cmdPieChartOptions.ZOrder" xml:space="preserve">
+    <value>21</value>
+  </data>
+  <data name="ucrPnlDataType.Location" type="System.Drawing.Point, System.Drawing">
+    <value>86, 5</value>
+  </data>
+  <data name="ucrPnlDataType.Size" type="System.Drawing.Size, System.Drawing">
+    <value>241, 36</value>
+  </data>
+  <data name="ucrPnlDataType.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlDataType.Name" xml:space="preserve">
+    <value>ucrPnlDataType</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlDataType.Type" xml:space="preserve">
+    <value>instat.UcrPanel, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlDataType.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlDataType.ZOrder" xml:space="preserve">
+    <value>22</value>
+  </data>
+  <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
+    <value>CenterScreen</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>Treemap</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>dlgTreemap</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Form, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="ucrReceiverWeightBy.Location" type="System.Drawing.Point, System.Drawing">
+    <value>254, 126</value>
+  </data>
+  <data name="ucrReceiverWeightBy.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="ucrReceiverWeightBy.Size" type="System.Drawing.Size, System.Drawing">
+    <value>120, 20</value>
+  </data>
+  <data name="ucrReceiverWeightBy.TabIndex" type="System.Int32, mscorlib">
+    <value>22</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverWeightBy.Name" xml:space="preserve">
+    <value>ucrReceiverWeightBy</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverWeightBy.Type" xml:space="preserve">
+    <value>instat.ucrReceiverSingle, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverWeightBy.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverWeightBy.ZOrder" xml:space="preserve">
+    <value>16</value>
+  </data>
+</root>

--- a/instat/dlgTreemap.resx
+++ b/instat/dlgTreemap.resx
@@ -150,72 +150,6 @@
   <data name="&gt;&gt;lblLabel.ZOrder" xml:space="preserve">
     <value>7</value>
   </data>
-  <data name="ucrInputLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>254, 244</value>
-  </data>
-  <data name="ucrInputLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>21, 17, 21, 17</value>
-  </data>
-  <data name="ucrInputLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 21</value>
-  </data>
-  <data name="ucrInputLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>25</value>
-  </data>
-  <data name="&gt;&gt;ucrInputLabel.Name" xml:space="preserve">
-    <value>ucrInputLabel</value>
-  </data>
-  <data name="&gt;&gt;ucrInputLabel.Type" xml:space="preserve">
-    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrInputLabel.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;ucrInputLabel.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="ucrSaveTreemap.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 380</value>
-  </data>
-  <data name="ucrSaveTreemap.Size" type="System.Drawing.Size, System.Drawing">
-    <value>255, 24</value>
-  </data>
-  <data name="ucrSaveTreemap.TabIndex" type="System.Int32, mscorlib">
-    <value>29</value>
-  </data>
-  <data name="&gt;&gt;ucrSaveTreemap.Name" xml:space="preserve">
-    <value>ucrSaveTreemap</value>
-  </data>
-  <data name="&gt;&gt;ucrSaveTreemap.Type" xml:space="preserve">
-    <value>instat.ucrSave, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrSaveTreemap.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;ucrSaveTreemap.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="ucrChkIsCurrency.Location" type="System.Drawing.Point, System.Drawing">
-    <value>254, 180</value>
-  </data>
-  <data name="ucrChkIsCurrency.Size" type="System.Drawing.Size, System.Drawing">
-    <value>82, 20</value>
-  </data>
-  <data name="ucrChkIsCurrency.TabIndex" type="System.Int32, mscorlib">
-    <value>28</value>
-  </data>
-  <data name="&gt;&gt;ucrChkIsCurrency.Name" xml:space="preserve">
-    <value>ucrChkIsCurrency</value>
-  </data>
-  <data name="&gt;&gt;ucrChkIsCurrency.Type" xml:space="preserve">
-    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrChkIsCurrency.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;ucrChkIsCurrency.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
   <data name="rdoPrimary.Appearance" type="System.Windows.Forms.Appearance, System.Windows.Forms">
     <value>Button</value>
   </data>
@@ -375,65 +309,65 @@
   <data name="&gt;&gt;lblIdentifier.ZOrder" xml:space="preserve">
     <value>15</value>
   </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
-  </data>
-  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>418, 464</value>
-  </data>
-  <data name="ucrInputSummary.Location" type="System.Drawing.Point, System.Drawing">
-    <value>307, 154</value>
-  </data>
-  <data name="ucrInputSummary.Size" type="System.Drawing.Size, System.Drawing">
-    <value>67, 21</value>
-  </data>
-  <data name="ucrInputSummary.TabIndex" type="System.Int32, mscorlib">
-    <value>37</value>
-  </data>
-  <data name="&gt;&gt;ucrInputSummary.Name" xml:space="preserve">
-    <value>ucrInputSummary</value>
-  </data>
-  <data name="&gt;&gt;ucrInputSummary.Type" xml:space="preserve">
-    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrInputSummary.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;ucrInputSummary.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="lblSummary.AutoSize" type="System.Boolean, mscorlib">
+  <data name="lblSymbol.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="lblSummary.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="lblSymbol.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="lblSummary.Location" type="System.Drawing.Point, System.Drawing">
-    <value>252, 156</value>
+  <data name="lblSymbol.Location" type="System.Drawing.Point, System.Drawing">
+    <value>272, 203</value>
   </data>
-  <data name="lblSummary.Size" type="System.Drawing.Size, System.Drawing">
-    <value>53, 13</value>
+  <data name="lblSymbol.Size" type="System.Drawing.Size, System.Drawing">
+    <value>44, 13</value>
   </data>
-  <data name="lblSummary.TabIndex" type="System.Int32, mscorlib">
-    <value>36</value>
+  <data name="lblSymbol.TabIndex" type="System.Int32, mscorlib">
+    <value>31</value>
   </data>
-  <data name="lblSummary.Text" xml:space="preserve">
-    <value>Summary:</value>
+  <data name="lblSymbol.Text" xml:space="preserve">
+    <value>Symbol:</value>
   </data>
-  <data name="&gt;&gt;lblSummary.Name" xml:space="preserve">
-    <value>lblSummary</value>
+  <data name="&gt;&gt;lblSymbol.Name" xml:space="preserve">
+    <value>lblSymbol</value>
   </data>
-  <data name="&gt;&gt;lblSummary.Type" xml:space="preserve">
+  <data name="&gt;&gt;lblSymbol.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;lblSummary.Parent" xml:space="preserve">
+  <data name="&gt;&gt;lblSymbol.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;lblSummary.ZOrder" xml:space="preserve">
-    <value>1</value>
+  <data name="&gt;&gt;lblSymbol.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="lblFill.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblFill.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblFill.Location" type="System.Drawing.Point, System.Drawing">
+    <value>254, 277</value>
+  </data>
+  <data name="lblFill.Size" type="System.Drawing.Size, System.Drawing">
+    <value>22, 13</value>
+  </data>
+  <data name="lblFill.TabIndex" type="System.Int32, mscorlib">
+    <value>33</value>
+  </data>
+  <data name="lblFill.Text" xml:space="preserve">
+    <value>Fill:</value>
+  </data>
+  <data name="&gt;&gt;lblFill.Name" xml:space="preserve">
+    <value>lblFill</value>
+  </data>
+  <data name="&gt;&gt;lblFill.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblFill.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;lblFill.ZOrder" xml:space="preserve">
+    <value>3</value>
   </data>
   <data name="lblTextColour.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -486,55 +420,55 @@
   <data name="&gt;&gt;ucrColourText.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="lblBoxColour.AutoSize" type="System.Boolean, mscorlib">
+  <data name="lblTileColour.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="lblBoxColour.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="lblTileColour.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="lblBoxColour.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="lblTileColour.Location" type="System.Drawing.Point, System.Drawing">
     <value>9, 23</value>
   </data>
-  <data name="lblBoxColour.Size" type="System.Drawing.Size, System.Drawing">
-    <value>60, 13</value>
+  <data name="lblTileColour.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 13</value>
   </data>
-  <data name="lblBoxColour.TabIndex" type="System.Int32, mscorlib">
+  <data name="lblTileColour.TabIndex" type="System.Int32, mscorlib">
     <value>36</value>
   </data>
-  <data name="lblBoxColour.Text" xml:space="preserve">
-    <value>Box colour:</value>
+  <data name="lblTileColour.Text" xml:space="preserve">
+    <value>Tile colour:</value>
   </data>
-  <data name="&gt;&gt;lblBoxColour.Name" xml:space="preserve">
-    <value>lblBoxColour</value>
+  <data name="&gt;&gt;lblTileColour.Name" xml:space="preserve">
+    <value>lblTileColour</value>
   </data>
-  <data name="&gt;&gt;lblBoxColour.Type" xml:space="preserve">
+  <data name="&gt;&gt;lblTileColour.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;lblBoxColour.Parent" xml:space="preserve">
+  <data name="&gt;&gt;lblTileColour.Parent" xml:space="preserve">
     <value>grpOptions</value>
   </data>
-  <data name="&gt;&gt;lblBoxColour.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;lblTileColour.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
-  <data name="ucrColourBox.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="ucrColourTile.Location" type="System.Drawing.Point, System.Drawing">
     <value>80, 21</value>
   </data>
-  <data name="ucrColourBox.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="ucrColourTile.Size" type="System.Drawing.Size, System.Drawing">
     <value>137, 21</value>
   </data>
-  <data name="ucrColourBox.TabIndex" type="System.Int32, mscorlib">
+  <data name="ucrColourTile.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;ucrColourBox.Name" xml:space="preserve">
-    <value>ucrColourBox</value>
+  <data name="&gt;&gt;ucrColourTile.Name" xml:space="preserve">
+    <value>ucrColourTile</value>
   </data>
-  <data name="&gt;&gt;ucrColourBox.Type" xml:space="preserve">
+  <data name="&gt;&gt;ucrColourTile.Type" xml:space="preserve">
     <value>instat.ucrColors, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="&gt;&gt;ucrColourBox.Parent" xml:space="preserve">
+  <data name="&gt;&gt;ucrColourTile.Parent" xml:space="preserve">
     <value>grpOptions</value>
   </data>
-  <data name="&gt;&gt;ucrColourBox.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;ucrColourTile.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
   <data name="grpOptions.Location" type="System.Drawing.Point, System.Drawing">
@@ -561,59 +495,65 @@
   <data name="&gt;&gt;grpOptions.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
-  <data name="lblFill.AutoSize" type="System.Boolean, mscorlib">
+  <data name="lblSummary.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="lblFill.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="lblSummary.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="lblFill.Location" type="System.Drawing.Point, System.Drawing">
-    <value>254, 277</value>
+  <data name="lblSummary.Location" type="System.Drawing.Point, System.Drawing">
+    <value>252, 156</value>
   </data>
-  <data name="lblFill.Size" type="System.Drawing.Size, System.Drawing">
-    <value>22, 13</value>
+  <data name="lblSummary.Size" type="System.Drawing.Size, System.Drawing">
+    <value>53, 13</value>
   </data>
-  <data name="lblFill.TabIndex" type="System.Int32, mscorlib">
-    <value>33</value>
+  <data name="lblSummary.TabIndex" type="System.Int32, mscorlib">
+    <value>36</value>
   </data>
-  <data name="lblFill.Text" xml:space="preserve">
-    <value>Fill:</value>
+  <data name="lblSummary.Text" xml:space="preserve">
+    <value>Summary:</value>
   </data>
-  <data name="&gt;&gt;lblFill.Name" xml:space="preserve">
-    <value>lblFill</value>
+  <data name="&gt;&gt;lblSummary.Name" xml:space="preserve">
+    <value>lblSummary</value>
   </data>
-  <data name="&gt;&gt;lblFill.Type" xml:space="preserve">
+  <data name="&gt;&gt;lblSummary.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;lblFill.Parent" xml:space="preserve">
+  <data name="&gt;&gt;lblSummary.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;lblFill.ZOrder" xml:space="preserve">
-    <value>3</value>
+  <data name="&gt;&gt;lblSummary.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
-  <data name="ucrReceiverFill.Location" type="System.Drawing.Point, System.Drawing">
-    <value>254, 292</value>
+  <data name="ucrInputSummary.Location" type="System.Drawing.Point, System.Drawing">
+    <value>307, 154</value>
   </data>
-  <data name="ucrReceiverFill.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
+  <data name="ucrInputSummary.Size" type="System.Drawing.Size, System.Drawing">
+    <value>67, 21</value>
   </data>
-  <data name="ucrReceiverFill.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 20</value>
+  <data name="ucrInputSummary.TabIndex" type="System.Int32, mscorlib">
+    <value>37</value>
   </data>
-  <data name="ucrReceiverFill.TabIndex" type="System.Int32, mscorlib">
-    <value>34</value>
+  <data name="&gt;&gt;ucrInputSummary.Name" xml:space="preserve">
+    <value>ucrInputSummary</value>
   </data>
-  <data name="&gt;&gt;ucrReceiverFill.Name" xml:space="preserve">
-    <value>ucrReceiverFill</value>
+  <data name="&gt;&gt;ucrInputSummary.Type" xml:space="preserve">
+    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="&gt;&gt;ucrReceiverFill.Type" xml:space="preserve">
-    <value>instat.ucrReceiverSingle, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverFill.Parent" xml:space="preserve">
+  <data name="&gt;&gt;ucrInputSummary.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;ucrReceiverFill.ZOrder" xml:space="preserve">
-    <value>4</value>
+  <data name="&gt;&gt;ucrInputSummary.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>418, 464</value>
   </data>
   <data name="ucrInputSymbol.Location" type="System.Drawing.Point, System.Drawing">
     <value>323, 201</value>
@@ -636,35 +576,95 @@
   <data name="&gt;&gt;ucrInputSymbol.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
-  <data name="lblSymbol.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
+  <data name="ucrInputLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>254, 244</value>
   </data>
-  <data name="lblSymbol.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
+  <data name="ucrInputLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>21, 17, 21, 17</value>
   </data>
-  <data name="lblSymbol.Location" type="System.Drawing.Point, System.Drawing">
-    <value>272, 203</value>
+  <data name="ucrInputLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>120, 21</value>
   </data>
-  <data name="lblSymbol.Size" type="System.Drawing.Size, System.Drawing">
-    <value>44, 13</value>
+  <data name="ucrInputLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>25</value>
   </data>
-  <data name="lblSymbol.TabIndex" type="System.Int32, mscorlib">
-    <value>31</value>
+  <data name="&gt;&gt;ucrInputLabel.Name" xml:space="preserve">
+    <value>ucrInputLabel</value>
   </data>
-  <data name="lblSymbol.Text" xml:space="preserve">
-    <value>Symbol:</value>
+  <data name="&gt;&gt;ucrInputLabel.Type" xml:space="preserve">
+    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="&gt;&gt;lblSymbol.Name" xml:space="preserve">
-    <value>lblSymbol</value>
-  </data>
-  <data name="&gt;&gt;lblSymbol.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblSymbol.Parent" xml:space="preserve">
+  <data name="&gt;&gt;ucrInputLabel.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;lblSymbol.ZOrder" xml:space="preserve">
-    <value>6</value>
+  <data name="&gt;&gt;ucrInputLabel.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="ucrSaveTreemap.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 380</value>
+  </data>
+  <data name="ucrSaveTreemap.Size" type="System.Drawing.Size, System.Drawing">
+    <value>255, 24</value>
+  </data>
+  <data name="ucrSaveTreemap.TabIndex" type="System.Int32, mscorlib">
+    <value>29</value>
+  </data>
+  <data name="&gt;&gt;ucrSaveTreemap.Name" xml:space="preserve">
+    <value>ucrSaveTreemap</value>
+  </data>
+  <data name="&gt;&gt;ucrSaveTreemap.Type" xml:space="preserve">
+    <value>instat.ucrSave, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrSaveTreemap.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrSaveTreemap.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="ucrChkIsCurrency.Location" type="System.Drawing.Point, System.Drawing">
+    <value>254, 180</value>
+  </data>
+  <data name="ucrChkIsCurrency.Size" type="System.Drawing.Size, System.Drawing">
+    <value>82, 20</value>
+  </data>
+  <data name="ucrChkIsCurrency.TabIndex" type="System.Int32, mscorlib">
+    <value>28</value>
+  </data>
+  <data name="&gt;&gt;ucrChkIsCurrency.Name" xml:space="preserve">
+    <value>ucrChkIsCurrency</value>
+  </data>
+  <data name="&gt;&gt;ucrChkIsCurrency.Type" xml:space="preserve">
+    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrChkIsCurrency.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrChkIsCurrency.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="ucrReceiverWeightBy.Location" type="System.Drawing.Point, System.Drawing">
+    <value>254, 126</value>
+  </data>
+  <data name="ucrReceiverWeightBy.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="ucrReceiverWeightBy.Size" type="System.Drawing.Size, System.Drawing">
+    <value>120, 20</value>
+  </data>
+  <data name="ucrReceiverWeightBy.TabIndex" type="System.Int32, mscorlib">
+    <value>22</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverWeightBy.Name" xml:space="preserve">
+    <value>ucrReceiverWeightBy</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverWeightBy.Type" xml:space="preserve">
+    <value>instat.ucrReceiverSingle, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverWeightBy.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverWeightBy.ZOrder" xml:space="preserve">
+    <value>16</value>
   </data>
   <data name="ucrReceiverIdentifier.Location" type="System.Drawing.Point, System.Drawing">
     <value>254, 76</value>
@@ -756,6 +756,9 @@
   <data name="&gt;&gt;ucrPnlDataType.ZOrder" xml:space="preserve">
     <value>20</value>
   </data>
+  <data name="$this.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterScreen</value>
   </data>
@@ -768,28 +771,28 @@
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
     <value>System.Windows.Forms.Form, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="ucrReceiverWeightBy.Location" type="System.Drawing.Point, System.Drawing">
-    <value>254, 126</value>
+  <data name="ucrReceiverFill.Location" type="System.Drawing.Point, System.Drawing">
+    <value>254, 292</value>
   </data>
-  <data name="ucrReceiverWeightBy.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="ucrReceiverFill.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
   </data>
-  <data name="ucrReceiverWeightBy.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="ucrReceiverFill.Size" type="System.Drawing.Size, System.Drawing">
     <value>120, 20</value>
   </data>
-  <data name="ucrReceiverWeightBy.TabIndex" type="System.Int32, mscorlib">
-    <value>22</value>
+  <data name="ucrReceiverFill.TabIndex" type="System.Int32, mscorlib">
+    <value>34</value>
   </data>
-  <data name="&gt;&gt;ucrReceiverWeightBy.Name" xml:space="preserve">
-    <value>ucrReceiverWeightBy</value>
+  <data name="&gt;&gt;ucrReceiverFill.Name" xml:space="preserve">
+    <value>ucrReceiverFill</value>
   </data>
-  <data name="&gt;&gt;ucrReceiverWeightBy.Type" xml:space="preserve">
+  <data name="&gt;&gt;ucrReceiverFill.Type" xml:space="preserve">
     <value>instat.ucrReceiverSingle, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="&gt;&gt;ucrReceiverWeightBy.Parent" xml:space="preserve">
+  <data name="&gt;&gt;ucrReceiverFill.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;ucrReceiverWeightBy.ZOrder" xml:space="preserve">
-    <value>16</value>
+  <data name="&gt;&gt;ucrReceiverFill.ZOrder" xml:space="preserve">
+    <value>4</value>
   </data>
 </root>

--- a/instat/dlgTreemap.vb
+++ b/instat/dlgTreemap.vb
@@ -280,7 +280,7 @@ Public Class dlgTreemap
         TestOkEnabled()
     End Sub
 
-    Private Sub CoreControls_ContentsChanged() Handles ucrReceiverIdentifier.ControlContentsChanged, ucrSaveTreemap.ControlContentsChanged, ucrPnlDataType.ControlContentsChanged
+    Private Sub CoreControls_ContentsChanged() Handles ucrReceiverIdentifier.ControlContentsChanged, ucrSaveTreemap.ControlContentsChanged, ucrPnlDataType.ControlContentsChanged, ucrReceiverWeightBy.ControlContentsChanged
         TestOkEnabled()
     End Sub
 

--- a/instat/dlgTreemap.vb
+++ b/instat/dlgTreemap.vb
@@ -1,0 +1,334 @@
+﻿' R- Instat
+' Copyright (C) 2015-2017
+'
+' This program is free software: you can redistribute it and/or modify
+' it under the terms of the GNU General Public License as published by
+' the Free Software Foundation, either version 3 of the License, or
+' (at your option) any later version.
+'
+' This program is distributed in the hope that it will be useful,
+' but WITHOUT ANY WARRANTY; without even the implied warranty of
+' MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+' GNU General Public License for more details.
+'
+' You should have received a copy of the GNU General Public License 
+' along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Imports instat
+Imports instat.Translations
+
+Public Class dlgTreemap
+    Private clsBaseOperator As New ROperator
+
+    Private clsPipeOperator As New ROperator
+    Private clsGroupByFunction As New RFunction
+    Private clsSummariseFunction As New RFunction
+    Private clsSummaryFunction As New RFunction
+
+    Private clsGgplotFunction As New RFunction
+    Private clsGeomTreemapFunction As New RFunction
+    Private clsGeomTreemapAesFunction As New RFunction
+    Private clsGeomTreemapTextFunction As New RFunction
+    Private clsGeomTreemapTextAesFunction As New RFunction
+
+    Private clsPaste0Function As New RFunction
+    Private clsDollarFunction As New RFunction
+
+    Private clsLocalAesFunction As New RFunction
+
+    Private clsRCoordPolarParam As New RParameter
+    Private clsLabsFunction As New RFunction
+    Private clsXlabFunction As New RFunction
+    Private clsYlabFunction As New RFunction
+    Private clsXScalecontinuousFunction As New RFunction
+    Private clsYScalecontinuousFunction As New RFunction
+    Private clsRFacetFunction As New RFunction
+    Private clsThemeFuction As New RFunction
+    Private dctThemeFunctions As New Dictionary(Of String, RFunction)
+
+    Private bReset As Boolean = True
+    Private bFirstLoad As Boolean = True
+
+    Private Sub dlgTreemap_Load(sender As Object, e As EventArgs) Handles MyBase.Load
+        If bFirstLoad Then
+            InitialiseDialog()
+            bFirstLoad = False
+        End If
+        If bReset Then
+            SetDefaults()
+        End If
+        SetRCodeForControls(bReset)
+        bReset = False
+        autoTranslate(Me)
+        TestOkEnabled()
+    End Sub
+
+    Private Sub InitialiseDialog()
+        ucrBase.clsRsyntax.bExcludeAssignedFunctionOutput = False
+        ucrBase.clsRsyntax.iCallType = 3
+        'ucrBase.iHelpTopicID = 
+
+        ucrPnlDataType.AddRadioButton(rdoPrimary)
+        ucrPnlDataType.AddRadioButton(rdoSummary)
+        ucrPnlDataType.AddParameterPresentCondition(rdoPrimary, "group_by", False)
+        ucrPnlDataType.AddParameterPresentCondition(rdoSummary, "group_by", True)
+
+        ucrSelectorTreemap.SetParameter(New RParameter("data", 0))
+        ucrSelectorTreemap.SetParameterIsrfunction()
+
+        ucrReceiverIdentifier.Selector = ucrSelectorTreemap
+        ucrReceiverIdentifier.SetParameter(New RParameter("0", 0, bNewIncludeArgumentName:=False))
+        ucrReceiverIdentifier.bWithQuotes = False
+        ucrReceiverIdentifier.SetParameterIsString()
+
+        ucrReceiverWeightBy.Selector = ucrSelectorTreemap
+        ucrReceiverWeightBy.SetIncludedDataTypes({"numeric"})
+        ucrReceiverWeightBy.strSelectorHeading = "Numerics"
+        ucrReceiverWeightBy.SetParameter(New RParameter("area", 1))
+        ucrReceiverWeightBy.bWithQuotes = False
+        ucrReceiverWeightBy.SetParameterIsString()
+        ucrReceiverWeightBy.SetValuesToIgnore({".n"})
+
+        ucrInputSummary.SetItems({"sum", "mean", "min", "max"})
+        ucrInputSummary.AddQuotesIfUnrecognised = False
+        ucrInputSummary.SetLinkedDisplayControl(lblSummary)
+
+        ucrChkIsCurrency.SetText("Is Currency")
+        ucrChkIsCurrency.SetParameter(New RParameter("weight", iNewPosition:=2, bNewIncludeArgumentName:=False), bNewChangeParameterValue:=False, bNewAddRemoveParameter:=True)
+        ucrChkIsCurrency.AddToLinkedControls(ucrInputSymbol, {True}, bNewLinkedHideIfParameterMissing:=True)
+
+        ucrInputSymbol.SetParameter(New RParameter("prefix", 3))
+        ucrInputSymbol.SetLinkedDisplayControl(lblSymbol)
+
+        ucrInputLabel.SetItems({"Identifier only", "Identifier & Weight", "Weight only", "None"})
+        ucrInputLabel.AddParameterPresentCondition("Identifier only", "group")
+        ucrInputLabel.AddParameterPresentCondition("Identifier & Weight", "\n")
+        ucrInputLabel.AddParameterPresentCondition("Weight only", "weight")
+        ucrInputLabel.AddParameterPresentCondition("None", "label", bNewIsPositive:=False)
+        ucrInputLabel.SetDropDownStyleAsNonEditable()
+
+        ucrReceiverFill.Selector = ucrSelectorTreemap
+        ucrReceiverFill.SetParameter(New RParameter("fill", 3))
+        ucrReceiverFill.bWithQuotes = False
+        ucrReceiverFill.SetParameterIsString()
+
+        ucrColourBox.SetParameter(New RParameter("fill", 3))
+
+        ucrColourText.SetParameter(New RParameter("colour", 3))
+    End Sub
+
+    Private Sub SetDefaults()
+        clsBaseOperator = New ROperator
+        clsPipeOperator = New ROperator
+        clsGroupByFunction = New RFunction
+        clsSummariseFunction = New RFunction
+        clsSummaryFunction = New RFunction
+        clsGgplotFunction = New RFunction
+        clsGeomTreemapFunction = New RFunction
+        clsGeomTreemapAesFunction = New RFunction
+        clsGeomTreemapTextFunction = New RFunction
+        clsGeomTreemapTextAesFunction = New RFunction
+        clsPaste0Function = New RFunction
+        clsDollarFunction = New RFunction
+        clsLocalAesFunction = New RFunction
+        clsRCoordPolarParam = New RParameter
+        clsLabsFunction = New RFunction
+        clsXlabFunction = New RFunction
+        clsYlabFunction = New RFunction
+        clsXScalecontinuousFunction = New RFunction
+        clsYScalecontinuousFunction = New RFunction
+        clsRFacetFunction = New RFunction
+        clsThemeFuction = New RFunction
+        dctThemeFunctions = New Dictionary(Of String, RFunction)
+
+        ucrSelectorTreemap.Reset()
+        ucrSelectorTreemap.SetGgplotFunction(clsBaseOperator)
+        ucrReceiverIdentifier.SetMeAsReceiver()
+        ucrSaveTreemap.Reset()
+
+        clsPipeOperator.SetOperation("%>%")
+
+        clsGroupByFunction.SetPackageName("dplyr")
+        clsGroupByFunction.SetRCommand("group_by")
+
+        clsSummariseFunction.SetPackageName("dplyr")
+        clsSummariseFunction.SetRCommand("summarise")
+        clsSummariseFunction.AddParameter(".n", "n()", iPosition:=0)
+
+        clsSummaryFunction.SetRCommand("sum")
+        clsSummaryFunction.AddParameter("na.rm", "TRUE", iPosition:=1)
+
+        clsBaseOperator.SetOperation("+")
+        clsBaseOperator.AddParameter("ggplot", clsRFunctionParameter:=clsGgplotFunction, iPosition:=0)
+        clsBaseOperator.AddParameter("geomfunc", clsRFunctionParameter:=clsGeomTreemapFunction, iPosition:=2)
+
+        clsGgplotFunction.SetPackageName("ggplot2")
+        clsGgplotFunction.SetRCommand("ggplot")
+        clsGgplotFunction.AddParameter("data", clsROperatorParameter:=clsPipeOperator, iPosition:=0)
+        clsGgplotFunction.AddParameter("mapping", clsRFunctionParameter:=clsGeomTreemapAesFunction, iPosition:=1)
+
+        clsGeomTreemapAesFunction.SetPackageName("ggplot2")
+        clsGeomTreemapAesFunction.SetRCommand("aes")
+
+        clsGeomTreemapFunction.SetPackageName("treemapify")
+        clsGeomTreemapFunction.SetRCommand("geom_treemap")
+        clsGeomTreemapFunction.AddParameter("fill", Chr(34) & "brown" & Chr(34), iPosition:=2)
+
+        clsGeomTreemapTextFunction.SetPackageName("treemapify")
+        clsGeomTreemapTextFunction.SetRCommand("geom_treemap_text")
+        clsGeomTreemapTextFunction.AddParameter("mapping", clsRFunctionParameter:=clsGeomTreemapTextAesFunction, iPosition:=0)
+        clsGeomTreemapTextFunction.AddParameter("colour", Chr(34) & "white" & Chr(34), iPosition:=2)
+
+        clsGeomTreemapTextAesFunction.SetPackageName("ggplot2")
+        clsGeomTreemapTextAesFunction.SetRCommand("aes")
+        clsGeomTreemapTextAesFunction.AddParameter("label", clsRFunctionParameter:=clsPaste0Function, iPosition:=2)
+
+        clsPaste0Function.SetRCommand("paste0")
+        clsPaste0Function.AddParameter("group", ucrReceiverIdentifier.GetVariableNames(), iPosition:=0)
+
+        clsDollarFunction.SetPackageName("scales")
+        clsDollarFunction.SetRCommand("dollar")
+        clsDollarFunction.AddParameter("prefix", Chr(34) & "$" & Chr(34), iPosition:=3)
+
+        clsLabsFunction = GgplotDefaults.clsDefaultLabs.Clone()
+        clsXlabFunction = GgplotDefaults.clsXlabTitleFunction.Clone()
+        clsYlabFunction = GgplotDefaults.clsYlabTitleFunction.Clone()
+        clsXScalecontinuousFunction = GgplotDefaults.clsXScalecontinuousFunction.Clone()
+        clsYScalecontinuousFunction = GgplotDefaults.clsYScalecontinuousFunction.Clone
+        clsRFacetFunction = GgplotDefaults.clsFacetFunction.Clone()
+        clsBaseOperator.AddParameter(GgplotDefaults.clsDefaultThemeParameter.Clone())
+        clsThemeFuction = GgplotDefaults.clsDefaultThemeFunction.Clone
+        dctThemeFunctions = New Dictionary(Of String, RFunction)(GgplotDefaults.dctThemeFunctions)
+        clsLocalAesFunction = GgplotDefaults.clsAesFunction.Clone()
+
+        clsBaseOperator.SetAssignTo("last_graph", strTempDataframe:=ucrSelectorTreemap.ucrAvailableDataFrames.cboAvailableDataFrames.Text, strTempGraph:="last_graph")
+        ucrBase.clsRsyntax.SetBaseROperator(clsBaseOperator)
+    End Sub
+
+    Private Sub SetRCodeForControls(bReset As Boolean)
+        ucrPnlDataType.SetRCode(clsPipeOperator, bReset)
+        ucrSelectorTreemap.SetRCode(clsPipeOperator, bReset)
+        ucrReceiverIdentifier.SetRCode(clsGroupByFunction, bReset)
+        ucrReceiverWeightBy.SetRCode(clsGeomTreemapAesFunction, bReset)
+        ucrReceiverWeightBy.SetRCode(clsGeomTreemapAesFunction, bReset)
+        ucrChkIsCurrency.SetRCode(clsPaste0Function, bReset)
+        ucrInputSymbol.SetRCode(clsDollarFunction, bReset)
+        ucrInputLabel.SetRCode(clsPaste0Function, bReset)
+        ucrReceiverFill.SetRCode(clsGeomTreemapAesFunction, bReset)
+        ucrColourBox.SetRCode(clsGeomTreemapFunction, bReset)
+        ucrColourText.SetRCode(clsGeomTreemapTextFunction, bReset)
+
+        ucrInputLabel.SetText("Identifier only")
+        SetLabel()
+    End Sub
+
+    Private Sub TestOkEnabled()
+        If Not ucrReceiverIdentifier.IsEmpty() AndAlso ucrSaveTreemap.IsComplete() Then
+            ucrBase.OKEnabled(True)
+        Else
+            ucrBase.OKEnabled(False)
+        End If
+    End Sub
+
+    Private Sub ucrBase_ClickReset(sender As Object, e As EventArgs) Handles ucrBase.ClickReset
+        SetDefaults()
+        SetRCodeForControls(True)
+        TestOkEnabled()
+    End Sub
+
+    Private Sub CoreControls_ContentsChanged() Handles ucrReceiverIdentifier.ControlContentsChanged, ucrSaveTreemap.ControlContentsChanged
+        TestOkEnabled()
+    End Sub
+
+    Private Sub ucrPnlDataType_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrPnlDataType.ControlValueChanged
+        If rdoPrimary.Checked Then
+            lblGroupByIdentifier.Text = "Identifier:"
+            lblWeightBy.Text = "Weight By (Optional):"
+            clsPipeOperator.AddParameter("1", clsRFunctionParameter:=clsGroupByFunction, iPosition:=1)
+            clsPipeOperator.AddParameter("2", clsRFunctionParameter:=clsSummariseFunction, iPosition:=2)
+        ElseIf rdoSummary.Checked Then
+            lblGroupByIdentifier.Text = "Identifier (Optional):"
+            lblWeightBy.Text = "Weight By:"
+            clsPipeOperator.RemoveParameterByName("1")
+            clsPipeOperator.RemoveParameterByName("2")
+        End If
+    End Sub
+
+    Private Sub ucrInputLabel_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrInputLabel.ControlValueChanged
+        SetLabel()
+    End Sub
+
+    Private Sub SetLabel()
+        clsPaste0Function.ClearParameters()
+        Select Case ucrInputLabel.GetText()
+            Case "Identifier only"
+                clsBaseOperator.AddParameter("geomfunc2", clsRFunctionParameter:=clsGeomTreemapTextFunction, iPosition:=3)
+                clsGeomTreemapTextAesFunction.AddParameter("label", clsRFunctionParameter:=clsPaste0Function, iPosition:=2)
+                clsPaste0Function.AddParameter("group", ucrReceiverIdentifier.GetVariableNames(False), iPosition:=0, bIncludeArgumentName:=False)
+            Case "Identifier & Weight", "Weight only"
+                clsBaseOperator.AddParameter("geomfunc2", clsRFunctionParameter:=clsGeomTreemapTextFunction, iPosition:=3)
+                clsGeomTreemapTextAesFunction.AddParameter("label", clsRFunctionParameter:=clsPaste0Function, iPosition:=2)
+                clsPaste0Function.AddParameter("group", ucrReceiverIdentifier.GetVariableNames(False), iPosition:=0, bIncludeArgumentName:=False)
+                clsPaste0Function.AddParameter("\n", "\n", iPosition:=1, bIncludeArgumentName:=False)
+                SetWeightLabel()
+            Case "None"
+                clsBaseOperator.RemoveParameterByName("geomfunc2")
+                clsGeomTreemapTextAesFunction.RemoveParameterByName("label")
+        End Select
+    End Sub
+
+    Private Sub SetWeightLabel()
+        If ucrChkIsCurrency.Checked Then
+            clsPaste0Function.AddParameter("weight", clsRFunctionParameter:=clsDollarFunction, iPosition:=2, bIncludeArgumentName:=False)
+        Else
+            clsPaste0Function.AddParameter("weight", ucrReceiverIdentifier.GetVariableNames(), iPosition:=2, bIncludeArgumentName:=False)
+        End If
+    End Sub
+
+    Private Sub ucrReceiverFill_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverFill.ControlValueChanged
+        If ucrReceiverFill.IsEmpty() Then
+            clsGeomTreemapFunction.AddParameter("fill", ucrColourBox.GetText(), iPosition:=3)
+            ucrColourBox.Enabled = True
+        Else
+            clsGeomTreemapFunction.RemoveParameterByName("fill")
+            ucrColourBox.Enabled = False
+        End If
+    End Sub
+
+    Private Sub ucrReceivers_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverIdentifier.ControlValueChanged, ucrReceiverWeightBy.ControlValueChanged, ucrPnlDataType.ControlValueChanged
+        If rdoPrimary.Checked Then
+            If ucrReceiverWeightBy.IsEmpty Then
+                clsGeomTreemapAesFunction.AddParameter("area", ".n", iPosition:=0)
+            Else
+                clsGeomTreemapAesFunction.AddParameter("area", ucrReceiverWeightBy.GetVariableNames(), iPosition:=0)
+            End If
+        ElseIf rdoSummary.Checked Then
+            clsGeomTreemapAesFunction.AddParameter("area", ucrReceiverWeightBy.GetVariableNames(), iPosition:=0)
+        End If
+        SetLabel()
+    End Sub
+
+    Private Sub ucrReceiverWeightBy_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverWeightBy.ControlValueChanged
+        If ucrReceiverWeightBy.IsEmpty Then
+            ucrChkIsCurrency.Visible = False
+        Else
+            ucrChkIsCurrency.Visible = True
+        End If
+    End Sub
+
+    Private Sub ucrInputSummary_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrInputSummary.ControlValueChanged
+        clsSummaryFunction.SetRCommand(ucrInputSummary.GetText())
+    End Sub
+
+    Private Sub ucrSelectorTreemap_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrSelectorTreemap.ControlValueChanged, ucrPnlDataType.ControlValueChanged
+        SetPipeAssignTo()
+    End Sub
+
+    Private Sub SetPipeAssignTo()
+        If rdoPrimary.Checked Then
+            clsPipeOperator.SetAssignTo(ucrSelectorTreemap.ucrAvailableDataFrames.cboAvailableDataFrames.Text & "_summary")
+        ElseIf rdoSummary.Checked Then
+            clsPipeOperator.RemoveAssignTo()
+        End If
+    End Sub
+End Class

--- a/instat/dlgTreemap.vb
+++ b/instat/dlgTreemap.vb
@@ -125,8 +125,8 @@ Public Class dlgTreemap
         ucrReceiverFill.bWithQuotes = False
         ucrReceiverFill.SetParameterIsString()
 
-        ucrColourBox.SetParameter(New RParameter("fill", 3))
-        ucrColourBox.SetColours()
+        ucrColourTile.SetParameter(New RParameter("fill", 3))
+        ucrColourTile.SetColours()
 
         ucrColourText.SetParameter(New RParameter("colour", 3))
         ucrColourText.SetColours()
@@ -245,7 +245,7 @@ Public Class dlgTreemap
         ucrInputSymbol.SetRCode(clsDollarFunction, bReset)
         ucrInputLabel.SetRCode(clsPaste0Function, bReset)
         ucrReceiverFill.SetRCode(clsGeomTreemapAesFunction, bReset)
-        ucrColourBox.SetRCode(clsGeomTreemapFunction, bReset)
+        ucrColourTile.SetRCode(clsGeomTreemapFunction, bReset)
         ucrColourText.SetRCode(clsGeomTreemapTextFunction, bReset)
         If bReset Then
             ucrInputLabel.SetText(strIdentifier)
@@ -344,11 +344,11 @@ Public Class dlgTreemap
 
     Private Sub ucrReceiverFill_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverFill.ControlValueChanged
         If ucrReceiverFill.IsEmpty() Then
-            clsGeomTreemapFunction.AddParameter("fill", ucrColourBox.GetText(), iPosition:=3)
-            ucrColourBox.Enabled = True
+            clsGeomTreemapFunction.AddParameter("fill", ucrColourTile.GetText(), iPosition:=3)
+            ucrColourTile.Enabled = True
         Else
             clsGeomTreemapFunction.RemoveParameterByName("fill")
-            ucrColourBox.Enabled = False
+            ucrColourTile.Enabled = False
         End If
     End Sub
 
@@ -437,5 +437,9 @@ Public Class dlgTreemap
         sdgPlots.tbpFacet.Enabled = True
         sdgPlots.tbpLayers.Enabled = True
         bResetSubdialog = False
+    End Sub
+
+    Private Sub CoreControls_ContentsChanged(ucrChangedControl As ucrCore) Handles ucrSaveTreemap.ControlContentsChanged, ucrReceiverWeightBy.ControlContentsChanged, ucrReceiverIdentifier.ControlContentsChanged, ucrPnlDataType.ControlContentsChanged
+
     End Sub
 End Class


### PR DESCRIPTION
@africanmathsinitiative/developers this is ready for review.
Implements the `treemap` graph from the `treemapify` package, see details here https://cran.r-project.org/web/packages/treemapify/vignettes/introduction-to-treemapify.html

An interesting test is to use the WorldBank97 data from the Procurement library and use `country` as the identifier. You could also weight by the contract value. This will test the "Primary data" option. Use the "country" sheet to test the "Summary data" option.

- Install the `treemapify` package to test as it's not yet included in R-Instat
- I have excluded the dialog from the project so that there are no vbproj changes. To test, include in the project and add the dialog somewhere in frmMain. Eventually this will be a graph under the describe menu, and on the procurement menu
- The geom only works with summarised data so the dialog has "Primary data" and "Summary data" options at the top. If "Primary data" then the data is summarised in the code to use the geom. In this case, facets are disabled.
- For now I haven't added a "Treemap Options" button to get to layer options, like on most dialog, as this could add bugs due to the summarising in the code. I think its not essential.
- Layers tab is disabled on Plot Options dialog since the geom have not yet been added. This can be enabled once geoms are defined.