### PR TITLE
Improves PR #5769 Issue multiline commands in script window

### DIFF
--- a/instat/clsRLink.vb
+++ b/instat/clsRLink.vb
@@ -18,55 +18,132 @@ Imports RDotNet
 Imports unvell.ReoGrid
 Imports System.IO
 
+'''--------------------------------------------------------------------------------------------
+''' <summary>   An object of this class represents an R interface. 
+'''             Each instance of this class has its own R environment.
+'''             <para>
+'''             This class provides methods and fields to:</para>
+''' <list type="bullet">
+'''     <item><description>
+'''             Define the R environment including paths and R versions.
+'''     </description></item><item><description>
+'''             Open a direct link to the R environment and load the required R packages. 
+'''     </description></item><item><description>
+'''             Execute a specified R script and display the output as text, graph or in a 
+'''             web browser.
+'''     </description></item><item><description>
+'''             Write to log and debug files.
+'''     </description></item><item><description>
+'''             Specify the fonts and colours to be used in the output window.
+'''     </description></item><item><description>
+'''             Populate and configure the data frame control combo box, and the list view control.
+'''     </description></item><item><description>
+'''             Get names of data frames, columns, models, tables, filters, graphs and survs.
+'''     </description></item><item><description>
+'''             Get properties and other metadata.
+'''     </description></item><item><description>
+'''             Execute specific climatic and corruption commands.
+'''     </description></item>
+''' </list></summary>
+'''--------------------------------------------------------------------------------------------
 Public Class RLink
-    ' R interface class. Each instance of the class has its own REngine instance
-    Dim strClimateObjectPath As String = "/ClimateObject/R" 'new climateobject path
-    Public strClimateObject As String = "ClimateObject"
-    Dim strInstatObjectPath As String = "/InstatObject/R" 'path to the Instat object
-    Public strInstatDataObject As String = "data_book"
-    Public strDataBookClassName As String = "DataBook"
 
+    ''' <summary>   Full pathname of the climate object file. </summary>
+    Dim strClimateObjectPath As String = "/ClimateObject/R" 'TODO SJL 23/04/20 Not used. Delete?
+
+    ''' <summary>   The name of the climate object. </summary>
+    Public strClimateObject As String = "ClimateObject" 'TODO SJL 23/04/20 make constant?
+
+    ''' <summary>   Full pathname of the instat object file. </summary>
+    Dim strInstatObjectPath As String = "/InstatObject/R" 'TODO SJL 23/04/20 make private constant?
+
+    ''' <summary>   The instat data book object. </summary> 
+    Public strInstatDataObject As String = "data_book" 'TODO SJL 23/04/20 make private constant?
+
+    ''' <summary>   Name of the data book class. </summary>
+    Public strDataBookClassName As String = "DataBook" 'TODO SJL 23/04/20 make private constant?
+
+
+    ''' <summary>   True if no R code has been executed yet. </summary>
     Private bFirstRCode As Boolean = True
+
+    ''' <summary>   If true then write executed R script to the debug log file. </summary>
     Private bDebugLogExists As Boolean = False
+
+    ''' <summary>   If true then write executed R script to the save log file. </summary>
     Private bAutoSaveLogExists As Boolean = False
+
+    ''' <summary>   True if log file has not yet been created yet. </summary>
     Private bFirstLogCode As Boolean = True
+
+    ''' <summary>   True if there is R code still currently executing. </summary>
     Public bRCodeRunning As Boolean = False
 
+
+    ''' <summary>   Full pathname of the automatic save log file. </summary>
     Public strAutoSaveLogFilePath As String = ""
+
+    ''' <summary>   Full pathname of the automatic save debug log file. </summary>
     Public strAutoSaveDebugLogFilePath As String = ""
 
-    Public clsEngine As REngine
+
+    ''' <summary>   The link to the R environment. </summary>
+    Public clsEngine As REngine 'TODO SJL 23/04/20 Make private?
+
+    ''' <summary>   True if the link to the R environment is initialised. </summary>
     Public bREngineInitialised As Boolean = False
+
+
     ''' The R output window (the window on the right that displays the R scripts and results).
     Public rtbOutput As New ucrWPFRichTextBox
+
     ''' The log window.
     Public txtLog As New TextBox
-    ''' True if the log window is defined, else false.
-    Public bLog As Boolean = False
-    ''' <summary> If true then the R output window is defined.</summary>
-    Public bOutput As Boolean = False
-    Public bClimateObjectExists As Boolean = False
-    Public bInstatObjectExists As Boolean = False
-    Public bClimsoftLinkExists As Boolean = False
 
-    ''' <summary> if true then show the executed commands in 'rtbOutput' TBD - is this the output window?</summary>
+    ''' True if the log window is defined
+    Public bLog As Boolean = False
+
+    ''' <summary> True if the R output window is defined.</summary>
+    Public bOutput As Boolean = False
+
+
+    ''' <summary>   True to climate object exists. </summary>
+    Public bClimateObjectExists As Boolean = False 'TODO SJL 23/04/20 Not used. Delete?
+
+    ''' <summary>   True if the connection to R is initialized and open. </summary>
+    Public bInstatObjectExists As Boolean = False
+
+
+    ''' <summary>   True to climsoft link exists. </summary>
+    Public bClimsoftLinkExists As Boolean = False 'TODO SJL 23/04/20 Not used. Delete?
+
+    ''' <summary> If true then show the executed commands in the R output window.</summary>
     Public bShowCommands As Boolean = True
+
+
     ''' <summary> The font for the R script. </summary>
     Public fScript As Font = New Font("Microsoft Sans Serif", 11, FontStyle.Regular)
+
     ''' <summary> The colour for the R script. </summary>
     Public clrScript As Color = Color.Black
-    '
+
     ''' <summary> The font for output generated by the R script. </summary>
     Public fOutput As Font = New Font(FontFamily.GenericMonospace, 11, FontStyle.Regular)
-    ''' <summary> The colour of output generated by the R script. </summary>
+
+    ''' <summary> The colour for output generated by the R script. </summary>
     Public clrOutput As Color = Color.Blue
-    '
+
     ''' <summary> The font for the R script comment. </summary>
     Public fComments As Font = New Font("Microsoft Sans Serif", 11, FontStyle.Regular)
-    ''' <summary> The colour of the R script comment. </summary>
+
+    ''' <summary> The colour for the R script comment. </summary>
     Public clrComments As Color = Color.Green
 
+
+    ''' <summary>   The graph display option (e.g. 'view_output_window' or 'view_separate_window'). </summary>
     Public strGraphDisplayOption As String = "view_output_window"
+
+
     ''' <summary> The current grid (the worksheet that appears similar to a spreadsheet on the 
     ''' left-hand side of the display). </summary>
     Private grdDataView As ReoGridControl
@@ -74,14 +151,75 @@ Public Class RLink
     ''' <summary> If true then, by default, display the waiting dialog (the dialog that is 
     ''' optionally displayed while an R script Is running). </summary>
     Private bShowWaitDialog As Boolean = True
+
     ''' The time in seconds to wait before showing the waiting dialog
     Private iWaitDelay As Integer = 2
 
-    Private strRVersionMajorRequired As String = "3"
-	Private strRVersionMinorRequired As String = "6"
-	Private strRVersionRequired As String = strRVersionMajorRequired & "." & strRVersionMinorRequired & ".0"
-	Private strRBundledVersion As String = "3.6.2"
 
+    ''' <summary>   The R version major required. </summary>
+    Private strRVersionMajorRequired As String = "3"
+
+    ''' <summary>   The R version minor required. </summary>
+    Private strRVersionMinorRequired As String = "6"
+
+    ''' <summary>   The R version required. </summary>
+    Private strRVersionRequired As String = strRVersionMajorRequired & "." & strRVersionMinorRequired & ".0"
+
+    ''' <summary>   The R bundled version. </summary>
+    Private strRBundledVersion As String = "3.6.2"
+
+
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Initialises the connection with the R environment:
+    ''' <list type="bullet">
+    '''     <item><description>
+    '''             Ensures that a suitable version of R is installed
+    '''     </description></item><item><description>
+    '''             Sets the necessary environment variables
+    '''     </description></item><item><description>
+    '''             Creates and initializes the REngine (which enacpsulates the R environment)
+    '''     </description></item><item><description>
+    '''             Sets the working directory
+    '''     </description></item><item><description>
+    '''             Loads the R packages, and displays information about any missing packages 
+    '''     </description></item>
+    ''' </list></summary>
+    '''
+    ''' <param name="strScript">        (Optional) The R setup script to execute. If "" then 
+    '''                                 a default setup script is used. </param>
+    ''' <param name="iCallType">        (Optional) How to display the output from the setup script:
+    ''' <list type="bullet">
+    '''     <item>
+    '''        <description>0 Executes <paramref name="strScript"/> and ignores the result.</description>
+    '''     </item>
+    '''     <item>
+    '''        <description>1 Executes <paramref name="strScript"/>, stores the result in a
+    '''        temporary R variable, and then outputs the variable's value as text.</description>
+    '''     </item>
+    '''     <item>
+    '''        <description>2 Executes <paramref name="strScript"/> and if successful shows the
+    '''        result as text.</description>
+    '''     </item>
+    '''     <item>
+    '''        <description>3 Executes <paramref name="strScript"/> and if successful shows the
+    '''        result as a graph.</description>
+    '''     </item>
+    '''     <item>
+    '''        <description>4 Executes <paramref name="strScript"/>, stores the result in a
+    '''        temporary R variable, and then outputs the variable's value in a web browser.</description>
+    '''     </item>
+    ''' </list>
+    '''                                 Note: If a script line contains "$get_graphs" then call 
+    '''                                 type is set to 3 just for that line.</param>
+    ''' <param name="strComment">       (Optional) The comment to display before the first line of
+    '''                                 <paramref name="strScript"/>.
+    '''                                 If <paramref name="strScript"/> is not defined then a
+    '''                                 default comment is used. </param>
+    ''' <param name="bSeparateThread">  (Optional) If true then execute the R script in a new 
+    '''                                 thread. </param>
+    '''
+    ''' <returns>   True if it succeeds, false if it fails. </returns>
+    '''--------------------------------------------------------------------------------------------
     Public Function StartREngine(Optional strScript As String = "", Optional iCallType As Integer = 0, Optional strComment As String = "", Optional bSeparateThread As Boolean = True) As Boolean
         Dim strMissingPackages() As String
         Dim expTemp As SymbolicExpression
