### PR TITLE
One & two variable summarise improvements

### DIFF
--- a/instat/dlgDescribeTwoVariable.Designer.vb
+++ b/instat/dlgDescribeTwoVariable.Designer.vb
@@ -40,15 +40,22 @@ Partial Class dlgDescribeTwoVariable
     Private Sub InitializeComponent()
         Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(dlgDescribeTwoVariable))
         Me.cmdSummaries = New System.Windows.Forms.Button()
-        Me.cmdDisplayOptions = New System.Windows.Forms.Button()
         Me.lblFirstVariable = New System.Windows.Forms.Label()
         Me.lbSecondVariable = New System.Windows.Forms.Label()
+        Me.grpOptions = New System.Windows.Forms.GroupBox()
+        Me.lblSummary = New System.Windows.Forms.Label()
+        Me.lblFirstType = New System.Windows.Forms.Label()
+        Me.lblBy = New System.Windows.Forms.Label()
+        Me.lblSecondType = New System.Windows.Forms.Label()
+        Me.lblSummaryName = New System.Windows.Forms.Label()
+        Me.grpSummaries = New System.Windows.Forms.GroupBox()
+        Me.ucrChkOmitMissing = New instat.ucrCheck()
         Me.ucrReceiverSecondVar = New instat.ucrReceiverSingle()
         Me.ucrReceiverFirstVars = New instat.ucrReceiverMultiple()
         Me.ucrSelectorDescribeTwoVar = New instat.ucrSelectorByDataFrameAddRemove()
         Me.ucrBase = New instat.ucrButtons()
-        Me.ucrChkSaveResult = New instat.ucrCheck()
-        Me.ucrChkOmitMissing = New instat.ucrCheck()
+        Me.grpOptions.SuspendLayout()
+        Me.grpSummaries.SuspendLayout()
         Me.SuspendLayout()
         '
         'cmdSummaries
@@ -57,13 +64,6 @@ Partial Class dlgDescribeTwoVariable
         Me.cmdSummaries.Name = "cmdSummaries"
         Me.cmdSummaries.Tag = "Summaries"
         Me.cmdSummaries.UseVisualStyleBackColor = True
-        '
-        'cmdDisplayOptions
-        '
-        resources.ApplyResources(Me.cmdDisplayOptions, "cmdDisplayOptions")
-        Me.cmdDisplayOptions.Name = "cmdDisplayOptions"
-        Me.cmdDisplayOptions.Tag = "Display_Options"
-        Me.cmdDisplayOptions.UseVisualStyleBackColor = True
         '
         'lblFirstVariable
         '
@@ -76,6 +76,57 @@ Partial Class dlgDescribeTwoVariable
         resources.ApplyResources(Me.lbSecondVariable, "lbSecondVariable")
         Me.lbSecondVariable.Name = "lbSecondVariable"
         Me.lbSecondVariable.Tag = ""
+        '
+        'grpOptions
+        '
+        Me.grpOptions.Controls.Add(Me.ucrChkOmitMissing)
+        Me.grpOptions.Controls.Add(Me.cmdSummaries)
+        resources.ApplyResources(Me.grpOptions, "grpOptions")
+        Me.grpOptions.Name = "grpOptions"
+        Me.grpOptions.TabStop = False
+        '
+        'lblSummary
+        '
+        resources.ApplyResources(Me.lblSummary, "lblSummary")
+        Me.lblSummary.Name = "lblSummary"
+        '
+        'lblFirstType
+        '
+        Me.lblFirstType.ForeColor = System.Drawing.SystemColors.ControlText
+        resources.ApplyResources(Me.lblFirstType, "lblFirstType")
+        Me.lblFirstType.Name = "lblFirstType"
+        '
+        'lblBy
+        '
+        resources.ApplyResources(Me.lblBy, "lblBy")
+        Me.lblBy.Name = "lblBy"
+        '
+        'lblSecondType
+        '
+        resources.ApplyResources(Me.lblSecondType, "lblSecondType")
+        Me.lblSecondType.Name = "lblSecondType"
+        '
+        'lblSummaryName
+        '
+        resources.ApplyResources(Me.lblSummaryName, "lblSummaryName")
+        Me.lblSummaryName.Name = "lblSummaryName"
+        '
+        'grpSummaries
+        '
+        Me.grpSummaries.Controls.Add(Me.lblFirstType)
+        Me.grpSummaries.Controls.Add(Me.lblSummaryName)
+        Me.grpSummaries.Controls.Add(Me.lblSummary)
+        Me.grpSummaries.Controls.Add(Me.lblBy)
+        Me.grpSummaries.Controls.Add(Me.lblSecondType)
+        resources.ApplyResources(Me.grpSummaries, "grpSummaries")
+        Me.grpSummaries.Name = "grpSummaries"
+        Me.grpSummaries.TabStop = False
+        '
+        'ucrChkOmitMissing
+        '
+        Me.ucrChkOmitMissing.Checked = False
+        resources.ApplyResources(Me.ucrChkOmitMissing, "ucrChkOmitMissing")
+        Me.ucrChkOmitMissing.Name = "ucrChkOmitMissing"
         '
         'ucrReceiverSecondVar
         '
@@ -108,30 +159,16 @@ Partial Class dlgDescribeTwoVariable
         resources.ApplyResources(Me.ucrBase, "ucrBase")
         Me.ucrBase.Name = "ucrBase"
         '
-        'ucrChkSaveResult
-        '
-        Me.ucrChkSaveResult.Checked = False
-        resources.ApplyResources(Me.ucrChkSaveResult, "ucrChkSaveResult")
-        Me.ucrChkSaveResult.Name = "ucrChkSaveResult"
-        '
-        'ucrChkOmitMissing
-        '
-        Me.ucrChkOmitMissing.Checked = False
-        resources.ApplyResources(Me.ucrChkOmitMissing, "ucrChkOmitMissing")
-        Me.ucrChkOmitMissing.Name = "ucrChkOmitMissing"
-        '
         'dlgDescribeTwoVariable
         '
         resources.ApplyResources(Me, "$this")
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
-        Me.Controls.Add(Me.ucrChkSaveResult)
-        Me.Controls.Add(Me.ucrChkOmitMissing)
+        Me.Controls.Add(Me.grpSummaries)
+        Me.Controls.Add(Me.grpOptions)
         Me.Controls.Add(Me.lbSecondVariable)
         Me.Controls.Add(Me.lblFirstVariable)
-        Me.Controls.Add(Me.cmdDisplayOptions)
         Me.Controls.Add(Me.ucrReceiverSecondVar)
         Me.Controls.Add(Me.ucrReceiverFirstVars)
-        Me.Controls.Add(Me.cmdSummaries)
         Me.Controls.Add(Me.ucrSelectorDescribeTwoVar)
         Me.Controls.Add(Me.ucrBase)
         Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow
@@ -139,6 +176,9 @@ Partial Class dlgDescribeTwoVariable
         Me.MinimizeBox = False
         Me.Name = "dlgDescribeTwoVariable"
         Me.Tag = "Describe_Two_Variable"
+        Me.grpOptions.ResumeLayout(False)
+        Me.grpSummaries.ResumeLayout(False)
+        Me.grpSummaries.PerformLayout()
         Me.ResumeLayout(False)
         Me.PerformLayout()
 
@@ -149,9 +189,14 @@ Partial Class dlgDescribeTwoVariable
     Friend WithEvents ucrReceiverFirstVars As ucrReceiverMultiple
     Friend WithEvents cmdSummaries As Button
     Friend WithEvents ucrReceiverSecondVar As ucrReceiverSingle
-    Friend WithEvents cmdDisplayOptions As Button
     Friend WithEvents lblFirstVariable As Label
     Friend WithEvents lbSecondVariable As Label
-    Friend WithEvents ucrChkSaveResult As ucrCheck
     Friend WithEvents ucrChkOmitMissing As ucrCheck
+    Friend WithEvents grpOptions As GroupBox
+    Friend WithEvents lblSecondType As Label
+    Friend WithEvents lblBy As Label
+    Friend WithEvents lblFirstType As Label
+    Friend WithEvents lblSummary As Label
+    Friend WithEvents lblSummaryName As Label
+    Friend WithEvents grpSummaries As GroupBox
 End Class

--- a/instat/dlgDescribeTwoVariable.Designer.vb
+++ b/instat/dlgDescribeTwoVariable.Designer.vb
@@ -42,9 +42,9 @@ Partial Class dlgDescribeTwoVariable
         Me.cmdSummaries = New System.Windows.Forms.Button()
         Me.cmdDisplayOptions = New System.Windows.Forms.Button()
         Me.lblFirstVariable = New System.Windows.Forms.Label()
-        Me.lbMultipleVariables = New System.Windows.Forms.Label()
-        Me.ucrReceiverFirstVar = New instat.ucrReceiverSingle()
-        Me.ucrReceiverSecondVar = New instat.ucrReceiverMultiple()
+        Me.lbSecondVariable = New System.Windows.Forms.Label()
+        Me.ucrReceiverSecondVar = New instat.ucrReceiverSingle()
+        Me.ucrReceiverFirstVars = New instat.ucrReceiverMultiple()
         Me.ucrSelectorDescribeTwoVar = New instat.ucrSelectorByDataFrameAddRemove()
         Me.ucrBase = New instat.ucrButtons()
         Me.ucrChkSaveResult = New instat.ucrCheck()
