### PR TITLE
Solves #5613 problem deleting only data frame.

### DIFF
--- a/instat/clsGridLink.vb
+++ b/instat/clsGridLink.vb
@@ -94,7 +94,7 @@ Public Class clsGridLink
         clsGetCombinedMetadata.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_combined_metadata")
         clsSetMetadataChanged.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$set_metadata_changed")
 
-        If frmMain.clsRLink.bInstatObjectExists Then
+        If frmMain.clsRLink.bInstatObjectExists AndAlso frmMain.clsRLink.GetDataFrameCount() > 0 Then
             expTemp = frmMain.clsRLink.RunInternalScriptGetValue(clsDataChanged.ToScript())
             If expTemp IsNot Nothing AndAlso expTemp.Type <> Internals.SymbolicExpressionType.Null Then
                 bRDataChanged = expTemp.AsLogical(0)

--- a/instat/clsRLink.vb
+++ b/instat/clsRLink.vb
@@ -1078,6 +1078,21 @@ Public Class RLink
         Return bExists
     End Function
 
+    Public Function GetDataFrameCount() As Integer
+        Dim iCount As Integer
+        Dim clsDataFrameCount As New RFunction
+        Dim expCount As SymbolicExpression
+
+        clsDataFrameCount.SetRCommand(strInstatDataObject & "$dataframe_count")
+        expCount = RunInternalScriptGetValue(clsDataFrameCount.ToScript(), bSilent:=True)
+        If expCount IsNot Nothing AndAlso Not expCount.Type = Internals.SymbolicExpressionType.Null Then
+            iCount = expCount.AsInteger(0)
+        Else
+            iCount = 0
+        End If
+        Return iCount
+    End Function
+
     Public Function GetDataFrameLength(strDataFrameName As String, Optional bUseCurrentFilter As Boolean = False) As Integer
         Dim iLength As Integer
         Dim clsDataFrameLength As New RFunction


### PR DESCRIPTION
Created new function `clsRLink.GetDataFrameCount()` which returns the number of data frames in `data_book`.
Added an extra check in `clsGridLink.UpdateGrids()` so that the grid is only updated if there is at least one data frame.