### PR TITLE
fixes #5577 Errors in R-Instat repeat the previous command

### DIFF
--- a/instat/clsRLink.vb
+++ b/instat/clsRLink.vb
@@ -567,12 +567,14 @@ Public Class RLink
                 strCapturedScript = "capture.output(" & strSplitScript & ")"
             End If
             Try
-                Evaluate(strTempAssignTo & " <- " & strCapturedScript, bSilent:=bSilent, bSeparateThread:=bSeparateThread, bShowWaitDialogOverride:=bShowWaitDialogOverride)
-                expTemp = GetSymbol(strTempAssignTo)
-                If expTemp IsNot Nothing Then
-                    strTemp = String.Join(Environment.NewLine, expTemp.AsCharacter())
-                    If strTemp <> "" Then
-                        strOutput = strOutput & strTemp & Environment.NewLine
+                If Evaluate(strTempAssignTo & " <- " & strCapturedScript, bSilent:=bSilent, bSeparateThread:=bSeparateThread, bShowWaitDialogOverride:=bShowWaitDialogOverride) = True Then
+                    expTemp = GetSymbol(strTempAssignTo)
+                    Evaluate("rm(" & strTempAssignTo & ")", bSilent:=True)
+                    If expTemp IsNot Nothing Then
+                        strTemp = String.Join(Environment.NewLine, expTemp.AsCharacter())
+                        If strTemp <> "" Then
+                            strOutput = strOutput & strTemp & Environment.NewLine
+                        End If
                     End If
                 End If
             Catch e As Exception

--- a/instat/clsRLink.vb
+++ b/instat/clsRLink.vb
@@ -567,7 +567,7 @@ Public Class RLink
                 strCapturedScript = "capture.output(" & strSplitScript & ")"
             End If
             Try
-                If Evaluate(strTempAssignTo & " <- " & strCapturedScript, bSilent:=bSilent, bSeparateThread:=bSeparateThread, bShowWaitDialogOverride:=bShowWaitDialogOverride) = True Then
+                If Evaluate(strTempAssignTo & " <- " & strCapturedScript, bSilent:=bSilent, bSeparateThread:=bSeparateThread, bShowWaitDialogOverride:=bShowWaitDialogOverride) Then
                     expTemp = GetSymbol(strTempAssignTo)
                     Evaluate("rm(" & strTempAssignTo & ")", bSilent:=True)
                     If expTemp IsNot Nothing Then


### PR DESCRIPTION
Fixes #5577. This was caused by the following:

- `RLink.RunScript(...)`, line 570
  - Calls `Evaluate(...)` with the R script (e.g. `.temp_val <- capture.output(2+x)`)
  - `Evaluate(...)` returns `True` if script executed successfully, else `False`
  - Line 570 ignores the return value
- `RLink.RunScript(...)`, lines 571-577
  - Extracts and displays the value of `.temp_val`
  - If the script was not successful then `.temp_val` still contains its previous value (or is potentially undefined)

Issue fixed by:

- line 570: Check the return value of `Evaluate(...)`
- If `True` then
  - Extract and display the value of `.temp_val`
  - Remove `.temp_val` (as recommended by @dannyparsons it's good to keep the R environment tidy and remove variables after using them)
- Else do nothing