@@ -69,22 +69,13 @@ Partial Class dlgDescribeTwoVariable
         '
         resources.ApplyResources(Me.lblFirstVariable, "lblFirstVariable")
         Me.lblFirstVariable.Name = "lblFirstVariable"
-        Me.lblFirstVariable.Tag = "First_Variable"
+        Me.lblFirstVariable.Tag = ""
         '
-        'lbMultipleVariables
+        'lbSecondVariable
         '
-        resources.ApplyResources(Me.lbMultipleVariables, "lbMultipleVariables")
-        Me.lbMultipleVariables.Name = "lbMultipleVariables"
-        Me.lbMultipleVariables.Tag = "Multiple_Variables"
-        '
-        'ucrReceiverFirstVar
-        '
-        Me.ucrReceiverFirstVar.frmParent = Me
-        resources.ApplyResources(Me.ucrReceiverFirstVar, "ucrReceiverFirstVar")
-        Me.ucrReceiverFirstVar.Name = "ucrReceiverFirstVar"
-        Me.ucrReceiverFirstVar.Selector = Nothing
-        Me.ucrReceiverFirstVar.strNcFilePath = ""
-        Me.ucrReceiverFirstVar.ucrSelector = Nothing
+        resources.ApplyResources(Me.lbSecondVariable, "lbSecondVariable")
+        Me.lbSecondVariable.Name = "lbSecondVariable"
+        Me.lbSecondVariable.Tag = ""
         '
         'ucrReceiverSecondVar
         '
@@ -95,8 +86,18 @@ Partial Class dlgDescribeTwoVariable
         Me.ucrReceiverSecondVar.strNcFilePath = ""
         Me.ucrReceiverSecondVar.ucrSelector = Nothing
         '
+        'ucrReceiverFirstVars
+        '
+        Me.ucrReceiverFirstVars.frmParent = Me
+        resources.ApplyResources(Me.ucrReceiverFirstVars, "ucrReceiverFirstVars")
+        Me.ucrReceiverFirstVars.Name = "ucrReceiverFirstVars"
+        Me.ucrReceiverFirstVars.Selector = Nothing
+        Me.ucrReceiverFirstVars.strNcFilePath = ""
+        Me.ucrReceiverFirstVars.ucrSelector = Nothing
+        '
         'ucrSelectorDescribeTwoVar
         '
+        Me.ucrSelectorDescribeTwoVar.bDropUnusedFilterLevels = False
         Me.ucrSelectorDescribeTwoVar.bShowHiddenColumns = False
         Me.ucrSelectorDescribeTwoVar.bUseCurrentFilter = True
         resources.ApplyResources(Me.ucrSelectorDescribeTwoVar, "ucrSelectorDescribeTwoVar")
@@ -125,11 +126,11 @@ Partial Class dlgDescribeTwoVariable
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
         Me.Controls.Add(Me.ucrChkSaveResult)
         Me.Controls.Add(Me.ucrChkOmitMissing)
-        Me.Controls.Add(Me.lbMultipleVariables)
+        Me.Controls.Add(Me.lbSecondVariable)
         Me.Controls.Add(Me.lblFirstVariable)
         Me.Controls.Add(Me.cmdDisplayOptions)
-        Me.Controls.Add(Me.ucrReceiverFirstVar)
         Me.Controls.Add(Me.ucrReceiverSecondVar)
+        Me.Controls.Add(Me.ucrReceiverFirstVars)
         Me.Controls.Add(Me.cmdSummaries)
         Me.Controls.Add(Me.ucrSelectorDescribeTwoVar)
         Me.Controls.Add(Me.ucrBase)
@@ -145,12 +146,12 @@ Partial Class dlgDescribeTwoVariable
 
     Friend WithEvents ucrBase As ucrButtons
     Friend WithEvents ucrSelectorDescribeTwoVar As ucrSelectorByDataFrameAddRemove
-    Friend WithEvents ucrReceiverSecondVar As ucrReceiverMultiple
+    Friend WithEvents ucrReceiverFirstVars As ucrReceiverMultiple
     Friend WithEvents cmdSummaries As Button
-    Friend WithEvents ucrReceiverFirstVar As ucrReceiverSingle
+    Friend WithEvents ucrReceiverSecondVar As ucrReceiverSingle
     Friend WithEvents cmdDisplayOptions As Button
     Friend WithEvents lblFirstVariable As Label
-    Friend WithEvents lbMultipleVariables As Label
+    Friend WithEvents lbSecondVariable As Label
     Friend WithEvents ucrChkSaveResult As ucrCheck
     Friend WithEvents ucrChkOmitMissing As ucrCheck
 End Class

--- a/instat/dlgDescribeTwoVariable.resx
+++ b/instat/dlgDescribeTwoVariable.resx
@@ -117,9 +117,13 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="cmdSummaries.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="cmdSummaries.Location" type="System.Drawing.Point, System.Drawing">
-    <value>305, 222</value>
+    <value>9, 45</value>
   </data>
   <data name="cmdSummaries.Size" type="System.Drawing.Size, System.Drawing">
     <value>105, 23</value>
@@ -138,37 +142,16 @@
     <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;cmdSummaries.Parent" xml:space="preserve">
-    <value>$this</value>
+    <value>grpOptions</value>
   </data>
   <data name="&gt;&gt;cmdSummaries.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="cmdDisplayOptions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>304, 221</value>
-  </data>
-  <data name="cmdDisplayOptions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>105, 23</value>
-  </data>
-  <data name="cmdDisplayOptions.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="cmdDisplayOptions.Text" xml:space="preserve">
-    <value>Display Options</value>
-  </data>
-  <data name="&gt;&gt;cmdDisplayOptions.Name" xml:space="preserve">
-    <value>cmdDisplayOptions</value>
-  </data>
-  <data name="&gt;&gt;cmdDisplayOptions.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cmdDisplayOptions.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;cmdDisplayOptions.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>1</value>
   </data>
   <data name="lblFirstVariable.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
+  </data>
+  <data name="lblFirstVariable.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
   <data name="lblFirstVariable.Location" type="System.Drawing.Point, System.Drawing">
     <value>268, 45</value>
@@ -194,6 +177,9 @@
   <data name="&gt;&gt;lblFirstVariable.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
+  <data name="lbSecondVariable.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
   <data name="lbSecondVariable.Location" type="System.Drawing.Point, System.Drawing">
     <value>268, 155</value>
   </data>
@@ -218,38 +204,8 @@
   <data name="&gt;&gt;lbSecondVariable.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
-  </data>
-  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>415, 309</value>
-  </data>
-  <data name="ucrChkSaveResult.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 224</value>
-  </data>
-  <data name="ucrChkSaveResult.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 20</value>
-  </data>
-  <data name="ucrChkSaveResult.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;ucrChkSaveResult.Name" xml:space="preserve">
-    <value>ucrChkSaveResult</value>
-  </data>
-  <data name="&gt;&gt;ucrChkSaveResult.Type" xml:space="preserve">
-    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrChkSaveResult.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;ucrChkSaveResult.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="ucrChkOmitMissing.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 198</value>
+    <value>9, 19</value>
   </data>
   <data name="ucrChkOmitMissing.Size" type="System.Drawing.Size, System.Drawing">
     <value>143, 20</value>
@@ -264,15 +220,209 @@
     <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ucrChkOmitMissing.Parent" xml:space="preserve">
-    <value>$this</value>
+    <value>grpOptions</value>
   </data>
   <data name="&gt;&gt;ucrChkOmitMissing.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="grpOptions.Location" type="System.Drawing.Point, System.Drawing">
+    <value>236, 202</value>
+  </data>
+  <data name="grpOptions.Size" type="System.Drawing.Size, System.Drawing">
+    <value>155, 76</value>
+  </data>
+  <data name="grpOptions.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="grpOptions.Text" xml:space="preserve">
+    <value>Options</value>
+  </data>
+  <data name="&gt;&gt;grpOptions.Name" xml:space="preserve">
+    <value>grpOptions</value>
+  </data>
+  <data name="&gt;&gt;grpOptions.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;grpOptions.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;grpOptions.ZOrder" xml:space="preserve">
     <value>1</value>
