### PR TITLE
Removing filters from row names dialogue

### DIFF
--- a/instat/dlgRownamesOrNumbers.vb
+++ b/instat/dlgRownamesOrNumbers.vb
@@ -48,6 +48,7 @@ Public Class dlgRowNamesOrNumbers
         ucrReceiverRowNames.SetParameterIsRFunction()
         ucrReceiverRowNames.Selector = ucrSelectorRowNames
         ucrReceiverRowNames.SetMeAsReceiver()
+        ucrReceiverRowNames.bUseFilteredData = False
 
         ' main rdo options
         ucrPnlOverallOptions.AddRadioButton(rdoCopyRowNamesIntoFirstColumn)


### PR DESCRIPTION
disabling the use of filters in the row names dialogue #5608 