@@ -119,7 +257,7 @@ Public Class RLink
         Catch ex As Exception
             ' Modified message since currently we recommend use of same R version as bundled version
             MsgBox(ex.Message & Environment.NewLine & "Could not establish connection to R." & vbNewLine & "R-Instat requires version " & strRVersionRequired & " of R." & vbNewLine & "Note that R-Instat does not work with R below 3.5.0. We recommend using R " & strRBundledVersion & ".  Try reruning the installation to install R " & strRBundledVersion & " or download R " & strRBundledVersion & " from https://cran.r-project.org/bin/windows/base/old/" & strRBundledVersion & "/ and restart R-Instat." & vbNewLine & ex.Message, MsgBoxStyle.Critical, "Cannot initialise R connection.")
-			Application.Exit()
+            Application.Exit()
             Environment.Exit(0)
         End Try
         Try
@@ -128,25 +266,25 @@ Public Class RLink
                 strMajor = expTemp.AsCharacter(0)
             End If
             expTemp = RunInternalScriptGetValue("R.Version()$minor", bSilent:=True)
-			If expTemp IsNot Nothing AndAlso expTemp.Type <> Internals.SymbolicExpressionType.Null Then
-				strMinor = expTemp.AsCharacter(0)
-			End If
-			Dim strRVersionRunning = strMajor & "." & strMinor
-			If strMinor.Count >= 3 Then
+            If expTemp IsNot Nothing AndAlso expTemp.Type <> Internals.SymbolicExpressionType.Null Then
+                strMinor = expTemp.AsCharacter(0)
+            End If
+            Dim strRVersionRunning = strMajor & "." & strMinor
+            If strMinor.Count >= 3 Then
                 If Not (strMajor = strRVersionMajorRequired AndAlso strMinor.Count > 0 AndAlso strMinor(0) >= strRVersionMinorRequired) Then
-					MsgBox("Your current version of R is outdated. You are currently running R version: " & strRVersionRunning & vbNewLine &
-						   "R-Instat requires at least version " & strRVersionRequired & " or greater." &
-						   vbNewLine & "Try reruning the installation to install an updated version of R or download R from " &
-						   "https://cran.r-project.org/bin/windows/base/" & strRVersionRequired & "and restart R-Instat.", MsgBoxStyle.Critical, "R Version not supported.")
-					Application.Exit()
+                    MsgBox("Your current version of R is outdated. You are currently running R version: " & strRVersionRunning & vbNewLine &
+                           "R-Instat requires at least version " & strRVersionRequired & " or greater." &
+                           vbNewLine & "Try reruning the installation to install an updated version of R or download R from " &
+                           "https://cran.r-project.org/bin/windows/base/" & strRVersionRequired & "and restart R-Instat.", MsgBoxStyle.Critical, "R Version not supported.")
+                    Application.Exit()
                     Environment.Exit(0)
                 End If
             Else
-				MsgBox("Could not determine version of R installed on your machine. R-Instat requires version: " & strRVersionRequired & vbNewLine &
-					   "Try uninstalling any versions of R and rerun the installation to install R " & strRVersionRequired & " or download R " &
-					   strRVersionRequired & "From https://cran.r-project.org/bin/windows/base/old/" & strRVersionRequired &
-					   "And restart R-Instat.", MsgBoxStyle.Critical, "R Version error.")
-				Application.Exit()
+                MsgBox("Could not determine version of R installed on your machine. R-Instat requires version: " & strRVersionRequired & vbNewLine &
+                       "Try uninstalling any versions of R and rerun the installation to install R " & strRVersionRequired & " or download R " &
+                       strRVersionRequired & "From https://cran.r-project.org/bin/windows/base/old/" & strRVersionRequired &
+                       "And restart R-Instat.", MsgBoxStyle.Critical, "R Version error.")
+                Application.Exit()
                 Environment.Exit(0)
             End If
         Catch ex As Exception
@@ -184,6 +322,7 @@ Public Class RLink
         Return bClose
     End Function
 
+
     ''' <summary> This method executes the <paramref name="strNewScript"/> R script and displays 
     '''           the output as text or graph (determined by <paramref name="strNewScript"/>).
     '''           <para>R commands may be split over multiple lines. This is only allowed if the  
@@ -206,7 +345,7 @@ Public Class RLink
 
         'for each line in script
         For Each strScriptLine As String In strNewScript.Split(Environment.NewLine)
-            'remove any comments (character '#' and anything after)
+            'remove any comments (character '#' and anything after) 
             Dim iCommentPos As Integer = strScriptLine.IndexOf("#")
             Select Case iCommentPos
                 Case 0      'a normal comment line (starts with '#')
@@ -234,6 +373,7 @@ Public Class RLink
                 strLast3Chars = strTrimmedLine.Substring(strTrimmedLine.Length - 3)
             End If
             If cLastChar = "+" OrElse cLastChar = "," OrElse strLast3Chars = "%>%" OrElse iNumOpenCurlies <> iNumClosedCurlies Then
+                
                 Continue For
             End If
 
@@ -249,6 +389,7 @@ Public Class RLink
         Return strScriptCmd
     End Function
 
+    ''' <summary>   Closes down the R engine (which encapsulates the R environment). </summary>
     Public Sub CloseREngine()
         If clsEngine IsNot Nothing Then
             Try
@@ -259,12 +400,11 @@ Public Class RLink
         End If
     End Sub
 
-    ''' <summary>
-    ''' This method returns the packages not installed.
-    ''' </summary>
-    ''' <returns>
-    ''' Returns the packages not installed as an array of strings.
-    ''' </returns>    
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Gets packages not installed. </summary>
+    '''
+    ''' <returns>   The packages not installed. </returns>
+    '''--------------------------------------------------------------------------------------------
     Public Function GetPackagesNotInstalled() As String()
         Dim chrPackagesNotInstalled As CharacterVector
         Dim clsPackagesNotInstalled As New RFunction
@@ -280,6 +420,14 @@ Public Class RLink
         End If
     End Function
 
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Loads the required packages. </summary>
+    '''
+    ''' <param name="bSilent">  (Optional) if false and an exception is raised then open a message
+    '''                         box that displays the exception message. </param>
+    '''
+    ''' <returns>   True if it succeeds, false if it fails. </returns>
+    '''--------------------------------------------------------------------------------------------
     Public Function LoadedRequiredPackages(Optional bSilent As Boolean = False) As Boolean
         Dim clsLoadPackages As New RFunction
 
@@ -287,6 +435,14 @@ Public Class RLink
         Return RunInternalScript(clsLoadPackages.ToScript(), bSilent:=bSilent)
     End Function
 
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Loads the <paramref name="strFile"/> data file. </summary>
+    '''
+    ''' <param name="strFile">          The data file to load. </param>
+    ''' <param name="bKeepExisting">    (Optional) the value for the 'keep_existing' parameter. </param>
+    ''' <param name="strComment">       (Optional) The comment to show before executing the 
+    '''                                 R script. </param>
+    '''--------------------------------------------------------------------------------------------
     Public Sub LoadInstatDataObjectFromFile(strFile As String, Optional bKeepExisting As Boolean = False, Optional strComment As String = "")
         Dim clsImportRDS As New RFunction
         Dim clsReadRDS As New RFunction
@@ -307,77 +463,84 @@ Public Class RLink
         bInstatObjectExists = True
     End Sub
 
-    ''' <summary>
-    ''' This method sets the current grid (the worksheet that appears similar to a spreadsheet 
-    ''' on the left-hand side of the display).
-    ''' </summary>
-    ''' <param name="grdNewDataGrid"> is the current grid.</param>
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Sets the current grid (the worksheet that appears similar to a spreadsheet
+    '''             on the left-hand side of the display). </summary>
+    '''
+    ''' <param name="grdNewDataGrid">   The current grid. </param>
+    '''--------------------------------------------------------------------------------------------
     Public Sub SetDataViewGrid(grdNewDataGrid As ReoGridControl)
+        'TODO SJL 19/04/20 Never used, remove?
         grdDataView = grdNewDataGrid
     End Sub
 
-    ''' <summary>
-    ''' This method sets the font and colour for output generated by the R script.
-    ''' </summary>
-    ''' <param name="tempFont"> is the font to use for output text.</param>
-    ''' <param name="tempColor"> is the colour to use for output text.</param>
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Sets the font and colour for output generated by the R script. </summary>
+    '''
+    ''' <param name="tempFont">     The font to use for output text. </param>
+    ''' <param name="tempColor">    The colour to use for output text. </param>
+    '''--------------------------------------------------------------------------------------------
     Public Sub SetFormatOutput(tempFont As Font, tempColor As Color)
         fOutput = tempFont
         clrOutput = tempColor
     End Sub
 
-    ''' <summary>
-    ''' This method sets the font and colour for the R script.
-    ''' </summary>
-    ''' <param name="tempFont"> is the font to use for output text.</param>
-    ''' <param name="tempColor"> is the colour to use for output text.</param>
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Sets the font and colour for the R script. </summary>
+    '''
+    ''' <param name="tempFont">     The font to use for the R script. </param>
+    ''' <param name="tempColor">    The colour to use for the R script. </param>
+    '''--------------------------------------------------------------------------------------------
     Public Sub SetFormatScript(tempFont As Font, tempColor As Color)
         fScript = tempFont
         clrScript = tempColor
     End Sub
 
-    ''' <summary>
-    ''' This method sets the font and colour for the R script comment.
-    ''' </summary>
-    ''' <param name="tempFont"> is the font to use for output text.</param>
-    ''' <param name="tempColor"> is the colour to use for output text.</param>
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Sets the font and colour for the R script comment. </summary>
+    '''
+    ''' <param name="tempFont">     The font to use for the R script comment. </param>
+    ''' <param name="tempColor">    The colour to use for the R script comment. </param>
+    '''--------------------------------------------------------------------------------------------
     Public Sub SetFormatComment(tempFont As Font, tempColor As Color)
         fComments = tempFont
         clrComments = tempColor
     End Sub
 
-    ''' <summary>
-    ''' This method sets the R output window (the window on the right that displays the R scripts and results).
-    ''' </summary>
-    ''' <param name="tempOutput"> is the R output window.</param>
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Sets the R output window (the window on the right that displays the R scripts 
+    '''             and results). </summary>
+    '''
+    ''' <param name="tempOutput">   The R output window. </param>
+    '''--------------------------------------------------------------------------------------------
     Public Sub SetOutput(tempOutput As ucrWPFRichTextBox)
         'TEST temporary
         rtbOutput = tempOutput
         bOutput = True
     End Sub
 
-    ''' <summary>
-    ''' This method sets the log window.
-    ''' </summary>
-    ''' <param name="tempLog"> is the log window.</param>
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Sets the log window. </summary>
+    '''
+    ''' <param name="tempLog">  The log window. </param>
+    '''--------------------------------------------------------------------------------------------
     Public Sub SetLog(tempLog As TextBox)
         txtLog = tempLog
         bLog = True
     End Sub
 
