### PR TITLE
Fixed the button examples problems on the new dataframe dialog

### DIFF
--- a/instat/dlgNewDataFrame.vb
+++ b/instat/dlgNewDataFrame.vb
@@ -24,7 +24,7 @@ Public Class dlgNewDataFrame
     Private bReset As Boolean = True
 
     Private Sub dlgNewDataFrame_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
+        'autoTranslate(Me) this subroutine was causing a bug in the button examples
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False


### PR DESCRIPTION
@africanmathsinitiative/developers this is ready for review.
I was still looking at what was causing the change to the text for button examples