### PR TITLE
Having the ExportFile,fieldName textbox, in dlgExportGraphAs Image as read only

### DIFF
--- a/instat/dlgExportGraphAsImage.Designer.vb
+++ b/instat/dlgExportGraphAsImage.Designer.vb
@@ -90,7 +90,7 @@ Partial Class dlgExportGraphAsImage
         '
         Me.ucrInputFile.AddQuotesIfUnrecognised = True
         Me.ucrInputFile.IsMultiline = False
-        Me.ucrInputFile.IsReadOnly = False
+        Me.ucrInputFile.IsReadOnly = True
         resources.ApplyResources(Me.ucrInputFile, "ucrInputFile")
         Me.ucrInputFile.Name = "ucrInputFile"
         '


### PR DESCRIPTION
Changing the  image  fieldname  textbox  for dlgExportGraphAsImage as read only #5589