-    ''' <summary>
-    ''' This method returns the data frame names.
-    ''' </summary>
-    ''' <returns>
-    ''' Returns the data frame names as a list of strings.
-    ''' </returns>    
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Gets a list of data frame names. </summary>
+    '''
+    ''' <returns>   The data frame names. </returns>
+    '''--------------------------------------------------------------------------------------------
     Public Function GetDataFrameNames() As List(Of String)
         Dim chrDataFrameNames As CharacterVector = Nothing
         Dim lstDataFrameNames As New List(Of String)
         Dim clsGetDataNames As New RFunction
         Dim expNames As SymbolicExpression
 
-        clsGetDataNames.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_data_names")
+        clsGetDataNames.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_data_names") 'TODO SJL 20/04/20 move to inside if statement?
         If bInstatObjectExists Then
             expNames = RunInternalScriptGetValue(clsGetDataNames.ToScript(), bSilent:=True)
             If expNames IsNot Nothing AndAlso Not expNames.Type = Internals.SymbolicExpressionType.Null Then
@@ -388,14 +551,15 @@ Public Class RLink
         Return lstDataFrameNames
     End Function
 
-    ''' <summary>
-    ''' This method returns the data names linked to <paramref name="strDataName"/>.
-    ''' </summary>
-    ''' <param name="strDataName"> is the data frame to link to.</param>
-    ''' <param name="bIncludeSelf"> if true then also return the <paramref name="strDataName"/> data name.</param>
-    ''' <returns>
-    ''' Returns the data names linked to <paramref name="strDataName"/> as a list of strings.
-    ''' </returns>    
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Gets the list of data names linked to <paramref name="strDataName"/>. </summary>
+    '''
+    ''' <param name="strDataName">  The data frame to link to. </param>
+    ''' <param name="bIncludeSelf"> (Optional) If true then also return the <paramref name="strDataName"/> 
+    '''                             data name.</param>.
+    '''
+    ''' <returns>   The data names linked to <paramref name="strDataName"/>. </returns>
+    '''--------------------------------------------------------------------------------------------
     Public Function GetLinkedToDataFrameNames(strDataName As String, Optional bIncludeSelf As Boolean = True) As List(Of String)
         Dim chrDataFrameNames As CharacterVector = Nothing
         Dim lstDataFrameNames As New List(Of String)
@@ -419,14 +583,15 @@ Public Class RLink
         Return lstDataFrameNames
     End Function
 
-    ''' <summary>
-    ''' This method returns <paramref name="strDataFrameName"/>. TBD
-    ''' </summary>
-    ''' <param name="strDataFrameName"> is the data name TBD.</param>
-    ''' <param name="bIncludeHiddenColumns"> is the column name TBD.</param>
-    ''' <returns>
-    ''' Returns TBD.
-    ''' </returns>    
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Gets the column names for a returned dataframe. </summary>
+    '''
+    ''' <param name="strDataFrameName">         The dataframe name. </param>
+    ''' <param name="bIncludeHiddenColumns">    (Optional) If true then also include the hidden 
+    '''                                         column names in the returned list. </param>
+    '''
+    ''' <returns>   The column names. </returns>
+    '''--------------------------------------------------------------------------------------------
     Public Function GetColumnNames(strDataFrameName As String, Optional bIncludeHiddenColumns As Boolean = True) As List(Of String)
         Dim chrCurrColumns As CharacterVector = Nothing
         Dim lstCurrColumns As New List(Of String)
@@ -448,13 +613,36 @@ Public Class RLink
         Return lstCurrColumns
     End Function
 
-    'bIncludeOverall = True includes an extra item in the combo box for overall i.e. items not at data frame level 
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Fills the data frame control combo box with the specified data frame names and
+    '''             sets the combo box index.
+    '''             The data frames to include, and the source of the index are set by the 
+    '''             parameters below.</summary>
+    '''
+    ''' <param name="cboDataFrames">                    [in,out] The combobox data frames control. </param>
+    ''' <param name="bSetDefault">                      (Optional) If true then sets the combo box 
+    '''                                                 index to the index of the current worksheet.
+    '''                                                 If false then sets the index to the index of 
+    '''                                                 the current data frame. </param>
+    ''' <param name="bIncludeOverall">                  (Optional) If true then adds an extra item 
+    '''                                                 in the combo box for '[Overall]' i.e. items 
+    '''                                                 not at data frame level. </param>
+    ''' <param name="strCurrentDataFrame">              (Optional) The current data frame. </param>
+    ''' <param name="bOnlyLinkedToPrimaryDataFrames">   (Optional) If true then only fill the 
+    '''                                                 combo box with data frame names linked to 
+    '''                                                 <paramref name="strPrimaryDataFrame"/>. </param>
+    ''' <param name="strPrimaryDataFrame">              (Optional) The primary data frame. </param>
+    ''' <param name="bIncludePrimaryDataFrameAsLinked"> (Optional) If true then also include the 
+    '''                                                 <paramref name="strPrimaryDataFrame"/> in 
+    '''                                                 the list of data frames. 
+    '''                                                 This parameter is only used if 
+    '''                                                 <paramref name="bOnlyLinkedToPrimaryDataFrames"/> 
+    '''                                                 is true.</param>
+    '''--------------------------------------------------------------------------------------------
     Public Sub FillComboDataFrames(ByRef cboDataFrames As ComboBox, Optional bSetDefault As Boolean = True, Optional bIncludeOverall As Boolean = False, Optional strCurrentDataFrame As String = "", Optional bOnlyLinkedToPrimaryDataFrames As Boolean = False, Optional strPrimaryDataFrame As String = "", Optional bIncludePrimaryDataFrameAsLinked As Boolean = True)
-        'This sub is filling the cboDataFrames with the relevant dat frame names (obtained by using GetDataFrameNames()) and potentially "[Overall]".  On thing it is doing, is setting the selected index in the cboDataFrames.
-        'It is used on the ucrDataFrame in the FillComboBox sub.
         If bInstatObjectExists Then
             If bIncludeOverall Then
-                cboDataFrames.Items.Add("[Overall]") 'Task/question: explain this.
+                cboDataFrames.Items.Add("[Overall]") 'TODO legacy - Task/question: explain this.
             End If
             If bOnlyLinkedToPrimaryDataFrames Then
                 cboDataFrames.Items.AddRange(GetLinkedToDataFrameNames(strPrimaryDataFrame, bIncludePrimaryDataFrameAsLinked).ToArray)
@@ -462,7 +650,7 @@ Public Class RLink
                 cboDataFrames.Items.AddRange(GetDataFrameNames().ToArray)
             End If
             AdjustComboBoxWidth(cboDataFrames)
-            'Task/Question: From what I understood, if bSetDefault is true or if the strCurrentDataFrame (given as an argument) is actually not in cboDataFrames (is this case generic or should it never happen ?), then the selected Index should be the current worksheet.
+            'TODO Legacy - Task/Question: From what I understood, if bSetDefault is true or if the strCurrentDataFrame (given as an argument) is actually not in cboDataFrames (is this case generic or should it never happen ?), then the selected Index should be the current worksheet.
             If (bSetDefault OrElse cboDataFrames.Items.IndexOf(strCurrentDataFrame) = -1) AndAlso (grdDataView IsNot Nothing) AndAlso (grdDataView.CurrentWorksheet IsNot Nothing) Then
                 cboDataFrames.SelectedIndex = cboDataFrames.Items.IndexOf(grdDataView.CurrentWorksheet.Name)
             ElseIf cboDataFrames.Items.IndexOf(strCurrentDataFrame) <> -1 Then
@@ -471,9 +659,15 @@ Public Class RLink
         End If
     End Sub
 
-    'TODO This is used above but will not be once ucrDataFrame uses proper controls
-    ' Then this can be removed
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Adjust combo box width. </summary>
+    '''
+    ''' <param name="cboCurrent">   The combo box to adjust. </param>
+    '''--------------------------------------------------------------------------------------------
     Public Shared Sub AdjustComboBoxWidth(cboCurrent As ComboBox)
+        'TODO Legacy - This is used above but will not be once ucrDataFrame uses proper controls
+        ' Then this can be removed
+        ' TODO SJL 20/04/20 This is only used by the function above. Make private?
         Dim iWidth As Integer = cboCurrent.DropDownWidth
         Dim graTemp As System.Drawing.Graphics = cboCurrent.CreateGraphics()
         Dim font As Font = cboCurrent.Font
