### PR TITLE
Replaces PR #5796 Issue multiline commands in script window

### DIFF
--- a/instat/clsRLink.vb
+++ b/instat/clsRLink.vb
@@ -321,7 +321,7 @@ Public Class RLink
         Return bClose
     End Function
 
-
+    '''--------------------------------------------------------------------------------------------
     ''' <summary> This method executes the <paramref name="strNewScript"/> R script and displays 
     '''           the output as text or graph (determined by <paramref name="strNewScript"/>).
     '''           <para>R commands may be split over multiple lines. This is only allowed if the  
@@ -331,23 +331,17 @@ Public Class RLink
     '''           entered by a human from a dialog window (e.g. a script window). These scripts 
     '''           may contain R commands split over multiple lines to make the commands more 
     '''           readable.</para>
-
+    ''' </summary>
     ''' <param name="strNewScript">    The R script to execute.</param>
     ''' <param name="strNewComment">   Shown as a comment. If this parameter is "" then shows 
     '''                                <paramref name="strNewScript"/> as the comment.</param>
-    ''' <param name="bClearScriptCmd"> (Optional) If true then the command buffer is flushed 
-    '''                                before <paramref name="strNewScript"/> is processed. 
-    '''                                Otherwise <paramref name="strNewScript"/> is treated as a 
-    '''                                continuation of the previous string that was sent to this 
-    '''                                function.</param>
-
-    Public Sub RunScriptFromWindow(strNewScript As String, strNewComment As String, Optional bClearScriptCmd As Boolean = True)
-        Static strScriptCmd As String = "" 'static so that script can be added to with successive calls of this function
-
-        'by default, flush out any unexecuted full or partial commands
-        If bClearScriptCmd Then
-            strScriptCmd = ""
-        End If
+    ''' 
+    ''' <returns> Any text at the end of <paramref name="strNewScript"/> that was not executed.
+    '''           If all the text in <paramref name="strNewScript"/> was executed then returns "".
+    '''           </returns>
+    '''--------------------------------------------------------------------------------------------
+    Public Function RunScriptFromWindow(strNewScript As String, strNewComment As String) As String
+        Dim strScriptCmd As String = ""
 
         'for each line in script
         For Each strScriptLine As String In strNewScript.Split(Environment.NewLine)
@@ -369,19 +363,17 @@ Public Class RLink
             'else append line of script to command
             strScriptCmd &= strScriptLine
 
-            'if line ends in a '+', ',', or '%>%'; or there are open curly braces, 
+            'if line ends in a '+', ',', or '%>%'; or there are open curly braces; or open quotations, 
             '    then assume command is not complete
             Dim cLastChar As Char = strTrimmedLine.Last
             Dim strLast3Chars As String = ""
             Dim iNumOpenCurlies = strScriptCmd.Where(Function(c) c = "{"c).Count
             Dim iNumClosedCurlies = strScriptCmd.Where(Function(c) c = "}"c).Count
+            Dim iNumDoubleQuotes = strScriptCmd.Where(Function(c) c = """"c).Count
             If strTrimmedLine.Length >= 3 Then
                 strLast3Chars = strTrimmedLine.Substring(strTrimmedLine.Length - 3)
             End If
-            If cLastChar = "+" OrElse cLastChar = "," OrElse strLast3Chars = "%>%" OrElse iNumOpenCurlies <> iNumClosedCurlies Then
-                If Not bClearScriptCmd Then 'only add carriage return if executing a single line (not needed when executing entire script window or selected text)
-                    strScriptCmd &= vbCrLf
-                End If
+            If cLastChar = "+" OrElse cLastChar = "," OrElse strLast3Chars = "%>%" OrElse iNumOpenCurlies <> iNumClosedCurlies OrElse iNumDoubleQuotes Mod 2 Then
                 Continue For
             End If
 
@@ -394,7 +386,8 @@ Public Class RLink
             strScriptCmd = ""
             strNewComment = ""
         Next
-    End Sub
+        Return strScriptCmd
+    End Function
 
     ''' <summary>   Closes down the R engine (which encapsulates the R environment). </summary>
     Public Sub CloseREngine()