+  </data>
+  <data name="lblSummary.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblSummary.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblSummary.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 43</value>
+  </data>
+  <data name="lblSummary.Size" type="System.Drawing.Size, System.Drawing">
+    <value>53, 13</value>
+  </data>
+  <data name="lblSummary.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="lblSummary.Text" xml:space="preserve">
+    <value>Summary:</value>
+  </data>
+  <data name="&gt;&gt;lblSummary.Name" xml:space="preserve">
+    <value>lblSummary</value>
+  </data>
+  <data name="&gt;&gt;lblSummary.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblSummary.Parent" xml:space="preserve">
+    <value>grpSummaries</value>
+  </data>
+  <data name="&gt;&gt;lblSummary.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="lblFirstType.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblFirstType.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 16</value>
+  </data>
+  <data name="lblFirstType.Size" type="System.Drawing.Size, System.Drawing">
+    <value>55, 13</value>
+  </data>
+  <data name="lblFirstType.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="lblFirstType.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>TopRight</value>
+  </data>
+  <data name="&gt;&gt;lblFirstType.Name" xml:space="preserve">
+    <value>lblFirstType</value>
+  </data>
+  <data name="&gt;&gt;lblFirstType.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblFirstType.Parent" xml:space="preserve">
+    <value>grpSummaries</value>
+  </data>
+  <data name="&gt;&gt;lblFirstType.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="lblBy.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblBy.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblBy.Location" type="System.Drawing.Point, System.Drawing">
+    <value>64, 16</value>
+  </data>
+  <data name="lblBy.Size" type="System.Drawing.Size, System.Drawing">
+    <value>18, 13</value>
+  </data>
+  <data name="lblBy.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="lblBy.Text" xml:space="preserve">
+    <value>by</value>
+  </data>
+  <data name="&gt;&gt;lblBy.Name" xml:space="preserve">
+    <value>lblBy</value>
+  </data>
+  <data name="&gt;&gt;lblBy.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblBy.Parent" xml:space="preserve">
+    <value>grpSummaries</value>
+  </data>
+  <data name="&gt;&gt;lblBy.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="lblSecondType.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblSecondType.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblSecondType.Location" type="System.Drawing.Point, System.Drawing">
+    <value>82, 16</value>
+  </data>
+  <data name="lblSecondType.Size" type="System.Drawing.Size, System.Drawing">
+    <value>0, 13</value>
+  </data>
+  <data name="lblSecondType.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="&gt;&gt;lblSecondType.Name" xml:space="preserve">
+    <value>lblSecondType</value>
+  </data>
+  <data name="&gt;&gt;lblSecondType.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblSecondType.Parent" xml:space="preserve">
+    <value>grpSummaries</value>
+  </data>
+  <data name="&gt;&gt;lblSecondType.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="lblSummaryName.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblSummaryName.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblSummaryName.Location" type="System.Drawing.Point, System.Drawing">
+    <value>60, 43</value>
+  </data>
+  <data name="lblSummaryName.Size" type="System.Drawing.Size, System.Drawing">
+    <value>0, 13</value>
+  </data>
+  <data name="lblSummaryName.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="&gt;&gt;lblSummaryName.Name" xml:space="preserve">
+    <value>lblSummaryName</value>
+  </data>
+  <data name="&gt;&gt;lblSummaryName.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblSummaryName.Parent" xml:space="preserve">
+    <value>grpSummaries</value>
+  </data>
+  <data name="&gt;&gt;lblSummaryName.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="grpSummaries.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 202</value>
+  </data>
+  <data name="grpSummaries.Size" type="System.Drawing.Size, System.Drawing">
+    <value>210, 72</value>
+  </data>
+  <data name="grpSummaries.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="&gt;&gt;grpSummaries.Name" xml:space="preserve">
+    <value>grpSummaries</value>
+  </data>
+  <data name="&gt;&gt;grpSummaries.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;grpSummaries.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;grpSummaries.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>419, 341</value>
   </data>
   <data name="ucrReceiverFirstVars.Location" type="System.Drawing.Point, System.Drawing">
     <value>271, 63</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="ucrReceiverFirstVars.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
   </data>
@@ -292,7 +442,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrReceiverFirstVars.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>5</value>
   </data>
   <data name="ucrSelectorDescribeTwoVar.Location" type="System.Drawing.Point, System.Drawing">
     <value>10, 10</value>
@@ -316,10 +466,10 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrSelectorDescribeTwoVar.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>6</value>
   </data>
   <data name="ucrBase.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 250</value>
+    <value>10, 286</value>
   </data>
   <data name="ucrBase.Size" type="System.Drawing.Size, System.Drawing">
     <value>410, 52</value>
@@ -337,7 +487,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrBase.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>7</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterScreen</value>
@@ -373,6 +523,6 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrReceiverSecondVar.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>4</value>
   </data>
 </root>

--- a/instat/dlgDescribeTwoVariable.resx
+++ b/instat/dlgDescribeTwoVariable.resx
@@ -174,13 +174,13 @@
     <value>268, 45</value>
   </data>
   <data name="lblFirstVariable.Size" type="System.Drawing.Size, System.Drawing">
-    <value>70, 13</value>
+    <value>75, 13</value>
   </data>
   <data name="lblFirstVariable.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
   <data name="lblFirstVariable.Text" xml:space="preserve">
-    <value>First Variable:</value>
+    <value>First Variables:</value>
   </data>
   <data name="&gt;&gt;lblFirstVariable.Name" xml:space="preserve">
     <value>lblFirstVariable</value>
@@ -194,28 +194,28 @@
   <data name="&gt;&gt;lblFirstVariable.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
-  <data name="lbMultipleVariables.Location" type="System.Drawing.Point, System.Drawing">
-    <value>268, 90</value>
+  <data name="lbSecondVariable.Location" type="System.Drawing.Point, System.Drawing">
+    <value>268, 155</value>
   </data>
-  <data name="lbMultipleVariables.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="lbSecondVariable.Size" type="System.Drawing.Size, System.Drawing">
     <value>100, 15</value>
   </data>
-  <data name="lbMultipleVariables.TabIndex" type="System.Int32, mscorlib">
+  <data name="lbSecondVariable.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
   </data>
-  <data name="lbMultipleVariables.Text" xml:space="preserve">
-    <value>Multiple Variables:</value>
+  <data name="lbSecondVariable.Text" xml:space="preserve">
+    <value>Second Variable:</value>
   </data>
-  <data name="&gt;&gt;lbMultipleVariables.Name" xml:space="preserve">
-    <value>lbMultipleVariables</value>
+  <data name="&gt;&gt;lbSecondVariable.Name" xml:space="preserve">
+    <value>lbSecondVariable</value>
   </data>
-  <data name="&gt;&gt;lbMultipleVariables.Type" xml:space="preserve">
+  <data name="&gt;&gt;lbSecondVariable.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;lbMultipleVariables.Parent" xml:space="preserve">
+  <data name="&gt;&gt;lbSecondVariable.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;lbMultipleVariables.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;lbSecondVariable.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
@@ -269,29 +269,29 @@
   <data name="&gt;&gt;ucrChkOmitMissing.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="ucrReceiverSecondVar.Location" type="System.Drawing.Point, System.Drawing">
-    <value>268, 105</value>
+  <data name="ucrReceiverFirstVars.Location" type="System.Drawing.Point, System.Drawing">
+    <value>271, 63</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="ucrReceiverSecondVar.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="ucrReceiverFirstVars.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
   </data>
-  <data name="ucrReceiverSecondVar.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="ucrReceiverFirstVars.Size" type="System.Drawing.Size, System.Drawing">
     <value>120, 87</value>
   </data>
-  <data name="ucrReceiverSecondVar.TabIndex" type="System.Int32, mscorlib">
+  <data name="ucrReceiverFirstVars.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
   </data>
-  <data name="&gt;&gt;ucrReceiverSecondVar.Name" xml:space="preserve">
-    <value>ucrReceiverSecondVar</value>
+  <data name="&gt;&gt;ucrReceiverFirstVars.Name" xml:space="preserve">
+    <value>ucrReceiverFirstVars</value>
   </data>
-  <data name="&gt;&gt;ucrReceiverSecondVar.Type" xml:space="preserve">
+  <data name="&gt;&gt;ucrReceiverFirstVars.Type" xml:space="preserve">
     <value>instat.ucrReceiverMultiple, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="&gt;&gt;ucrReceiverSecondVar.Parent" xml:space="preserve">
+  <data name="&gt;&gt;ucrReceiverFirstVars.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;ucrReceiverSecondVar.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;ucrReceiverFirstVars.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
   <data name="ucrSelectorDescribeTwoVar.Location" type="System.Drawing.Point, System.Drawing">
@@ -351,28 +351,28 @@
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
     <value>System.Windows.Forms.Form, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="ucrReceiverFirstVar.Location" type="System.Drawing.Point, System.Drawing">
-    <value>268, 60</value>
+  <data name="ucrReceiverSecondVar.Location" type="System.Drawing.Point, System.Drawing">
+    <value>271, 170</value>
   </data>
-  <data name="ucrReceiverFirstVar.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="ucrReceiverSecondVar.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
   </data>
-  <data name="ucrReceiverFirstVar.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="ucrReceiverSecondVar.Size" type="System.Drawing.Size, System.Drawing">
     <value>120, 20</value>
   </data>
-  <data name="ucrReceiverFirstVar.TabIndex" type="System.Int32, mscorlib">
+  <data name="ucrReceiverSecondVar.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
-  <data name="&gt;&gt;ucrReceiverFirstVar.Name" xml:space="preserve">
-    <value>ucrReceiverFirstVar</value>
+  <data name="&gt;&gt;ucrReceiverSecondVar.Name" xml:space="preserve">
+    <value>ucrReceiverSecondVar</value>
   </data>