@@ -493,6 +687,13 @@ Public Class RLink
         cboCurrent.DropDownWidth = iWidth
     End Sub
 
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Fills the <paramref name="cboColumns"/> combo box with the <paramref name="strDataFrame"/> 
+    '''             data frame's column names. </summary>
+    '''
+    ''' <param name="strDataFrame"> The data frame name. </param>
+    ''' <param name="cboColumns">   [in,out] The combobox columns control. </param>
+    '''--------------------------------------------------------------------------------------------
     Public Sub FillColumnNames(strDataFrame As String, ByRef cboColumns As ComboBox)
         Dim lstCurrColumns As New List(Of String)
 
@@ -503,6 +704,12 @@ Public Class RLink
         cboColumns.Items.AddRange(lstCurrColumns.ToArray)
     End Sub
 
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   TODO SJL 20/04/20 Not used, remove?. </summary>
+    '''
+    ''' <param name="strDataFrame"> The data frame. </param>
+    ''' <param name="lstColumns">   [in,out] The list columns. </param>
+    '''--------------------------------------------------------------------------------------------
     Public Sub FillColumnNames(strDataFrame As String, ByRef lstColumns As ListView)
         Dim lstCurrColumns As List(Of String)
 
@@ -518,14 +725,15 @@ Public Class RLink
 
     End Sub
 
-    ''' <summary>
-    ''' This method returns TBD.
-    ''' </summary>
-    ''' <param name="strPrefix"> is TBD.</param>
-    ''' <param name="strDataFrameName"> is TBD.</param>
-    ''' <returns>
-    ''' Returns TBD.
-    ''' </returns>    
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Gets the <paramref name="strDataFrameName"/> data frame's next default column 
+    '''             name. </summary>
+    '''
+    ''' <param name="strPrefix">        The value for the R 'prefix' parameter. </param>
+    ''' <param name="strDataFrameName"> The data frame name. </param>
+    '''
+    ''' <returns>   The default column names. </returns>
+    '''--------------------------------------------------------------------------------------------
     Public Function GetDefaultColumnNames(strPrefix As String, strDataFrameName As String) As String
         Dim strNextDefault As String = ""
         Dim clsGetNextDefault As New RFunction
@@ -538,14 +746,18 @@ Public Class RLink
         Return strNextDefault
     End Function
 
-    ''' <summary>
-    ''' This method returns TBD.
-    ''' </summary>
-    ''' <param name="strPrefix"> is TBD.</param>
-    ''' <param name="lstItems"> is TBD.</param>
-    ''' <returns>
-    ''' Returns TBD.
-    ''' </returns>    
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Gets the name of the next default item from the <paramref name="lstItems"/> 
+    '''             list of named items. 
+    '''             These items may be data frames, tables, graphs or any other type of named R 
+    '''             item. </summary>
+    '''
+    ''' <param name="strPrefix">    The value for the R 'prefix' parameter. </param>
+    ''' <param name="lstItems">     The list of named items. </param>
+    '''
+    ''' <returns>   The name of next default. If the R command doesn't return any items, then
+    '''             returns "".</returns>
+    '''--------------------------------------------------------------------------------------------
     Public Function GetNextDefault(strPrefix As String, lstItems As List(Of String)) As String
         Dim strNextDefault As String
         Dim clsGetDefault As New RFunction
@@ -567,6 +779,12 @@ Public Class RLink
         Return strNextDefault
     End Function
 
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Appends <paramref name="strScript"/> as a new line to the automatic save log
+    '''             file. If the log file doesn't exist yet, then it creates it. </summary>
+    '''
+    ''' <param name="strScript">    The text to add to the save log file. </param>
+    '''--------------------------------------------------------------------------------------------
     Private Sub AppendToAutoSaveLog(strScript As String)
         Dim strTempFile As String
         Dim i As Integer = 1
@@ -597,6 +815,7 @@ Public Class RLink
         End Try
     End Sub
 
+    '''--------------------------------------------------------------------------------------------
     ''' <summary>
     ''' This method executes the <paramref name="strScript"/> R script and displays the output. The
     ''' output may be displayed as text, graph or in a web browser (see <paramref name="iCallType"/>).
@@ -640,6 +859,7 @@ Public Class RLink
     ''' <paramref name="strScript"/>.</param>
     ''' <param name="bSilent"> if false and an exception is raised then open a message box that 
     ''' displays the exception message.</param>
+    '''--------------------------------------------------------------------------------------------
     Public Sub RunScript(strScript As String, Optional iCallType As Integer = 0, Optional strComment As String = "", Optional bSeparateThread As Boolean = True, Optional bShowWaitDialogOverride As Nullable(Of Boolean) = Nothing, Optional bUpdateGrids As Boolean = True, Optional bSilent As Boolean = False)
         Dim strCapturedScript As String
         Dim expTemp As RDotNet.SymbolicExpression
@@ -671,7 +891,7 @@ Public Class RLink
         ' if the output window is defined then output comments (if exists) and script (if 'bShowCommands' is true).
         If bOutput Then
             If strComment <> "" AndAlso bShowCommands Then
-                'TODO SJL - why is this needed in addition to the else block? 
+                'TODO SJL 20/04/20 - why is this needed in addition to the else block? 
                 ' (only difference I see is 'TrimEnd' which trims any trailing newlines but then adds a newline after anyway)
                 rtbOutput.AppendText(clrComments, fComments, strComment & Environment.NewLine, clrScript, fScript, strScript.TrimEnd(Environment.NewLine.ToCharArray) & Environment.NewLine)
             Else
@@ -684,7 +904,7 @@ Public Class RLink
             End If
         End If
 
-        'TODO SJL - is the commented out check below needed?
+        'TODO SJL 20/04/20 - is the commented out check below needed?
         'If strScript.Length > 2000 Then
         '    MsgBox("The following command cannot be run because it exceeds the character limit of 2000 characters for a command in R-Instat." & Environment.NewLine & strScript & Environment.NewLine & Environment.NewLine & "It may be possible to run the command directly in R.", MsgBoxStyle.Critical, "Cannot run command")
 
@@ -828,53 +1048,64 @@ Public Class RLink
         End If
     End Sub
 
-
-    ''' <summary>
-    ''' This method executes the <paramref name="strScript"/> R script and returns the result as a
-    ''' 'SymbolicExpression' object.
-    ''' </summary>
-    ''' <param name="strScript"> is the R script to execute.</param>
-    ''' <param name="strVariableName"> is the name of the variable to store the result of
-    ''' <paramref name="strScript"/>. The variable is deleted before returning.</param>
-    ''' <param name="bSilent"> if false and an exception is raised then open a message box that 
-    ''' displays the exception message.</param>
-    ''' <param name="bSeparateThread"> if true then execute the R script in a new thread.</param>
-    ''' <param name="bShowWaitDialogOverride"> if true and <paramref name="bSeparateThread"/> is 
-    ''' also true then display a waiting dialog while the R script is executing.</param>
-    ''' <returns>
-    ''' Returns the output returned from <paramref name="strScript"/> as a collection of strings. 
-    ''' If an exception is raised then returns 'Nothing'.
-    ''' </returns>    
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Executes the the <paramref name="strScript"/> R script and returns the result 
+    '''             as a 'SymbolicExpression' object. </summary>
+    '''
+    ''' <param name="strScript">                The R script to execute. </param>
+    ''' <param name="strVariableName">          (Optional) The name of the variable to store the 
+    '''                                         result of <paramref name="strScript"/>. The variable 
+    '''                                         is deleted before returning.</param>
+    ''' <param name="bSilent">                  (Optional) If false and an exception is raised then
+    '''                                         open a message box that displays the exception
+    '''                                         message. </param>
+    ''' <param name="bSeparateThread">          (Optional) If true then executes
+    '''                                         <paramref name="strScript"/> in a new thread. </param>
+    ''' <param name="bShowWaitDialogOverride">  (Optional) if true and
+    '''                                         <paramref name="bSeparateThread"/> is also true then
+    '''                                         display a waiting dialog while the R script is
+    '''                                         executing. </param>
+    ''' <param name="strError">                 [in,out] (Optional) The error. </param>
+    '''
+    ''' <returns>   The output returned from <paramref name="strScript"/> as a collection of strings.
+    '''             If an exception is raised then returns 'Nothing'. </returns>
+    '''--------------------------------------------------------------------------------------------
     Public Function RunInternalScriptGetValue(strScript As String, Optional strVariableName As String = ".temp_value", Optional bSilent As Boolean = False, Optional bSeparateThread As Boolean = True, Optional bShowWaitDialogOverride As Nullable(Of Boolean) = Nothing, Optional ByRef strError As String = "") As SymbolicExpression
         Dim expTemp As SymbolicExpression
         Dim strCommand As String
 
         expTemp = Nothing
-        'TODO Bug here if strScript is multiple lines. Wrong value will be returned
+        'TODO Legacy - Bug here if strScript is multiple lines. Wrong value will be returned
         strCommand = strVariableName & " <- " & strScript
         If clsEngine IsNot Nothing Then
             Evaluate(strCommand, bSilent:=bSilent, bSeparateThread:=bSeparateThread, bShowWaitDialogOverride:=bShowWaitDialogOverride, strError:=strError)
             expTemp = GetSymbol(strVariableName, bSilent:=True)
-            'Very important to remove the variable after getting it othewise could be returning wrong variable later if a command gives an error
+            'Very important to remove the variable after getting it otherwise could be returning wrong variable later if a command gives an error
             Evaluate("rm(" & strVariableName & ")", bSilent:=bSilent, bSeparateThread:=bSeparateThread)
         End If
         Return expTemp
     End Function
 