--- a/instat/ucrScript.vb
+++ b/instat/ucrScript.vb
@@ -70,10 +70,14 @@ Public Class ucrScript
     End Sub
 
     Private Sub mnuRunCurrentLine_Click(sender As Object, e As EventArgs) Handles mnuRunCurrentLine.Click
+        Static strScriptCmd As String = "" 'static so that script can be added to with successive calls of this function
+
         If txtScript.TextLength > 0 Then
             Dim lineNum As Integer = txtScript.GetLineFromCharIndex(txtScript.GetFirstCharIndexOfCurrentLine())
             If lineNum < txtScript.Lines.Length Then
-                RunText(txtScript.Lines(lineNum), False)
+                'add the new text to any unexecuted script remaining from previous calls to this function
+                strScriptCmd &= vbCrLf & txtScript.Lines(lineNum) 'insert carraige return to ensure that new text starts on new line
+                strScriptCmd = RunText(strScriptCmd)
                 If lineNum < txtScript.Lines.Length - 1 Then
                     txtScript.SelectionStart = txtScript.GetFirstCharIndexFromLine(lineNum + 1)
                     txtScript.ScrollToCaret()
@@ -82,11 +86,12 @@ Public Class ucrScript
         End If
     End Sub
 
-    Private Sub RunText(strText As String, Optional bClearScriptCmd As Boolean = True)
+    Private Function RunText(strText As String) As String
         If strText <> "" Then
-            frmMain.clsRLink.RunScriptFromWindow(strNewScript:=strText, strNewComment:=strComment, bClearScriptCmd)
+            strText = frmMain.clsRLink.RunScriptFromWindow(strNewScript:=strText, strNewComment:=strComment)
         End If
-    End Sub
+        Return strText
+    End Function
 
     Private Sub mnuOpenScript_Click(sender As Object, e As EventArgs) Handles mnuOpenScriptasFile.Click
         Dim strScriptFilename As String = ""

--- a/instat/ucrScript.vb
+++ b/instat/ucrScript.vb
@@ -76,7 +76,7 @@ Public Class ucrScript
             Dim lineNum As Integer = txtScript.GetLineFromCharIndex(txtScript.GetFirstCharIndexOfCurrentLine())
             If lineNum < txtScript.Lines.Length Then
                 'add the new text to any unexecuted script remaining from previous calls to this function
-                strScriptCmd &= vbCrLf & txtScript.Lines(lineNum) 'insert carraige return to ensure that new text starts on new line
+                strScriptCmd &= vbCrLf & txtScript.Lines(lineNum) 'insert carriage return to ensure that new text starts on new line
                 strScriptCmd = RunText(strScriptCmd)
                 If lineNum < txtScript.Lines.Length - 1 Then
                     txtScript.SelectionStart = txtScript.GetFirstCharIndexFromLine(lineNum + 1)


### PR DESCRIPTION
PR #5796 had merge conflicts. I could not fix them in a good way so I made this new PR from the master branch and reimplemented the changes.

@Patowhiz You have already peer reviewed these changes. The only new part is the check for open double quotations (") on lines 372 and 376. Please could you quickly review these lines? Thanks

@rdstern The test case below should now pass. Please could you test? Thanks
P.S. It's strange that the '=' works on the last line, but not the first!
```
Input <- ("
 Individual  Hand     Length
 A           Left     17.5
 B           Left     18.4
 C           Left     16.2
 D           Left     14.5
 E           Left     13.5
 F           Left     18.9
 G           Left     19.5
 H           Left     21.1
 I           Left     17.8
 J           Left     16.8
 K           Left     18.4
 L           Left     17.3
 M           Left     18.9
 N           Left     16.4
 O           Left     17.5
 P           Left     15.0
 A           Right    17.6
 B           Right    18.5
 C           Right    15.9
 D           Right    14.9
 E           Right    13.7
 F           Right    18.9
 G           Right    19.5
 H           Right    21.5
 I           Right    18.5
 J           Right    17.1
 K           Right    18.9
 L           Right    17.5
 M           Right    19.5
 N           Right    16.5
 O           Right    17.4
 P           Right    15.6
")

Data = read.table(textConnection(Input),header=TRUE)
```