-  <data name="&gt;&gt;ucrReceiverFirstVar.Type" xml:space="preserve">
+  <data name="&gt;&gt;ucrReceiverSecondVar.Type" xml:space="preserve">
     <value>instat.ucrReceiverSingle, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="&gt;&gt;ucrReceiverFirstVar.Parent" xml:space="preserve">
+  <data name="&gt;&gt;ucrReceiverSecondVar.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;ucrReceiverFirstVar.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;ucrReceiverSecondVar.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
 </root>

--- a/instat/dlgDescribeTwoVariable.vb
+++ b/instat/dlgDescribeTwoVariable.vb
@@ -87,9 +87,13 @@ Public Class dlgDescribeTwoVariable
         clsRAnova.AddParameter("means", "FALSE", iPosition:=4)
 
         clsSummariesList.SetRCommand("c")
-        clsSummariesList.AddParameter("summary_count_non_missing", Chr(34) & "summary_count_non_missing" & Chr(34), bIncludeArgumentName:=False)
-        clsSummariesList.AddParameter("summary_count", Chr(34) & "summary_count" & Chr(34), bIncludeArgumentName:=False)
-        clsSummariesList.AddParameter("summary_sum", Chr(34) & "summary_sum" & Chr(34), bIncludeArgumentName:=False)
+        clsSummariesList.AddParameter("summary_count_missing", Chr(34) & "summary_count_missing" & Chr(34), bIncludeArgumentName:=False, iPosition:=0)
+        clsSummariesList.AddParameter("summary_min", Chr(34) & "summary_min" & Chr(34), bIncludeArgumentName:=False, iPosition:=1)
+        clsSummariesList.AddParameter("lower_quartile", Chr(34) & "lower_quartile" & Chr(34), bIncludeArgumentName:=False, iPosition:=2)
+        clsSummariesList.AddParameter("summary_median", Chr(34) & "summary_median" & Chr(34), bIncludeArgumentName:=False, iPosition:=3)
+        clsSummariesList.AddParameter("summary_mean", Chr(34) & "summary_mean" & Chr(34), bIncludeArgumentName:=False, iPosition:=4)
+        clsSummariesList.AddParameter("upper_quartile", Chr(34) & "upper_quartile" & Chr(34), bIncludeArgumentName:=False, iPosition:=5)
+        clsSummariesList.AddParameter("summary_max", Chr(34) & "summary_max" & Chr(34), bIncludeArgumentName:=False, iPosition:=6)
 
         clsRCustomSummary.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$summary")
         clsRCustomSummary.AddParameter("summaries", clsRFunctionParameter:=clsSummariesList)

--- a/instat/dlgOneVariableSummarise.Designer.vb
+++ b/instat/dlgOneVariableSummarise.Designer.vb
@@ -40,15 +40,17 @@ Partial Class dlgOneVariableSummarise
     Private Sub InitializeComponent()
         Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(dlgOneVariableSummarise))
         Me.lblSelectedVariable = New System.Windows.Forms.Label()
-        Me.ucrBase = New instat.ucrButtons()
-        Me.ucrReceiverOneVarSummarise = New instat.ucrReceiverMultiple()
-        Me.ucrSelectorOneVarSummarise = New instat.ucrSelectorByDataFrameAddRemove()
-        Me.ucrChkOmitMissing = New instat.ucrCheck()
-        Me.ucrChkSaveResult = New instat.ucrCheck()
-        Me.ucrChkCustomise = New instat.ucrCheck()
         Me.lblMaxSum = New System.Windows.Forms.Label()
-        Me.ucrNudMaxSum = New instat.ucrNud()
         Me.cmdSummaries = New System.Windows.Forms.Button()
+        Me.lblSummaries = New System.Windows.Forms.Label()
+        Me.rdoDefault = New System.Windows.Forms.RadioButton()
+        Me.rdoCustomised = New System.Windows.Forms.RadioButton()
+        Me.ucrNudMaxSum = New instat.ucrNud()
+        Me.ucrChkOmitMissing = New instat.ucrCheck()
+        Me.ucrSelectorOneVarSummarise = New instat.ucrSelectorByDataFrameAddRemove()
+        Me.ucrReceiverOneVarSummarise = New instat.ucrReceiverMultiple()
+        Me.ucrBase = New instat.ucrButtons()
+        Me.ucrPnlSummaries = New instat.UcrPanel()
         Me.SuspendLayout()
         '
         'lblSelectedVariable
@@ -57,50 +59,36 @@ Partial Class dlgOneVariableSummarise
         Me.lblSelectedVariable.Name = "lblSelectedVariable"
         Me.lblSelectedVariable.Tag = "Selected_Variable"
         '
-        'ucrBase
-        '
-        resources.ApplyResources(Me.ucrBase, "ucrBase")
-        Me.ucrBase.Name = "ucrBase"
-        '
-        'ucrReceiverOneVarSummarise
-        '
-        Me.ucrReceiverOneVarSummarise.frmParent = Me
-        resources.ApplyResources(Me.ucrReceiverOneVarSummarise, "ucrReceiverOneVarSummarise")
-        Me.ucrReceiverOneVarSummarise.Name = "ucrReceiverOneVarSummarise"
-        Me.ucrReceiverOneVarSummarise.Selector = Nothing
-        Me.ucrReceiverOneVarSummarise.strNcFilePath = ""
-        Me.ucrReceiverOneVarSummarise.ucrSelector = Nothing
-        '
-        'ucrSelectorOneVarSummarise
-        '
-        Me.ucrSelectorOneVarSummarise.bDropUnusedFilterLevels = False
-        Me.ucrSelectorOneVarSummarise.bShowHiddenColumns = False
-        Me.ucrSelectorOneVarSummarise.bUseCurrentFilter = True
-        resources.ApplyResources(Me.ucrSelectorOneVarSummarise, "ucrSelectorOneVarSummarise")
-        Me.ucrSelectorOneVarSummarise.Name = "ucrSelectorOneVarSummarise"
-        '
-        'ucrChkOmitMissing
-        '
-        Me.ucrChkOmitMissing.Checked = False
-        resources.ApplyResources(Me.ucrChkOmitMissing, "ucrChkOmitMissing")
-        Me.ucrChkOmitMissing.Name = "ucrChkOmitMissing"
-        '
-        'ucrChkSaveResult
-        '
-        Me.ucrChkSaveResult.Checked = False
-        resources.ApplyResources(Me.ucrChkSaveResult, "ucrChkSaveResult")
-        Me.ucrChkSaveResult.Name = "ucrChkSaveResult"
-        '
-        'ucrChkCustomise
-        '
-        Me.ucrChkCustomise.Checked = False
-        resources.ApplyResources(Me.ucrChkCustomise, "ucrChkCustomise")
-        Me.ucrChkCustomise.Name = "ucrChkCustomise"
-        '
         'lblMaxSum
         '
         resources.ApplyResources(Me.lblMaxSum, "lblMaxSum")
         Me.lblMaxSum.Name = "lblMaxSum"
+        '
+        'cmdSummaries
+        '
+        resources.ApplyResources(Me.cmdSummaries, "cmdSummaries")
+        Me.cmdSummaries.Name = "cmdSummaries"
+        Me.cmdSummaries.Tag = "Summaries"
+        Me.cmdSummaries.UseVisualStyleBackColor = True
+        '
+        'lblSummaries
+        '
+        resources.ApplyResources(Me.lblSummaries, "lblSummaries")
+        Me.lblSummaries.Name = "lblSummaries"
+        '
+        'rdoDefault
+        '
+        resources.ApplyResources(Me.rdoDefault, "rdoDefault")
+        Me.rdoDefault.Name = "rdoDefault"
+        Me.rdoDefault.TabStop = True
+        Me.rdoDefault.UseVisualStyleBackColor = True
+        '
+        'rdoCustomised
+        '
+        resources.ApplyResources(Me.rdoCustomised, "rdoCustomised")
+        Me.rdoCustomised.Name = "rdoCustomised"
+        Me.rdoCustomised.TabStop = True
+        Me.rdoCustomised.UseVisualStyleBackColor = True
         '
         'ucrNudMaxSum
         '
@@ -112,27 +100,55 @@ Partial Class dlgOneVariableSummarise
         Me.ucrNudMaxSum.Name = "ucrNudMaxSum"
         Me.ucrNudMaxSum.Value = New Decimal(New Integer() {0, 0, 0, 0})
         '
-        'cmdSummaries
+        'ucrChkOmitMissing
         '