-    ''' <summary>
-    ''' This method executes the <paramref name="strScript"/> R script and returns the result as a 
-    ''' collection of strings.
-    ''' </summary>
-    ''' <param name="strScript"> is the R script to execute.</param>
-    ''' <param name="bSilent"> if false and an exception is raised then open a message box that 
-    ''' displays the exception message.</param>
-    ''' <param name="bSeparateThread"> if true then execute the R script in a new thread.</param>
-    ''' <param name="bShowWaitDialogOverride"> if true and <paramref name="bSeparateThread"/> is 
-    ''' also true then display a waiting dialog while the R script is executing.</param>
-    ''' <returns>
-    ''' Returns the output returned from <paramref name="strScript"/> as a collection of strings. 
-    ''' If an exception is raised then returns 'Nothing'.
-    ''' </returns>    
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Executes the the <paramref name="strScript"/> R script and returns the result 
+    '''             as a collection of strings. </summary>
+    '''
+    ''' <param name="strScript">                The R script to execute. </param>
+    ''' <param name="bSilent">                  (Optional) If false and an exception is raised then
+    '''                                         opens a message box that displays the exception
+    '''                                         message. </param>
+    ''' <param name="bSeparateThread">          (Optional) If true then executes
+    '''                                         <paramref name="strScript"/> in a new thread. </param>
+    ''' <param name="bShowWaitDialogOverride">  (Optional) if true and <paramref name="bSeparateThread"/> 
+    '''                                         is also true then displays a waiting dialog while 
+    '''                                         the R script is executing. </param>
+    ''' <param name="strError">                 [in,out] (Optional) The output returned from 
+    '''                                         <paramref name="strScript"/> as a collection of 
+    '''                                         strings.
+    '''                                         If an exception is raised then returns 'Nothing'. </param>
+    '''
+    ''' <returns>   The result of the script execution as a collection of strings. </returns>
+    '''--------------------------------------------------------------------------------------------
     Public Function RunInternalScriptGetOutput(strScript As String, Optional bSilent As Boolean = False, Optional bSeparateThread As Boolean = True, Optional bShowWaitDialogOverride As Nullable(Of Boolean) = Nothing, Optional ByRef strError As String = "") As CharacterVector
         Dim chrTemp As CharacterVector
         Dim expTemp As SymbolicExpression
@@ -891,18 +1122,26 @@ Public Class RLink
         Return chrTemp
     End Function
 
-    ''' <summary>
-    ''' This method executes the <paramref name="strScript"/> R script and returns true if execution was successful.
-    ''' </summary>
-    ''' <param name="strScript"> is the R script to execute.</param>
-    ''' <param name="bSilent"> if false and an exception is raised then open a message box that displays the exception 
-    ''' message.</param>
-    ''' <param name="bSeparateThread"> if true then execute the R script in a new thread.</param>
-    ''' <param name="bShowWaitDialogOverride"> if true and <paramref name="bSeparateThread"/> is also true then display a waiting dialog while the 
-    ''' R script is executing.</param>
-    ''' <returns>
-    ''' Returns true if <paramref name="strScript"/> executes without raising an exception, else returns false.
-    ''' </returns>    
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Executes the <paramref name="strScript"/> R script, optionally stores the 
+    '''             result in <paramref name="strVariableName"/>, and returns true if execution 
+    '''             was successful. </summary>
+    '''
+    ''' <param name="strScript">                The R script to execute. </param>
+    ''' <param name="strVariableName">          (Optional) The name of the variable to store the
+    '''                                         result of the R script execution. </param>
+    ''' <param name="bSilent">                  (Optional) If false and an exception is raised then
+    '''                                         opens a message box that displays the exception
+    '''                                         message. </param>
+    ''' <param name="bSeparateThread">          (Optional) If true then executes the R script in a new
+    '''                                         thread. </param>
+    ''' <param name="bShowWaitDialogOverride">  (Optional) If true and <paramref name="bSeparateThread"/> 
+    '''                                         is also true then displays a waiting dialog while 
+    '''                                         the R script is executing. </param>
+    '''
+    ''' <returns>   True if <paramref name="strScript"/> executes without raising an exception, 
+    '''             else returns false. </returns>
+    '''--------------------------------------------------------------------------------------------
     Public Function RunInternalScript(strScript As String, Optional strVariableName As String = "", Optional bSilent As Boolean = False, Optional bSeparateThread As Boolean = True, Optional bShowWaitDialogOverride As Nullable(Of Boolean) = Nothing) As Boolean
         Dim strCommand As String
         Dim bReturn As Boolean
@@ -920,19 +1159,28 @@ Public Class RLink
         End If
     End Function
 
-
-    ''' <summary>
-    ''' This method executes the <paramref name="strScript"/> R script and returns true if execution was successful.
-    ''' </summary>
-    ''' <param name="strScript"> is the R script to execute.</param>
-    ''' <param name="bSilent"> If true then do NOT open a message box when an exception is raised.
-    '''                        If false then do NOT open a message box when an exception is raised.</param>
-    ''' <param name="bSeparateThread"> if true then execute the R script in a new thread.</param>
-    ''' <param name="bShowWaitDialogOverride"> if true and <paramref name="bSeparateThread"/> is also true then display a waiting dialog while the 
-    ''' R script is executing.</param>
-    ''' <returns>
-    ''' Returns true if <paramref name="strScript"/> executes without raising an exception, else returns false.
-    ''' </returns>    
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Executes the <paramref name="strScript"/> R script and returns true if 
+    '''             execution was successful. </summary>
+    '''
+    ''' <param name="strScript">                The R script to execute. </param>
+    ''' <param name="bSilent">                  (Optional) If false and an exception is raised then
+    '''                                         open a message box that displays the exception
+    '''                                         message. </param>
+    ''' <param name="bSeparateThread">          (Optional) If true then execute the R script in a new
+    '''                                         thread. </param>
+    ''' <param name="bShowWaitDialogOverride">  (Optional) If true and
+    '''                                         <paramref name="bSeparateThread"/> is also true then
+    '''                                         display a waiting dialog while the R script is
+    '''                                         executing. </param>
+    ''' <param name="strError">                 [in,out] (Optional) The error message of the caught 
+    '''                                         error. If no error is caught then is an empty
+    '''                                         string. 
+    '''                                         Note that the input value is ignored. </param>
+    '''
+    ''' <returns>   True if <paramref name="strScript"/> executes without raising an exception, 
+    '''             else returns false. </returns>
+    '''--------------------------------------------------------------------------------------------
     Private Function Evaluate(strScript As String, Optional bSilent As Boolean = False, Optional bSeparateThread As Boolean = True, Optional bShowWaitDialogOverride As Nullable(Of Boolean) = Nothing, Optional ByRef strError As String = "") As Boolean
         Dim thrRScript As Threading.Thread
         Dim thrDelay As Threading.Thread
@@ -993,7 +1241,7 @@ Public Class RLink
             ' append script to log file
             Try
                 If bDebugLogExists Then
-                    Dim ts As New Stopwatch ' TODO SJL what is the purpose of the stopwatch?
+                    Dim ts As New Stopwatch ' TODO SJL 20/04/20 what is the purpose of the stopwatch?
                     ts.Start()
                     Using w As StreamWriter = File.AppendText(strAutoSaveDebugLogFilePath)
                         w.WriteLine(strScript)
@@ -1066,17 +1314,18 @@ Public Class RLink
         End If
         bRCodeRunning = False
         strError = strTempError
-        Return bReturn ' return if script executed without raising an exception
+        Return bReturn 'return if script executed without raising an exception
     End Function
 
-    ''' <summary>
-    ''' This method returns TBD.
-    ''' </summary>
-    ''' <param name="strSymbol"> is TBD.</param>
-    ''' <param name="bSilent"> is TBD.</param>
-    ''' <returns>
-    ''' Returns TBD.
-    ''' </returns>    
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Gets the symbol named <paramref name="strSymbol"/>. </summary>
+    '''
+    ''' <param name="strSymbol">    The name of the symbol to return. </param>
+    ''' <param name="bSilent">      (Optional) If false and an exception is raised then open a
+    '''                             message box that displays the exception message. </param>
+    '''
+    ''' <returns>   The symbol named <paramref name="strSymbol"/>. </returns>
+    '''--------------------------------------------------------------------------------------------
     Private Function GetSymbol(strSymbol As String, Optional bSilent As Boolean = False) As SymbolicExpression
         Dim expTemp As SymbolicExpression = Nothing
 
@@ -1092,15 +1341,15 @@ Public Class RLink
         Return expTemp
     End Function
 
-    ''' <summary>
-    ''' This method returns TBD.
-    ''' </summary>
-    ''' <param name="strPrefix"> is TBD.</param>
-    ''' <param name="iStartIndex"> is TBD.</param>
-    ''' <param name="bIncludeIndex"> is TBD.</param>
-    ''' <returns>
-    ''' Returns TBD.
-    ''' </returns>    
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Gets the next default data frame name. </summary>
+    '''
+    ''' <param name="strPrefix">        The value for the R 'prefix' parameter. </param>
+    ''' <param name="iStartIndex">      (Optional) The value for the R 'start_index' parameter. </param>
+    ''' <param name="bIncludeIndex">    (Optional) The value for the R 'include_index' parameter. </param>
+    '''
+    ''' <returns>   The next default data frame name. </returns>
+    '''--------------------------------------------------------------------------------------------
     Public Function GetDefaultDataFrameName(strPrefix As String, Optional iStartIndex As Integer = 1, Optional bIncludeIndex As Boolean = True) As String
         Dim strTemp As String
         Dim clsGetNextDataName As New RFunction
@@ -1126,12 +1375,11 @@ Public Class RLink
         Return strTemp
     End Function
 
-    ''' <summary>
-    ''' This method returns TBD.
-    ''' </summary>
-    ''' <returns>
-    ''' Returns TBD.
-    ''' </returns>    
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Gets the R setup script.</summary>
+    '''
+    ''' <returns>   The R setup script. </returns>
+    '''--------------------------------------------------------------------------------------------
     Public Function GetRSetupScript() As String
         Dim clsSetWd As New RFunction
         Dim clsSource As New RFunction
@@ -1154,11 +1402,38 @@ Public Class RLink
         Return strScript
     End Function
 
