### PR TITLE
Fixes #5742 Issue multiline commands in script window

### DIFF
--- a/instat/clsRLink.vb
+++ b/instat/clsRLink.vb
@@ -197,24 +197,22 @@ Public Class RLink
     ''' <param name="strNewComment"> is shown as a comment. If this parameter is "" then shows 
     '''                              <paramref name="strNewScript"/> as the comment.</param>
     Public Sub RunScriptFromWindow(strNewScript As String, strNewComment As String)
-        Dim strScriptLines() As String = strNewScript.Split(Environment.NewLine)
-        Dim strScriptCmds(strScriptLines.Length - 1) As String 'num of cmds is always <= num of lines
-        Dim iScriptCmdIndex = 0
+        Dim strScriptCmd As String = ""
 
-        'create an array of clean, single-line R commands
-        For i = 0 To strScriptLines.Length - 1
-            Dim strScriptLine As String = strScriptLines(i).Trim(vbLf) 'remove linefeed at end of line
+        'for each line in script
+        For Each strScriptLine As String In strNewScript.Split(Environment.NewLine)
+            strScriptLine = strScriptLine.Trim(vbLf) 'remove linefeed at end of line
+            strScriptLine = Trim(strScriptLine)      'trim any spaces from front or end
 
             'if line is empty or a comment, then ignore line
             If strScriptLine.Count <= 0 Or strScriptLine.StartsWith("#") Then
                 Continue For
             End If
 
-            'else add line of script to array of cmds
-            strScriptCmds(iScriptCmdIndex) &= strScriptLine
+            'else append line of script to command
+            strScriptCmd &= strScriptLine
 
-            'if line ends in a '+', ',', or '%>%' then assume cmd is not complete
-            strScriptLine = Trim(strScriptLine) 'trim any spaces from front or end
+            'if line ends in a '+', ',', or '%>%' then assume command is not complete
             Dim cLastChar As Char = strScriptLine.Last
             Dim strLast3Chars As String = ""
             If strScriptLine.Length >= 3 Then
@@ -224,19 +222,13 @@ Public Class RLink
                 Continue For
             End If
 
-            'else assume cmd is complete
-            iScriptCmdIndex += 1
-        Next
-
-        'execute each R command
-        For i = 0 To iScriptCmdIndex - 1
+            'else execute command
             Dim iCallType As Integer = 2
-
-            If strScriptCmds(i).Contains(strInstatDataObject & "$get_graphs") Then
+            If strScriptCmd.Contains(strInstatDataObject & "$get_graphs") Then
                 iCallType = 3
             End If
-
-            RunScript(strScriptCmds(i), iCallType:=iCallType, strComment:=strNewComment, bSeparateThread:=False, bSilent:=False)
+            RunScript(strScriptCmd, iCallType:=iCallType, strComment:=strNewComment, bSeparateThread:=False, bSilent:=False)
+            strScriptCmd = ""
             strNewComment = ""
         Next
     End Sub

--- a/instat/ucrScript.vb
+++ b/instat/ucrScript.vb
@@ -73,7 +73,7 @@ Public Class ucrScript
         If txtScript.TextLength > 0 Then
             Dim lineNum As Integer = txtScript.GetLineFromCharIndex(txtScript.GetFirstCharIndexOfCurrentLine())
             If lineNum < txtScript.Lines.Length Then
-                RunText(txtScript.Lines(lineNum))
+                RunText(txtScript.Lines(lineNum), False)
                 If lineNum < txtScript.Lines.Length - 1 Then
                     txtScript.SelectionStart = txtScript.GetFirstCharIndexFromLine(lineNum + 1)
                     txtScript.ScrollToCaret()
@@ -82,9 +82,9 @@ Public Class ucrScript
         End If
     End Sub
 
-    Private Sub RunText(strText As String)
+    Private Sub RunText(strText As String, Optional bClearScriptCmd As Boolean = True)
         If strText <> "" Then
-            frmMain.clsRLink.RunScriptFromWindow(strNewScript:=strText, strNewComment:=strComment)
+            frmMain.clsRLink.RunScriptFromWindow(strNewScript:=strText, strNewComment:=strComment, bClearScriptCmd)
         End If
     End Sub
 


### PR DESCRIPTION
Fixes #5742 Issue multiline commands in script window.

Note that this issue also has an optional enhancement to allow multi-line functions (enclosed with '{' and '}') to be executed in the script window. This PR does **not** implement this optional enhancement.

**Issue**

In the R-Instat script window, if the user splits commands over multiple lines then R-Instat displays an error. 

@rdstern and @dannyparsons requested that if a script line ends with '+', ',', or '%>%', then the command may continue onto the next line.

**Analysis and solution**

The R  script window commands are processed by 'ucrScript'. It would be possible to add the multi-line functionality to this class.

However, R scripts can also be manually executed from the log window. Therefore I decided to add the multi-line functionality to the 'clsRLink.RunScriptFromWindow' function. This executes R scripts from both the script and log windows. Implementing the functionality here guarantees that a script will be executed in the same way regardless of whether it comes from the script window or the log window. 

Counter argument: The log window only contains computer-generated R commands and therefore is unlikely to have multi-line commands (at least for now). 

**Testing**

I tested with the following scripts:

```
# generate artificial data
set.seed(4321)
x <- 1:100
y <- (x + x^2 + x^3) + rnorm(length(x), mean = 0, sd = mean(x^3) / 4)
my.data <- data.frame(x = x, y = y,
group = c("A", "B"),
y2 = y * c(0.5,2),
w = sqrt(x))

# give a name to a formula
formula <- y ~ poly(x, 3, raw = TRUE)
# no weights
ggplot2::ggplot(my.data, aes(x, y)) +
geom_point() +
geom_smooth(method = "lm", formula = formula) +
ggpmisc::stat_poly_eq(formula = formula, parse = TRUE)

# Initialize `x` 
x <- rnorm(100)

# Update value of `x` and assign it to `x`
x %<>% abs %>% 
sort
```
 All tests passed correctly.