-        resources.ApplyResources(Me.cmdSummaries, "cmdSummaries")
-        Me.cmdSummaries.Name = "cmdSummaries"
-        Me.cmdSummaries.Tag = "Summaries"
-        Me.cmdSummaries.UseVisualStyleBackColor = True
+        Me.ucrChkOmitMissing.Checked = False
+        resources.ApplyResources(Me.ucrChkOmitMissing, "ucrChkOmitMissing")
+        Me.ucrChkOmitMissing.Name = "ucrChkOmitMissing"
+        '
+        'ucrSelectorOneVarSummarise
+        '
+        Me.ucrSelectorOneVarSummarise.bDropUnusedFilterLevels = False
+        Me.ucrSelectorOneVarSummarise.bShowHiddenColumns = False
+        Me.ucrSelectorOneVarSummarise.bUseCurrentFilter = True
+        resources.ApplyResources(Me.ucrSelectorOneVarSummarise, "ucrSelectorOneVarSummarise")
+        Me.ucrSelectorOneVarSummarise.Name = "ucrSelectorOneVarSummarise"
+        '
+        'ucrReceiverOneVarSummarise
+        '
+        Me.ucrReceiverOneVarSummarise.frmParent = Me
+        resources.ApplyResources(Me.ucrReceiverOneVarSummarise, "ucrReceiverOneVarSummarise")
+        Me.ucrReceiverOneVarSummarise.Name = "ucrReceiverOneVarSummarise"
+        Me.ucrReceiverOneVarSummarise.Selector = Nothing
+        Me.ucrReceiverOneVarSummarise.strNcFilePath = ""
+        Me.ucrReceiverOneVarSummarise.ucrSelector = Nothing
+        '
+        'ucrBase
+        '
+        resources.ApplyResources(Me.ucrBase, "ucrBase")
+        Me.ucrBase.Name = "ucrBase"
+        '
+        'ucrPnlSummaries
+        '
+        resources.ApplyResources(Me.ucrPnlSummaries, "ucrPnlSummaries")
+        Me.ucrPnlSummaries.Name = "ucrPnlSummaries"
         '
         'dlgOneVariableSummarise
         '
         resources.ApplyResources(Me, "$this")
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.Controls.Add(Me.rdoCustomised)
+        Me.Controls.Add(Me.rdoDefault)
+        Me.Controls.Add(Me.lblSummaries)
         Me.Controls.Add(Me.lblMaxSum)
         Me.Controls.Add(Me.ucrNudMaxSum)
-        Me.Controls.Add(Me.ucrChkCustomise)
-        Me.Controls.Add(Me.ucrChkSaveResult)
         Me.Controls.Add(Me.ucrChkOmitMissing)
         Me.Controls.Add(Me.ucrSelectorOneVarSummarise)
         Me.Controls.Add(Me.ucrReceiverOneVarSummarise)
         Me.Controls.Add(Me.ucrBase)
         Me.Controls.Add(Me.lblSelectedVariable)
         Me.Controls.Add(Me.cmdSummaries)
+        Me.Controls.Add(Me.ucrPnlSummaries)
         Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow
         Me.MaximizeBox = False
         Me.MinimizeBox = False
@@ -147,10 +163,12 @@ Partial Class dlgOneVariableSummarise
     Friend WithEvents ucrBase As ucrButtons
     Friend WithEvents ucrReceiverOneVarSummarise As ucrReceiverMultiple
     Friend WithEvents ucrSelectorOneVarSummarise As ucrSelectorByDataFrameAddRemove
-    Friend WithEvents ucrChkSaveResult As ucrCheck
     Friend WithEvents ucrChkOmitMissing As ucrCheck
-    Friend WithEvents ucrChkCustomise As ucrCheck
     Friend WithEvents lblMaxSum As Label
     Friend WithEvents ucrNudMaxSum As ucrNud
     Friend WithEvents cmdSummaries As Button
+    Friend WithEvents rdoCustomised As RadioButton
+    Friend WithEvents rdoDefault As RadioButton
+    Friend WithEvents lblSummaries As Label
+    Friend WithEvents ucrPnlSummaries As UcrPanel
 End Class

--- a/instat/dlgOneVariableSummarise.resx
+++ b/instat/dlgOneVariableSummarise.resx
@@ -117,6 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="lblSelectedVariable.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="lblSelectedVariable.Location" type="System.Drawing.Point, System.Drawing">
     <value>261, 45</value>
@@ -141,46 +145,19 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblSelectedVariable.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="ucrBase.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 288</value>
-  </data>
-  <data name="ucrBase.Size" type="System.Drawing.Size, System.Drawing">
-    <value>410, 52</value>
-  </data>
-  <data name="ucrBase.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
   </data>
-  <data name="&gt;&gt;ucrBase.Name" xml:space="preserve">
-    <value>ucrBase</value>
-  </data>
-  <data name="&gt;&gt;ucrBase.Type" xml:space="preserve">
-    <value>instat.ucrButtons, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrBase.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;ucrBase.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
-  </data>
-  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>415, 345</value>
+  <data name="lblMaxSum.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
   <data name="lblMaxSum.Location" type="System.Drawing.Point, System.Drawing">
-    <value>7, 210</value>
+    <value>10, 238</value>
   </data>
   <data name="lblMaxSum.Size" type="System.Drawing.Size, System.Drawing">
     <value>187, 13</value>
   </data>
   <data name="lblMaxSum.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
+    <value>7</value>
   </data>
   <data name="lblMaxSum.Text" xml:space="preserve">
     <value>Maximum Factor Levels Shown:</value>
@@ -195,18 +172,136 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblMaxSum.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="cmdSummaries.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cmdSummaries.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cmdSummaries.Location" type="System.Drawing.Point, System.Drawing">
+    <value>232, 200</value>
+  </data>
+  <data name="cmdSummaries.Size" type="System.Drawing.Size, System.Drawing">
+    <value>116, 23</value>
+  </data>
+  <data name="cmdSummaries.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="cmdSummaries.Text" xml:space="preserve">
+    <value>Choose Summaries...</value>
+  </data>
+  <data name="&gt;&gt;cmdSummaries.Name" xml:space="preserve">
+    <value>cmdSummaries</value>
+  </data>
+  <data name="&gt;&gt;cmdSummaries.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cmdSummaries.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;cmdSummaries.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="lblSummaries.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblSummaries.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblSummaries.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 205</value>
+  </data>
+  <data name="lblSummaries.Size" type="System.Drawing.Size, System.Drawing">
+    <value>61, 13</value>
+  </data>
+  <data name="lblSummaries.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="lblSummaries.Text" xml:space="preserve">
+    <value>Summaries:</value>
+  </data>
+  <data name="&gt;&gt;lblSummaries.Name" xml:space="preserve">
+    <value>lblSummaries</value>
+  </data>
+  <data name="&gt;&gt;lblSummaries.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblSummaries.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;lblSummaries.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="rdoDefault.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="rdoDefault.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="rdoDefault.Location" type="System.Drawing.Point, System.Drawing">
+    <value>79, 203</value>
+  </data>
+  <data name="rdoDefault.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 17</value>
+  </data>
+  <data name="rdoDefault.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="rdoDefault.Text" xml:space="preserve">
+    <value>Default</value>
+  </data>
+  <data name="&gt;&gt;rdoDefault.Name" xml:space="preserve">
+    <value>rdoDefault</value>
+  </data>
+  <data name="&gt;&gt;rdoDefault.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rdoDefault.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;rdoDefault.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="rdoCustomised.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="rdoCustomised.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="rdoCustomised.Location" type="System.Drawing.Point, System.Drawing">
+    <value>147, 203</value>
+  </data>
+  <data name="rdoCustomised.Size" type="System.Drawing.Size, System.Drawing">
+    <value>79, 17</value>
+  </data>
+  <data name="rdoCustomised.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="rdoCustomised.Text" xml:space="preserve">
+    <value>Customised</value>
+  </data>
+  <data name="&gt;&gt;rdoCustomised.Name" xml:space="preserve">
+    <value>rdoCustomised</value>
+  </data>
+  <data name="&gt;&gt;rdoCustomised.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rdoCustomised.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;rdoCustomised.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
   <data name="ucrNudMaxSum.Location" type="System.Drawing.Point, System.Drawing">
-
-    <value>200, 207</value>
-
+    <value>205, 235</value>
   </data>
   <data name="ucrNudMaxSum.Size" type="System.Drawing.Size, System.Drawing">
     <value>50, 20</value>
   </data>
   <data name="ucrNudMaxSum.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
+    <value>8</value>
   </data>
   <data name="&gt;&gt;ucrNudMaxSum.Name" xml:space="preserve">
     <value>ucrNudMaxSum</value>
@@ -218,58 +313,16 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrNudMaxSum.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="ucrChkCustomise.Location" type="System.Drawing.Point, System.Drawing">
-    <value>261, 163</value>
-  </data>
-  <data name="ucrChkCustomise.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 20</value>
-  </data>
-  <data name="ucrChkCustomise.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;ucrChkCustomise.Name" xml:space="preserve">
-    <value>ucrChkCustomise</value>
-  </data>
-  <data name="&gt;&gt;ucrChkCustomise.Type" xml:space="preserve">
-    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrChkCustomise.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;ucrChkCustomise.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="ucrChkSaveResult.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 262</value>
-  </data>
-  <data name="ucrChkSaveResult.Size" type="System.Drawing.Size, System.Drawing">
-    <value>166, 20</value>
-  </data>
-  <data name="ucrChkSaveResult.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;ucrChkSaveResult.Name" xml:space="preserve">
-    <value>ucrChkSaveResult</value>
-  </data>
-  <data name="&gt;&gt;ucrChkSaveResult.Type" xml:space="preserve">
-    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrChkSaveResult.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;ucrChkSaveResult.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="ucrChkOmitMissing.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 235</value>
+    <value>14, 235</value>
   </data>
   <data name="ucrChkOmitMissing.Size" type="System.Drawing.Size, System.Drawing">
     <value>166, 20</value>
   </data>
   <data name="ucrChkOmitMissing.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