+    ''' <summary>   Creates a new instat object. </summary>
     Public Sub CreateNewInstatObject()
         RunScript(strInstatDataObject & " <- " & strDataBookClassName & "$new()", strComment:="Defining new Instat Object")
         bInstatObjectExists = True
     End Sub
 
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Fills the list view control <paramref name="lstView"/> with the type of items 
+    '''             specified by <paramref name="strType"/>. </summary>
+    '''
+    ''' <param name="lstView">              The list view control. </param>
+    ''' <param name="strType">              The type of item to display in the list view.
+    '''                                     This can be 'data frame', 'graph', model', 'column' etc. 
+    '''                                     For a full list of possible values, please see the 
+    '''                                     select statement in the function body below. </param>
+    ''' <param name="lstIncludedDataTypes"> (Optional) List of item names to display in the list 
+    '''                                     view control. These are passed as 'include' parameters to 
+    '''                                     the R 'list' command.</param>
+    ''' <param name="lstExcludedDataTypes"> (Optional) List of item names **not** to display in the list
+    '''                                     view control. These are passed as 'exclude' parameters to
+    '''                                     the R 'list' command. </param>
+    ''' <param name="strDataFrameName">     (Optional) The data frame name. </param>
+    ''' <param name="strHeading">           (Optional) The heading for the list view display. </param>
+    ''' <param name="strExcludedItems">     (Optional) List of item names to exclude from the list
+    '''                                     view control. These are passed as parameter values for 
+    '''                                     the 'excluded_items' R parameter. </param>
+    ''' <param name="strDatabaseQuery">     (Optional) The database query. Only used if 
+    '''                                     <paramref name="strType"/> is 'database_variables'.</param>
+    ''' <param name="strNcFilePath">        (Optional) Full pathname of the non client file. 
+    '''                                     Only used if <paramref name="strType"/> is 
+    '''                                     'nc_dim_variables'.</param>
+    '''--------------------------------------------------------------------------------------------
     Public Sub FillListView(lstView As ListView, strType As String, Optional lstIncludedDataTypes As List(Of KeyValuePair(Of String, String())) = Nothing, Optional lstExcludedDataTypes As List(Of KeyValuePair(Of String, String())) = Nothing, Optional strDataFrameName As String = "", Optional strHeading As String = "Variables", Optional strExcludedItems As String() = Nothing, Optional strDatabaseQuery As String = "", Optional strNcFilePath As String = "")
         Dim vecColumns As GenericVector = Nothing
         Dim chrCurrColumns As CharacterVector
@@ -1306,6 +1581,21 @@ Public Class RLink
         End If
     End Sub
 
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Selects the specified <paramref name="strDataFrameName"/> data frame columns in 
+    '''             the <paramref name="ucrCurrentReceiver"/> receiver. 
+    '''             Columns are specified by <paramref name="strProperty"/> property and 
+    '''             <paramref name="strValues"/> values.</summary>
+    '''
+    ''' <param name="ucrCurrentReceiver">   The receiver to add the column names to (may be a single 
+    '''                                     or multiple receiver). </param>
+    ''' <param name="strDataFrameName">     The data frame name. </param>
+    ''' <param name="strProperty">          Type of column to display in the receiver.
+    '''                                     This is passed as a parameter to the R 'list' command. </param>
+    ''' <param name="strValues">            List of column names to display in the receiver.
+    '''                                     These are passed as 'include' parameters to
+    '''                                     the R 'list' command. </param>
+    '''--------------------------------------------------------------------------------------------
     Public Sub SelectColumnsWithMetadataProperty(ucrCurrentReceiver As ucrReceiver, strDataFrameName As String, strProperty As String, strValues As String())
         Dim vecColumns As GenericVector
         Dim chrCurrColumns As CharacterVector
@@ -1358,14 +1648,15 @@ Public Class RLink
         ucrCurrentReceiver.Selector.LoadList()
     End Sub
 
-    ''' <summary>
-    ''' This method returns TBD.
-    ''' </summary>
-    ''' <param name="lstStrings"> is TBD.</param>
-    ''' <param name="bWithQuotes"> is TBD.</param>
-    ''' <returns>
-    ''' Returns TBD.
-    ''' </returns>    
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Gets a single concatenated string containing all the strings in <paramref name="lstStrings"/>.
+    '''             The returned string has the form "(str1,str2,str3, ...)". </summary>
+    '''
+    ''' <param name="lstStrings">   The list of strings to concatenate. </param>
+    ''' <param name="bWithQuotes">  (Optional) If true then surround each string with quotes. </param>
+    '''
+    ''' <returns>   As single concatenated string containing all the strings in <paramref name="lstStrings"/>. </returns>
+    '''--------------------------------------------------------------------------------------------
     Public Function GetListAsRString(lstStrings As List(Of String), Optional bWithQuotes As Boolean = True) As String
         Dim strTemp As String = ""
         Dim i As Integer
@@ -1395,6 +1686,13 @@ Public Class RLink
         Return strTemp
     End Function
 
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Queries if a given data frame exists. </summary>
+    '''
+    ''' <param name="strDataFrameName"> The data frame name. </param>
+    '''
+    ''' <returns>   True if <paramref name="strDataFrameName"/> data frame exists, else false. </returns>
+    '''--------------------------------------------------------------------------------------------
     Public Function DataFrameExists(strDataFrameName As String) As Boolean
         Dim bExists As Boolean
         Dim clsDataFrameExists As New RFunction
@@ -1411,12 +1709,11 @@ Public Class RLink
         Return bExists
     End Function
 
-    ''' <summary>
-    ''' This method returns TBD.
-    ''' </summary>
-    ''' <returns>
-    ''' Returns TBD.
-    ''' </returns>    
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Gets the data frame count. </summary>
+    '''
+    ''' <returns>   The data frame count. </returns>
+    '''--------------------------------------------------------------------------------------------
     Public Function GetDataFrameCount() As Integer
         Dim iCount As Integer
         Dim clsDataFrameCount As New RFunction
@@ -1432,14 +1729,15 @@ Public Class RLink
         Return iCount
     End Function
 
-    ''' <summary>
-    ''' This method returns TBD.
-    ''' </summary>
-    ''' <param name="strDataFrameName"> is TBD.</param>
-    ''' <param name="bUseCurrentFilter"> is TBD.</param>
-    ''' <returns>
-    ''' Returns TBD.
-    ''' </returns>    
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Gets the length of <paramref name="strDataFrameName"/> data frame. </summary>
+    '''
+    ''' <param name="strDataFrameName">     The name of the data frame. </param>
+    ''' <param name="bUseCurrentFilter">    (Optional) The value for the R 'use_current_filter' 
+    '''                                     parameter. </param>
+    '''
+    ''' <returns>   The data frame length. </returns>
+    '''--------------------------------------------------------------------------------------------
     Public Function GetDataFrameLength(strDataFrameName As String, Optional bUseCurrentFilter As Boolean = False) As Integer
         Dim iLength As Integer
         Dim clsDataFrameLength As New RFunction
@@ -1461,13 +1759,14 @@ Public Class RLink
         Return iLength
     End Function
 
-    ''' <summary>
-    ''' This method returns TBD.
-    ''' </summary>
-    ''' <param name="strDataFrameName"> is TBD.</param>
-    ''' <returns>
-    ''' Returns TBD.
-    ''' </returns>    
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Gets the number of columns in the <paramref name="strDataFrameName"/> data 
+    '''             frame. </summary>
+    '''
+    ''' <param name="strDataFrameName"> The data frame name. </param>
+    '''
+    ''' <returns>   The number of columns in the <paramref name="strDataFrameName"/> data frame. </returns>
+    '''--------------------------------------------------------------------------------------------
     Public Function GetDataFrameColumnCount(strDataFrameName As String) As Integer
         Dim iColumnCount As Integer
         Dim clsDataFrameColCount As New RFunction
@@ -1484,13 +1783,13 @@ Public Class RLink
         Return iColumnCount
     End Function
 
-    ''' <summary>
-    ''' This method returns TBD.
-    ''' </summary>
-    ''' <param name="strDataFrameName"> is TBD.</param>
-    ''' <returns>
-    ''' Returns TBD.
-    ''' </returns>    
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Gets the names of the <paramref name="strDataFrameName"/> data frame's models. </summary>
+    '''
+    ''' <param name="strDataFrameName"> (Optional) The data frame name. </param>
+    '''
+    ''' <returns>   The names of the <paramref name="strDataFrameName"/> data frame's models. </returns>
+    '''--------------------------------------------------------------------------------------------
     Public Function GetModelNames(Optional strDataFrameName As String = "") As List(Of String)
         Dim chrModelNames As CharacterVector
         Dim lstModelNames As New List(Of String)
@@ -1511,13 +1810,13 @@ Public Class RLink
         Return lstModelNames
     End Function
 
-    ''' <summary>
-    ''' This method returns TBD.
-    ''' </summary>
-    ''' <param name="strDataFrameName"> is TBD.</param>
-    ''' <returns>
-    ''' Returns TBD.
-    ''' </returns>    
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Gets the names of the <paramref name="strDataFrameName"/> data frame's tables. </summary>
+    '''
+    ''' <param name="strDataFrameName"> (Optional) The data frame name. </param>
+    '''
+    ''' <returns>   The names of the <paramref name="strDataFrameName"/> data frame's tables. </returns>
+    '''--------------------------------------------------------------------------------------------
     Public Function GetTableNames(Optional strDataFrameName As String = "") As List(Of String)
         Dim chrTableNames As CharacterVector
         Dim lstTableNames As New List(Of String)
@@ -1538,13 +1837,13 @@ Public Class RLink
         Return lstTableNames
     End Function
 
-    ''' <summary>
-    ''' This method returns TBD.
-    ''' </summary>
-    ''' <param name="strDataFrameName"> is TBD.</param>
-    ''' <returns>
-    ''' Returns TBD.
-    ''' </returns>    
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Gets the names of the <paramref name="strDataFrameName"/> data frame's filters. </summary>
+    '''
+    ''' <param name="strDataFrameName"> (Optional) The data frame name. </param>
+    '''
+    ''' <returns>   The names of the <paramref name="strDataFrameName"/> data frame's filters. </returns>
+    '''--------------------------------------------------------------------------------------------
     Public Function GetFilterNames(strDataFrameName As String) As List(Of String)
         Dim expFilterNames As SymbolicExpression
         Dim chrFilterNames As CharacterVector
@@ -1565,13 +1864,13 @@ Public Class RLink
         Return lstFilterNames
     End Function
 
-    ''' <summary>
-    ''' This method returns TBD.
-    ''' </summary>
-    ''' <param name="strDataFrameName"> is TBD.</param>
-    ''' <returns>
-    ''' Returns TBD.
-    ''' </returns>    
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Gets the names of the <paramref name="strDataFrameName"/> data frame's graphs. </summary>
+    '''
+    ''' <param name="strDataFrameName"> (Optional) The data frame name. </param>
+    '''
+    ''' <returns>   The names of the <paramref name="strDataFrameName"/> data frame's graphs. </returns>
+    '''--------------------------------------------------------------------------------------------
     Public Function GetGraphNames(Optional strDataFrameName As String = "") As List(Of String)
         Dim chrGraphNames As CharacterVector
         Dim lstGraphNames As New List(Of String)
@@ -1592,13 +1891,13 @@ Public Class RLink
         Return lstGraphNames
     End Function
 
-    ''' <summary>
-    ''' This method returns TBD.
-    ''' </summary>
-    ''' <param name="strDataFrameName"> is TBD.</param>
-    ''' <returns>
-    ''' Returns TBD.
-    ''' </returns>    
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Gets the names of the <paramref name="strDataFrameName"/> data frame's survs. </summary>
+    '''
+    ''' <param name="strDataFrameName"> (Optional) The data frame name. </param>
+    '''
+    ''' <returns>   The names of the <paramref name="strDataFrameName"/> data frame's survs. </returns>
+    '''--------------------------------------------------------------------------------------------
     Public Function GetSurvNames(Optional strDataFrameName As String = "") As List(Of String)
         Dim chrSurvNames As CharacterVector
         Dim lstSurvNames As New List(Of String)
@@ -1619,15 +1918,18 @@ Public Class RLink
         Return lstSurvNames
     End Function
 
-    ''' <summary>
-    ''' This method returns TBD.
-    ''' </summary>
-    ''' <param name="strDataFrameName"> is TBD.</param>
-    ''' <param name="strColumnName"> is TBD.</param>
-    ''' <returns>
-    ''' Returns TBD.
-    ''' </returns>    
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Gets the data type of the <paramref name="strColumnName"/> column in the 
+    '''             <paramref name="strDataFrameName"/> data frame. </summary>
+    '''
+    ''' <param name="strDataFrameName"> The data frame name. </param>
+    ''' <param name="strColumnName">    The column name. </param>
+    '''
+    ''' <returns>   The data type of the <paramref name="strColumnName"/> column in the
+    '''             <paramref name="strDataFrameName"/> data frame. </returns>
+    '''--------------------------------------------------------------------------------------------
     Public Function GetDataType(strDataFrameName As String, strColumnName As String) As String
+        'TODO SJL 22/04/20 What's the difference between this function and the function below? Could we delete one?
         Dim strDataType As String
         Dim clsGetDataType As New RFunction
         Dim expType As SymbolicExpression
@@ -1644,14 +1946,16 @@ Public Class RLink
         Return strDataType
     End Function
 
-    ''' <summary>
-    ''' This method returns TBD.
-    ''' </summary>
-    ''' <param name="strDataName"> is TBD.</param>
-    ''' <param name="strColumnName"> is TBD.</param>
-    ''' <returns>
-    ''' Returns TBD.
-    ''' </returns>    
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Gets the data type of the <paramref name="strColumnName"/> column in the 
+    '''             <paramref name="strDataName"/> data frame. </summary>
+    '''
+    ''' <param name="strDataName"> The data frame name. </param>
+    ''' <param name="strColumnName">    The column name. </param>
+    '''
+    ''' <returns>   The data type of the <paramref name="strColumnName"/> column in the
+    '''             <paramref name="strDataName"/> data frame. </returns>
+    '''--------------------------------------------------------------------------------------------
     Public Function GetColumnType(strDataName As String, strColumnName As String) As String
         Dim strDataType As String
         Dim clsGetColumnType As New RFunction
@@ -1669,6 +1973,18 @@ Public Class RLink
         Return strDataType
     End Function
 
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Makes a syntactically valid R name from <paramref name="strText"/>. Please see 
+    '''             the R documentation for valid name syntax.<para>
+    '''             If it's not possible to make a valid name from <paramref name="strText"/> then 
+    '''             returns "".</para> </summary>
+    '''
+    ''' <param name="strText">  The name to convert to a valid name. </param>
+    '''
+    ''' <returns>   A syntactically valid R name derived from <paramref name="strText"/>. 
+    '''             If it's not possible to make a valid name from <paramref name="strText"/> then
+    '''             returns "".</returns>
+    '''--------------------------------------------------------------------------------------------
     Public Function MakeValidText(strText As String) As String
         Dim strOut As String
         Dim clsMakeNames As New RFunction
@@ -1685,6 +2001,16 @@ Public Class RLink
         Return strOut
     End Function
 
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   If <paramref name="strText"/> is a syntactically valid R name then returns true, 
+    '''             else returns false. 
+    '''             Please see the R documentation for valid name syntax. </summary>
+    '''
+    ''' <param name="strText">  The name to check. </param>
+    '''
+    ''' <returns>   True if <paramref name="strText"/> is a syntactically valid R name,
+    '''             else returns false. </returns>
+    '''--------------------------------------------------------------------------------------------
     Public Function IsValidText(strText As String) As String
         Dim strValidText As String
         Dim clsMakeNames As New RFunction
@@ -1693,13 +2019,11 @@ Public Class RLink
         Return (strText = strValidText)
     End Function
 
-    'Corruption analysis functions
-    ''' <summary>
-    ''' This method returns TBD.
-    ''' </summary>
-    ''' <returns>
-    ''' Returns TBD.
-    ''' </returns>    
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Gets corruption contract data frame names. </summary>
+    '''
+    ''' <returns>   The corruption contract data frame names. </returns>
+    '''--------------------------------------------------------------------------------------------
     Public Function GetCorruptionContractDataFrameNames() As List(Of String)
         Dim clsGetDataNames As New RFunction
         Dim lstNames As List(Of String)
@@ -1715,14 +2039,15 @@ Public Class RLink
         Return lstNames
     End Function
 
-    ''' <summary>
-    ''' This method returns TBD.
-    ''' </summary>
-    ''' <param name="strDataName"> is TBD.</param>
-    ''' <param name="strType"> is TBD.</param>
-    ''' <returns>
-    ''' Returns TBD.
-    ''' </returns>    
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Gets corruption column of type <paramref name="strType"/> in data frame 
+    '''             <paramref name="strDataName"/>. </summary>
+    '''
+    ''' <param name="strDataName">  The data frame name. </param>
+    ''' <param name="strType">      The column type. </param>
+    '''
+    ''' <returns>   The corruption column of type <paramref name="strType"/> in data frame <paramref name="strDataName"/>. </returns>
+    '''--------------------------------------------------------------------------------------------
     Public Function GetCorruptionColumnOfType(strDataName As String, strType As String) As String
         Dim clsGetColumnName As New RFunction
         Dim strColumn As String
@@ -1740,13 +2065,15 @@ Public Class RLink
         Return strColumn
     End Function
 
-    ''' <summary>
-    ''' This method returns TBD.
-    ''' </summary>
-    ''' <param name="strDataName"> is TBD.</param>
-    ''' <returns>
-    ''' Returns TBD.
-    ''' </returns>    
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Gets names of the columns of the corruption components in 
+    '''             the <paramref name="strDataName"/> data frame. </summary>
+    '''
+    ''' <param name="strDataName">  The data frame name. </param>
+    '''
+    ''' <returns>   The names of the columns of the corruption components in
+    '''             the <paramref name="strDataName"/> data frame. </returns>
+    '''--------------------------------------------------------------------------------------------
     Public Function GetCorruptionComponentsColumnNames(strDataName As String) As String()
         Dim clsGetComponents As New RFunction
         Dim strColumn() As String
@@ -1763,15 +2090,14 @@ Public Class RLink
         Return strColumn
     End Function
 
-    ''' <summary>
-    ''' This method returns the climatic column name of the column named 
-    ''' <paramref name="strType"/> in data name <paramref name="strDataName"/>. TBD
-    ''' </summary>
-    ''' <param name="strDataName"> is the data name TBD.</param>
-    ''' <param name="strType"> is the column name TBD.</param>
-    ''' <returns>
-    ''' Returns the climatic column name.
-    ''' </returns>    
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Gets climatic column of type. </summary>
+    '''
+    ''' <param name="strDataName">  The data frame name. </param>
+    ''' <param name="strType">      The column type. </param>
+    '''
+    ''' <returns>   The climatic column of type. </returns>
+    '''--------------------------------------------------------------------------------------------
     Public Function GetClimaticColumnOfType(strDataName As String, strType As String) As String
         Dim clsGetColumnName As New RFunction
         Dim strColumn As String
@@ -1789,13 +2115,13 @@ Public Class RLink
         Return strColumn
     End Function
 
-    ''' <summary>
-    ''' This method returns TBD.
-    ''' </summary>
-    ''' <param name="strDataName"> is TBD.</param>
-    ''' <returns>
-    ''' Returns TBD.
-    ''' </returns>    
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Gets CRI column names. </summary>
+    '''
+    ''' <param name="strDataName">  The data frame name. </param>
+    '''
+    ''' <returns>   The CRI column names. </returns>
+    '''--------------------------------------------------------------------------------------------
     Public Function GetCRIColumnNames(strDataName As String) As String()
         Dim clsGetColumnName As New RFunction
         Dim strColumn() As String
@@ -1812,13 +2138,13 @@ Public Class RLink
         Return strColumn
     End Function
 
-    ''' <summary>
-    ''' This method returns TBD.
-    ''' </summary>
-    ''' <param name="strDataName"> is TBD.</param>
-    ''' <returns>
-    ''' Returns TBD.
-    ''' </returns>    
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Gets red flag column names. </summary>
+    '''
+    ''' <param name="strDataName">  The data frame name. </param>
+    '''
+    ''' <returns>   The red flag column names. </returns>
+    '''--------------------------------------------------------------------------------------------
     Public Function GetRedFlagColumnNames(strDataName As String) As String()
         Dim clsGetColumnName As New RFunction
         Dim strColumn() As String
@@ -1835,6 +2161,16 @@ Public Class RLink
         Return strColumn
     End Function
 
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Returns true if column <paramref name="strColumn"/> in data frame 
+    '''             <paramref name="strDataName"/> contains binary data. Else returns false. </summary>
+    '''
+    ''' <param name="strDataName">  The data frame name. </param>
+    ''' <param name="strColumn">    The column. </param>
+    '''
+    ''' <returns>   True if column <paramref name="strColumn"/> in data frame
+    '''             <paramref name="strDataName"/> contains binary data. Else returns false. </returns>
+    '''--------------------------------------------------------------------------------------------
     Public Function IsBinary(strDataName As String, strColumn As String) As Boolean
         Dim clsGetColumn As New RFunction
         Dim clsIsBinary As New RFunction
@@ -1855,6 +2191,19 @@ Public Class RLink
         Return bIsBinary
     End Function
 
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Returns true if column <paramref name="strColumn"/> in data frame 
+    '''             <paramref name="strDataName"/> has property <paramref name="strProperty"/>. 
+    '''             Else returns false. </summary>
+    '''
+    ''' <param name="strDataName">  The data frame name. </param>
+    ''' <param name="strProperty">  The property to look for. </param>
+    ''' <param name="strColumn">    (Optional) The column name. </param>
+    '''
+    ''' <returns>   True if column <paramref name="strColumn"/> in data frame
+    '''             <paramref name="strDataName"/> has property <paramref name="strProperty"/>.
+    '''             Else returns false. </returns>
+    '''--------------------------------------------------------------------------------------------
     Public Function IsVariablesMetadata(strDataName As String, strProperty As String, Optional strColumn As String = "") As Boolean
         Dim clsIsVarMetadata As New RFunction
         Dim bIsVarMetadata As Boolean
@@ -1875,19 +2224,21 @@ Public Class RLink
         Return bIsVarMetadata
     End Function
 
-    ''' <summary>
-    ''' This method sets whether to show the wait window (the window that is optionally displayed 
-    ''' while an R script is running).
-    ''' </summary>
-    ''' <param name="bNewShow"> is the R output window.</param>
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Sets whether to show the wait window (the window that is optionally displayed 
+    '''             while an R script is running). </summary>
+    '''
+    ''' <param name="bNewShow"> If true then show the wait window. </param>
+    '''--------------------------------------------------------------------------------------------
     Public Sub SetShowWaitDialog(bNewShow As Boolean)
         bShowWaitDialog = bNewShow
     End Sub
 
-    ''' <summary>
-    ''' This method sets the time in seconds to wait before showing the waiting dialog.
-    ''' </summary>
-    ''' <param name="iTimeInSeconds"> is the delay in seconds (must be >= 0).</param>
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Sets the time in seconds to wait before showing the waiting dialog. </summary>
+    '''
+    ''' <param name="iTimeInSeconds">   The delay in seconds (must be >= 0). </param>
+    '''--------------------------------------------------------------------------------------------
     Public Sub SetWaitDelayTime(iTimeInSeconds As Integer)
         If iTimeInSeconds <= 0 Then
             MsgBox("Wait time must be a positive integer. Resetting to default of 2 seconds.", MsgBoxStyle.Exclamation, "Invalid value")
@@ -1896,6 +2247,7 @@ Public Class RLink
         iWaitDelay = iTimeInSeconds
     End Sub
 
+    ''' <summary>   Closes the current instat data object, and opens a new one. </summary>
     Public Sub CloseData()
         Dim clsRm As New RFunction
         Dim clsCreateIO As New ROperator
@@ -1913,6 +2265,11 @@ Public Class RLink
         RunScript(clsCreateIO.ToScript(), strComment:="Creating New Instat Object")
     End Sub
 
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   View last graph. </summary>
+    '''
+    ''' <param name="bAsPlotly">    (Optional) If true then view last graph as plotly. </param>
+    '''--------------------------------------------------------------------------------------------
     Public Sub ViewLastGraph(Optional bAsPlotly As Boolean = False)
         Dim clsLastGraph As New RFunction
         Dim clsInteractivePlot As New RFunction
@@ -1931,14 +2288,13 @@ Public Class RLink
         End If
     End Sub
 
-    'construct and format the comment
-    ''' <summary>
-    ''' This method returns TBD.
-    ''' </summary>
-    ''' <param name="strComment"> is TBD.</param>
-    ''' <returns>
-    ''' Returns TBD.
-    ''' </returns>    
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>   Prefixes each line of text in <paramref name="strComment"/> with '# '. </summary>
+    '''
+    ''' <param name="strComment">   The comment text. </param>
+    '''
+    ''' <returns>   <paramref name="strComment"/> converted to a valid R comment. </returns>
+    '''--------------------------------------------------------------------------------------------
     Public Function GetFormattedComment(strComment As String) As String
         Dim strReconstructedComment As String = ""
         Dim arrCommentParts As String()

--- a/instat/clsRLink.vb
+++ b/instat/clsRLink.vb
@@ -197,18 +197,12 @@ Public Class RLink
     ''' <param name="strNewScript">    The R script to execute.</param>
     ''' <param name="strNewComment">   Shown as a comment. If this parameter is "" then shows 
     '''                                <paramref name="strNewScript"/> as the comment.</param>
-    ''' <param name="bClearScriptCmd"> (Optional) If true then the command buffer is flushed 
-    '''                                before <paramref name="strNewScript"/> is processed. 
-    '''                                Otherwise <paramref name="strNewScript"/> is treated as a 
-    '''                                continuation of the previous string that was sent to this 
-    '''                                function.</param>
-    Public Sub RunScriptFromWindow(strNewScript As String, strNewComment As String, Optional bClearScriptCmd As Boolean = True)
-        Static strScriptCmd As String = "" 'static so that script can be added to with successive calls of this function
-
-        'by default, flush out any unexecuted full or partial commands
-        If bClearScriptCmd Then
-            strScriptCmd = ""
-        End If
+    ''' 
+    ''' <returns> Any text at the end of <paramref name="strNewScript"/> that was not executed.
+    '''           If all the text in <paramref name="strNewScript"/> was executed then returns "".
+    '''           </returns>
+    Public Function RunScriptFromWindow(strNewScript As String, strNewComment As String) As String
+        Dim strScriptCmd As String = ""
 
         'for each line in script
         For Each strScriptLine As String In strNewScript.Split(Environment.NewLine)
@@ -240,9 +234,6 @@ Public Class RLink
                 strLast3Chars = strTrimmedLine.Substring(strTrimmedLine.Length - 3)
             End If
             If cLastChar = "+" OrElse cLastChar = "," OrElse strLast3Chars = "%>%" OrElse iNumOpenCurlies <> iNumClosedCurlies Then
-                If Not bClearScriptCmd Then 'only add carriage return if executing a single line (not needed when executing entire script window or selected text)
-                    strScriptCmd &= vbCrLf
-                End If
                 Continue For
             End If
 
@@ -255,7 +246,8 @@ Public Class RLink
             strScriptCmd = ""
             strNewComment = ""
         Next
-    End Sub
+        Return strScriptCmd
+    End Function
 
     Public Sub CloseREngine()
         If clsEngine IsNot Nothing Then

--- a/instat/ucrScript.vb
+++ b/instat/ucrScript.vb
@@ -70,10 +70,14 @@ Public Class ucrScript
     End Sub
 
     Private Sub mnuRunCurrentLine_Click(sender As Object, e As EventArgs) Handles mnuRunCurrentLine.Click
+        Static strScriptCmd As String = "" 'static so that script can be added to with successive calls of this function
+
         If txtScript.TextLength > 0 Then
             Dim lineNum As Integer = txtScript.GetLineFromCharIndex(txtScript.GetFirstCharIndexOfCurrentLine())
             If lineNum < txtScript.Lines.Length Then
-                RunText(txtScript.Lines(lineNum), False)
+                'add the new text to any unexecuted script remaining from previous calls to this function
+                strScriptCmd &= vbCrLf & txtScript.Lines(lineNum) 'insert carraige return to ensure that new text starts on new line
+                strScriptCmd = RunText(strScriptCmd)
                 If lineNum < txtScript.Lines.Length - 1 Then
                     txtScript.SelectionStart = txtScript.GetFirstCharIndexFromLine(lineNum + 1)
                     txtScript.ScrollToCaret()
@@ -82,11 +86,12 @@ Public Class ucrScript
         End If
     End Sub
 
-    Private Sub RunText(strText As String, Optional bClearScriptCmd As Boolean = True)
+    Private Function RunText(strText As String) As String
         If strText <> "" Then
-            frmMain.clsRLink.RunScriptFromWindow(strNewScript:=strText, strNewComment:=strComment, bClearScriptCmd)
+            strText = frmMain.clsRLink.RunScriptFromWindow(strNewScript:=strText, strNewComment:=strComment)
         End If
-    End Sub
+        Return strText
+    End Function
 
     Private Sub mnuOpenScript_Click(sender As Object, e As EventArgs) Handles mnuOpenScriptasFile.Click
         Dim strScriptFilename As String = ""


### PR DESCRIPTION
PR #5769 implements multiline commands in the the script window. After the merge @Patowhiz provided peer review comments. This PR addresses those peer review comments.

In particular, 'clsRLink.RunScriptFromWindow' is now a pure function (removed static variable). 

The static variable was moved to 'ucrScript.mnuRunCurrentLine_Click' (this is the function that allows the user to execute script line by line using ctrl-enter). It is better to have the static here because this is the only function that requires unexecuted script to be kept for successive calls.

@Patowhiz please could you peer review again?

@rdstern when @Patowhiz has finished his peer review, please could you test again. The functionality should be exactly the same. 
The only side-effect of the change is that the buffer used by executing line by line (ctrl-enter) is only cleared when a complete command is executed. I'm concerned that theoretically, the user could enter incorrect code that causes subsequent (valid) commands not to run correctly. In this case, the only way to clear the buffer would be to restart R-Instat. I tried to trigger this error but could not. Maybe in practice it's not a big issue.