+    <value>9</value>
   </data>
   <data name="&gt;&gt;ucrChkOmitMissing.Name" xml:space="preserve">
     <value>ucrChkOmitMissing</value>
@@ -281,12 +334,11 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrChkOmitMissing.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>5</value>
   </data>
   <data name="ucrSelectorOneVarSummarise.Location" type="System.Drawing.Point, System.Drawing">
     <value>10, 10</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="ucrSelectorOneVarSummarise.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
   </data>
@@ -306,34 +358,58 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrSelectorOneVarSummarise.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>6</value>
   </data>
-  <data name="cmdSummaries.AutoSize" type="System.Boolean, mscorlib">
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
+  </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
   </data>
-  <data name="cmdSummaries.Location" type="System.Drawing.Point, System.Drawing">
-    <value>305, 189</value>
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>421, 327</value>
   </data>
-  <data name="cmdSummaries.Size" type="System.Drawing.Size, System.Drawing">
-    <value>77, 23</value>
+  <data name="ucrBase.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 273</value>
   </data>
-  <data name="cmdSummaries.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
+  <data name="ucrBase.Size" type="System.Drawing.Size, System.Drawing">
+    <value>410, 52</value>
   </data>
-  <data name="cmdSummaries.Text" xml:space="preserve">
-    <value>Summaries...</value>
+  <data name="ucrBase.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
   </data>
-  <data name="&gt;&gt;cmdSummaries.Name" xml:space="preserve">
-    <value>cmdSummaries</value>
+  <data name="&gt;&gt;ucrBase.Name" xml:space="preserve">
+    <value>ucrBase</value>
   </data>
-  <data name="&gt;&gt;cmdSummaries.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;ucrBase.Type" xml:space="preserve">
+    <value>instat.ucrButtons, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="&gt;&gt;cmdSummaries.Parent" xml:space="preserve">
+  <data name="&gt;&gt;ucrBase.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;cmdSummaries.ZOrder" xml:space="preserve">
-    <value>9</value>
+  <data name="&gt;&gt;ucrBase.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="ucrPnlSummaries.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 192</value>
+  </data>
+  <data name="ucrPnlSummaries.Size" type="System.Drawing.Size, System.Drawing">
+    <value>352, 37</value>
+  </data>
+  <data name="ucrPnlSummaries.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlSummaries.Name" xml:space="preserve">
+    <value>ucrPnlSummaries</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlSummaries.Type" xml:space="preserve">
+    <value>instat.UcrPanel, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlSummaries.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlSummaries.ZOrder" xml:space="preserve">
+    <value>11</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterScreen</value>
@@ -369,6 +445,6 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrReceiverOneVarSummarise.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>7</value>
   </data>
 </root>

--- a/instat/dlgOneVariableSummarise.vb
+++ b/instat/dlgOneVariableSummarise.vb
@@ -162,7 +162,7 @@ Public Class dlgOneVariableSummarise
         strDefaultColumns = Nothing
     End Sub
 
-    Private Sub Controls_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrReceiverOneVarSummarise.ControlContentsChanged, ucrNudMaxSum.ControlContentsChanged
+    Private Sub Controls_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrReceiverOneVarSummarise.ControlContentsChanged, ucrNudMaxSum.ControlContentsChanged, ucrPnlSummaries.ControlValueChanged
         TestOKEnabled()
     End Sub
 

--- a/instat/dlgOneVariableSummarise.vb
+++ b/instat/dlgOneVariableSummarise.vb
@@ -14,6 +14,7 @@
 ' You should have received a copy of the GNU General Public License 
 ' along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+Imports instat
 Imports instat.Translations
 
 Public Class dlgOneVariableSummarise
@@ -53,24 +54,20 @@ Public Class dlgOneVariableSummarise
 
         ucrNudMaxSum.SetParameter(New RParameter("maxsum", 2))
         ucrNudMaxSum.SetRDefault("7")
+        ucrNudMaxSum.SetLinkedDisplayControl(lblMaxSum)
+
+        ucrPnlSummaries.AddRadioButton(rdoDefault)
+        ucrPnlSummaries.AddRadioButton(rdoCustomised)
+        ucrPnlSummaries.AddFunctionNamesCondition(rdoCustomised, frmMain.clsRLink.strInstatDataObject & "$summary")
+        ucrPnlSummaries.AddFunctionNamesCondition(rdoDefault, "summary")
+        ucrPnlSummaries.AddToLinkedControls(ucrNudMaxSum, {rdoDefault}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
+        ucrPnlSummaries.AddToLinkedControls(ucrChkOmitMissing, {rdoCustomised}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
 
         ucrChkOmitMissing.SetParameter(New RParameter("na.rm", 3))
         ucrChkOmitMissing.SetText("Omit Missing Values")
         ucrChkOmitMissing.SetRDefault("FALSE")
         ucrChkOmitMissing.SetValuesCheckedAndUnchecked("TRUE", "FALSE")
         ucrChkOmitMissing.bUpdateRCodeFromControl = True
-
-        ucrChkCustomise.SetText("Customise")
-        ucrChkCustomise.AddFunctionNamesCondition(True, frmMain.clsRLink.strInstatDataObject & "$summary")
-        ucrChkCustomise.AddFunctionNamesCondition(False, "summary")
-        ucrChkCustomise.AddToLinkedControls(ucrNudMaxSum, {False}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
-        ucrNudMaxSum.SetLinkedDisplayControl(lblMaxSum)
-
-        ucrChkSaveResult.SetText("Save Result") 'this is disabled in the initial implementation
-        ucrChkSaveResult.Enabled = False
-        'ucrChkSaveResult.SetParameter(New RParameter("store_results"))
-        'ucrChkSaveResult.SetValuesCheckedAndUnchecked("TRUE", "FALSE")
-        'ucrChkSaveResult.SetRDefault("FALSE")
     End Sub
 
     Private Sub SetDefaults()
@@ -78,8 +75,6 @@ Public Class dlgOneVariableSummarise
         clsSummaryFunction = New RFunction
         clsInstatSummaryFunction = New RFunction
         clsConcFunction = New RFunction
-
-        cmdSummaries.Enabled = False
 
         ucrSelectorOneVarSummarise.Reset()
 
@@ -107,13 +102,14 @@ Public Class dlgOneVariableSummarise
         ucrNudMaxSum.SetRCode(clsSummaryFunction, bReset)
         ucrReceiverOneVarSummarise.SetRCode(clsSummaryFunction, bReset)
         ucrChkOmitMissing.SetRCode(clsSummaryFunction, bReset)
-        ucrChkCustomise.SetRCode(ucrBase.clsRsyntax.clsBaseFunction, bReset)
+        ucrPnlSummaries.SetRCode(ucrBase.clsRsyntax.clsBaseFunction, bReset)
         ucrSelectorOneVarSummarise.SetRCode(clsInstatSummaryFunction, bReset)
+        ChangeBaseFunction()
     End Sub
 
     Public Sub TestOKEnabled()
         'We cannot test the values on the sub dialog because the sub dialog may not be in sync with the main dialog code. This only happens once the sub dialog has been opened.
-        If ucrReceiverOneVarSummarise.IsEmpty() OrElse (ucrChkCustomise.Checked AndAlso clsSummariesList.clsParameters.Count = 0) OrElse ucrNudMaxSum.GetText = "" Then
+        If ucrReceiverOneVarSummarise.IsEmpty() OrElse (rdoCustomised.Checked AndAlso clsSummariesList.clsParameters.Count = 0) OrElse ucrNudMaxSum.GetText = "" Then
             ucrBase.OKEnabled(False)
         Else
             ucrBase.OKEnabled(True)
@@ -136,15 +132,13 @@ Public Class dlgOneVariableSummarise
     End Sub
 
     Private Sub ChangeBaseFunction()
-        If ucrChkCustomise.Checked Then
+        If rdoCustomised.Checked Then
             ucrBase.clsRsyntax.SetBaseRFunction(clsInstatSummaryFunction)
-            cmdSummaries.Enabled = True
-        Else
+            cmdSummaries.Visible = True
+        ElseIf rdoDefault.Checked Then
             ucrBase.clsRsyntax.SetBaseRFunction(clsSummaryFunction)
-            cmdSummaries.Enabled = False
+            cmdSummaries.Visible = False
         End If
-        'We need to update the base function to include the 
-        'ucrBaseDescribeOneVar.clsRsyntax.clsBaseFunction.AddParameter(ucrChkOmitMissing.GetParameter())
     End Sub
 
     Private Sub ucrReceiverDescribeOneVar_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverOneVarSummarise.ControlValueChanged
@@ -168,11 +162,11 @@ Public Class dlgOneVariableSummarise
         strDefaultColumns = Nothing
     End Sub
 
-    Private Sub ucrChkCustomise_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrChkCustomise.ControlValueChanged
-        ChangeBaseFunction()
+    Private Sub Controls_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrReceiverOneVarSummarise.ControlContentsChanged, ucrNudMaxSum.ControlContentsChanged
+        TestOKEnabled()
     End Sub
 
-    Private Sub Controls_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrReceiverOneVarSummarise.ControlContentsChanged, ucrChkCustomise.ControlContentsChanged, ucrNudMaxSum.ControlContentsChanged
-        TestOKEnabled()
+    Private Sub ucrPnlSummaries_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrPnlSummaries.ControlValueChanged
+        ChangeBaseFunction()
     End Sub
 End Class

--- a/instat/sdgDescribeDisplay.vb
+++ b/instat/sdgDescribeDisplay.vb
@@ -69,10 +69,10 @@ Public Class sdgDescribeDisplay
     End Sub
 
     Public Sub GrpBoxEnable()
-        If ((dlgDescribeTwoVariable.strSecondVarType = "factor") And (dlgDescribeTwoVariable.strVarType = "numeric" OrElse dlgDescribeTwoVariable.strVarType = "integer")) Then
+        If ((dlgDescribeTwoVariable.strFirstVariablesType = "factor") And (dlgDescribeTwoVariable.strSecondVariableType = "numeric" OrElse dlgDescribeTwoVariable.strSecondVariableType = "integer")) Then
             grpAnovaOptions.Enabled = True
             grpFrequenciesOptions.Enabled = False
-        ElseIf ((dlgDescribeTwoVariable.strVarType = "factor") And (dlgDescribeTwoVariable.strSecondVarType = "factor")) Then
+        ElseIf ((dlgDescribeTwoVariable.strSecondVariableType = "factor") And (dlgDescribeTwoVariable.strFirstVariablesType = "factor")) Then
             grpFrequenciesOptions.Enabled = True
             grpAnovaOptions.Enabled = False
         End If

--- a/instat/static/InstatObject/R/Backend_Components/summary_functions.R
+++ b/instat/static/InstatObject/R/Backend_Components/summary_functions.R
@@ -251,6 +251,7 @@ DataBook$set("public", "summary", function(data_name, columns_to_summarise, summ
   
   summary_names <- ifelse(startsWith(summaries, "summary_"), substr(summaries, 9, nchar(summaries)), summaries)
   summary_names <- gsub("_", "-", summary_names)
+  summary_names <- make.unique(summary_names)
   summary_count_names <- summary_names[1:count_summaries_max]
   summary_other_names <- summary_names[(count_summaries_max + 1):summaries_max]
   col_data_type <- self$get_variables_metadata(data_name = data_name, column = columns_to_summarise, property = data_type_label)

--- a/instat/static/InstatObject/R/data_object_R6.R
+++ b/instat/static/InstatObject/R/data_object_R6.R
@@ -610,6 +610,18 @@ DataSheet$set("public", "anova_tables", function(x_col_names, y_col_name, signif
 }
 )
 
+DataSheet$set("public", "cor", function(x_col_names, y_col_name, use = "everything", method = c("pearson", "kendall", "spearman")) {
+  x <- self$get_columns_from_data(x_col_names, force_as_data_frame = TRUE)
+  y <- self$get_columns_from_data(y_col_name)
+  x <- sapply(x, as.numeric)
+  y <- as.numeric(y)
+  results <- cor(x = x, y = y, use = use, method = method)
+  dimnames(results)[[2]] <- y_col_name
+  cat("Correlations:\n")
+  return(t(results))
+}
+)
+
 DataSheet$set("public", "rename_column_in_data", function(curr_col_name = "", new_col_name = "", label = "") {
   curr_data <- self$get_data_frame(use_current_filter = FALSE)
   # Column name must be character

--- a/instat/static/InstatObject/R/data_object_R6.R
+++ b/instat/static/InstatObject/R/data_object_R6.R
@@ -596,30 +596,16 @@ DataSheet$set("public", "get_columns_from_data", function(col_names, force_as_da
 }
 )
 
-DataSheet$set("public", "frequency_tables", function(x_col_names, y_col_name, addmargins = FALSE,  proportions = FALSE, percentages = FALSE,  transpose = FALSE) {
-  if(missing(x_col_names) || missing(y_col_name)) stop("Both x_col_names and y_col_name are required")
-  multiply_by = 1
-  for (i in 1:length(x_col_names)){
-    if(transpose)(my_table = table(private$data[[y_col_name]], private$data[[x_col_names[i]]])) else(my_table = table(private$data[[x_col_names[i]]], private$data[[y_col_name]]))
-    
-    if(percentages && proportions)( multiply_by = 100)
-    else if(percentages && !proportions)warning("Proportions should be set to true to display percentages.")
-    if(addmargins && proportions)(print(addmargins(prop.table(my_table)*multiply_by))) #Is FUN appropriate here?
-    else if(addmargins && !proportions)(print(addmargins(my_table)))
-    else if(!addmargins && proportions)(print(prop.table(my_table)*multiply_by))
-    else if(!addmargins && !proportions)(print(my_table))
-  }
-}
-)
-
 DataSheet$set("public", "anova_tables", function(x_col_names, y_col_name, signif.stars = FALSE, sign_level = FALSE, means = FALSE) {
   if(missing(x_col_names) || missing(y_col_name)) stop("Both x_col_names and y_col_names are required")
-  if(sign_level || signif.stars)warning("This is nolonger descriptive")
-  if(sign_level)(end_col = 5)else(end_col = 4)
-  for (i in 1:length(x_col_names)){
-    my_model = lm(formula = as.formula(paste(as.name(y_col_name),as.name(x_col_names[i]), sep = "~")), data=private$data)
-    print(anova(my_model)[1:end_col], signif.stars = signif.stars)
-    if(means)(print(model.tables(aov(my_model), type = "means")))
+  if(sign_level || signif.stars) message("This is no longer descriptive")
+  if(sign_level) end_col = 5 else end_col = 4
+  for (i in seq_along(x_col_names)) {
+    mod <- lm(formula = as.formula(paste0("as.numeric(", as.name(y_col_name), ") ~ ", as.name(x_col_names[i]))), data = self$get_data_frame())
+    cat("ANOVA table: ", y_col_name, " ~ ", x_col_names[i], "\n", sep = "")
+    print(anova(mod)[1:end_col], signif.stars = signif.stars)
+    cat("\n")
+    if(means) (print(model.tables(aov(mod), type = "means")))
   }
 }
 )

--- a/instat/static/InstatObject/R/instat_object_R6.R
+++ b/instat/static/InstatObject/R/instat_object_R6.R
@@ -789,8 +789,12 @@ DataBook$set("public", "rename_column_in_data", function(data_name, column_name,
 } 
 )
 
-DataBook$set("public", "frequency_tables", function(data_name, x_col_names, y_col_name, addmargins = FALSE, proportions = FALSE, percentages = FALSE, transpose = FALSE) {
-  self$get_data_objects(data_name)$frequency_tables(x_col_names, y_col_name, addmargins = addmargins, proportions = proportions, percentages = percentages, transpose = transpose)
+DataBook$set("public", "frequency_tables", function(data_name, x_col_names, y_col_name, n_column_factors = 1, store_results = TRUE, drop = TRUE, na.rm = FALSE, summary_name = NA, include_margins = FALSE, return_output = TRUE, treat_columns_as_factor = FALSE, page_by = "default", as_html = TRUE, signif_fig = 2, na_display = "", na_level_display = "NA", weights = NULL, caption = NULL, result_names = NULL, percentage_type = "none", perc_total_columns = NULL, perc_total_factors = c(), perc_total_filter = NULL, perc_decimal = FALSE, margin_name = "(All)", additional_filter, ...) {
+  for(i in seq_along(x_col_names)) {
+    cat(x_col_names[i], "by", y_col_name, "\n")
+    print(data_book$summary_table(data_name = data_name, summaries = count_label, factors=c(x_col_names[i], y_col_name), n_column_factors = n_column_factors, store_results = store_results, drop = drop, na.rm = na.rm, summary_name = summary_name, include_margins = include_margins, return_output = return_output, treat_columns_as_factor = treat_columns_as_factor, page_by = page_by, as_html = as_html, signif_fig = signif_fig, na_display = na_display, na_level_display = na_level_display, weights = weights, caption = caption, result_names = result_names, percentage_type = percentage_type, perc_total_columns = perc_total_columns, perc_total_factors = perc_total_factors, perc_total_filter = perc_total_filter, perc_decimal = perc_decimal, margin_name = margin_name, additional_filter = additional_filter, ... = ...))
+    cat("\n")
+  }
 } 
 )
 

--- a/instat/static/InstatObject/R/instat_object_R6.R
+++ b/instat/static/InstatObject/R/instat_object_R6.R
@@ -803,6 +803,11 @@ DataBook$set("public", "anova_tables", function(data_name, x_col_names, y_col_na
 } 
 )
 
+DataBook$set("public", "cor", function(data_name, x_col_names, y_col_name, use = "everything", method = c("pearson", "kendall", "spearman")) {
+  self$get_data_objects(data_name)$cor(x_col_names = x_col_names, y_col_name = y_col_name, use = use, method = method)
+} 
+)
+
 DataBook$set("public", "remove_columns_in_data", function(data_name, cols, allow_delete_all = FALSE) {
   self$get_data_objects(data_name)$remove_columns_in_data(cols = cols, allow_delete_all = allow_delete_all)
 } 

--- a/instat/ucrReceiverMultiple.vb
+++ b/instat/ucrReceiverMultiple.vb
@@ -19,6 +19,8 @@ Imports RDotNet
 Public Class ucrReceiverMultiple
 
     Public bSingleType As Boolean = False
+    ' If bSingleType and bCategoricalNumeric then categorical and numeric are the only considered types
+    Public bCategoricalNumeric As Boolean = False
 
     Private Sub ucrReceiverMultiple_Load(sender As Object, e As EventArgs) Handles Me.Load
         If bFirstLoad Then
@@ -359,7 +361,7 @@ Public Class ucrReceiverMultiple
         lstSelectedVariables.Enabled = Not bFixreceiver
     End Sub
 
-    Public Function GetCurrentItemTypes(Optional bUnique As Boolean = False) As List(Of String)
+    Public Function GetCurrentItemTypes(Optional bUnique As Boolean = False, Optional bIsCategoricalNumeric As Boolean = False) As List(Of String)
         Dim clsGetDataType As New RFunction
         Dim strDataTypes As New List(Of String)
         Dim strDataFrame As String
@@ -383,11 +385,21 @@ Public Class ucrReceiverMultiple
                 If expTypes IsNot Nothing AndAlso expTypes.Type <> Internals.SymbolicExpressionType.Null Then
                     strDataTypes = expTypes.AsCharacter.ToList()
                 End If
-                If bUnique Then
-                    strDataTypes = strDataTypes.Distinct().ToList()
-                End If
                 If strDataTypes.Count = 2 AndAlso strDataTypes.Contains("ordered") AndAlso strDataTypes.Contains("factor") Then
                     strDataTypes = {"factor"}.ToList
+                End If
+                If bIsCategoricalNumeric Then
+                    ' logical can be considered as both categorical or numeric so should be dealt with on individual dialogs
+                    For i As Integer = 0 To strDataTypes.Count - 1
+                        If strDataTypes(i).Contains("factor") OrElse strDataTypes(i).Contains("character") Then
+                            strDataTypes(i) = "categorical"
+                        ElseIf Not strDataTypes(i).Contains("logical") Then
+                            strDataTypes(i) = "numeric"
+                        End If
+                    Next
+                End If
+                If bUnique Then
+                    strDataTypes = strDataTypes.Distinct().ToList()
                 End If
             End If
         End If
@@ -435,39 +447,53 @@ Public Class ucrReceiverMultiple
 
         If bSingleType Then
             If (Not IsEmpty()) Then
-                strVariableTypes = GetCurrentItemTypes(True)
-                If strVariableTypes.Count > 1 AndAlso Not (strVariableTypes.Count = 2 AndAlso strVariableTypes.Contains("numeric") AndAlso strVariableTypes.Contains("integer")) AndAlso Not (strVariableTypes.Count = 2 AndAlso strVariableTypes.Contains("factor") AndAlso strVariableTypes.Contains("ordered,factor")) Then
+                strVariableTypes = GetCurrentItemTypes(True, bCategoricalNumeric)
+                If strVariableTypes.Count > 1 AndAlso Not (strVariableTypes.Count = 2 AndAlso strVariableTypes.Contains("numeric") AndAlso strVariableTypes.Contains("integer")) AndAlso Not (strVariableTypes.Count = 2 AndAlso strVariableTypes.Contains("factor") AndAlso strVariableTypes.Contains("ordered,factor")) AndAlso Not (bCategoricalNumeric AndAlso strVariableTypes.Count = 2 AndAlso strVariableTypes.Contains("logical")) Then
                     MsgBox("Cannot add these variables. All variables must be of the same data type.", MsgBoxStyle.OkOnly, "Cannot add variables.")
                     Clear()
                     SetSelectorHeading("Variables")
                 ElseIf strVariableTypes.Count > 0 Then
-                    If strVariableTypes(0) = "integer" Then
-                        SetDataType("numeric", bStrict:=True)
-                        SetSelectorHeading("Numerics")
-                    ElseIf strVariableTypes(0) = "ordered,factor" OrElse strVariableTypes(0) = "factor" Then
-                        SetDataType("factor", bStrict:=True)
-                        SetSelectorHeading("Factors")
+                    If bCategoricalNumeric Then
+                        If strVariableTypes.Contains("categorical") Then
+                            SetIncludedDataTypes({"factor", "character", "logical"}, bStrict:=True)
+                            SetSelectorHeading("Categorical Variables")
+                        ElseIf strVariableTypes.Contains("numeric") Then
+                            SetExcludedDataTypes({"factor", "character"})
+                            SetSelectorHeading("Numerics")
+                        Else
+                            ' Else it is logical only
+                            RemoveIncludedMetadataProperty(strProperty:="class")
+                            RemoveExcludedMetadataProperty(strProperty:="class")
+                            SetSelectorHeading("Variables")
+                        End If
                     Else
-                        SetDataType(strVariableTypes(0), bStrict:=True)
-                        SetSelectorHeading(strVariableTypes(0) & " Variables")
+                        If strVariableTypes(0) = "integer" OrElse strVariableTypes(0) = "numeric" Then
+                            SetDataType("numeric", bStrict:=True)
+                            SetSelectorHeading("Numerics")
+                        ElseIf strVariableTypes(0) = "ordered,factor" OrElse strVariableTypes(0) = "factor" Then
+                            SetDataType("factor", bStrict:=True)
+                            SetSelectorHeading("Factors")
+                        Else
+                            SetDataType(strVariableTypes(0), bStrict:=True)
+                            SetSelectorHeading(strVariableTypes(0) & " Variables")
+                        End If
                     End If
                 Else
                     RemoveIncludedMetadataProperty(strProperty:="class")
+                    RemoveExcludedMetadataProperty(strProperty:="class")
                     SetSelectorHeading("Variables")
                 End If
             Else
                 RemoveIncludedMetadataProperty(strProperty:="class")
+                RemoveExcludedMetadataProperty(strProperty:="class")
                 SetSelectorHeading("Variables")
             End If
-        Else
-            ' Removed as this was causing data type to be removed on reset for any receiver
-            ' Left as comment in case this cause other issues
-            'RemoveIncludedMetadataProperty(strProperty:="class")
         End If
     End Sub
 
-    Public Sub SetSingleTypeStatus(bIsSingleType As Boolean)
+    Public Sub SetSingleTypeStatus(bIsSingleType As Boolean, Optional bIsCategoricalNumeric As Boolean = False)
         bSingleType = bIsSingleType
+        bCategoricalNumeric = bIsCategoricalNumeric
         CheckSingleType()
     End Sub
 

--- a/instat/ucrReceiverMultiple.vb
+++ b/instat/ucrReceiverMultiple.vb
@@ -439,19 +439,25 @@ Public Class ucrReceiverMultiple
                 If strVariableTypes.Count > 1 AndAlso Not (strVariableTypes.Count = 2 AndAlso strVariableTypes.Contains("numeric") AndAlso strVariableTypes.Contains("integer")) AndAlso Not (strVariableTypes.Count = 2 AndAlso strVariableTypes.Contains("factor") AndAlso strVariableTypes.Contains("ordered,factor")) Then
                     MsgBox("Cannot add these variables. All variables must be of the same data type.", MsgBoxStyle.OkOnly, "Cannot add variables.")
                     Clear()
+                    SetSelectorHeading("Variables")
                 ElseIf strVariableTypes.Count > 0 Then
                     If strVariableTypes(0) = "integer" Then
                         SetDataType("numeric", bStrict:=True)
-                    ElseIf strVariableTypes(0) = "ordered,factor" Then
+                        SetSelectorHeading("Numerics")
+                    ElseIf strVariableTypes(0) = "ordered,factor" OrElse strVariableTypes(0) = "factor" Then
                         SetDataType("factor", bStrict:=True)
+                        SetSelectorHeading("Factors")
                     Else
                         SetDataType(strVariableTypes(0), bStrict:=True)
+                        SetSelectorHeading(strVariableTypes(0) & " Variables")
                     End If
                 Else
                     RemoveIncludedMetadataProperty(strProperty:="class")
+                    SetSelectorHeading("Variables")
                 End If
             Else
                 RemoveIncludedMetadataProperty(strProperty:="class")
+                SetSelectorHeading("Variables")
             End If
         Else
             ' Removed as this was causing data type to be removed on reset for any receiver


### PR DESCRIPTION
- dialog design modified, checkbox for customise replaced with radio buttons
- improved display of names of summaries in output
- removed scientific notation of summaries
- corrected summaries for Dates
- corrected error for invalid summaries on some data type
- ordered summaries in output by size and groupings

**Edit**
Added improvements to two variable summarise dialog here since the improved summary methods were needed
- added a box on the dialog showing the summary that will be done based on the variables selected
- allowed for broad categorical/numeric types (implemented in multiple receiver) to be chosen in the first receiver (e.g. factor and character are allowed together, or numeric and date)
- created a correlation function that ensures columns are converted to numeric first (e.g. date and logical)