### PR TITLE
Initial Implementation of homogenization 

### DIFF
--- a/instat/dlgHomogenization.Designer.vb
+++ b/instat/dlgHomogenization.Designer.vb
@@ -23,17 +23,114 @@ Partial Class dlgHomogenization
     <System.Diagnostics.DebuggerStepThrough()> _
     Private Sub InitializeComponent()
         Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(dlgHomogenization))
+        Me.ucrBase = New instat.ucrButtons()
+        Me.ucrSelectorHomogenization = New instat.ucrSelectorByDataFrameAddRemove()
+        Me.ucrReceiverElement = New instat.ucrReceiverSingle()
+        Me.lblElement = New System.Windows.Forms.Label()
+        Me.grpMethods = New System.Windows.Forms.GroupBox()
+        Me.grpCptOptions = New System.Windows.Forms.GroupBox()
+        Me.ucrPnlMethods = New instat.UcrPanel()
+        Me.rdoCptVariance = New System.Windows.Forms.RadioButton()
+        Me.rdoMeanVariance = New System.Windows.Forms.RadioButton()
+        Me.rdoCptMean = New System.Windows.Forms.RadioButton()
+        Me.grpMethods.SuspendLayout()
         Me.SuspendLayout()
+        '
+        'ucrBase
+        '
+        resources.ApplyResources(Me.ucrBase, "ucrBase")
+        Me.ucrBase.Name = "ucrBase"
+        '
+        'ucrSelectorHomogenization
+        '
+        Me.ucrSelectorHomogenization.bDropUnusedFilterLevels = False
+        Me.ucrSelectorHomogenization.bShowHiddenColumns = False
+        Me.ucrSelectorHomogenization.bUseCurrentFilter = True
+        resources.ApplyResources(Me.ucrSelectorHomogenization, "ucrSelectorHomogenization")
+        Me.ucrSelectorHomogenization.Name = "ucrSelectorHomogenization"
+        '
+        'ucrReceiverElement
+        '
+        Me.ucrReceiverElement.frmParent = Me
+        resources.ApplyResources(Me.ucrReceiverElement, "ucrReceiverElement")
+        Me.ucrReceiverElement.Name = "ucrReceiverElement"
+        Me.ucrReceiverElement.Selector = Nothing
+        Me.ucrReceiverElement.strNcFilePath = ""
+        Me.ucrReceiverElement.ucrSelector = Nothing
+        '
+        'lblElement
+        '
+        resources.ApplyResources(Me.lblElement, "lblElement")
+        Me.lblElement.Name = "lblElement"
+        '
+        'grpMethods
+        '
+        Me.grpMethods.Controls.Add(Me.rdoCptMean)
+        Me.grpMethods.Controls.Add(Me.rdoMeanVariance)
+        Me.grpMethods.Controls.Add(Me.rdoCptVariance)
+        Me.grpMethods.Controls.Add(Me.ucrPnlMethods)
+        resources.ApplyResources(Me.grpMethods, "grpMethods")
+        Me.grpMethods.Name = "grpMethods"
+        Me.grpMethods.TabStop = False
+        '
+        'grpCptOptions
+        '
+        resources.ApplyResources(Me.grpCptOptions, "grpCptOptions")
+        Me.grpCptOptions.Name = "grpCptOptions"
+        Me.grpCptOptions.TabStop = False
+        '
+        'ucrPnlMethods
+        '
+        resources.ApplyResources(Me.ucrPnlMethods, "ucrPnlMethods")
+        Me.ucrPnlMethods.Name = "ucrPnlMethods"
+        '
+        'rdoCptVariance
+        '
+        resources.ApplyResources(Me.rdoCptVariance, "rdoCptVariance")
+        Me.rdoCptVariance.Name = "rdoCptVariance"
+        Me.rdoCptVariance.UseVisualStyleBackColor = True
+        '
+        'rdoMeanVariance
+        '
+        resources.ApplyResources(Me.rdoMeanVariance, "rdoMeanVariance")
+        Me.rdoMeanVariance.Name = "rdoMeanVariance"
+        Me.rdoMeanVariance.UseVisualStyleBackColor = True
+        '
+        'rdoCptMean
+        '
+        resources.ApplyResources(Me.rdoCptMean, "rdoCptMean")
+        Me.rdoCptMean.Name = "rdoCptMean"
+        Me.rdoCptMean.UseVisualStyleBackColor = True
         '
         'dlgHomogenization
         '
         resources.ApplyResources(Me, "$this")
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.Controls.Add(Me.grpCptOptions)
+        Me.Controls.Add(Me.grpMethods)
+        Me.Controls.Add(Me.lblElement)
+        Me.Controls.Add(Me.ucrReceiverElement)
+        Me.Controls.Add(Me.ucrSelectorHomogenization)
+        Me.Controls.Add(Me.ucrBase)
         Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow
         Me.MaximizeBox = False
         Me.MinimizeBox = False
         Me.Name = "dlgHomogenization"
+        Me.grpMethods.ResumeLayout(False)
+        Me.grpMethods.PerformLayout()
         Me.ResumeLayout(False)
+        Me.PerformLayout()
 
     End Sub
+
+    Friend WithEvents ucrBase As ucrButtons
+    Friend WithEvents ucrSelectorHomogenization As ucrSelectorByDataFrameAddRemove
+    Friend WithEvents ucrReceiverElement As ucrReceiverSingle
+    Friend WithEvents lblElement As Label
+    Friend WithEvents grpCptOptions As GroupBox
+    Friend WithEvents grpMethods As GroupBox
+    Friend WithEvents ucrPnlMethods As UcrPanel
+    Friend WithEvents rdoCptMean As RadioButton
+    Friend WithEvents rdoMeanVariance As RadioButton
+    Friend WithEvents rdoCptVariance As RadioButton
 End Class

--- a/instat/dlgHomogenization.Designer.vb
+++ b/instat/dlgHomogenization.Designer.vb
@@ -65,6 +65,7 @@ Partial Class dlgHomogenization
         Me.ucrReceiverElement = New instat.ucrReceiverSingle()
         Me.ucrSelectorHomogenization = New instat.ucrSelectorByDataFrameAddRemove()
         Me.ucrBase = New instat.ucrButtons()
+        Me.rdoPettitt = New System.Windows.Forms.RadioButton()
         Me.grpMethods.SuspendLayout()
         Me.grpCptOptions.SuspendLayout()
         Me.grpOutputOptions.SuspendLayout()
@@ -78,6 +79,7 @@ Partial Class dlgHomogenization
         '
         'grpMethods
         '
+        Me.grpMethods.Controls.Add(Me.rdoPettitt)
         Me.grpMethods.Controls.Add(Me.rdoSnht)
         Me.grpMethods.Controls.Add(Me.rdoCptMean)
         Me.grpMethods.Controls.Add(Me.rdoCptMeanVariance)
@@ -366,6 +368,12 @@ Partial Class dlgHomogenization
         resources.ApplyResources(Me.ucrBase, "ucrBase")
         Me.ucrBase.Name = "ucrBase"
         '
+        'rdoPettitt
+        '
+        resources.ApplyResources(Me.rdoPettitt, "rdoPettitt")
+        Me.rdoPettitt.Name = "rdoPettitt"
+        Me.rdoPettitt.UseVisualStyleBackColor = True
+        '
         'dlgHomogenization
         '
         resources.ApplyResources(Me, "$this")
@@ -442,4 +450,5 @@ Partial Class dlgHomogenization
     Friend WithEvents ucrNudPeriod As ucrNud
     Friend WithEvents ucrChkRobust As ucrCheck
     Friend WithEvents ucrChkScaled As ucrCheck
+    Friend WithEvents rdoPettitt As RadioButton
 End Class

--- a/instat/dlgHomogenization.Designer.vb
+++ b/instat/dlgHomogenization.Designer.vb
@@ -26,12 +26,12 @@ Partial Class dlgHomogenization
         Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(dlgHomogenization))
         Me.lblElement = New System.Windows.Forms.Label()
         Me.grpMethods = New System.Windows.Forms.GroupBox()
-        Me.rdoBuishand = New System.Windows.Forms.RadioButton()
-        Me.rdoPettitt = New System.Windows.Forms.RadioButton()
-        Me.rdoSnht = New System.Windows.Forms.RadioButton()
         Me.rdoCptMean = New System.Windows.Forms.RadioButton()
         Me.rdoCptMeanVariance = New System.Windows.Forms.RadioButton()
         Me.rdoCptVariance = New System.Windows.Forms.RadioButton()
+        Me.rdoBuishand = New System.Windows.Forms.RadioButton()
+        Me.rdoPettitt = New System.Windows.Forms.RadioButton()
+        Me.rdoSnht = New System.Windows.Forms.RadioButton()
         Me.ucrPnlMethods = New instat.UcrPanel()
         Me.grpCptOptions = New System.Windows.Forms.GroupBox()
         Me.ucrInputComboMeanVarDistribution = New instat.ucrInputComboBox()
@@ -56,11 +56,6 @@ Partial Class dlgHomogenization
         Me.rdoMultiple = New System.Windows.Forms.RadioButton()
         Me.rdoNeighbouring = New System.Windows.Forms.RadioButton()
         Me.lblNeighbouring = New System.Windows.Forms.Label()
-        Me.grpSnhtOptions = New System.Windows.Forms.GroupBox()
-        Me.lblPeriod = New System.Windows.Forms.Label()
-        Me.ucrNudPeriod = New instat.ucrNud()
-        Me.ucrChkRobust = New instat.ucrCheck()
-        Me.ucrChkScaled = New instat.ucrCheck()
         Me.ucrReceiverNeighbour = New instat.ucrReceiverSingle()
         Me.ucrPnlOptions = New instat.UcrPanel()
         Me.ucrSaveResult = New instat.ucrSave()
@@ -70,7 +65,6 @@ Partial Class dlgHomogenization
         Me.grpMethods.SuspendLayout()
         Me.grpCptOptions.SuspendLayout()
         Me.grpOutputOptions.SuspendLayout()
-        Me.grpSnhtOptions.SuspendLayout()
         Me.SuspendLayout()
         '
         'lblElement
@@ -91,24 +85,6 @@ Partial Class dlgHomogenization
         Me.grpMethods.Name = "grpMethods"
         Me.grpMethods.TabStop = False
         '
-        'rdoBuishand
-        '
-        resources.ApplyResources(Me.rdoBuishand, "rdoBuishand")
-        Me.rdoBuishand.Name = "rdoBuishand"
-        Me.rdoBuishand.UseVisualStyleBackColor = True
-        '
-        'rdoPettitt
-        '
-        resources.ApplyResources(Me.rdoPettitt, "rdoPettitt")
-        Me.rdoPettitt.Name = "rdoPettitt"
-        Me.rdoPettitt.UseVisualStyleBackColor = True
-        '
-        'rdoSnht
-        '
-        resources.ApplyResources(Me.rdoSnht, "rdoSnht")
-        Me.rdoSnht.Name = "rdoSnht"
-        Me.rdoSnht.UseVisualStyleBackColor = True
-        '
         'rdoCptMean
         '
         resources.ApplyResources(Me.rdoCptMean, "rdoCptMean")
@@ -126,6 +102,24 @@ Partial Class dlgHomogenization
         resources.ApplyResources(Me.rdoCptVariance, "rdoCptVariance")
         Me.rdoCptVariance.Name = "rdoCptVariance"
         Me.rdoCptVariance.UseVisualStyleBackColor = True
+        '
+        'rdoBuishand
+        '
+        resources.ApplyResources(Me.rdoBuishand, "rdoBuishand")
+        Me.rdoBuishand.Name = "rdoBuishand"
+        Me.rdoBuishand.UseVisualStyleBackColor = True
+        '
+        'rdoPettitt
+        '
+        resources.ApplyResources(Me.rdoPettitt, "rdoPettitt")
+        Me.rdoPettitt.Name = "rdoPettitt"
+        Me.rdoPettitt.UseVisualStyleBackColor = True
+        '
+        'rdoSnht
+        '
+        resources.ApplyResources(Me.rdoSnht, "rdoSnht")
+        Me.rdoSnht.Name = "rdoSnht"
+        Me.rdoSnht.UseVisualStyleBackColor = True
         '
         'ucrPnlMethods
         '
@@ -304,43 +298,6 @@ Partial Class dlgHomogenization
         resources.ApplyResources(Me.lblNeighbouring, "lblNeighbouring")
         Me.lblNeighbouring.Name = "lblNeighbouring"
         '
-        'grpSnhtOptions
-        '
-        Me.grpSnhtOptions.Controls.Add(Me.lblPeriod)
-        Me.grpSnhtOptions.Controls.Add(Me.ucrNudPeriod)
-        Me.grpSnhtOptions.Controls.Add(Me.ucrChkRobust)
-        Me.grpSnhtOptions.Controls.Add(Me.ucrChkScaled)
-        resources.ApplyResources(Me.grpSnhtOptions, "grpSnhtOptions")
-        Me.grpSnhtOptions.Name = "grpSnhtOptions"
-        Me.grpSnhtOptions.TabStop = False
-        '
-        'lblPeriod
-        '
-        resources.ApplyResources(Me.lblPeriod, "lblPeriod")
-        Me.lblPeriod.Name = "lblPeriod"
-        '
-        'ucrNudPeriod
-        '
-        Me.ucrNudPeriod.DecimalPlaces = New Decimal(New Integer() {0, 0, 0, 0})
-        Me.ucrNudPeriod.Increment = New Decimal(New Integer() {1, 0, 0, 0})
-        resources.ApplyResources(Me.ucrNudPeriod, "ucrNudPeriod")
-        Me.ucrNudPeriod.Maximum = New Decimal(New Integer() {100, 0, 0, 0})
-        Me.ucrNudPeriod.Minimum = New Decimal(New Integer() {0, 0, 0, 0})
-        Me.ucrNudPeriod.Name = "ucrNudPeriod"
-        Me.ucrNudPeriod.Value = New Decimal(New Integer() {0, 0, 0, 0})
-        '
-        'ucrChkRobust
-        '
-        Me.ucrChkRobust.Checked = False
-        resources.ApplyResources(Me.ucrChkRobust, "ucrChkRobust")
-        Me.ucrChkRobust.Name = "ucrChkRobust"
-        '
-        'ucrChkScaled
-        '
-        Me.ucrChkScaled.Checked = False
-        resources.ApplyResources(Me.ucrChkScaled, "ucrChkScaled")
-        Me.ucrChkScaled.Name = "ucrChkScaled"
-        '
         'ucrReceiverNeighbour
         '
         Me.ucrReceiverNeighbour.frmParent = Me
@@ -386,7 +343,6 @@ Partial Class dlgHomogenization
         '
         resources.ApplyResources(Me, "$this")
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
-        Me.Controls.Add(Me.grpSnhtOptions)
         Me.Controls.Add(Me.lblNeighbouring)
         Me.Controls.Add(Me.ucrReceiverNeighbour)
         Me.Controls.Add(Me.rdoNeighbouring)
@@ -410,8 +366,6 @@ Partial Class dlgHomogenization
         Me.grpCptOptions.ResumeLayout(False)
         Me.grpCptOptions.PerformLayout()
         Me.grpOutputOptions.ResumeLayout(False)
-        Me.grpSnhtOptions.ResumeLayout(False)
-        Me.grpSnhtOptions.PerformLayout()
         Me.ResumeLayout(False)
         Me.PerformLayout()
 
@@ -453,11 +407,6 @@ Partial Class dlgHomogenization
     Friend WithEvents ucrInputComboVarDistribution As ucrInputComboBox
     Friend WithEvents ucrInputComboMeanVarDistribution As ucrInputComboBox
     Friend WithEvents rdoSnht As RadioButton
-    Friend WithEvents grpSnhtOptions As GroupBox
-    Friend WithEvents lblPeriod As Label
-    Friend WithEvents ucrNudPeriod As ucrNud
-    Friend WithEvents ucrChkRobust As ucrCheck
-    Friend WithEvents ucrChkScaled As ucrCheck
     Friend WithEvents rdoPettitt As RadioButton
     Friend WithEvents rdoBuishand As RadioButton
 End Class

--- a/instat/dlgHomogenization.Designer.vb
+++ b/instat/dlgHomogenization.Designer.vb
@@ -29,31 +29,34 @@ Partial Class dlgHomogenization
         Me.rdoCptMean = New System.Windows.Forms.RadioButton()
         Me.rdoMeanVariance = New System.Windows.Forms.RadioButton()
         Me.rdoCptVariance = New System.Windows.Forms.RadioButton()
+        Me.ucrPnlMethods = New instat.UcrPanel()
         Me.grpCptOptions = New System.Windows.Forms.GroupBox()
+        Me.lblPenaltyValue = New System.Windows.Forms.Label()
+        Me.ucrInputPenValue = New instat.ucrInputTextBox()
         Me.lblMinSegLen = New System.Windows.Forms.Label()
         Me.lblQ = New System.Windows.Forms.Label()
         Me.lblPenalty = New System.Windows.Forms.Label()
         Me.Label2 = New System.Windows.Forms.Label()
         Me.lblDistribution = New System.Windows.Forms.Label()
-        Me.grpOutputOptions = New System.Windows.Forms.GroupBox()
-        Me.ttOptions = New System.Windows.Forms.ToolTip(Me.components)
-        Me.lblPenaltyValue = New System.Windows.Forms.Label()
-        Me.ucrSaveResult = New instat.ucrSave()
-        Me.ucrChkPlot = New instat.ucrCheck()
-        Me.ucrChkSummary = New instat.ucrCheck()
-        Me.ucrInputPenValue = New instat.ucrInputTextBox()
         Me.ucrNudMinSegLen = New instat.ucrNud()
         Me.ucrInputQ = New instat.ucrInputTextBox()
         Me.ucrInputComboDistribution = New instat.ucrInputComboBox()
         Me.ucrInputComboMethod = New instat.ucrInputComboBox()
         Me.ucrInputComboPenalty = New instat.ucrInputComboBox()
-        Me.ucrPnlMethods = New instat.UcrPanel()
-        Me.ucrReceiverElement = New instat.ucrReceiverSingle()
-        Me.ucrSelectorHomogenization = New instat.ucrSelectorByDataFrameAddRemove()
-        Me.ucrBase = New instat.ucrButtons()
+        Me.grpOutputOptions = New System.Windows.Forms.GroupBox()
+        Me.ucrChkPlot = New instat.ucrCheck()
+        Me.ucrChkSummary = New instat.ucrCheck()
+        Me.ttOptions = New System.Windows.Forms.ToolTip(Me.components)
         Me.rdoSingle = New System.Windows.Forms.RadioButton()
         Me.rdoMultiple = New System.Windows.Forms.RadioButton()
         Me.ucrPnlOptions = New instat.UcrPanel()
+        Me.ucrSaveResult = New instat.ucrSave()
+        Me.ucrReceiverElement = New instat.ucrReceiverSingle()
+        Me.ucrSelectorHomogenization = New instat.ucrSelectorByDataFrameAddRemove()
+        Me.ucrBase = New instat.ucrButtons()
+        Me.rdoNeighbouring = New System.Windows.Forms.RadioButton()
+        Me.lblNeighbouring = New System.Windows.Forms.Label()
+        Me.ucrReceiverNeighbour = New instat.ucrReceiverSingle()
         Me.grpMethods.SuspendLayout()
         Me.grpCptOptions.SuspendLayout()
         Me.grpOutputOptions.SuspendLayout()
@@ -92,6 +95,11 @@ Partial Class dlgHomogenization
         Me.rdoCptVariance.Name = "rdoCptVariance"
         Me.rdoCptVariance.UseVisualStyleBackColor = True
         '
+        'ucrPnlMethods
+        '
+        resources.ApplyResources(Me.ucrPnlMethods, "ucrPnlMethods")
+        Me.ucrPnlMethods.Name = "ucrPnlMethods"
+        '
         'grpCptOptions
         '
         Me.grpCptOptions.Controls.Add(Me.lblPenaltyValue)
@@ -109,6 +117,19 @@ Partial Class dlgHomogenization
         resources.ApplyResources(Me.grpCptOptions, "grpCptOptions")
         Me.grpCptOptions.Name = "grpCptOptions"
         Me.grpCptOptions.TabStop = False
+        '
+        'lblPenaltyValue
+        '
+        resources.ApplyResources(Me.lblPenaltyValue, "lblPenaltyValue")
+        Me.lblPenaltyValue.Name = "lblPenaltyValue"
+        '
+        'ucrInputPenValue
+        '
+        Me.ucrInputPenValue.AddQuotesIfUnrecognised = True
+        Me.ucrInputPenValue.IsMultiline = False
+        Me.ucrInputPenValue.IsReadOnly = False
+        resources.ApplyResources(Me.ucrInputPenValue, "ucrInputPenValue")
+        Me.ucrInputPenValue.Name = "ucrInputPenValue"
         '
         'lblMinSegLen
         '
@@ -134,44 +155,6 @@ Partial Class dlgHomogenization
         '
         resources.ApplyResources(Me.lblDistribution, "lblDistribution")
         Me.lblDistribution.Name = "lblDistribution"
-        '
-        'grpOutputOptions
-        '
-        Me.grpOutputOptions.Controls.Add(Me.ucrChkPlot)
-        Me.grpOutputOptions.Controls.Add(Me.ucrChkSummary)
-        resources.ApplyResources(Me.grpOutputOptions, "grpOutputOptions")
-        Me.grpOutputOptions.Name = "grpOutputOptions"
-        Me.grpOutputOptions.TabStop = False
-        '
-        'lblPenaltyValue
-        '
-        resources.ApplyResources(Me.lblPenaltyValue, "lblPenaltyValue")
-        Me.lblPenaltyValue.Name = "lblPenaltyValue"
-        '
-        'ucrSaveResult
-        '
-        resources.ApplyResources(Me.ucrSaveResult, "ucrSaveResult")
-        Me.ucrSaveResult.Name = "ucrSaveResult"
-        '
-        'ucrChkPlot
-        '
-        Me.ucrChkPlot.Checked = False
-        resources.ApplyResources(Me.ucrChkPlot, "ucrChkPlot")
-        Me.ucrChkPlot.Name = "ucrChkPlot"
-        '
-        'ucrChkSummary
-        '
-        Me.ucrChkSummary.Checked = False
-        resources.ApplyResources(Me.ucrChkSummary, "ucrChkSummary")
-        Me.ucrChkSummary.Name = "ucrChkSummary"
-        '
-        'ucrInputPenValue
-        '
-        Me.ucrInputPenValue.AddQuotesIfUnrecognised = True
-        Me.ucrInputPenValue.IsMultiline = False
-        Me.ucrInputPenValue.IsReadOnly = False
-        resources.ApplyResources(Me.ucrInputPenValue, "ucrInputPenValue")
-        Me.ucrInputPenValue.Name = "ucrInputPenValue"
         '
         'ucrNudMinSegLen
         '
@@ -212,32 +195,25 @@ Partial Class dlgHomogenization
         resources.ApplyResources(Me.ucrInputComboPenalty, "ucrInputComboPenalty")
         Me.ucrInputComboPenalty.Name = "ucrInputComboPenalty"
         '
-        'ucrPnlMethods
+        'grpOutputOptions
         '
-        resources.ApplyResources(Me.ucrPnlMethods, "ucrPnlMethods")
-        Me.ucrPnlMethods.Name = "ucrPnlMethods"
+        Me.grpOutputOptions.Controls.Add(Me.ucrChkPlot)
+        Me.grpOutputOptions.Controls.Add(Me.ucrChkSummary)
+        resources.ApplyResources(Me.grpOutputOptions, "grpOutputOptions")
+        Me.grpOutputOptions.Name = "grpOutputOptions"
+        Me.grpOutputOptions.TabStop = False
         '
-        'ucrReceiverElement
+        'ucrChkPlot
         '
-        Me.ucrReceiverElement.frmParent = Me
-        resources.ApplyResources(Me.ucrReceiverElement, "ucrReceiverElement")
-        Me.ucrReceiverElement.Name = "ucrReceiverElement"
-        Me.ucrReceiverElement.Selector = Nothing
-        Me.ucrReceiverElement.strNcFilePath = ""
-        Me.ucrReceiverElement.ucrSelector = Nothing
+        Me.ucrChkPlot.Checked = False
+        resources.ApplyResources(Me.ucrChkPlot, "ucrChkPlot")
+        Me.ucrChkPlot.Name = "ucrChkPlot"
         '
-        'ucrSelectorHomogenization
+        'ucrChkSummary
         '
-        Me.ucrSelectorHomogenization.bDropUnusedFilterLevels = False
-        Me.ucrSelectorHomogenization.bShowHiddenColumns = False
-        Me.ucrSelectorHomogenization.bUseCurrentFilter = True
-        resources.ApplyResources(Me.ucrSelectorHomogenization, "ucrSelectorHomogenization")
-        Me.ucrSelectorHomogenization.Name = "ucrSelectorHomogenization"
-        '
-        'ucrBase
-        '
-        resources.ApplyResources(Me.ucrBase, "ucrBase")
-        Me.ucrBase.Name = "ucrBase"
+        Me.ucrChkSummary.Checked = False
+        resources.ApplyResources(Me.ucrChkSummary, "ucrChkSummary")
+        Me.ucrChkSummary.Name = "ucrChkSummary"
         '
         'rdoSingle
         '
@@ -268,10 +244,66 @@ Partial Class dlgHomogenization
         resources.ApplyResources(Me.ucrPnlOptions, "ucrPnlOptions")
         Me.ucrPnlOptions.Name = "ucrPnlOptions"
         '
+        'ucrSaveResult
+        '
+        resources.ApplyResources(Me.ucrSaveResult, "ucrSaveResult")
+        Me.ucrSaveResult.Name = "ucrSaveResult"
+        '
+        'ucrReceiverElement
+        '
+        Me.ucrReceiverElement.frmParent = Me
+        resources.ApplyResources(Me.ucrReceiverElement, "ucrReceiverElement")
+        Me.ucrReceiverElement.Name = "ucrReceiverElement"
+        Me.ucrReceiverElement.Selector = Nothing
+        Me.ucrReceiverElement.strNcFilePath = ""
+        Me.ucrReceiverElement.ucrSelector = Nothing
+        '
+        'ucrSelectorHomogenization
+        '
+        Me.ucrSelectorHomogenization.bDropUnusedFilterLevels = False
+        Me.ucrSelectorHomogenization.bShowHiddenColumns = False
+        Me.ucrSelectorHomogenization.bUseCurrentFilter = True
+        resources.ApplyResources(Me.ucrSelectorHomogenization, "ucrSelectorHomogenization")
+        Me.ucrSelectorHomogenization.Name = "ucrSelectorHomogenization"
+        '
+        'ucrBase
+        '
+        resources.ApplyResources(Me.ucrBase, "ucrBase")
+        Me.ucrBase.Name = "ucrBase"
+        '
+        'rdoNeighbouring
+        '
+        resources.ApplyResources(Me.rdoNeighbouring, "rdoNeighbouring")
+        Me.rdoNeighbouring.BackColor = System.Drawing.SystemColors.Control
+        Me.rdoNeighbouring.FlatAppearance.BorderColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoNeighbouring.FlatAppearance.BorderSize = 2
+        Me.rdoNeighbouring.FlatAppearance.CheckedBackColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoNeighbouring.Name = "rdoNeighbouring"
+        Me.rdoNeighbouring.TabStop = True
+        Me.rdoNeighbouring.Tag = ""
+        Me.rdoNeighbouring.UseVisualStyleBackColor = False
+        '
+        'lblNeighbouring
+        '
+        resources.ApplyResources(Me.lblNeighbouring, "lblNeighbouring")
+        Me.lblNeighbouring.Name = "lblNeighbouring"
+        '
+        'ucrReceiverNeighbour
+        '
+        Me.ucrReceiverNeighbour.frmParent = Me
+        resources.ApplyResources(Me.ucrReceiverNeighbour, "ucrReceiverNeighbour")
+        Me.ucrReceiverNeighbour.Name = "ucrReceiverNeighbour"
+        Me.ucrReceiverNeighbour.Selector = Nothing
+        Me.ucrReceiverNeighbour.strNcFilePath = ""
+        Me.ucrReceiverNeighbour.ucrSelector = Nothing
+        '
         'dlgHomogenization
         '
         resources.ApplyResources(Me, "$this")
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.Controls.Add(Me.lblNeighbouring)
+        Me.Controls.Add(Me.ucrReceiverNeighbour)
+        Me.Controls.Add(Me.rdoNeighbouring)
         Me.Controls.Add(Me.rdoSingle)
         Me.Controls.Add(Me.rdoMultiple)
         Me.Controls.Add(Me.ucrPnlOptions)
@@ -327,4 +359,7 @@ Partial Class dlgHomogenization
     Friend WithEvents rdoSingle As RadioButton
     Friend WithEvents rdoMultiple As RadioButton
     Friend WithEvents ucrPnlOptions As UcrPanel
+    Friend WithEvents rdoNeighbouring As RadioButton
+    Friend WithEvents lblNeighbouring As Label
+    Friend WithEvents ucrReceiverNeighbour As ucrReceiverSingle
 End Class

--- a/instat/dlgHomogenization.Designer.vb
+++ b/instat/dlgHomogenization.Designer.vb
@@ -27,36 +27,38 @@ Partial Class dlgHomogenization
         Me.lblElement = New System.Windows.Forms.Label()
         Me.grpMethods = New System.Windows.Forms.GroupBox()
         Me.rdoCptMean = New System.Windows.Forms.RadioButton()
-        Me.rdoMeanVariance = New System.Windows.Forms.RadioButton()
+        Me.rdoCptMeanVariance = New System.Windows.Forms.RadioButton()
         Me.rdoCptVariance = New System.Windows.Forms.RadioButton()
-        Me.ucrPnlMethods = New instat.UcrPanel()
         Me.grpCptOptions = New System.Windows.Forms.GroupBox()
         Me.lblPenaltyValue = New System.Windows.Forms.Label()
-        Me.ucrInputPenValue = New instat.ucrInputTextBox()
         Me.lblMinSegLen = New System.Windows.Forms.Label()
         Me.lblQ = New System.Windows.Forms.Label()
         Me.lblPenalty = New System.Windows.Forms.Label()
         Me.Label2 = New System.Windows.Forms.Label()
         Me.lblDistribution = New System.Windows.Forms.Label()
-        Me.ucrNudMinSegLen = New instat.ucrNud()
-        Me.ucrInputQ = New instat.ucrInputTextBox()
-        Me.ucrInputComboDistribution = New instat.ucrInputComboBox()
-        Me.ucrInputComboMethod = New instat.ucrInputComboBox()
-        Me.ucrInputComboPenalty = New instat.ucrInputComboBox()
         Me.grpOutputOptions = New System.Windows.Forms.GroupBox()
-        Me.ucrChkPlot = New instat.ucrCheck()
-        Me.ucrChkSummary = New instat.ucrCheck()
         Me.ttOptions = New System.Windows.Forms.ToolTip(Me.components)
         Me.rdoSingle = New System.Windows.Forms.RadioButton()
         Me.rdoMultiple = New System.Windows.Forms.RadioButton()
-        Me.ucrPnlOptions = New instat.UcrPanel()
-        Me.ucrSaveResult = New instat.ucrSave()
-        Me.ucrReceiverElement = New instat.ucrReceiverSingle()
-        Me.ucrSelectorHomogenization = New instat.ucrSelectorByDataFrameAddRemove()
-        Me.ucrBase = New instat.ucrButtons()
         Me.rdoNeighbouring = New System.Windows.Forms.RadioButton()
         Me.lblNeighbouring = New System.Windows.Forms.Label()
         Me.ucrReceiverNeighbour = New instat.ucrReceiverSingle()
+        Me.ucrPnlOptions = New instat.UcrPanel()
+        Me.ucrSaveResult = New instat.ucrSave()
+        Me.ucrChkPlot = New instat.ucrCheck()
+        Me.ucrChkSummary = New instat.ucrCheck()
+        Me.ucrInputPenValue = New instat.ucrInputTextBox()
+        Me.ucrNudMinSegLen = New instat.ucrNud()
+        Me.ucrInputQ = New instat.ucrInputTextBox()
+        Me.ucrInputComboMeanDistribution = New instat.ucrInputComboBox()
+        Me.ucrInputComboMethod = New instat.ucrInputComboBox()
+        Me.ucrInputComboPenalty = New instat.ucrInputComboBox()
+        Me.ucrPnlMethods = New instat.UcrPanel()
+        Me.ucrReceiverElement = New instat.ucrReceiverSingle()
+        Me.ucrSelectorHomogenization = New instat.ucrSelectorByDataFrameAddRemove()
+        Me.ucrBase = New instat.ucrButtons()
+        Me.ucrInputComboMeanVarDistribution = New instat.ucrInputComboBox()
+        Me.ucrInputComboVarDistribution = New instat.ucrInputComboBox()
         Me.grpMethods.SuspendLayout()
         Me.grpCptOptions.SuspendLayout()
         Me.grpOutputOptions.SuspendLayout()
@@ -70,7 +72,7 @@ Partial Class dlgHomogenization
         'grpMethods
         '
         Me.grpMethods.Controls.Add(Me.rdoCptMean)
-        Me.grpMethods.Controls.Add(Me.rdoMeanVariance)
+        Me.grpMethods.Controls.Add(Me.rdoCptMeanVariance)
         Me.grpMethods.Controls.Add(Me.rdoCptVariance)
         Me.grpMethods.Controls.Add(Me.ucrPnlMethods)
         resources.ApplyResources(Me.grpMethods, "grpMethods")
@@ -83,11 +85,11 @@ Partial Class dlgHomogenization
         Me.rdoCptMean.Name = "rdoCptMean"
         Me.rdoCptMean.UseVisualStyleBackColor = True
         '
-        'rdoMeanVariance
+        'rdoCptMeanVariance
         '
-        resources.ApplyResources(Me.rdoMeanVariance, "rdoMeanVariance")
-        Me.rdoMeanVariance.Name = "rdoMeanVariance"
-        Me.rdoMeanVariance.UseVisualStyleBackColor = True
+        resources.ApplyResources(Me.rdoCptMeanVariance, "rdoCptMeanVariance")
+        Me.rdoCptMeanVariance.Name = "rdoCptMeanVariance"
+        Me.rdoCptMeanVariance.UseVisualStyleBackColor = True
         '
         'rdoCptVariance
         '
@@ -95,13 +97,10 @@ Partial Class dlgHomogenization
         Me.rdoCptVariance.Name = "rdoCptVariance"
         Me.rdoCptVariance.UseVisualStyleBackColor = True
         '
-        'ucrPnlMethods
-        '
-        resources.ApplyResources(Me.ucrPnlMethods, "ucrPnlMethods")
-        Me.ucrPnlMethods.Name = "ucrPnlMethods"
-        '
         'grpCptOptions
         '
+        Me.grpCptOptions.Controls.Add(Me.ucrInputComboMeanVarDistribution)
+        Me.grpCptOptions.Controls.Add(Me.ucrInputComboVarDistribution)
         Me.grpCptOptions.Controls.Add(Me.lblPenaltyValue)
         Me.grpCptOptions.Controls.Add(Me.ucrInputPenValue)
         Me.grpCptOptions.Controls.Add(Me.lblMinSegLen)
@@ -111,7 +110,7 @@ Partial Class dlgHomogenization
         Me.grpCptOptions.Controls.Add(Me.lblDistribution)
         Me.grpCptOptions.Controls.Add(Me.ucrNudMinSegLen)
         Me.grpCptOptions.Controls.Add(Me.ucrInputQ)
-        Me.grpCptOptions.Controls.Add(Me.ucrInputComboDistribution)
+        Me.grpCptOptions.Controls.Add(Me.ucrInputComboMeanDistribution)
         Me.grpCptOptions.Controls.Add(Me.ucrInputComboMethod)
         Me.grpCptOptions.Controls.Add(Me.ucrInputComboPenalty)
         resources.ApplyResources(Me.grpCptOptions, "grpCptOptions")
@@ -122,14 +121,6 @@ Partial Class dlgHomogenization
         '
         resources.ApplyResources(Me.lblPenaltyValue, "lblPenaltyValue")
         Me.lblPenaltyValue.Name = "lblPenaltyValue"
-        '
-        'ucrInputPenValue
-        '
-        Me.ucrInputPenValue.AddQuotesIfUnrecognised = True
-        Me.ucrInputPenValue.IsMultiline = False
-        Me.ucrInputPenValue.IsReadOnly = False
-        resources.ApplyResources(Me.ucrInputPenValue, "ucrInputPenValue")
-        Me.ucrInputPenValue.Name = "ucrInputPenValue"
         '
         'lblMinSegLen
         '
@@ -156,45 +147,6 @@ Partial Class dlgHomogenization
         resources.ApplyResources(Me.lblDistribution, "lblDistribution")
         Me.lblDistribution.Name = "lblDistribution"
         '
-        'ucrNudMinSegLen
-        '
-        Me.ucrNudMinSegLen.DecimalPlaces = New Decimal(New Integer() {0, 0, 0, 0})
-        Me.ucrNudMinSegLen.Increment = New Decimal(New Integer() {1, 0, 0, 0})
-        resources.ApplyResources(Me.ucrNudMinSegLen, "ucrNudMinSegLen")
-        Me.ucrNudMinSegLen.Maximum = New Decimal(New Integer() {100, 0, 0, 0})
-        Me.ucrNudMinSegLen.Minimum = New Decimal(New Integer() {0, 0, 0, 0})
-        Me.ucrNudMinSegLen.Name = "ucrNudMinSegLen"
-        Me.ucrNudMinSegLen.Value = New Decimal(New Integer() {0, 0, 0, 0})
-        '
-        'ucrInputQ
-        '
-        Me.ucrInputQ.AddQuotesIfUnrecognised = True
-        Me.ucrInputQ.IsMultiline = False
-        Me.ucrInputQ.IsReadOnly = False
-        resources.ApplyResources(Me.ucrInputQ, "ucrInputQ")
-        Me.ucrInputQ.Name = "ucrInputQ"
-        '
-        'ucrInputComboDistribution
-        '
-        Me.ucrInputComboDistribution.AddQuotesIfUnrecognised = True
-        Me.ucrInputComboDistribution.IsReadOnly = False
-        resources.ApplyResources(Me.ucrInputComboDistribution, "ucrInputComboDistribution")
-        Me.ucrInputComboDistribution.Name = "ucrInputComboDistribution"
-        '
-        'ucrInputComboMethod
-        '
-        Me.ucrInputComboMethod.AddQuotesIfUnrecognised = True
-        Me.ucrInputComboMethod.IsReadOnly = False
-        resources.ApplyResources(Me.ucrInputComboMethod, "ucrInputComboMethod")
-        Me.ucrInputComboMethod.Name = "ucrInputComboMethod"
-        '
-        'ucrInputComboPenalty
-        '
-        Me.ucrInputComboPenalty.AddQuotesIfUnrecognised = True
-        Me.ucrInputComboPenalty.IsReadOnly = False
-        resources.ApplyResources(Me.ucrInputComboPenalty, "ucrInputComboPenalty")
-        Me.ucrInputComboPenalty.Name = "ucrInputComboPenalty"
-        '
         'grpOutputOptions
         '
         Me.grpOutputOptions.Controls.Add(Me.ucrChkPlot)
@@ -202,18 +154,6 @@ Partial Class dlgHomogenization
         resources.ApplyResources(Me.grpOutputOptions, "grpOutputOptions")
         Me.grpOutputOptions.Name = "grpOutputOptions"
         Me.grpOutputOptions.TabStop = False
-        '
-        'ucrChkPlot
-        '
-        Me.ucrChkPlot.Checked = False
-        resources.ApplyResources(Me.ucrChkPlot, "ucrChkPlot")
-        Me.ucrChkPlot.Name = "ucrChkPlot"
-        '
-        'ucrChkSummary
-        '
-        Me.ucrChkSummary.Checked = False
-        resources.ApplyResources(Me.ucrChkSummary, "ucrChkSummary")
-        Me.ucrChkSummary.Name = "ucrChkSummary"
         '
         'rdoSingle
         '
@@ -238,38 +178,6 @@ Partial Class dlgHomogenization
         Me.rdoMultiple.TabStop = True
         Me.rdoMultiple.Tag = ""
         Me.rdoMultiple.UseVisualStyleBackColor = False
-        '
-        'ucrPnlOptions
-        '
-        resources.ApplyResources(Me.ucrPnlOptions, "ucrPnlOptions")
-        Me.ucrPnlOptions.Name = "ucrPnlOptions"
-        '
-        'ucrSaveResult
-        '
-        resources.ApplyResources(Me.ucrSaveResult, "ucrSaveResult")
-        Me.ucrSaveResult.Name = "ucrSaveResult"
-        '
-        'ucrReceiverElement
-        '
-        Me.ucrReceiverElement.frmParent = Me
-        resources.ApplyResources(Me.ucrReceiverElement, "ucrReceiverElement")
-        Me.ucrReceiverElement.Name = "ucrReceiverElement"
-        Me.ucrReceiverElement.Selector = Nothing
-        Me.ucrReceiverElement.strNcFilePath = ""
-        Me.ucrReceiverElement.ucrSelector = Nothing
-        '
-        'ucrSelectorHomogenization
-        '
-        Me.ucrSelectorHomogenization.bDropUnusedFilterLevels = False
-        Me.ucrSelectorHomogenization.bShowHiddenColumns = False
-        Me.ucrSelectorHomogenization.bUseCurrentFilter = True
-        resources.ApplyResources(Me.ucrSelectorHomogenization, "ucrSelectorHomogenization")
-        Me.ucrSelectorHomogenization.Name = "ucrSelectorHomogenization"
-        '
-        'ucrBase
-        '
-        resources.ApplyResources(Me.ucrBase, "ucrBase")
-        Me.ucrBase.Name = "ucrBase"
         '
         'rdoNeighbouring
         '
@@ -296,6 +204,116 @@ Partial Class dlgHomogenization
         Me.ucrReceiverNeighbour.Selector = Nothing
         Me.ucrReceiverNeighbour.strNcFilePath = ""
         Me.ucrReceiverNeighbour.ucrSelector = Nothing
+        '
+        'ucrPnlOptions
+        '
+        resources.ApplyResources(Me.ucrPnlOptions, "ucrPnlOptions")
+        Me.ucrPnlOptions.Name = "ucrPnlOptions"
+        '
+        'ucrSaveResult
+        '
+        resources.ApplyResources(Me.ucrSaveResult, "ucrSaveResult")
+        Me.ucrSaveResult.Name = "ucrSaveResult"
+        '
+        'ucrChkPlot
+        '
+        Me.ucrChkPlot.Checked = False
+        resources.ApplyResources(Me.ucrChkPlot, "ucrChkPlot")
+        Me.ucrChkPlot.Name = "ucrChkPlot"
+        '
+        'ucrChkSummary
+        '
+        Me.ucrChkSummary.Checked = False
+        resources.ApplyResources(Me.ucrChkSummary, "ucrChkSummary")
+        Me.ucrChkSummary.Name = "ucrChkSummary"
+        '
+        'ucrInputPenValue
+        '
+        Me.ucrInputPenValue.AddQuotesIfUnrecognised = True
+        Me.ucrInputPenValue.IsMultiline = False
+        Me.ucrInputPenValue.IsReadOnly = False
+        resources.ApplyResources(Me.ucrInputPenValue, "ucrInputPenValue")
+        Me.ucrInputPenValue.Name = "ucrInputPenValue"
+        '
+        'ucrNudMinSegLen
+        '
+        Me.ucrNudMinSegLen.DecimalPlaces = New Decimal(New Integer() {0, 0, 0, 0})
+        Me.ucrNudMinSegLen.Increment = New Decimal(New Integer() {1, 0, 0, 0})
+        resources.ApplyResources(Me.ucrNudMinSegLen, "ucrNudMinSegLen")
+        Me.ucrNudMinSegLen.Maximum = New Decimal(New Integer() {100, 0, 0, 0})
+        Me.ucrNudMinSegLen.Minimum = New Decimal(New Integer() {0, 0, 0, 0})
+        Me.ucrNudMinSegLen.Name = "ucrNudMinSegLen"
+        Me.ucrNudMinSegLen.Value = New Decimal(New Integer() {0, 0, 0, 0})
+        '
+        'ucrInputQ
+        '
+        Me.ucrInputQ.AddQuotesIfUnrecognised = True
+        Me.ucrInputQ.IsMultiline = False
+        Me.ucrInputQ.IsReadOnly = False
+        resources.ApplyResources(Me.ucrInputQ, "ucrInputQ")
+        Me.ucrInputQ.Name = "ucrInputQ"
+        '
+        'ucrInputComboMeanDistribution
+        '
+        Me.ucrInputComboMeanDistribution.AddQuotesIfUnrecognised = True
+        Me.ucrInputComboMeanDistribution.IsReadOnly = False
+        resources.ApplyResources(Me.ucrInputComboMeanDistribution, "ucrInputComboMeanDistribution")
+        Me.ucrInputComboMeanDistribution.Name = "ucrInputComboMeanDistribution"
+        '
+        'ucrInputComboMethod
+        '
+        Me.ucrInputComboMethod.AddQuotesIfUnrecognised = True
+        Me.ucrInputComboMethod.IsReadOnly = False
+        resources.ApplyResources(Me.ucrInputComboMethod, "ucrInputComboMethod")
+        Me.ucrInputComboMethod.Name = "ucrInputComboMethod"
+        '
+        'ucrInputComboPenalty
+        '
+        Me.ucrInputComboPenalty.AddQuotesIfUnrecognised = True
+        Me.ucrInputComboPenalty.IsReadOnly = False
+        resources.ApplyResources(Me.ucrInputComboPenalty, "ucrInputComboPenalty")
+        Me.ucrInputComboPenalty.Name = "ucrInputComboPenalty"
+        '
+        'ucrPnlMethods
+        '
+        resources.ApplyResources(Me.ucrPnlMethods, "ucrPnlMethods")
+        Me.ucrPnlMethods.Name = "ucrPnlMethods"
+        '
+        'ucrReceiverElement
+        '
+        Me.ucrReceiverElement.frmParent = Me
+        resources.ApplyResources(Me.ucrReceiverElement, "ucrReceiverElement")
+        Me.ucrReceiverElement.Name = "ucrReceiverElement"
+        Me.ucrReceiverElement.Selector = Nothing
+        Me.ucrReceiverElement.strNcFilePath = ""
+        Me.ucrReceiverElement.ucrSelector = Nothing
+        '
+        'ucrSelectorHomogenization
+        '
+        Me.ucrSelectorHomogenization.bDropUnusedFilterLevels = False
+        Me.ucrSelectorHomogenization.bShowHiddenColumns = False
+        Me.ucrSelectorHomogenization.bUseCurrentFilter = True
+        resources.ApplyResources(Me.ucrSelectorHomogenization, "ucrSelectorHomogenization")
+        Me.ucrSelectorHomogenization.Name = "ucrSelectorHomogenization"
+        '
+        'ucrBase
+        '
+        resources.ApplyResources(Me.ucrBase, "ucrBase")
+        Me.ucrBase.Name = "ucrBase"
+        '
+        'ucrInputComboMeanVarDistribution
+        '
+        Me.ucrInputComboMeanVarDistribution.AddQuotesIfUnrecognised = True
+        Me.ucrInputComboMeanVarDistribution.IsReadOnly = False
+        resources.ApplyResources(Me.ucrInputComboMeanVarDistribution, "ucrInputComboMeanVarDistribution")
+        Me.ucrInputComboMeanVarDistribution.Name = "ucrInputComboMeanVarDistribution"
+        '
+        'ucrInputComboVarDistribution
+        '
+        Me.ucrInputComboVarDistribution.AddQuotesIfUnrecognised = True
+        Me.ucrInputComboVarDistribution.IsReadOnly = False
+        resources.ApplyResources(Me.ucrInputComboVarDistribution, "ucrInputComboVarDistribution")
+        Me.ucrInputComboVarDistribution.Name = "ucrInputComboVarDistribution"
         '
         'dlgHomogenization
         '
@@ -337,14 +355,14 @@ Partial Class dlgHomogenization
     Friend WithEvents grpMethods As GroupBox
     Friend WithEvents ucrPnlMethods As UcrPanel
     Friend WithEvents rdoCptMean As RadioButton
-    Friend WithEvents rdoMeanVariance As RadioButton
+    Friend WithEvents rdoCptMeanVariance As RadioButton
     Friend WithEvents rdoCptVariance As RadioButton
     Friend WithEvents grpOutputOptions As GroupBox
     Friend WithEvents ucrChkPlot As ucrCheck
     Friend WithEvents ucrChkSummary As ucrCheck
     Friend WithEvents ucrNudMinSegLen As ucrNud
     Friend WithEvents ucrInputQ As ucrInputTextBox
-    Friend WithEvents ucrInputComboDistribution As ucrInputComboBox
+    Friend WithEvents ucrInputComboMeanDistribution As ucrInputComboBox
     Friend WithEvents ucrInputComboMethod As ucrInputComboBox
     Friend WithEvents ucrInputComboPenalty As ucrInputComboBox
     Friend WithEvents lblPenalty As Label
@@ -362,4 +380,6 @@ Partial Class dlgHomogenization
     Friend WithEvents rdoNeighbouring As RadioButton
     Friend WithEvents lblNeighbouring As Label
     Friend WithEvents ucrReceiverNeighbour As ucrReceiverSingle
+    Friend WithEvents ucrInputComboVarDistribution As ucrInputComboBox
+    Friend WithEvents ucrInputComboMeanVarDistribution As ucrInputComboBox
 End Class

--- a/instat/dlgHomogenization.Designer.vb
+++ b/instat/dlgHomogenization.Designer.vb
@@ -22,41 +22,37 @@ Partial Class dlgHomogenization
     'Do not modify it using the code editor.
     <System.Diagnostics.DebuggerStepThrough()> _
     Private Sub InitializeComponent()
+        Me.components = New System.ComponentModel.Container()
         Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(dlgHomogenization))
-        Me.ucrBase = New instat.ucrButtons()
-        Me.ucrSelectorHomogenization = New instat.ucrSelectorByDataFrameAddRemove()
-        Me.ucrReceiverElement = New instat.ucrReceiverSingle()
         Me.lblElement = New System.Windows.Forms.Label()
         Me.grpMethods = New System.Windows.Forms.GroupBox()
-        Me.grpCptOptions = New System.Windows.Forms.GroupBox()
-        Me.ucrPnlMethods = New instat.UcrPanel()
-        Me.rdoCptVariance = New System.Windows.Forms.RadioButton()
-        Me.rdoMeanVariance = New System.Windows.Forms.RadioButton()
         Me.rdoCptMean = New System.Windows.Forms.RadioButton()
+        Me.rdoMeanVariance = New System.Windows.Forms.RadioButton()
+        Me.rdoCptVariance = New System.Windows.Forms.RadioButton()
+        Me.grpCptOptions = New System.Windows.Forms.GroupBox()
+        Me.lblMinSegLen = New System.Windows.Forms.Label()
+        Me.lblQ = New System.Windows.Forms.Label()
+        Me.lblPenalty = New System.Windows.Forms.Label()
+        Me.Label2 = New System.Windows.Forms.Label()
+        Me.lblDistribution = New System.Windows.Forms.Label()
+        Me.grpOutputOptions = New System.Windows.Forms.GroupBox()
+        Me.ucrSaveResult = New instat.ucrSave()
+        Me.ucrChkPlot = New instat.ucrCheck()
+        Me.ucrChkSummary = New instat.ucrCheck()
+        Me.ucrNudMinSegLen = New instat.ucrNud()
+        Me.ucrInputQ = New instat.ucrInputTextBox()
+        Me.ucrInputComboDistribution = New instat.ucrInputComboBox()
+        Me.ucrInputComboMethod = New instat.ucrInputComboBox()
+        Me.ucrInputComboPenalty = New instat.ucrInputComboBox()
+        Me.ucrPnlMethods = New instat.UcrPanel()
+        Me.ucrReceiverElement = New instat.ucrReceiverSingle()
+        Me.ucrSelectorHomogenization = New instat.ucrSelectorByDataFrameAddRemove()
+        Me.ucrBase = New instat.ucrButtons()
+        Me.ttQ = New System.Windows.Forms.ToolTip(Me.components)
         Me.grpMethods.SuspendLayout()
+        Me.grpCptOptions.SuspendLayout()
+        Me.grpOutputOptions.SuspendLayout()
         Me.SuspendLayout()
-        '
-        'ucrBase
-        '
-        resources.ApplyResources(Me.ucrBase, "ucrBase")
-        Me.ucrBase.Name = "ucrBase"
-        '
-        'ucrSelectorHomogenization
-        '
-        Me.ucrSelectorHomogenization.bDropUnusedFilterLevels = False
-        Me.ucrSelectorHomogenization.bShowHiddenColumns = False
-        Me.ucrSelectorHomogenization.bUseCurrentFilter = True
-        resources.ApplyResources(Me.ucrSelectorHomogenization, "ucrSelectorHomogenization")
-        Me.ucrSelectorHomogenization.Name = "ucrSelectorHomogenization"
-        '
-        'ucrReceiverElement
-        '
-        Me.ucrReceiverElement.frmParent = Me
-        resources.ApplyResources(Me.ucrReceiverElement, "ucrReceiverElement")
-        Me.ucrReceiverElement.Name = "ucrReceiverElement"
-        Me.ucrReceiverElement.Selector = Nothing
-        Me.ucrReceiverElement.strNcFilePath = ""
-        Me.ucrReceiverElement.ucrSelector = Nothing
         '
         'lblElement
         '
@@ -73,22 +69,11 @@ Partial Class dlgHomogenization
         Me.grpMethods.Name = "grpMethods"
         Me.grpMethods.TabStop = False
         '
-        'grpCptOptions
+        'rdoCptMean
         '
-        resources.ApplyResources(Me.grpCptOptions, "grpCptOptions")
-        Me.grpCptOptions.Name = "grpCptOptions"
-        Me.grpCptOptions.TabStop = False
-        '
-        'ucrPnlMethods
-        '
-        resources.ApplyResources(Me.ucrPnlMethods, "ucrPnlMethods")
-        Me.ucrPnlMethods.Name = "ucrPnlMethods"
-        '
-        'rdoCptVariance
-        '
-        resources.ApplyResources(Me.rdoCptVariance, "rdoCptVariance")
-        Me.rdoCptVariance.Name = "rdoCptVariance"
-        Me.rdoCptVariance.UseVisualStyleBackColor = True
+        resources.ApplyResources(Me.rdoCptMean, "rdoCptMean")
+        Me.rdoCptMean.Name = "rdoCptMean"
+        Me.rdoCptMean.UseVisualStyleBackColor = True
         '
         'rdoMeanVariance
         '
@@ -96,16 +81,150 @@ Partial Class dlgHomogenization
         Me.rdoMeanVariance.Name = "rdoMeanVariance"
         Me.rdoMeanVariance.UseVisualStyleBackColor = True
         '
-        'rdoCptMean
+        'rdoCptVariance
         '
-        resources.ApplyResources(Me.rdoCptMean, "rdoCptMean")
-        Me.rdoCptMean.Name = "rdoCptMean"
-        Me.rdoCptMean.UseVisualStyleBackColor = True
+        resources.ApplyResources(Me.rdoCptVariance, "rdoCptVariance")
+        Me.rdoCptVariance.Name = "rdoCptVariance"
+        Me.rdoCptVariance.UseVisualStyleBackColor = True
+        '
+        'grpCptOptions
+        '
+        Me.grpCptOptions.Controls.Add(Me.lblMinSegLen)
+        Me.grpCptOptions.Controls.Add(Me.lblQ)
+        Me.grpCptOptions.Controls.Add(Me.lblPenalty)
+        Me.grpCptOptions.Controls.Add(Me.Label2)
+        Me.grpCptOptions.Controls.Add(Me.lblDistribution)
+        Me.grpCptOptions.Controls.Add(Me.ucrNudMinSegLen)
+        Me.grpCptOptions.Controls.Add(Me.ucrInputQ)
+        Me.grpCptOptions.Controls.Add(Me.ucrInputComboDistribution)
+        Me.grpCptOptions.Controls.Add(Me.ucrInputComboMethod)
+        Me.grpCptOptions.Controls.Add(Me.ucrInputComboPenalty)
+        resources.ApplyResources(Me.grpCptOptions, "grpCptOptions")
+        Me.grpCptOptions.Name = "grpCptOptions"
+        Me.grpCptOptions.TabStop = False
+        '
+        'lblMinSegLen
+        '
+        resources.ApplyResources(Me.lblMinSegLen, "lblMinSegLen")
+        Me.lblMinSegLen.Name = "lblMinSegLen"
+        '
+        'lblQ
+        '
+        resources.ApplyResources(Me.lblQ, "lblQ")
+        Me.lblQ.Name = "lblQ"
+        '
+        'lblPenalty
+        '
+        resources.ApplyResources(Me.lblPenalty, "lblPenalty")
+        Me.lblPenalty.Name = "lblPenalty"
+        '
+        'Label2
+        '
+        resources.ApplyResources(Me.Label2, "Label2")
+        Me.Label2.Name = "Label2"
+        '
+        'lblDistribution
+        '
+        resources.ApplyResources(Me.lblDistribution, "lblDistribution")
+        Me.lblDistribution.Name = "lblDistribution"
+        '
+        'grpOutputOptions
+        '
+        Me.grpOutputOptions.Controls.Add(Me.ucrChkPlot)
+        Me.grpOutputOptions.Controls.Add(Me.ucrChkSummary)
+        resources.ApplyResources(Me.grpOutputOptions, "grpOutputOptions")
+        Me.grpOutputOptions.Name = "grpOutputOptions"
+        Me.grpOutputOptions.TabStop = False
+        '
+        'ucrSaveResult
+        '
+        resources.ApplyResources(Me.ucrSaveResult, "ucrSaveResult")
+        Me.ucrSaveResult.Name = "ucrSaveResult"
+        '
+        'ucrChkPlot
+        '
+        Me.ucrChkPlot.Checked = False
+        resources.ApplyResources(Me.ucrChkPlot, "ucrChkPlot")
+        Me.ucrChkPlot.Name = "ucrChkPlot"
+        '
+        'ucrChkSummary
+        '
+        Me.ucrChkSummary.Checked = False
+        resources.ApplyResources(Me.ucrChkSummary, "ucrChkSummary")
+        Me.ucrChkSummary.Name = "ucrChkSummary"
+        '
+        'ucrNudMinSegLen
+        '
+        Me.ucrNudMinSegLen.DecimalPlaces = New Decimal(New Integer() {0, 0, 0, 0})
+        Me.ucrNudMinSegLen.Increment = New Decimal(New Integer() {1, 0, 0, 0})
+        resources.ApplyResources(Me.ucrNudMinSegLen, "ucrNudMinSegLen")
+        Me.ucrNudMinSegLen.Maximum = New Decimal(New Integer() {100, 0, 0, 0})
+        Me.ucrNudMinSegLen.Minimum = New Decimal(New Integer() {0, 0, 0, 0})
+        Me.ucrNudMinSegLen.Name = "ucrNudMinSegLen"
+        Me.ucrNudMinSegLen.Value = New Decimal(New Integer() {0, 0, 0, 0})
+        '
+        'ucrInputQ
+        '
+        Me.ucrInputQ.AddQuotesIfUnrecognised = True
+        Me.ucrInputQ.IsMultiline = False
+        Me.ucrInputQ.IsReadOnly = False
+        resources.ApplyResources(Me.ucrInputQ, "ucrInputQ")
+        Me.ucrInputQ.Name = "ucrInputQ"
+        '
+        'ucrInputComboDistribution
+        '
+        Me.ucrInputComboDistribution.AddQuotesIfUnrecognised = True
+        Me.ucrInputComboDistribution.IsReadOnly = False
+        resources.ApplyResources(Me.ucrInputComboDistribution, "ucrInputComboDistribution")
+        Me.ucrInputComboDistribution.Name = "ucrInputComboDistribution"
+        '
+        'ucrInputComboMethod
+        '
+        Me.ucrInputComboMethod.AddQuotesIfUnrecognised = True
+        Me.ucrInputComboMethod.IsReadOnly = False
+        resources.ApplyResources(Me.ucrInputComboMethod, "ucrInputComboMethod")
+        Me.ucrInputComboMethod.Name = "ucrInputComboMethod"
+        '
+        'ucrInputComboPenalty
+        '
+        Me.ucrInputComboPenalty.AddQuotesIfUnrecognised = True
+        Me.ucrInputComboPenalty.IsReadOnly = False
+        resources.ApplyResources(Me.ucrInputComboPenalty, "ucrInputComboPenalty")
+        Me.ucrInputComboPenalty.Name = "ucrInputComboPenalty"
+        '
+        'ucrPnlMethods
+        '
+        resources.ApplyResources(Me.ucrPnlMethods, "ucrPnlMethods")
+        Me.ucrPnlMethods.Name = "ucrPnlMethods"
+        '
+        'ucrReceiverElement
+        '
+        Me.ucrReceiverElement.frmParent = Me
+        resources.ApplyResources(Me.ucrReceiverElement, "ucrReceiverElement")
+        Me.ucrReceiverElement.Name = "ucrReceiverElement"
+        Me.ucrReceiverElement.Selector = Nothing
+        Me.ucrReceiverElement.strNcFilePath = ""
+        Me.ucrReceiverElement.ucrSelector = Nothing
+        '
+        'ucrSelectorHomogenization
+        '
+        Me.ucrSelectorHomogenization.bDropUnusedFilterLevels = False
+        Me.ucrSelectorHomogenization.bShowHiddenColumns = False
+        Me.ucrSelectorHomogenization.bUseCurrentFilter = True
+        resources.ApplyResources(Me.ucrSelectorHomogenization, "ucrSelectorHomogenization")
+        Me.ucrSelectorHomogenization.Name = "ucrSelectorHomogenization"
+        '
+        'ucrBase
+        '
+        resources.ApplyResources(Me.ucrBase, "ucrBase")
+        Me.ucrBase.Name = "ucrBase"
         '
         'dlgHomogenization
         '
         resources.ApplyResources(Me, "$this")
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.Controls.Add(Me.ucrSaveResult)
+        Me.Controls.Add(Me.grpOutputOptions)
         Me.Controls.Add(Me.grpCptOptions)
         Me.Controls.Add(Me.grpMethods)
         Me.Controls.Add(Me.lblElement)
@@ -118,6 +237,9 @@ Partial Class dlgHomogenization
         Me.Name = "dlgHomogenization"
         Me.grpMethods.ResumeLayout(False)
         Me.grpMethods.PerformLayout()
+        Me.grpCptOptions.ResumeLayout(False)
+        Me.grpCptOptions.PerformLayout()
+        Me.grpOutputOptions.ResumeLayout(False)
         Me.ResumeLayout(False)
         Me.PerformLayout()
 
@@ -133,4 +255,19 @@ Partial Class dlgHomogenization
     Friend WithEvents rdoCptMean As RadioButton
     Friend WithEvents rdoMeanVariance As RadioButton
     Friend WithEvents rdoCptVariance As RadioButton
+    Friend WithEvents grpOutputOptions As GroupBox
+    Friend WithEvents ucrChkPlot As ucrCheck
+    Friend WithEvents ucrChkSummary As ucrCheck
+    Friend WithEvents ucrNudMinSegLen As ucrNud
+    Friend WithEvents ucrInputQ As ucrInputTextBox
+    Friend WithEvents ucrInputComboDistribution As ucrInputComboBox
+    Friend WithEvents ucrInputComboMethod As ucrInputComboBox
+    Friend WithEvents ucrInputComboPenalty As ucrInputComboBox
+    Friend WithEvents lblPenalty As Label
+    Friend WithEvents Label2 As Label
+    Friend WithEvents lblDistribution As Label
+    Friend WithEvents lblMinSegLen As Label
+    Friend WithEvents lblQ As Label
+    Friend WithEvents ucrSaveResult As ucrSave
+    Friend WithEvents ttQ As ToolTip
 End Class

--- a/instat/dlgHomogenization.Designer.vb
+++ b/instat/dlgHomogenization.Designer.vb
@@ -36,9 +36,12 @@ Partial Class dlgHomogenization
         Me.Label2 = New System.Windows.Forms.Label()
         Me.lblDistribution = New System.Windows.Forms.Label()
         Me.grpOutputOptions = New System.Windows.Forms.GroupBox()
+        Me.ttOptions = New System.Windows.Forms.ToolTip(Me.components)
+        Me.lblPenaltyValue = New System.Windows.Forms.Label()
         Me.ucrSaveResult = New instat.ucrSave()
         Me.ucrChkPlot = New instat.ucrCheck()
         Me.ucrChkSummary = New instat.ucrCheck()
+        Me.ucrInputPenValue = New instat.ucrInputTextBox()
         Me.ucrNudMinSegLen = New instat.ucrNud()
         Me.ucrInputQ = New instat.ucrInputTextBox()
         Me.ucrInputComboDistribution = New instat.ucrInputComboBox()
@@ -48,7 +51,9 @@ Partial Class dlgHomogenization
         Me.ucrReceiverElement = New instat.ucrReceiverSingle()
         Me.ucrSelectorHomogenization = New instat.ucrSelectorByDataFrameAddRemove()
         Me.ucrBase = New instat.ucrButtons()
-        Me.ttQ = New System.Windows.Forms.ToolTip(Me.components)
+        Me.rdoSingle = New System.Windows.Forms.RadioButton()
+        Me.rdoMultiple = New System.Windows.Forms.RadioButton()
+        Me.ucrPnlOptions = New instat.UcrPanel()
         Me.grpMethods.SuspendLayout()
         Me.grpCptOptions.SuspendLayout()
         Me.grpOutputOptions.SuspendLayout()
@@ -89,6 +94,8 @@ Partial Class dlgHomogenization
         '
         'grpCptOptions
         '
+        Me.grpCptOptions.Controls.Add(Me.lblPenaltyValue)
+        Me.grpCptOptions.Controls.Add(Me.ucrInputPenValue)
         Me.grpCptOptions.Controls.Add(Me.lblMinSegLen)
         Me.grpCptOptions.Controls.Add(Me.lblQ)
         Me.grpCptOptions.Controls.Add(Me.lblPenalty)
@@ -136,6 +143,11 @@ Partial Class dlgHomogenization
         Me.grpOutputOptions.Name = "grpOutputOptions"
         Me.grpOutputOptions.TabStop = False
         '
+        'lblPenaltyValue
+        '
+        resources.ApplyResources(Me.lblPenaltyValue, "lblPenaltyValue")
+        Me.lblPenaltyValue.Name = "lblPenaltyValue"
+        '
         'ucrSaveResult
         '
         resources.ApplyResources(Me.ucrSaveResult, "ucrSaveResult")
@@ -152,6 +164,14 @@ Partial Class dlgHomogenization
         Me.ucrChkSummary.Checked = False
         resources.ApplyResources(Me.ucrChkSummary, "ucrChkSummary")
         Me.ucrChkSummary.Name = "ucrChkSummary"
+        '
+        'ucrInputPenValue
+        '
+        Me.ucrInputPenValue.AddQuotesIfUnrecognised = True
+        Me.ucrInputPenValue.IsMultiline = False
+        Me.ucrInputPenValue.IsReadOnly = False
+        resources.ApplyResources(Me.ucrInputPenValue, "ucrInputPenValue")
+        Me.ucrInputPenValue.Name = "ucrInputPenValue"
         '
         'ucrNudMinSegLen
         '
@@ -219,10 +239,42 @@ Partial Class dlgHomogenization
         resources.ApplyResources(Me.ucrBase, "ucrBase")
         Me.ucrBase.Name = "ucrBase"
         '
+        'rdoSingle
+        '
+        resources.ApplyResources(Me.rdoSingle, "rdoSingle")
+        Me.rdoSingle.BackColor = System.Drawing.SystemColors.Control
+        Me.rdoSingle.FlatAppearance.BorderColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoSingle.FlatAppearance.BorderSize = 2
+        Me.rdoSingle.FlatAppearance.CheckedBackColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoSingle.Name = "rdoSingle"
+        Me.rdoSingle.TabStop = True
+        Me.rdoSingle.Tag = ""
+        Me.rdoSingle.UseVisualStyleBackColor = False
+        '
+        'rdoMultiple
+        '
+        resources.ApplyResources(Me.rdoMultiple, "rdoMultiple")
+        Me.rdoMultiple.BackColor = System.Drawing.SystemColors.Control
+        Me.rdoMultiple.FlatAppearance.BorderColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoMultiple.FlatAppearance.BorderSize = 2
+        Me.rdoMultiple.FlatAppearance.CheckedBackColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoMultiple.Name = "rdoMultiple"
+        Me.rdoMultiple.TabStop = True
+        Me.rdoMultiple.Tag = ""
+        Me.rdoMultiple.UseVisualStyleBackColor = False
+        '
+        'ucrPnlOptions
+        '
+        resources.ApplyResources(Me.ucrPnlOptions, "ucrPnlOptions")
+        Me.ucrPnlOptions.Name = "ucrPnlOptions"
+        '
         'dlgHomogenization
         '
         resources.ApplyResources(Me, "$this")
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.Controls.Add(Me.rdoSingle)
+        Me.Controls.Add(Me.rdoMultiple)
+        Me.Controls.Add(Me.ucrPnlOptions)
         Me.Controls.Add(Me.ucrSaveResult)
         Me.Controls.Add(Me.grpOutputOptions)
         Me.Controls.Add(Me.grpCptOptions)
@@ -269,5 +321,10 @@ Partial Class dlgHomogenization
     Friend WithEvents lblMinSegLen As Label
     Friend WithEvents lblQ As Label
     Friend WithEvents ucrSaveResult As ucrSave
-    Friend WithEvents ttQ As ToolTip
+    Friend WithEvents ttOptions As ToolTip
+    Friend WithEvents lblPenaltyValue As Label
+    Friend WithEvents ucrInputPenValue As ucrInputTextBox
+    Friend WithEvents rdoSingle As RadioButton
+    Friend WithEvents rdoMultiple As RadioButton
+    Friend WithEvents ucrPnlOptions As UcrPanel
 End Class

--- a/instat/dlgHomogenization.Designer.vb
+++ b/instat/dlgHomogenization.Designer.vb
@@ -42,11 +42,19 @@ Partial Class dlgHomogenization
         Me.rdoMultiple = New System.Windows.Forms.RadioButton()
         Me.rdoNeighbouring = New System.Windows.Forms.RadioButton()
         Me.lblNeighbouring = New System.Windows.Forms.Label()
+        Me.rdoSnht = New System.Windows.Forms.RadioButton()
+        Me.grpSnhtOptions = New System.Windows.Forms.GroupBox()
+        Me.lblPeriod = New System.Windows.Forms.Label()
+        Me.ucrNudPeriod = New instat.ucrNud()
+        Me.ucrChkRobust = New instat.ucrCheck()
+        Me.ucrChkScaled = New instat.ucrCheck()
         Me.ucrReceiverNeighbour = New instat.ucrReceiverSingle()
         Me.ucrPnlOptions = New instat.UcrPanel()
         Me.ucrSaveResult = New instat.ucrSave()
         Me.ucrChkPlot = New instat.ucrCheck()
         Me.ucrChkSummary = New instat.ucrCheck()
+        Me.ucrInputComboMeanVarDistribution = New instat.ucrInputComboBox()
+        Me.ucrInputComboVarDistribution = New instat.ucrInputComboBox()
         Me.ucrInputPenValue = New instat.ucrInputTextBox()
         Me.ucrNudMinSegLen = New instat.ucrNud()
         Me.ucrInputQ = New instat.ucrInputTextBox()
@@ -57,11 +65,10 @@ Partial Class dlgHomogenization
         Me.ucrReceiverElement = New instat.ucrReceiverSingle()
         Me.ucrSelectorHomogenization = New instat.ucrSelectorByDataFrameAddRemove()
         Me.ucrBase = New instat.ucrButtons()
-        Me.ucrInputComboMeanVarDistribution = New instat.ucrInputComboBox()
-        Me.ucrInputComboVarDistribution = New instat.ucrInputComboBox()
         Me.grpMethods.SuspendLayout()
         Me.grpCptOptions.SuspendLayout()
         Me.grpOutputOptions.SuspendLayout()
+        Me.grpSnhtOptions.SuspendLayout()
         Me.SuspendLayout()
         '
         'lblElement
@@ -71,6 +78,7 @@ Partial Class dlgHomogenization
         '
         'grpMethods
         '
+        Me.grpMethods.Controls.Add(Me.rdoSnht)
         Me.grpMethods.Controls.Add(Me.rdoCptMean)
         Me.grpMethods.Controls.Add(Me.rdoCptMeanVariance)
         Me.grpMethods.Controls.Add(Me.rdoCptVariance)
@@ -196,6 +204,49 @@ Partial Class dlgHomogenization
         resources.ApplyResources(Me.lblNeighbouring, "lblNeighbouring")
         Me.lblNeighbouring.Name = "lblNeighbouring"
         '
+        'rdoSnht
+        '
+        resources.ApplyResources(Me.rdoSnht, "rdoSnht")
+        Me.rdoSnht.Name = "rdoSnht"
+        Me.rdoSnht.UseVisualStyleBackColor = True
+        '
+        'grpSnhtOptions
+        '
+        Me.grpSnhtOptions.Controls.Add(Me.lblPeriod)
+        Me.grpSnhtOptions.Controls.Add(Me.ucrNudPeriod)
+        Me.grpSnhtOptions.Controls.Add(Me.ucrChkRobust)
+        Me.grpSnhtOptions.Controls.Add(Me.ucrChkScaled)
+        resources.ApplyResources(Me.grpSnhtOptions, "grpSnhtOptions")
+        Me.grpSnhtOptions.Name = "grpSnhtOptions"
+        Me.grpSnhtOptions.TabStop = False
+        '
+        'lblPeriod
+        '
+        resources.ApplyResources(Me.lblPeriod, "lblPeriod")
+        Me.lblPeriod.Name = "lblPeriod"
+        '
+        'ucrNudPeriod
+        '
+        Me.ucrNudPeriod.DecimalPlaces = New Decimal(New Integer() {0, 0, 0, 0})
+        Me.ucrNudPeriod.Increment = New Decimal(New Integer() {1, 0, 0, 0})
+        resources.ApplyResources(Me.ucrNudPeriod, "ucrNudPeriod")
+        Me.ucrNudPeriod.Maximum = New Decimal(New Integer() {100, 0, 0, 0})
+        Me.ucrNudPeriod.Minimum = New Decimal(New Integer() {0, 0, 0, 0})
+        Me.ucrNudPeriod.Name = "ucrNudPeriod"
+        Me.ucrNudPeriod.Value = New Decimal(New Integer() {0, 0, 0, 0})
+        '
+        'ucrChkRobust
+        '
+        Me.ucrChkRobust.Checked = False
+        resources.ApplyResources(Me.ucrChkRobust, "ucrChkRobust")
+        Me.ucrChkRobust.Name = "ucrChkRobust"
+        '
+        'ucrChkScaled
+        '
+        Me.ucrChkScaled.Checked = False
+        resources.ApplyResources(Me.ucrChkScaled, "ucrChkScaled")
+        Me.ucrChkScaled.Name = "ucrChkScaled"
+        '
         'ucrReceiverNeighbour
         '
         Me.ucrReceiverNeighbour.frmParent = Me
@@ -226,6 +277,20 @@ Partial Class dlgHomogenization
         Me.ucrChkSummary.Checked = False
         resources.ApplyResources(Me.ucrChkSummary, "ucrChkSummary")
         Me.ucrChkSummary.Name = "ucrChkSummary"
+        '
+        'ucrInputComboMeanVarDistribution
+        '
+        Me.ucrInputComboMeanVarDistribution.AddQuotesIfUnrecognised = True
+        Me.ucrInputComboMeanVarDistribution.IsReadOnly = False
+        resources.ApplyResources(Me.ucrInputComboMeanVarDistribution, "ucrInputComboMeanVarDistribution")
+        Me.ucrInputComboMeanVarDistribution.Name = "ucrInputComboMeanVarDistribution"
+        '
+        'ucrInputComboVarDistribution
+        '
+        Me.ucrInputComboVarDistribution.AddQuotesIfUnrecognised = True
+        Me.ucrInputComboVarDistribution.IsReadOnly = False
+        resources.ApplyResources(Me.ucrInputComboVarDistribution, "ucrInputComboVarDistribution")
+        Me.ucrInputComboVarDistribution.Name = "ucrInputComboVarDistribution"
         '
         'ucrInputPenValue
         '
@@ -301,24 +366,11 @@ Partial Class dlgHomogenization
         resources.ApplyResources(Me.ucrBase, "ucrBase")
         Me.ucrBase.Name = "ucrBase"
         '
-        'ucrInputComboMeanVarDistribution
-        '
-        Me.ucrInputComboMeanVarDistribution.AddQuotesIfUnrecognised = True
-        Me.ucrInputComboMeanVarDistribution.IsReadOnly = False
-        resources.ApplyResources(Me.ucrInputComboMeanVarDistribution, "ucrInputComboMeanVarDistribution")
-        Me.ucrInputComboMeanVarDistribution.Name = "ucrInputComboMeanVarDistribution"
-        '
-        'ucrInputComboVarDistribution
-        '
-        Me.ucrInputComboVarDistribution.AddQuotesIfUnrecognised = True
-        Me.ucrInputComboVarDistribution.IsReadOnly = False
-        resources.ApplyResources(Me.ucrInputComboVarDistribution, "ucrInputComboVarDistribution")
-        Me.ucrInputComboVarDistribution.Name = "ucrInputComboVarDistribution"
-        '
         'dlgHomogenization
         '
         resources.ApplyResources(Me, "$this")
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.Controls.Add(Me.grpSnhtOptions)
         Me.Controls.Add(Me.lblNeighbouring)
         Me.Controls.Add(Me.ucrReceiverNeighbour)
         Me.Controls.Add(Me.rdoNeighbouring)
@@ -342,6 +394,8 @@ Partial Class dlgHomogenization
         Me.grpCptOptions.ResumeLayout(False)
         Me.grpCptOptions.PerformLayout()
         Me.grpOutputOptions.ResumeLayout(False)
+        Me.grpSnhtOptions.ResumeLayout(False)
+        Me.grpSnhtOptions.PerformLayout()
         Me.ResumeLayout(False)
         Me.PerformLayout()
 
@@ -382,4 +436,10 @@ Partial Class dlgHomogenization
     Friend WithEvents ucrReceiverNeighbour As ucrReceiverSingle
     Friend WithEvents ucrInputComboVarDistribution As ucrInputComboBox
     Friend WithEvents ucrInputComboMeanVarDistribution As ucrInputComboBox
+    Friend WithEvents rdoSnht As RadioButton
+    Friend WithEvents grpSnhtOptions As GroupBox
+    Friend WithEvents lblPeriod As Label
+    Friend WithEvents ucrNudPeriod As ucrNud
+    Friend WithEvents ucrChkRobust As ucrCheck
+    Friend WithEvents ucrChkScaled As ucrCheck
 End Class

--- a/instat/dlgHomogenization.Designer.vb
+++ b/instat/dlgHomogenization.Designer.vb
@@ -26,23 +26,35 @@ Partial Class dlgHomogenization
         Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(dlgHomogenization))
         Me.lblElement = New System.Windows.Forms.Label()
         Me.grpMethods = New System.Windows.Forms.GroupBox()
+        Me.rdoPettitt = New System.Windows.Forms.RadioButton()
+        Me.rdoSnht = New System.Windows.Forms.RadioButton()
         Me.rdoCptMean = New System.Windows.Forms.RadioButton()
         Me.rdoCptMeanVariance = New System.Windows.Forms.RadioButton()
         Me.rdoCptVariance = New System.Windows.Forms.RadioButton()
+        Me.ucrPnlMethods = New instat.UcrPanel()
         Me.grpCptOptions = New System.Windows.Forms.GroupBox()
+        Me.ucrInputComboMeanVarDistribution = New instat.ucrInputComboBox()
+        Me.ucrInputComboVarDistribution = New instat.ucrInputComboBox()
         Me.lblPenaltyValue = New System.Windows.Forms.Label()
+        Me.ucrInputPenValue = New instat.ucrInputTextBox()
         Me.lblMinSegLen = New System.Windows.Forms.Label()
         Me.lblQ = New System.Windows.Forms.Label()
         Me.lblPenalty = New System.Windows.Forms.Label()
         Me.Label2 = New System.Windows.Forms.Label()
         Me.lblDistribution = New System.Windows.Forms.Label()
+        Me.ucrNudMinSegLen = New instat.ucrNud()
+        Me.ucrInputQ = New instat.ucrInputTextBox()
+        Me.ucrInputComboMeanDistribution = New instat.ucrInputComboBox()
+        Me.ucrInputComboMethod = New instat.ucrInputComboBox()
+        Me.ucrInputComboPenalty = New instat.ucrInputComboBox()
         Me.grpOutputOptions = New System.Windows.Forms.GroupBox()
+        Me.ucrChkPlot = New instat.ucrCheck()
+        Me.ucrChkSummary = New instat.ucrCheck()
         Me.ttOptions = New System.Windows.Forms.ToolTip(Me.components)
         Me.rdoSingle = New System.Windows.Forms.RadioButton()
         Me.rdoMultiple = New System.Windows.Forms.RadioButton()
         Me.rdoNeighbouring = New System.Windows.Forms.RadioButton()
         Me.lblNeighbouring = New System.Windows.Forms.Label()
-        Me.rdoSnht = New System.Windows.Forms.RadioButton()
         Me.grpSnhtOptions = New System.Windows.Forms.GroupBox()
         Me.lblPeriod = New System.Windows.Forms.Label()
         Me.ucrNudPeriod = New instat.ucrNud()
@@ -51,21 +63,10 @@ Partial Class dlgHomogenization
         Me.ucrReceiverNeighbour = New instat.ucrReceiverSingle()
         Me.ucrPnlOptions = New instat.UcrPanel()
         Me.ucrSaveResult = New instat.ucrSave()
-        Me.ucrChkPlot = New instat.ucrCheck()
-        Me.ucrChkSummary = New instat.ucrCheck()
-        Me.ucrInputComboMeanVarDistribution = New instat.ucrInputComboBox()
-        Me.ucrInputComboVarDistribution = New instat.ucrInputComboBox()
-        Me.ucrInputPenValue = New instat.ucrInputTextBox()
-        Me.ucrNudMinSegLen = New instat.ucrNud()
-        Me.ucrInputQ = New instat.ucrInputTextBox()
-        Me.ucrInputComboMeanDistribution = New instat.ucrInputComboBox()
-        Me.ucrInputComboMethod = New instat.ucrInputComboBox()
-        Me.ucrInputComboPenalty = New instat.ucrInputComboBox()
-        Me.ucrPnlMethods = New instat.UcrPanel()
         Me.ucrReceiverElement = New instat.ucrReceiverSingle()
         Me.ucrSelectorHomogenization = New instat.ucrSelectorByDataFrameAddRemove()
         Me.ucrBase = New instat.ucrButtons()
-        Me.rdoPettitt = New System.Windows.Forms.RadioButton()
+        Me.rdoBuishand = New System.Windows.Forms.RadioButton()
         Me.grpMethods.SuspendLayout()
         Me.grpCptOptions.SuspendLayout()
         Me.grpOutputOptions.SuspendLayout()
@@ -79,6 +80,7 @@ Partial Class dlgHomogenization
         '
         'grpMethods
         '
+        Me.grpMethods.Controls.Add(Me.rdoBuishand)
         Me.grpMethods.Controls.Add(Me.rdoPettitt)
         Me.grpMethods.Controls.Add(Me.rdoSnht)
         Me.grpMethods.Controls.Add(Me.rdoCptMean)
@@ -88,6 +90,18 @@ Partial Class dlgHomogenization
         resources.ApplyResources(Me.grpMethods, "grpMethods")
         Me.grpMethods.Name = "grpMethods"
         Me.grpMethods.TabStop = False
+        '
+        'rdoPettitt
+        '
+        resources.ApplyResources(Me.rdoPettitt, "rdoPettitt")
+        Me.rdoPettitt.Name = "rdoPettitt"
+        Me.rdoPettitt.UseVisualStyleBackColor = True
+        '
+        'rdoSnht
+        '
+        resources.ApplyResources(Me.rdoSnht, "rdoSnht")
+        Me.rdoSnht.Name = "rdoSnht"
+        Me.rdoSnht.UseVisualStyleBackColor = True
         '
         'rdoCptMean
         '
@@ -106,6 +120,11 @@ Partial Class dlgHomogenization
         resources.ApplyResources(Me.rdoCptVariance, "rdoCptVariance")
         Me.rdoCptVariance.Name = "rdoCptVariance"
         Me.rdoCptVariance.UseVisualStyleBackColor = True
+        '
+        'ucrPnlMethods
+        '
+        resources.ApplyResources(Me.ucrPnlMethods, "ucrPnlMethods")
+        Me.ucrPnlMethods.Name = "ucrPnlMethods"
         '
         'grpCptOptions
         '
@@ -127,10 +146,32 @@ Partial Class dlgHomogenization
         Me.grpCptOptions.Name = "grpCptOptions"
         Me.grpCptOptions.TabStop = False
         '
+        'ucrInputComboMeanVarDistribution
+        '
+        Me.ucrInputComboMeanVarDistribution.AddQuotesIfUnrecognised = True
+        Me.ucrInputComboMeanVarDistribution.IsReadOnly = False
+        resources.ApplyResources(Me.ucrInputComboMeanVarDistribution, "ucrInputComboMeanVarDistribution")
+        Me.ucrInputComboMeanVarDistribution.Name = "ucrInputComboMeanVarDistribution"
+        '
+        'ucrInputComboVarDistribution
+        '
+        Me.ucrInputComboVarDistribution.AddQuotesIfUnrecognised = True
+        Me.ucrInputComboVarDistribution.IsReadOnly = False
+        resources.ApplyResources(Me.ucrInputComboVarDistribution, "ucrInputComboVarDistribution")
+        Me.ucrInputComboVarDistribution.Name = "ucrInputComboVarDistribution"
+        '
         'lblPenaltyValue
         '
         resources.ApplyResources(Me.lblPenaltyValue, "lblPenaltyValue")
         Me.lblPenaltyValue.Name = "lblPenaltyValue"
+        '
+        'ucrInputPenValue
+        '
+        Me.ucrInputPenValue.AddQuotesIfUnrecognised = True
+        Me.ucrInputPenValue.IsMultiline = False
+        Me.ucrInputPenValue.IsReadOnly = False
+        resources.ApplyResources(Me.ucrInputPenValue, "ucrInputPenValue")
+        Me.ucrInputPenValue.Name = "ucrInputPenValue"
         '
         'lblMinSegLen
         '
@@ -157,6 +198,45 @@ Partial Class dlgHomogenization
         resources.ApplyResources(Me.lblDistribution, "lblDistribution")
         Me.lblDistribution.Name = "lblDistribution"
         '
+        'ucrNudMinSegLen
+        '
+        Me.ucrNudMinSegLen.DecimalPlaces = New Decimal(New Integer() {0, 0, 0, 0})
+        Me.ucrNudMinSegLen.Increment = New Decimal(New Integer() {1, 0, 0, 0})
+        resources.ApplyResources(Me.ucrNudMinSegLen, "ucrNudMinSegLen")
+        Me.ucrNudMinSegLen.Maximum = New Decimal(New Integer() {100, 0, 0, 0})
+        Me.ucrNudMinSegLen.Minimum = New Decimal(New Integer() {0, 0, 0, 0})
+        Me.ucrNudMinSegLen.Name = "ucrNudMinSegLen"
+        Me.ucrNudMinSegLen.Value = New Decimal(New Integer() {0, 0, 0, 0})
+        '
+        'ucrInputQ
+        '
+        Me.ucrInputQ.AddQuotesIfUnrecognised = True
+        Me.ucrInputQ.IsMultiline = False
+        Me.ucrInputQ.IsReadOnly = False
+        resources.ApplyResources(Me.ucrInputQ, "ucrInputQ")
+        Me.ucrInputQ.Name = "ucrInputQ"
+        '
+        'ucrInputComboMeanDistribution
+        '
+        Me.ucrInputComboMeanDistribution.AddQuotesIfUnrecognised = True
+        Me.ucrInputComboMeanDistribution.IsReadOnly = False
+        resources.ApplyResources(Me.ucrInputComboMeanDistribution, "ucrInputComboMeanDistribution")
+        Me.ucrInputComboMeanDistribution.Name = "ucrInputComboMeanDistribution"
+        '
+        'ucrInputComboMethod
+        '
+        Me.ucrInputComboMethod.AddQuotesIfUnrecognised = True
+        Me.ucrInputComboMethod.IsReadOnly = False
+        resources.ApplyResources(Me.ucrInputComboMethod, "ucrInputComboMethod")
+        Me.ucrInputComboMethod.Name = "ucrInputComboMethod"
+        '
+        'ucrInputComboPenalty
+        '
+        Me.ucrInputComboPenalty.AddQuotesIfUnrecognised = True
+        Me.ucrInputComboPenalty.IsReadOnly = False
+        resources.ApplyResources(Me.ucrInputComboPenalty, "ucrInputComboPenalty")
+        Me.ucrInputComboPenalty.Name = "ucrInputComboPenalty"
+        '
         'grpOutputOptions
         '
         Me.grpOutputOptions.Controls.Add(Me.ucrChkPlot)
@@ -164,6 +244,18 @@ Partial Class dlgHomogenization
         resources.ApplyResources(Me.grpOutputOptions, "grpOutputOptions")
         Me.grpOutputOptions.Name = "grpOutputOptions"
         Me.grpOutputOptions.TabStop = False
+        '
+        'ucrChkPlot
+        '
+        Me.ucrChkPlot.Checked = False
+        resources.ApplyResources(Me.ucrChkPlot, "ucrChkPlot")
+        Me.ucrChkPlot.Name = "ucrChkPlot"
+        '
+        'ucrChkSummary
+        '
+        Me.ucrChkSummary.Checked = False
+        resources.ApplyResources(Me.ucrChkSummary, "ucrChkSummary")
+        Me.ucrChkSummary.Name = "ucrChkSummary"
         '
         'rdoSingle
         '
@@ -205,12 +297,6 @@ Partial Class dlgHomogenization
         '
         resources.ApplyResources(Me.lblNeighbouring, "lblNeighbouring")
         Me.lblNeighbouring.Name = "lblNeighbouring"
-        '
-        'rdoSnht
-        '
-        resources.ApplyResources(Me.rdoSnht, "rdoSnht")
-        Me.rdoSnht.Name = "rdoSnht"
-        Me.rdoSnht.UseVisualStyleBackColor = True
         '
         'grpSnhtOptions
         '
@@ -268,84 +354,6 @@ Partial Class dlgHomogenization
         resources.ApplyResources(Me.ucrSaveResult, "ucrSaveResult")
         Me.ucrSaveResult.Name = "ucrSaveResult"
         '
-        'ucrChkPlot
-        '
-        Me.ucrChkPlot.Checked = False
-        resources.ApplyResources(Me.ucrChkPlot, "ucrChkPlot")
-        Me.ucrChkPlot.Name = "ucrChkPlot"
-        '
-        'ucrChkSummary
-        '
-        Me.ucrChkSummary.Checked = False
-        resources.ApplyResources(Me.ucrChkSummary, "ucrChkSummary")
-        Me.ucrChkSummary.Name = "ucrChkSummary"
-        '
-        'ucrInputComboMeanVarDistribution
-        '
-        Me.ucrInputComboMeanVarDistribution.AddQuotesIfUnrecognised = True
-        Me.ucrInputComboMeanVarDistribution.IsReadOnly = False
-        resources.ApplyResources(Me.ucrInputComboMeanVarDistribution, "ucrInputComboMeanVarDistribution")
-        Me.ucrInputComboMeanVarDistribution.Name = "ucrInputComboMeanVarDistribution"
-        '
-        'ucrInputComboVarDistribution
-        '
-        Me.ucrInputComboVarDistribution.AddQuotesIfUnrecognised = True
-        Me.ucrInputComboVarDistribution.IsReadOnly = False
-        resources.ApplyResources(Me.ucrInputComboVarDistribution, "ucrInputComboVarDistribution")
-        Me.ucrInputComboVarDistribution.Name = "ucrInputComboVarDistribution"
-        '
-        'ucrInputPenValue
-        '
-        Me.ucrInputPenValue.AddQuotesIfUnrecognised = True
-        Me.ucrInputPenValue.IsMultiline = False
-        Me.ucrInputPenValue.IsReadOnly = False
-        resources.ApplyResources(Me.ucrInputPenValue, "ucrInputPenValue")
-        Me.ucrInputPenValue.Name = "ucrInputPenValue"
-        '
-        'ucrNudMinSegLen
-        '
-        Me.ucrNudMinSegLen.DecimalPlaces = New Decimal(New Integer() {0, 0, 0, 0})
-        Me.ucrNudMinSegLen.Increment = New Decimal(New Integer() {1, 0, 0, 0})
-        resources.ApplyResources(Me.ucrNudMinSegLen, "ucrNudMinSegLen")
-        Me.ucrNudMinSegLen.Maximum = New Decimal(New Integer() {100, 0, 0, 0})
-        Me.ucrNudMinSegLen.Minimum = New Decimal(New Integer() {0, 0, 0, 0})
-        Me.ucrNudMinSegLen.Name = "ucrNudMinSegLen"
-        Me.ucrNudMinSegLen.Value = New Decimal(New Integer() {0, 0, 0, 0})
-        '
-        'ucrInputQ
-        '
-        Me.ucrInputQ.AddQuotesIfUnrecognised = True
-        Me.ucrInputQ.IsMultiline = False
-        Me.ucrInputQ.IsReadOnly = False
-        resources.ApplyResources(Me.ucrInputQ, "ucrInputQ")
-        Me.ucrInputQ.Name = "ucrInputQ"
-        '
-        'ucrInputComboMeanDistribution
-        '
-        Me.ucrInputComboMeanDistribution.AddQuotesIfUnrecognised = True
-        Me.ucrInputComboMeanDistribution.IsReadOnly = False
-        resources.ApplyResources(Me.ucrInputComboMeanDistribution, "ucrInputComboMeanDistribution")
-        Me.ucrInputComboMeanDistribution.Name = "ucrInputComboMeanDistribution"
-        '
-        'ucrInputComboMethod
-        '
-        Me.ucrInputComboMethod.AddQuotesIfUnrecognised = True
-        Me.ucrInputComboMethod.IsReadOnly = False
-        resources.ApplyResources(Me.ucrInputComboMethod, "ucrInputComboMethod")
-        Me.ucrInputComboMethod.Name = "ucrInputComboMethod"
-        '
-        'ucrInputComboPenalty
-        '
-        Me.ucrInputComboPenalty.AddQuotesIfUnrecognised = True
-        Me.ucrInputComboPenalty.IsReadOnly = False
-        resources.ApplyResources(Me.ucrInputComboPenalty, "ucrInputComboPenalty")
-        Me.ucrInputComboPenalty.Name = "ucrInputComboPenalty"
-        '
-        'ucrPnlMethods
-        '
-        resources.ApplyResources(Me.ucrPnlMethods, "ucrPnlMethods")
-        Me.ucrPnlMethods.Name = "ucrPnlMethods"
-        '
         'ucrReceiverElement
         '
         Me.ucrReceiverElement.frmParent = Me
@@ -368,11 +376,11 @@ Partial Class dlgHomogenization
         resources.ApplyResources(Me.ucrBase, "ucrBase")
         Me.ucrBase.Name = "ucrBase"
         '
-        'rdoPettitt
+        'rdoBuishand
         '
-        resources.ApplyResources(Me.rdoPettitt, "rdoPettitt")
-        Me.rdoPettitt.Name = "rdoPettitt"
-        Me.rdoPettitt.UseVisualStyleBackColor = True
+        resources.ApplyResources(Me.rdoBuishand, "rdoBuishand")
+        Me.rdoBuishand.Name = "rdoBuishand"
+        Me.rdoBuishand.UseVisualStyleBackColor = True
         '
         'dlgHomogenization
         '
@@ -451,4 +459,5 @@ Partial Class dlgHomogenization
     Friend WithEvents ucrChkRobust As ucrCheck
     Friend WithEvents ucrChkScaled As ucrCheck
     Friend WithEvents rdoPettitt As RadioButton
+    Friend WithEvents rdoBuishand As RadioButton
 End Class

--- a/instat/dlgHomogenization.Designer.vb
+++ b/instat/dlgHomogenization.Designer.vb
@@ -26,6 +26,7 @@ Partial Class dlgHomogenization
         Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(dlgHomogenization))
         Me.lblElement = New System.Windows.Forms.Label()
         Me.grpMethods = New System.Windows.Forms.GroupBox()
+        Me.rdoBuishand = New System.Windows.Forms.RadioButton()
         Me.rdoPettitt = New System.Windows.Forms.RadioButton()
         Me.rdoSnht = New System.Windows.Forms.RadioButton()
         Me.rdoCptMean = New System.Windows.Forms.RadioButton()
@@ -66,7 +67,6 @@ Partial Class dlgHomogenization
         Me.ucrReceiverElement = New instat.ucrReceiverSingle()
         Me.ucrSelectorHomogenization = New instat.ucrSelectorByDataFrameAddRemove()
         Me.ucrBase = New instat.ucrButtons()
-        Me.rdoBuishand = New System.Windows.Forms.RadioButton()
         Me.grpMethods.SuspendLayout()
         Me.grpCptOptions.SuspendLayout()
         Me.grpOutputOptions.SuspendLayout()
@@ -80,16 +80,22 @@ Partial Class dlgHomogenization
         '
         'grpMethods
         '
-        Me.grpMethods.Controls.Add(Me.rdoBuishand)
-        Me.grpMethods.Controls.Add(Me.rdoPettitt)
-        Me.grpMethods.Controls.Add(Me.rdoSnht)
         Me.grpMethods.Controls.Add(Me.rdoCptMean)
         Me.grpMethods.Controls.Add(Me.rdoCptMeanVariance)
         Me.grpMethods.Controls.Add(Me.rdoCptVariance)
+        Me.grpMethods.Controls.Add(Me.rdoBuishand)
+        Me.grpMethods.Controls.Add(Me.rdoPettitt)
+        Me.grpMethods.Controls.Add(Me.rdoSnht)
         Me.grpMethods.Controls.Add(Me.ucrPnlMethods)
         resources.ApplyResources(Me.grpMethods, "grpMethods")
         Me.grpMethods.Name = "grpMethods"
         Me.grpMethods.TabStop = False
+        '
+        'rdoBuishand
+        '
+        resources.ApplyResources(Me.rdoBuishand, "rdoBuishand")
+        Me.rdoBuishand.Name = "rdoBuishand"
+        Me.rdoBuishand.UseVisualStyleBackColor = True
         '
         'rdoPettitt
         '
@@ -375,12 +381,6 @@ Partial Class dlgHomogenization
         '
         resources.ApplyResources(Me.ucrBase, "ucrBase")
         Me.ucrBase.Name = "ucrBase"
-        '
-        'rdoBuishand
-        '
-        resources.ApplyResources(Me.rdoBuishand, "rdoBuishand")
-        Me.rdoBuishand.Name = "rdoBuishand"
-        Me.rdoBuishand.UseVisualStyleBackColor = True
         '
         'dlgHomogenization
         '

--- a/instat/dlgHomogenization.resx
+++ b/instat/dlgHomogenization.resx
@@ -127,7 +127,7 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="lblElement.Location" type="System.Drawing.Point, System.Drawing">
-    <value>264, 49</value>
+    <value>264, 80</value>
   </data>
   <data name="lblElement.Size" type="System.Drawing.Size, System.Drawing">
     <value>48, 13</value>
@@ -148,7 +148,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblElement.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>7</value>
   </data>
   <data name="rdoCptMean.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -244,7 +244,7 @@
     <value>6, 17</value>
   </data>
   <data name="ucrPnlMethods.Size" type="System.Drawing.Size, System.Drawing">
-    <value>122, 68</value>
+    <value>197, 68</value>
   </data>
   <data name="ucrPnlMethods.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -262,7 +262,7 @@
     <value>3</value>
   </data>
   <data name="grpMethods.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 212</value>
+    <value>12, 243</value>
   </data>
   <data name="grpMethods.Size" type="System.Drawing.Size, System.Drawing">
     <value>209, 104</value>
@@ -283,7 +283,58 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;grpMethods.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>6</value>
+  </data>
+  <data name="lblPenaltyValue.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblPenaltyValue.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblPenaltyValue.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 142</value>
+  </data>
+  <data name="lblPenaltyValue.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 13</value>
+  </data>
+  <data name="lblPenaltyValue.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="lblPenaltyValue.Text" xml:space="preserve">
+    <value>Pen.Value:</value>
+  </data>
+  <data name="&gt;&gt;lblPenaltyValue.Name" xml:space="preserve">
+    <value>lblPenaltyValue</value>
+  </data>
+  <data name="&gt;&gt;lblPenaltyValue.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblPenaltyValue.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;lblPenaltyValue.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="ucrInputPenValue.Location" type="System.Drawing.Point, System.Drawing">
+    <value>68, 138</value>
+  </data>
+  <data name="ucrInputPenValue.Size" type="System.Drawing.Size, System.Drawing">
+    <value>55, 21</value>
+  </data>
+  <data name="ucrInputPenValue.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="&gt;&gt;ucrInputPenValue.Name" xml:space="preserve">
+    <value>ucrInputPenValue</value>
+  </data>
+  <data name="&gt;&gt;ucrInputPenValue.Type" xml:space="preserve">
+    <value>instat.ucrInputTextBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrInputPenValue.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrInputPenValue.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="lblMinSegLen.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -292,7 +343,7 @@
     <value>NoControl</value>
   </data>
   <data name="lblMinSegLen.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 101</value>
+    <value>4, 95</value>
   </data>
   <data name="lblMinSegLen.Size" type="System.Drawing.Size, System.Drawing">
     <value>64, 13</value>
@@ -313,7 +364,7 @@
     <value>grpCptOptions</value>
   </data>
   <data name="&gt;&gt;lblMinSegLen.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>2</value>
   </data>
   <data name="lblQ.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -322,7 +373,7 @@
     <value>NoControl</value>
   </data>
   <data name="lblQ.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 128</value>
+    <value>4, 120</value>
   </data>
   <data name="lblQ.Size" type="System.Drawing.Size, System.Drawing">
     <value>18, 13</value>
@@ -343,7 +394,7 @@
     <value>grpCptOptions</value>
   </data>
   <data name="&gt;&gt;lblQ.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>3</value>
   </data>
   <data name="lblPenalty.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -373,7 +424,7 @@
     <value>grpCptOptions</value>
   </data>
   <data name="&gt;&gt;lblPenalty.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>4</value>
   </data>
   <data name="Label2.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -403,7 +454,7 @@
     <value>grpCptOptions</value>
   </data>
   <data name="&gt;&gt;Label2.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>5</value>
   </data>
   <data name="lblDistribution.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -433,10 +484,10 @@
     <value>grpCptOptions</value>
   </data>
   <data name="&gt;&gt;lblDistribution.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>6</value>
   </data>
   <data name="ucrNudMinSegLen.Location" type="System.Drawing.Point, System.Drawing">
-    <value>69, 99</value>
+    <value>68, 91</value>
   </data>
   <data name="ucrNudMinSegLen.Size" type="System.Drawing.Size, System.Drawing">
     <value>50, 20</value>
@@ -454,10 +505,10 @@
     <value>grpCptOptions</value>
   </data>
   <data name="&gt;&gt;ucrNudMinSegLen.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>7</value>
   </data>
   <data name="ucrInputQ.Location" type="System.Drawing.Point, System.Drawing">
-    <value>69, 125</value>
+    <value>68, 114</value>
   </data>
   <data name="ucrInputQ.Size" type="System.Drawing.Size, System.Drawing">
     <value>55, 21</value>
@@ -475,10 +526,10 @@
     <value>grpCptOptions</value>
   </data>
   <data name="&gt;&gt;ucrInputQ.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>8</value>
   </data>
   <data name="ucrInputComboDistribution.Location" type="System.Drawing.Point, System.Drawing">
-    <value>69, 67</value>
+    <value>68, 67</value>
   </data>
   <data name="ucrInputComboDistribution.Size" type="System.Drawing.Size, System.Drawing">
     <value>64, 21</value>
@@ -496,10 +547,10 @@
     <value>grpCptOptions</value>
   </data>
   <data name="&gt;&gt;ucrInputComboDistribution.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>9</value>
   </data>
   <data name="ucrInputComboMethod.Location" type="System.Drawing.Point, System.Drawing">
-    <value>69, 43</value>
+    <value>68, 43</value>
   </data>
   <data name="ucrInputComboMethod.Size" type="System.Drawing.Size, System.Drawing">
     <value>64, 21</value>
@@ -517,10 +568,10 @@
     <value>grpCptOptions</value>
   </data>
   <data name="&gt;&gt;ucrInputComboMethod.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>10</value>
   </data>
   <data name="ucrInputComboPenalty.Location" type="System.Drawing.Point, System.Drawing">
-    <value>69, 19</value>
+    <value>68, 19</value>
   </data>
   <data name="ucrInputComboPenalty.Size" type="System.Drawing.Size, System.Drawing">
     <value>64, 21</value>
@@ -538,13 +589,13 @@
     <value>grpCptOptions</value>
   </data>
   <data name="&gt;&gt;ucrInputComboPenalty.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>11</value>
   </data>
   <data name="grpCptOptions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>227, 212</value>
+    <value>227, 243</value>
   </data>
   <data name="grpCptOptions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>179, 152</value>
+    <value>179, 170</value>
   </data>
   <data name="grpCptOptions.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -562,7 +613,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;grpCptOptions.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>5</value>
   </data>
   <data name="ucrChkPlot.Location" type="System.Drawing.Point, System.Drawing">
     <value>10, 19</value>
@@ -607,7 +658,7 @@
     <value>1</value>
   </data>
   <data name="grpOutputOptions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 322</value>
+    <value>12, 353</value>
   </data>
   <data name="grpOutputOptions.Size" type="System.Drawing.Size, System.Drawing">
     <value>209, 42</value>
@@ -628,10 +679,13 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;grpOutputOptions.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>4</value>
   </data>
+  <metadata name="ttOptions.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
   <data name="ucrSaveResult.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 377</value>
+    <value>12, 408</value>
   </data>
   <data name="ucrSaveResult.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>4, 5, 4, 5</value>
@@ -652,22 +706,115 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrSaveResult.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>3</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>45</value>
+    <value>56</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>6, 13</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>422, 467</value>
+    <value>422, 494</value>
+  </data>
+  <data name="rdoSingle.Appearance" type="System.Windows.Forms.Appearance, System.Windows.Forms">
+    <value>Button</value>
+  </data>
+  <data name="rdoSingle.FlatStyle" type="System.Windows.Forms.FlatStyle, System.Windows.Forms">
+    <value>Flat</value>
+  </data>
+  <data name="rdoSingle.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="rdoSingle.Location" type="System.Drawing.Point, System.Drawing">
+    <value>112, 27</value>
+  </data>
+  <data name="rdoSingle.Size" type="System.Drawing.Size, System.Drawing">
+    <value>101, 28</value>
+  </data>
+  <data name="rdoSingle.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="rdoSingle.Text" xml:space="preserve">
+    <value>Single</value>
+  </data>
+  <data name="rdoSingle.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleCenter</value>
+  </data>
+  <data name="&gt;&gt;rdoSingle.Name" xml:space="preserve">
+    <value>rdoSingle</value>
+  </data>
+  <data name="&gt;&gt;rdoSingle.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rdoSingle.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;rdoSingle.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="rdoMultiple.Appearance" type="System.Windows.Forms.Appearance, System.Windows.Forms">
+    <value>Button</value>
+  </data>
+  <data name="rdoMultiple.FlatStyle" type="System.Windows.Forms.FlatStyle, System.Windows.Forms">
+    <value>Flat</value>
+  </data>
+  <data name="rdoMultiple.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="rdoMultiple.Location" type="System.Drawing.Point, System.Drawing">
+    <value>210, 27</value>
+  </data>
+  <data name="rdoMultiple.Size" type="System.Drawing.Size, System.Drawing">
+    <value>101, 28</value>
+  </data>
+  <data name="rdoMultiple.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
+  </data>
+  <data name="rdoMultiple.Text" xml:space="preserve">
+    <value>Multiple</value>
+  </data>
+  <data name="rdoMultiple.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleCenter</value>
+  </data>
+  <data name="&gt;&gt;rdoMultiple.Name" xml:space="preserve">
+    <value>rdoMultiple</value>
+  </data>
+  <data name="&gt;&gt;rdoMultiple.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rdoMultiple.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;rdoMultiple.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="ucrPnlOptions.Location" type="System.Drawing.Point, System.Drawing">
+    <value>103, 21</value>
+  </data>
+  <data name="ucrPnlOptions.Size" type="System.Drawing.Size, System.Drawing">
+    <value>217, 36</value>
+  </data>
+  <data name="ucrPnlOptions.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlOptions.Name" xml:space="preserve">
+    <value>ucrPnlOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlOptions.Type" xml:space="preserve">
+    <value>instat.UcrPanel, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlOptions.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlOptions.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <data name="ucrSelectorHomogenization.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 27</value>
+    <value>12, 58</value>
   </data>
   <data name="ucrSelectorHomogenization.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
@@ -688,10 +835,10 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrSelectorHomogenization.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>9</value>
   </data>
   <data name="ucrBase.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 409</value>
+    <value>12, 440</value>
   </data>
   <data name="ucrBase.Size" type="System.Drawing.Size, System.Drawing">
     <value>410, 52</value>
@@ -709,7 +856,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrBase.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>10</value>
   </data>
   <data name="$this.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -720,10 +867,10 @@
   <data name="$this.Text" xml:space="preserve">
     <value>Homogenization (Change Point)</value>
   </data>
-  <data name="&gt;&gt;ttQ.Name" xml:space="preserve">
-    <value>ttQ</value>
+  <data name="&gt;&gt;ttOptions.Name" xml:space="preserve">
+    <value>ttOptions</value>
   </data>
-  <data name="&gt;&gt;ttQ.Type" xml:space="preserve">
+  <data name="&gt;&gt;ttOptions.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
@@ -733,7 +880,7 @@
     <value>System.Windows.Forms.Form, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="ucrReceiverElement.Location" type="System.Drawing.Point, System.Drawing">
-    <value>266, 65</value>
+    <value>266, 96</value>
   </data>
   <data name="ucrReceiverElement.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
@@ -754,9 +901,6 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrReceiverElement.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>8</value>
   </data>
-  <metadata name="ttQ.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
 </root>

--- a/instat/dlgHomogenization.resx
+++ b/instat/dlgHomogenization.resx
@@ -150,6 +150,36 @@
   <data name="&gt;&gt;lblElement.ZOrder" xml:space="preserve">
     <value>11</value>
   </data>
+  <data name="rdoBuishand.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="rdoBuishand.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="rdoBuishand.Location" type="System.Drawing.Point, System.Drawing">
+    <value>131, 63</value>
+  </data>
+  <data name="rdoBuishand.Size" type="System.Drawing.Size, System.Drawing">
+    <value>69, 17</value>
+  </data>
+  <data name="rdoBuishand.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
+  </data>
+  <data name="rdoBuishand.Text" xml:space="preserve">
+    <value>Buishand</value>
+  </data>
+  <data name="&gt;&gt;rdoBuishand.Name" xml:space="preserve">
+    <value>rdoBuishand</value>
+  </data>
+  <data name="&gt;&gt;rdoBuishand.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rdoBuishand.Parent" xml:space="preserve">
+    <value>grpMethods</value>
+  </data>
+  <data name="&gt;&gt;rdoBuishand.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="rdoPettitt.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -157,7 +187,7 @@
     <value>NoControl</value>
   </data>
   <data name="rdoPettitt.Location" type="System.Drawing.Point, System.Drawing">
-    <value>128, 40</value>
+    <value>131, 40</value>
   </data>
   <data name="rdoPettitt.Size" type="System.Drawing.Size, System.Drawing">
     <value>52, 17</value>
@@ -178,7 +208,7 @@
     <value>grpMethods</value>
   </data>
   <data name="&gt;&gt;rdoPettitt.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="rdoSnht.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -187,7 +217,7 @@
     <value>NoControl</value>
   </data>
   <data name="rdoSnht.Location" type="System.Drawing.Point, System.Drawing">
-    <value>128, 17</value>
+    <value>131, 17</value>
   </data>
   <data name="rdoSnht.Size" type="System.Drawing.Size, System.Drawing">
     <value>55, 17</value>
@@ -208,7 +238,7 @@
     <value>grpMethods</value>
   </data>
   <data name="&gt;&gt;rdoSnht.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="rdoCptMean.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -238,7 +268,7 @@
     <value>grpMethods</value>
   </data>
   <data name="&gt;&gt;rdoCptMean.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="rdoCptMeanVariance.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -268,7 +298,7 @@
     <value>grpMethods</value>
   </data>
   <data name="&gt;&gt;rdoCptMeanVariance.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="rdoCptVariance.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -298,7 +328,7 @@
     <value>grpMethods</value>
   </data>
   <data name="&gt;&gt;rdoCptVariance.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>5</value>
   </data>
   <data name="ucrPnlMethods.Location" type="System.Drawing.Point, System.Drawing">
     <value>6, 17</value>
@@ -319,7 +349,7 @@
     <value>grpMethods</value>
   </data>
   <data name="&gt;&gt;ucrPnlMethods.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>6</value>
   </data>
   <data name="grpMethods.Location" type="System.Drawing.Point, System.Drawing">
     <value>12, 243</value>
@@ -537,6 +567,48 @@
   <data name="&gt;&gt;grpCptOptions.ZOrder" xml:space="preserve">
     <value>9</value>
   </data>
+  <data name="ucrInputComboMeanVarDistribution.Location" type="System.Drawing.Point, System.Drawing">
+    <value>68, 67</value>
+  </data>
+  <data name="ucrInputComboMeanVarDistribution.Size" type="System.Drawing.Size, System.Drawing">
+    <value>64, 21</value>
+  </data>
+  <data name="ucrInputComboMeanVarDistribution.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMeanVarDistribution.Name" xml:space="preserve">
+    <value>ucrInputComboMeanVarDistribution</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMeanVarDistribution.Type" xml:space="preserve">
+    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMeanVarDistribution.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMeanVarDistribution.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="ucrInputComboVarDistribution.Location" type="System.Drawing.Point, System.Drawing">
+    <value>68, 67</value>
+  </data>
+  <data name="ucrInputComboVarDistribution.Size" type="System.Drawing.Size, System.Drawing">
+    <value>64, 21</value>
+  </data>
+  <data name="ucrInputComboVarDistribution.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboVarDistribution.Name" xml:space="preserve">
+    <value>ucrInputComboVarDistribution</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboVarDistribution.Type" xml:space="preserve">
+    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboVarDistribution.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboVarDistribution.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
   <data name="lblPenaltyValue.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -566,6 +638,27 @@
   </data>
   <data name="&gt;&gt;lblPenaltyValue.ZOrder" xml:space="preserve">
     <value>2</value>
+  </data>
+  <data name="ucrInputPenValue.Location" type="System.Drawing.Point, System.Drawing">
+    <value>68, 138</value>
+  </data>
+  <data name="ucrInputPenValue.Size" type="System.Drawing.Size, System.Drawing">
+    <value>55, 21</value>
+  </data>
+  <data name="ucrInputPenValue.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="&gt;&gt;ucrInputPenValue.Name" xml:space="preserve">
+    <value>ucrInputPenValue</value>
+  </data>
+  <data name="&gt;&gt;ucrInputPenValue.Type" xml:space="preserve">
+    <value>instat.ucrInputTextBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrInputPenValue.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrInputPenValue.ZOrder" xml:space="preserve">
+    <value>3</value>
   </data>
   <data name="lblMinSegLen.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -717,6 +810,111 @@
   <data name="&gt;&gt;lblDistribution.ZOrder" xml:space="preserve">
     <value>8</value>
   </data>
+  <data name="ucrNudMinSegLen.Location" type="System.Drawing.Point, System.Drawing">
+    <value>68, 91</value>
+  </data>
+  <data name="ucrNudMinSegLen.Size" type="System.Drawing.Size, System.Drawing">
+    <value>50, 20</value>
+  </data>
+  <data name="ucrNudMinSegLen.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;ucrNudMinSegLen.Name" xml:space="preserve">
+    <value>ucrNudMinSegLen</value>
+  </data>
+  <data name="&gt;&gt;ucrNudMinSegLen.Type" xml:space="preserve">
+    <value>instat.ucrNud, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrNudMinSegLen.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrNudMinSegLen.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="ucrInputQ.Location" type="System.Drawing.Point, System.Drawing">
+    <value>68, 114</value>
+  </data>
+  <data name="ucrInputQ.Size" type="System.Drawing.Size, System.Drawing">
+    <value>55, 21</value>
+  </data>
+  <data name="ucrInputQ.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;ucrInputQ.Name" xml:space="preserve">
+    <value>ucrInputQ</value>
+  </data>
+  <data name="&gt;&gt;ucrInputQ.Type" xml:space="preserve">
+    <value>instat.ucrInputTextBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrInputQ.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrInputQ.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="ucrInputComboMeanDistribution.Location" type="System.Drawing.Point, System.Drawing">
+    <value>68, 67</value>
+  </data>
+  <data name="ucrInputComboMeanDistribution.Size" type="System.Drawing.Size, System.Drawing">
+    <value>64, 21</value>
+  </data>
+  <data name="ucrInputComboMeanDistribution.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMeanDistribution.Name" xml:space="preserve">
+    <value>ucrInputComboMeanDistribution</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMeanDistribution.Type" xml:space="preserve">
+    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMeanDistribution.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMeanDistribution.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="ucrInputComboMethod.Location" type="System.Drawing.Point, System.Drawing">
+    <value>68, 43</value>
+  </data>
+  <data name="ucrInputComboMethod.Size" type="System.Drawing.Size, System.Drawing">
+    <value>64, 21</value>
+  </data>
+  <data name="ucrInputComboMethod.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMethod.Name" xml:space="preserve">
+    <value>ucrInputComboMethod</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMethod.Type" xml:space="preserve">
+    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMethod.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMethod.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="ucrInputComboPenalty.Location" type="System.Drawing.Point, System.Drawing">
+    <value>68, 19</value>
+  </data>
+  <data name="ucrInputComboPenalty.Size" type="System.Drawing.Size, System.Drawing">
+    <value>64, 21</value>
+  </data>
+  <data name="ucrInputComboPenalty.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboPenalty.Name" xml:space="preserve">
+    <value>ucrInputComboPenalty</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboPenalty.Type" xml:space="preserve">
+    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboPenalty.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboPenalty.ZOrder" xml:space="preserve">
+    <value>13</value>
+  </data>
   <data name="&gt;&gt;ucrChkPlot.Name" xml:space="preserve">
     <value>ucrChkPlot</value>
   </data>
@@ -764,6 +962,48 @@
   </data>
   <data name="&gt;&gt;grpOutputOptions.ZOrder" xml:space="preserve">
     <value>8</value>
+  </data>
+  <data name="ucrChkPlot.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 19</value>
+  </data>
+  <data name="ucrChkPlot.Size" type="System.Drawing.Size, System.Drawing">
+    <value>100, 20</value>
+  </data>
+  <data name="ucrChkPlot.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;ucrChkPlot.Name" xml:space="preserve">
+    <value>ucrChkPlot</value>
+  </data>
+  <data name="&gt;&gt;ucrChkPlot.Type" xml:space="preserve">
+    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrChkPlot.Parent" xml:space="preserve">
+    <value>grpOutputOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrChkPlot.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="ucrChkSummary.Location" type="System.Drawing.Point, System.Drawing">
+    <value>110, 19</value>
+  </data>
+  <data name="ucrChkSummary.Size" type="System.Drawing.Size, System.Drawing">
+    <value>93, 20</value>
+  </data>
+  <data name="ucrChkSummary.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;ucrChkSummary.Name" xml:space="preserve">
+    <value>ucrChkSummary</value>
+  </data>
+  <data name="&gt;&gt;ucrChkSummary.Type" xml:space="preserve">
+    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrChkSummary.Parent" xml:space="preserve">
+    <value>grpOutputOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrChkSummary.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <metadata name="ttOptions.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
@@ -1197,9 +1437,6 @@
   <data name="&gt;&gt;ucrBase.ZOrder" xml:space="preserve">
     <value>14</value>
   </data>
-  <data name="$this.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterScreen</value>
   </data>
@@ -1241,215 +1478,5 @@
   </data>
   <data name="&gt;&gt;ucrReceiverNeighbour.ZOrder" xml:space="preserve">
     <value>2</value>
-  </data>
-  <data name="ucrChkPlot.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 19</value>
-  </data>
-  <data name="ucrChkPlot.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 20</value>
-  </data>
-  <data name="ucrChkPlot.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;ucrChkPlot.Name" xml:space="preserve">
-    <value>ucrChkPlot</value>
-  </data>
-  <data name="&gt;&gt;ucrChkPlot.Type" xml:space="preserve">
-    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrChkPlot.Parent" xml:space="preserve">
-    <value>grpOutputOptions</value>
-  </data>
-  <data name="&gt;&gt;ucrChkPlot.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="ucrChkSummary.Location" type="System.Drawing.Point, System.Drawing">
-    <value>110, 19</value>
-  </data>
-  <data name="ucrChkSummary.Size" type="System.Drawing.Size, System.Drawing">
-    <value>93, 20</value>
-  </data>
-  <data name="ucrChkSummary.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;ucrChkSummary.Name" xml:space="preserve">
-    <value>ucrChkSummary</value>
-  </data>
-  <data name="&gt;&gt;ucrChkSummary.Type" xml:space="preserve">
-    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrChkSummary.Parent" xml:space="preserve">
-    <value>grpOutputOptions</value>
-  </data>
-  <data name="&gt;&gt;ucrChkSummary.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="ucrInputComboMeanVarDistribution.Location" type="System.Drawing.Point, System.Drawing">
-    <value>68, 67</value>
-  </data>
-  <data name="ucrInputComboMeanVarDistribution.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 21</value>
-  </data>
-  <data name="ucrInputComboMeanVarDistribution.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboMeanVarDistribution.Name" xml:space="preserve">
-    <value>ucrInputComboMeanVarDistribution</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboMeanVarDistribution.Type" xml:space="preserve">
-    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboMeanVarDistribution.Parent" xml:space="preserve">
-    <value>grpCptOptions</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboMeanVarDistribution.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="ucrInputComboVarDistribution.Location" type="System.Drawing.Point, System.Drawing">
-    <value>68, 67</value>
-  </data>
-  <data name="ucrInputComboVarDistribution.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 21</value>
-  </data>
-  <data name="ucrInputComboVarDistribution.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboVarDistribution.Name" xml:space="preserve">
-    <value>ucrInputComboVarDistribution</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboVarDistribution.Type" xml:space="preserve">
-    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboVarDistribution.Parent" xml:space="preserve">
-    <value>grpCptOptions</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboVarDistribution.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="ucrInputPenValue.Location" type="System.Drawing.Point, System.Drawing">
-    <value>68, 138</value>
-  </data>
-  <data name="ucrInputPenValue.Size" type="System.Drawing.Size, System.Drawing">
-    <value>55, 21</value>
-  </data>
-  <data name="ucrInputPenValue.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
-  </data>
-  <data name="&gt;&gt;ucrInputPenValue.Name" xml:space="preserve">
-    <value>ucrInputPenValue</value>
-  </data>
-  <data name="&gt;&gt;ucrInputPenValue.Type" xml:space="preserve">
-    <value>instat.ucrInputTextBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrInputPenValue.Parent" xml:space="preserve">
-    <value>grpCptOptions</value>
-  </data>
-  <data name="&gt;&gt;ucrInputPenValue.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="ucrNudMinSegLen.Location" type="System.Drawing.Point, System.Drawing">
-    <value>68, 91</value>
-  </data>
-  <data name="ucrNudMinSegLen.Size" type="System.Drawing.Size, System.Drawing">
-    <value>50, 20</value>
-  </data>
-  <data name="ucrNudMinSegLen.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;ucrNudMinSegLen.Name" xml:space="preserve">
-    <value>ucrNudMinSegLen</value>
-  </data>
-  <data name="&gt;&gt;ucrNudMinSegLen.Type" xml:space="preserve">
-    <value>instat.ucrNud, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrNudMinSegLen.Parent" xml:space="preserve">
-    <value>grpCptOptions</value>
-  </data>
-  <data name="&gt;&gt;ucrNudMinSegLen.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="ucrInputQ.Location" type="System.Drawing.Point, System.Drawing">
-    <value>68, 114</value>
-  </data>
-  <data name="ucrInputQ.Size" type="System.Drawing.Size, System.Drawing">
-    <value>55, 21</value>
-  </data>
-  <data name="ucrInputQ.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;ucrInputQ.Name" xml:space="preserve">
-    <value>ucrInputQ</value>
-  </data>
-  <data name="&gt;&gt;ucrInputQ.Type" xml:space="preserve">
-    <value>instat.ucrInputTextBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrInputQ.Parent" xml:space="preserve">
-    <value>grpCptOptions</value>
-  </data>
-  <data name="&gt;&gt;ucrInputQ.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="ucrInputComboMeanDistribution.Location" type="System.Drawing.Point, System.Drawing">
-    <value>68, 67</value>
-  </data>
-  <data name="ucrInputComboMeanDistribution.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 21</value>
-  </data>
-  <data name="ucrInputComboMeanDistribution.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboMeanDistribution.Name" xml:space="preserve">
-    <value>ucrInputComboMeanDistribution</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboMeanDistribution.Type" xml:space="preserve">
-    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboMeanDistribution.Parent" xml:space="preserve">
-    <value>grpCptOptions</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboMeanDistribution.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="ucrInputComboMethod.Location" type="System.Drawing.Point, System.Drawing">
-    <value>68, 43</value>
-  </data>
-  <data name="ucrInputComboMethod.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 21</value>
-  </data>
-  <data name="ucrInputComboMethod.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboMethod.Name" xml:space="preserve">
-    <value>ucrInputComboMethod</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboMethod.Type" xml:space="preserve">
-    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboMethod.Parent" xml:space="preserve">
-    <value>grpCptOptions</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboMethod.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="ucrInputComboPenalty.Location" type="System.Drawing.Point, System.Drawing">
-    <value>68, 19</value>
-  </data>
-  <data name="ucrInputComboPenalty.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 21</value>
-  </data>
-  <data name="ucrInputComboPenalty.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboPenalty.Name" xml:space="preserve">
-    <value>ucrInputComboPenalty</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboPenalty.Type" xml:space="preserve">
-    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboPenalty.Parent" xml:space="preserve">
-    <value>grpCptOptions</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboPenalty.ZOrder" xml:space="preserve">
-    <value>13</value>
   </data>
 </root>

--- a/instat/dlgHomogenization.resx
+++ b/instat/dlgHomogenization.resx
@@ -117,17 +117,189 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="ucrBase.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 409</value>
+  </data>
+  <data name="ucrBase.Size" type="System.Drawing.Size, System.Drawing">
+    <value>410, 52</value>
+  </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="ucrBase.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;ucrBase.Name" xml:space="preserve">
+    <value>ucrBase</value>
+  </data>
+  <data name="&gt;&gt;ucrBase.Type" xml:space="preserve">
+    <value>instat.ucrButtons, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrBase.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrBase.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="ucrSelectorHomogenization.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 27</value>
+  </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="ucrSelectorHomogenization.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="ucrSelectorHomogenization.Size" type="System.Drawing.Size, System.Drawing">
+    <value>210, 180</value>
+  </data>
+  <data name="ucrSelectorHomogenization.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;ucrSelectorHomogenization.Name" xml:space="preserve">
+    <value>ucrSelectorHomogenization</value>
+  </data>
+  <data name="&gt;&gt;ucrSelectorHomogenization.Type" xml:space="preserve">
+    <value>instat.ucrSelectorByDataFrameAddRemove, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrSelectorHomogenization.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrSelectorHomogenization.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>6, 13</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>436, 359</value>
+    <value>436, 467</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="grpCptOptions.Location" type="System.Drawing.Point, System.Drawing">
+    <value>222, 236</value>
+  </data>
+  <data name="grpCptOptions.Size" type="System.Drawing.Size, System.Drawing">
+    <value>200, 141</value>
+  </data>
+  <data name="grpCptOptions.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="grpCptOptions.Text" xml:space="preserve">
+    <value>Change Point Options</value>
+  </data>
+  <data name="&gt;&gt;grpCptOptions.Name" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;grpCptOptions.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;grpCptOptions.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;grpCptOptions.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;rdoCptMean.Name" xml:space="preserve">
+    <value>rdoCptMean</value>
+  </data>
+  <data name="&gt;&gt;rdoCptMean.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rdoCptMean.Parent" xml:space="preserve">
+    <value>grpMethods</value>
+  </data>
+  <data name="&gt;&gt;rdoCptMean.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;rdoMeanVariance.Name" xml:space="preserve">
+    <value>rdoMeanVariance</value>
+  </data>
+  <data name="&gt;&gt;rdoMeanVariance.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rdoMeanVariance.Parent" xml:space="preserve">
+    <value>grpMethods</value>
+  </data>
+  <data name="&gt;&gt;rdoMeanVariance.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;rdoCptVariance.Name" xml:space="preserve">
+    <value>rdoCptVariance</value>
+  </data>
+  <data name="&gt;&gt;rdoCptVariance.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rdoCptVariance.Parent" xml:space="preserve">
+    <value>grpMethods</value>
+  </data>
+  <data name="&gt;&gt;rdoCptVariance.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlMethods.Name" xml:space="preserve">
+    <value>ucrPnlMethods</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlMethods.Type" xml:space="preserve">
+    <value>instat.UcrPanel, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlMethods.Parent" xml:space="preserve">
+    <value>grpMethods</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlMethods.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="grpMethods.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 236</value>
+  </data>
+  <data name="grpMethods.Size" type="System.Drawing.Size, System.Drawing">
+    <value>200, 141</value>
+  </data>
+  <data name="grpMethods.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="grpMethods.Text" xml:space="preserve">
+    <value>Methods</value>
+  </data>
+  <data name="&gt;&gt;grpMethods.Name" xml:space="preserve">
+    <value>grpMethods</value>
+  </data>
+  <data name="&gt;&gt;grpMethods.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;grpMethods.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;grpMethods.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="lblElement.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblElement.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblElement.Location" type="System.Drawing.Point, System.Drawing">
+    <value>264, 49</value>
+  </data>
+  <data name="lblElement.Size" type="System.Drawing.Size, System.Drawing">
+    <value>48, 13</value>
+  </data>
+  <data name="lblElement.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="lblElement.Text" xml:space="preserve">
+    <value>Element:</value>
+  </data>
+  <data name="&gt;&gt;lblElement.Name" xml:space="preserve">
+    <value>lblElement</value>
+  </data>
+  <data name="&gt;&gt;lblElement.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblElement.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;lblElement.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterScreen</value>
   </data>
@@ -139,5 +311,140 @@
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
     <value>System.Windows.Forms.Form, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="ucrReceiverElement.Location" type="System.Drawing.Point, System.Drawing">
+    <value>266, 65</value>
+  </data>
+  <data name="ucrReceiverElement.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="ucrReceiverElement.Size" type="System.Drawing.Size, System.Drawing">
+    <value>120, 20</value>
+  </data>
+  <data name="ucrReceiverElement.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverElement.Name" xml:space="preserve">
+    <value>ucrReceiverElement</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverElement.Type" xml:space="preserve">
+    <value>instat.ucrReceiverSingle, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverElement.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverElement.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="ucrPnlMethods.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 29</value>
+  </data>
+  <data name="ucrPnlMethods.Size" type="System.Drawing.Size, System.Drawing">
+    <value>132, 84</value>
+  </data>
+  <data name="ucrPnlMethods.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlMethods.Name" xml:space="preserve">
+    <value>ucrPnlMethods</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlMethods.Type" xml:space="preserve">
+    <value>instat.UcrPanel, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlMethods.Parent" xml:space="preserve">
+    <value>grpMethods</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlMethods.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="rdoCptVariance.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="rdoCptVariance.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="rdoCptVariance.Location" type="System.Drawing.Point, System.Drawing">
+    <value>20, 62</value>
+  </data>
+  <data name="rdoCptVariance.Size" type="System.Drawing.Size, System.Drawing">
+    <value>67, 17</value>
+  </data>
+  <data name="rdoCptVariance.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="rdoCptVariance.Text" xml:space="preserve">
+    <value>Variance</value>
+  </data>
+  <data name="&gt;&gt;rdoCptVariance.Name" xml:space="preserve">
+    <value>rdoCptVariance</value>
+  </data>
+  <data name="&gt;&gt;rdoCptVariance.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rdoCptVariance.Parent" xml:space="preserve">
+    <value>grpMethods</value>
+  </data>
+  <data name="&gt;&gt;rdoCptVariance.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="rdoMeanVariance.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="rdoMeanVariance.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="rdoMeanVariance.Location" type="System.Drawing.Point, System.Drawing">
+    <value>20, 85</value>
+  </data>
+  <data name="rdoMeanVariance.Size" type="System.Drawing.Size, System.Drawing">
+    <value>118, 17</value>
+  </data>
+  <data name="rdoMeanVariance.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="rdoMeanVariance.Text" xml:space="preserve">
+    <value>Mean and Variance</value>
+  </data>
+  <data name="&gt;&gt;rdoMeanVariance.Name" xml:space="preserve">
+    <value>rdoMeanVariance</value>
+  </data>
+  <data name="&gt;&gt;rdoMeanVariance.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rdoMeanVariance.Parent" xml:space="preserve">
+    <value>grpMethods</value>
+  </data>
+  <data name="&gt;&gt;rdoMeanVariance.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="rdoCptMean.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="rdoCptMean.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="rdoCptMean.Location" type="System.Drawing.Point, System.Drawing">
+    <value>20, 39</value>
+  </data>
+  <data name="rdoCptMean.Size" type="System.Drawing.Size, System.Drawing">
+    <value>52, 17</value>
+  </data>
+  <data name="rdoCptMean.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="rdoCptMean.Text" xml:space="preserve">
+    <value>Mean</value>
+  </data>
+  <data name="&gt;&gt;rdoCptMean.Name" xml:space="preserve">
+    <value>rdoCptMean</value>
+  </data>
+  <data name="&gt;&gt;rdoCptMean.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rdoCptMean.Parent" xml:space="preserve">
+    <value>grpMethods</value>
+  </data>
+  <data name="&gt;&gt;rdoCptMean.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
 </root>

--- a/instat/dlgHomogenization.resx
+++ b/instat/dlgHomogenization.resx
@@ -180,34 +180,34 @@
   <data name="&gt;&gt;rdoCptMean.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="rdoMeanVariance.AutoSize" type="System.Boolean, mscorlib">
+  <data name="rdoCptMeanVariance.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="rdoMeanVariance.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="rdoCptMeanVariance.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="rdoMeanVariance.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="rdoCptMeanVariance.Location" type="System.Drawing.Point, System.Drawing">
     <value>10, 63</value>
   </data>
-  <data name="rdoMeanVariance.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="rdoCptMeanVariance.Size" type="System.Drawing.Size, System.Drawing">
     <value>118, 17</value>
   </data>
-  <data name="rdoMeanVariance.TabIndex" type="System.Int32, mscorlib">
+  <data name="rdoCptMeanVariance.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
   </data>
-  <data name="rdoMeanVariance.Text" xml:space="preserve">
+  <data name="rdoCptMeanVariance.Text" xml:space="preserve">
     <value>Mean and Variance</value>
   </data>
-  <data name="&gt;&gt;rdoMeanVariance.Name" xml:space="preserve">
-    <value>rdoMeanVariance</value>
+  <data name="&gt;&gt;rdoCptMeanVariance.Name" xml:space="preserve">
+    <value>rdoCptMeanVariance</value>
   </data>
-  <data name="&gt;&gt;rdoMeanVariance.Type" xml:space="preserve">
+  <data name="&gt;&gt;rdoCptMeanVariance.Type" xml:space="preserve">
     <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;rdoMeanVariance.Parent" xml:space="preserve">
+  <data name="&gt;&gt;rdoCptMeanVariance.Parent" xml:space="preserve">
     <value>grpMethods</value>
   </data>
-  <data name="&gt;&gt;rdoMeanVariance.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;rdoCptMeanVariance.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
   <data name="rdoCptVariance.AutoSize" type="System.Boolean, mscorlib">
@@ -285,6 +285,48 @@
   <data name="&gt;&gt;grpMethods.ZOrder" xml:space="preserve">
     <value>9</value>
   </data>
+  <data name="ucrInputComboMeanVarDistribution.Location" type="System.Drawing.Point, System.Drawing">
+    <value>68, 67</value>
+  </data>
+  <data name="ucrInputComboMeanVarDistribution.Size" type="System.Drawing.Size, System.Drawing">
+    <value>64, 21</value>
+  </data>
+  <data name="ucrInputComboMeanVarDistribution.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMeanVarDistribution.Name" xml:space="preserve">
+    <value>ucrInputComboMeanVarDistribution</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMeanVarDistribution.Type" xml:space="preserve">
+    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMeanVarDistribution.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMeanVarDistribution.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="ucrInputComboVarDistribution.Location" type="System.Drawing.Point, System.Drawing">
+    <value>68, 67</value>
+  </data>
+  <data name="ucrInputComboVarDistribution.Size" type="System.Drawing.Size, System.Drawing">
+    <value>64, 21</value>
+  </data>
+  <data name="ucrInputComboVarDistribution.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboVarDistribution.Name" xml:space="preserve">
+    <value>ucrInputComboVarDistribution</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboVarDistribution.Type" xml:space="preserve">
+    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboVarDistribution.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboVarDistribution.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
   <data name="lblPenaltyValue.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -313,7 +355,7 @@
     <value>grpCptOptions</value>
   </data>
   <data name="&gt;&gt;lblPenaltyValue.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>2</value>
   </data>
   <data name="ucrInputPenValue.Location" type="System.Drawing.Point, System.Drawing">
     <value>68, 138</value>
@@ -334,7 +376,7 @@
     <value>grpCptOptions</value>
   </data>
   <data name="&gt;&gt;ucrInputPenValue.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>3</value>
   </data>
   <data name="lblMinSegLen.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -364,7 +406,7 @@
     <value>grpCptOptions</value>
   </data>
   <data name="&gt;&gt;lblMinSegLen.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>4</value>
   </data>
   <data name="lblQ.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -394,7 +436,7 @@
     <value>grpCptOptions</value>
   </data>
   <data name="&gt;&gt;lblQ.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>5</value>
   </data>
   <data name="lblPenalty.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -424,7 +466,7 @@
     <value>grpCptOptions</value>
   </data>
   <data name="&gt;&gt;lblPenalty.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>6</value>
   </data>
   <data name="Label2.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -454,7 +496,7 @@
     <value>grpCptOptions</value>
   </data>
   <data name="&gt;&gt;Label2.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>7</value>
   </data>
   <data name="lblDistribution.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -484,7 +526,7 @@
     <value>grpCptOptions</value>
   </data>
   <data name="&gt;&gt;lblDistribution.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>8</value>
   </data>
   <data name="ucrNudMinSegLen.Location" type="System.Drawing.Point, System.Drawing">
     <value>68, 91</value>
@@ -505,7 +547,7 @@
     <value>grpCptOptions</value>
   </data>
   <data name="&gt;&gt;ucrNudMinSegLen.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>9</value>
   </data>
   <data name="ucrInputQ.Location" type="System.Drawing.Point, System.Drawing">
     <value>68, 114</value>
@@ -526,28 +568,28 @@
     <value>grpCptOptions</value>
   </data>
   <data name="&gt;&gt;ucrInputQ.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>10</value>
   </data>
-  <data name="ucrInputComboDistribution.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="ucrInputComboMeanDistribution.Location" type="System.Drawing.Point, System.Drawing">
     <value>68, 67</value>
   </data>
-  <data name="ucrInputComboDistribution.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="ucrInputComboMeanDistribution.Size" type="System.Drawing.Size, System.Drawing">
     <value>64, 21</value>
   </data>
-  <data name="ucrInputComboDistribution.TabIndex" type="System.Int32, mscorlib">
+  <data name="ucrInputComboMeanDistribution.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
-  <data name="&gt;&gt;ucrInputComboDistribution.Name" xml:space="preserve">
-    <value>ucrInputComboDistribution</value>
+  <data name="&gt;&gt;ucrInputComboMeanDistribution.Name" xml:space="preserve">
+    <value>ucrInputComboMeanDistribution</value>
   </data>
-  <data name="&gt;&gt;ucrInputComboDistribution.Type" xml:space="preserve">
+  <data name="&gt;&gt;ucrInputComboMeanDistribution.Type" xml:space="preserve">
     <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="&gt;&gt;ucrInputComboDistribution.Parent" xml:space="preserve">
+  <data name="&gt;&gt;ucrInputComboMeanDistribution.Parent" xml:space="preserve">
     <value>grpCptOptions</value>
   </data>
-  <data name="&gt;&gt;ucrInputComboDistribution.ZOrder" xml:space="preserve">
-    <value>9</value>
+  <data name="&gt;&gt;ucrInputComboMeanDistribution.ZOrder" xml:space="preserve">
+    <value>11</value>
   </data>
   <data name="ucrInputComboMethod.Location" type="System.Drawing.Point, System.Drawing">
     <value>68, 43</value>
@@ -568,7 +610,7 @@
     <value>grpCptOptions</value>
   </data>
   <data name="&gt;&gt;ucrInputComboMethod.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>12</value>
   </data>
   <data name="ucrInputComboPenalty.Location" type="System.Drawing.Point, System.Drawing">
     <value>68, 19</value>
@@ -589,7 +631,7 @@
     <value>grpCptOptions</value>
   </data>
   <data name="&gt;&gt;ucrInputComboPenalty.ZOrder" xml:space="preserve">
-    <value>11</value>
+    <value>13</value>
   </data>
   <data name="grpCptOptions.Location" type="System.Drawing.Point, System.Drawing">
     <value>227, 243</value>
@@ -756,6 +798,84 @@
   <data name="&gt;&gt;rdoMultiple.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
+  <data name="rdoNeighbouring.Appearance" type="System.Windows.Forms.Appearance, System.Windows.Forms">
+    <value>Button</value>
+  </data>
+  <data name="rdoNeighbouring.FlatStyle" type="System.Windows.Forms.FlatStyle, System.Windows.Forms">
+    <value>Flat</value>
+  </data>
+  <data name="rdoNeighbouring.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="rdoNeighbouring.Location" type="System.Drawing.Point, System.Drawing">
+    <value>161, 27</value>
+  </data>
+  <data name="rdoNeighbouring.Size" type="System.Drawing.Size, System.Drawing">
+    <value>101, 28</value>
+  </data>
+  <data name="rdoNeighbouring.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="rdoNeighbouring.Text" xml:space="preserve">
+    <value>Neighbouring</value>
+  </data>
+  <data name="rdoNeighbouring.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleCenter</value>
+  </data>
+  <data name="&gt;&gt;rdoNeighbouring.Name" xml:space="preserve">
+    <value>rdoNeighbouring</value>
+  </data>
+  <data name="&gt;&gt;rdoNeighbouring.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rdoNeighbouring.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;rdoNeighbouring.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="lblNeighbouring.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblNeighbouring.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblNeighbouring.Location" type="System.Drawing.Point, System.Drawing">
+    <value>264, 138</value>
+  </data>
+  <data name="lblNeighbouring.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 13</value>
+  </data>
+  <data name="lblNeighbouring.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="lblNeighbouring.Text" xml:space="preserve">
+    <value>Neighbour:</value>
+  </data>
+  <data name="&gt;&gt;lblNeighbouring.Name" xml:space="preserve">
+    <value>lblNeighbouring</value>
+  </data>
+  <data name="&gt;&gt;lblNeighbouring.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblNeighbouring.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;lblNeighbouring.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>56</value>
+  </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>422, 494</value>
+  </data>
   <data name="ucrPnlOptions.Location" type="System.Drawing.Point, System.Drawing">
     <value>51, 25</value>
   </data>
@@ -801,107 +921,29 @@
   <data name="&gt;&gt;ucrSaveResult.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>56</value>
-  </metadata>
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
+  <data name="ucrReceiverElement.Location" type="System.Drawing.Point, System.Drawing">
+    <value>266, 96</value>
   </data>
-  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>422, 494</value>
-  </data>
-  <data name="lblNeighbouring.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lblNeighbouring.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblNeighbouring.Location" type="System.Drawing.Point, System.Drawing">
-    <value>264, 138</value>
-  </data>
-  <data name="lblNeighbouring.Size" type="System.Drawing.Size, System.Drawing">
-    <value>59, 13</value>
-  </data>
-  <data name="lblNeighbouring.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="lblNeighbouring.Text" xml:space="preserve">
-    <value>Neighbour:</value>
-  </data>
-  <data name="&gt;&gt;lblNeighbouring.Name" xml:space="preserve">
-    <value>lblNeighbouring</value>
-  </data>
-  <data name="&gt;&gt;lblNeighbouring.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblNeighbouring.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;lblNeighbouring.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="ucrReceiverNeighbour.Location" type="System.Drawing.Point, System.Drawing">
-    <value>266, 154</value>
-  </data>
-  <data name="ucrReceiverNeighbour.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="ucrReceiverElement.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
   </data>
-  <data name="ucrReceiverNeighbour.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="ucrReceiverElement.Size" type="System.Drawing.Size, System.Drawing">
     <value>120, 20</value>
   </data>
-  <data name="ucrReceiverNeighbour.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
+  <data name="ucrReceiverElement.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
   </data>
-  <data name="&gt;&gt;ucrReceiverNeighbour.Name" xml:space="preserve">
-    <value>ucrReceiverNeighbour</value>
+  <data name="&gt;&gt;ucrReceiverElement.Name" xml:space="preserve">
+    <value>ucrReceiverElement</value>
   </data>
-  <data name="&gt;&gt;ucrReceiverNeighbour.Type" xml:space="preserve">
+  <data name="&gt;&gt;ucrReceiverElement.Type" xml:space="preserve">
     <value>instat.ucrReceiverSingle, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="&gt;&gt;ucrReceiverNeighbour.Parent" xml:space="preserve">
+  <data name="&gt;&gt;ucrReceiverElement.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;ucrReceiverNeighbour.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="rdoNeighbouring.Appearance" type="System.Windows.Forms.Appearance, System.Windows.Forms">
-    <value>Button</value>
-  </data>
-  <data name="rdoNeighbouring.FlatStyle" type="System.Windows.Forms.FlatStyle, System.Windows.Forms">
-    <value>Flat</value>
-  </data>
-  <data name="rdoNeighbouring.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="rdoNeighbouring.Location" type="System.Drawing.Point, System.Drawing">
-    <value>161, 27</value>
-  </data>
-  <data name="rdoNeighbouring.Size" type="System.Drawing.Size, System.Drawing">
-    <value>101, 28</value>
-  </data>
-  <data name="rdoNeighbouring.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="rdoNeighbouring.Text" xml:space="preserve">
-    <value>Neighbouring</value>
-  </data>
-  <data name="rdoNeighbouring.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleCenter</value>
-  </data>
-  <data name="&gt;&gt;rdoNeighbouring.Name" xml:space="preserve">
-    <value>rdoNeighbouring</value>
-  </data>
-  <data name="&gt;&gt;rdoNeighbouring.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rdoNeighbouring.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;rdoNeighbouring.ZOrder" xml:space="preserve">
-    <value>2</value>
+  <data name="&gt;&gt;ucrReceiverElement.ZOrder" xml:space="preserve">
+    <value>11</value>
   </data>
   <data name="ucrSelectorHomogenization.Location" type="System.Drawing.Point, System.Drawing">
     <value>12, 58</value>
@@ -948,6 +990,9 @@
   <data name="&gt;&gt;ucrBase.ZOrder" xml:space="preserve">
     <value>13</value>
   </data>
+  <data name="$this.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterScreen</value>
   </data>
@@ -966,28 +1011,28 @@
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
     <value>System.Windows.Forms.Form, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="ucrReceiverElement.Location" type="System.Drawing.Point, System.Drawing">
-    <value>266, 96</value>
+  <data name="ucrReceiverNeighbour.Location" type="System.Drawing.Point, System.Drawing">
+    <value>266, 154</value>
   </data>
-  <data name="ucrReceiverElement.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="ucrReceiverNeighbour.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
   </data>
-  <data name="ucrReceiverElement.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="ucrReceiverNeighbour.Size" type="System.Drawing.Size, System.Drawing">
     <value>120, 20</value>
   </data>
-  <data name="ucrReceiverElement.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
+  <data name="ucrReceiverNeighbour.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
   </data>
-  <data name="&gt;&gt;ucrReceiverElement.Name" xml:space="preserve">
-    <value>ucrReceiverElement</value>
+  <data name="&gt;&gt;ucrReceiverNeighbour.Name" xml:space="preserve">
+    <value>ucrReceiverNeighbour</value>
   </data>
-  <data name="&gt;&gt;ucrReceiverElement.Type" xml:space="preserve">
+  <data name="&gt;&gt;ucrReceiverNeighbour.Type" xml:space="preserve">
     <value>instat.ucrReceiverSingle, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="&gt;&gt;ucrReceiverElement.Parent" xml:space="preserve">
+  <data name="&gt;&gt;ucrReceiverNeighbour.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;ucrReceiverElement.ZOrder" xml:space="preserve">
-    <value>11</value>
+  <data name="&gt;&gt;ucrReceiverNeighbour.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
 </root>

--- a/instat/dlgHomogenization.resx
+++ b/instat/dlgHomogenization.resx
@@ -148,7 +148,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblElement.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>10</value>
   </data>
   <data name="rdoCptMean.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -268,7 +268,7 @@
     <value>209, 104</value>
   </data>
   <data name="grpMethods.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
+    <value>9</value>
   </data>
   <data name="grpMethods.Text" xml:space="preserve">
     <value>Methods</value>
@@ -283,7 +283,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;grpMethods.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>9</value>
   </data>
   <data name="lblPenaltyValue.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -598,7 +598,7 @@
     <value>179, 170</value>
   </data>
   <data name="grpCptOptions.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
+    <value>10</value>
   </data>
   <data name="grpCptOptions.Text" xml:space="preserve">
     <value>Change Point Options</value>
@@ -613,7 +613,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;grpCptOptions.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>8</value>
   </data>
   <data name="ucrChkPlot.Location" type="System.Drawing.Point, System.Drawing">
     <value>10, 19</value>
@@ -664,7 +664,7 @@
     <value>209, 42</value>
   </data>
   <data name="grpOutputOptions.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
+    <value>11</value>
   </data>
   <data name="grpOutputOptions.Text" xml:space="preserve">
     <value>Output Options</value>
@@ -679,47 +679,11 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;grpOutputOptions.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>7</value>
   </data>
   <metadata name="ttOptions.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <data name="ucrSaveResult.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 408</value>
-  </data>
-  <data name="ucrSaveResult.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
-  <data name="ucrSaveResult.Size" type="System.Drawing.Size, System.Drawing">
-    <value>209, 24</value>
-  </data>
-  <data name="ucrSaveResult.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
-  </data>
-  <data name="&gt;&gt;ucrSaveResult.Name" xml:space="preserve">
-    <value>ucrSaveResult</value>
-  </data>
-  <data name="&gt;&gt;ucrSaveResult.Type" xml:space="preserve">
-    <value>instat.ucrSave, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrSaveResult.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;ucrSaveResult.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>56</value>
-  </metadata>
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
-  </data>
-  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>422, 494</value>
-  </data>
   <data name="rdoSingle.Appearance" type="System.Windows.Forms.Appearance, System.Windows.Forms">
     <value>Button</value>
   </data>
@@ -730,13 +694,13 @@
     <value>NoControl</value>
   </data>
   <data name="rdoSingle.Location" type="System.Drawing.Point, System.Drawing">
-    <value>112, 27</value>
+    <value>62, 27</value>
   </data>
   <data name="rdoSingle.Size" type="System.Drawing.Size, System.Drawing">
     <value>101, 28</value>
   </data>
   <data name="rdoSingle.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
+    <value>1</value>
   </data>
   <data name="rdoSingle.Text" xml:space="preserve">
     <value>Single</value>
@@ -754,7 +718,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;rdoSingle.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>3</value>
   </data>
   <data name="rdoMultiple.Appearance" type="System.Windows.Forms.Appearance, System.Windows.Forms">
     <value>Button</value>
@@ -766,13 +730,13 @@
     <value>NoControl</value>
   </data>
   <data name="rdoMultiple.Location" type="System.Drawing.Point, System.Drawing">
-    <value>210, 27</value>
+    <value>260, 27</value>
   </data>
   <data name="rdoMultiple.Size" type="System.Drawing.Size, System.Drawing">
     <value>101, 28</value>
   </data>
   <data name="rdoMultiple.TabIndex" type="System.Int32, mscorlib">
-    <value>16</value>
+    <value>3</value>
   </data>
   <data name="rdoMultiple.Text" xml:space="preserve">
     <value>Multiple</value>
@@ -790,16 +754,16 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;rdoMultiple.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>4</value>
   </data>
   <data name="ucrPnlOptions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>103, 21</value>
+    <value>51, 25</value>
   </data>
   <data name="ucrPnlOptions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>217, 36</value>
+    <value>321, 30</value>
   </data>
   <data name="ucrPnlOptions.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
+    <value>0</value>
   </data>
   <data name="&gt;&gt;ucrPnlOptions.Name" xml:space="preserve">
     <value>ucrPnlOptions</value>
@@ -811,6 +775,132 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrPnlOptions.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="ucrSaveResult.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 408</value>
+  </data>
+  <data name="ucrSaveResult.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="ucrSaveResult.Size" type="System.Drawing.Size, System.Drawing">
+    <value>209, 24</value>
+  </data>
+  <data name="ucrSaveResult.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="&gt;&gt;ucrSaveResult.Name" xml:space="preserve">
+    <value>ucrSaveResult</value>
+  </data>
+  <data name="&gt;&gt;ucrSaveResult.Type" xml:space="preserve">
+    <value>instat.ucrSave, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrSaveResult.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrSaveResult.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>56</value>
+  </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>422, 494</value>
+  </data>
+  <data name="lblNeighbouring.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblNeighbouring.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblNeighbouring.Location" type="System.Drawing.Point, System.Drawing">
+    <value>264, 138</value>
+  </data>
+  <data name="lblNeighbouring.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 13</value>
+  </data>
+  <data name="lblNeighbouring.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="lblNeighbouring.Text" xml:space="preserve">
+    <value>Neighbour:</value>
+  </data>
+  <data name="&gt;&gt;lblNeighbouring.Name" xml:space="preserve">
+    <value>lblNeighbouring</value>
+  </data>
+  <data name="&gt;&gt;lblNeighbouring.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblNeighbouring.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;lblNeighbouring.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="ucrReceiverNeighbour.Location" type="System.Drawing.Point, System.Drawing">
+    <value>266, 154</value>
+  </data>
+  <data name="ucrReceiverNeighbour.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="ucrReceiverNeighbour.Size" type="System.Drawing.Size, System.Drawing">
+    <value>120, 20</value>
+  </data>
+  <data name="ucrReceiverNeighbour.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverNeighbour.Name" xml:space="preserve">
+    <value>ucrReceiverNeighbour</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverNeighbour.Type" xml:space="preserve">
+    <value>instat.ucrReceiverSingle, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverNeighbour.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverNeighbour.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="rdoNeighbouring.Appearance" type="System.Windows.Forms.Appearance, System.Windows.Forms">
+    <value>Button</value>
+  </data>
+  <data name="rdoNeighbouring.FlatStyle" type="System.Windows.Forms.FlatStyle, System.Windows.Forms">
+    <value>Flat</value>
+  </data>
+  <data name="rdoNeighbouring.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="rdoNeighbouring.Location" type="System.Drawing.Point, System.Drawing">
+    <value>161, 27</value>
+  </data>
+  <data name="rdoNeighbouring.Size" type="System.Drawing.Size, System.Drawing">
+    <value>101, 28</value>
+  </data>
+  <data name="rdoNeighbouring.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="rdoNeighbouring.Text" xml:space="preserve">
+    <value>Neighbouring</value>
+  </data>
+  <data name="rdoNeighbouring.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleCenter</value>
+  </data>
+  <data name="&gt;&gt;rdoNeighbouring.Name" xml:space="preserve">
+    <value>rdoNeighbouring</value>
+  </data>
+  <data name="&gt;&gt;rdoNeighbouring.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rdoNeighbouring.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;rdoNeighbouring.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
   <data name="ucrSelectorHomogenization.Location" type="System.Drawing.Point, System.Drawing">
@@ -823,7 +913,7 @@
     <value>210, 180</value>
   </data>
   <data name="ucrSelectorHomogenization.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
+    <value>4</value>
   </data>
   <data name="&gt;&gt;ucrSelectorHomogenization.Name" xml:space="preserve">
     <value>ucrSelectorHomogenization</value>
@@ -835,7 +925,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrSelectorHomogenization.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>12</value>
   </data>
   <data name="ucrBase.Location" type="System.Drawing.Point, System.Drawing">
     <value>12, 440</value>
@@ -844,7 +934,7 @@
     <value>410, 52</value>
   </data>
   <data name="ucrBase.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
+    <value>13</value>
   </data>
   <data name="&gt;&gt;ucrBase.Name" xml:space="preserve">
     <value>ucrBase</value>
@@ -856,10 +946,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrBase.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="$this.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
+    <value>13</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterScreen</value>
@@ -889,7 +976,7 @@
     <value>120, 20</value>
   </data>
   <data name="ucrReceiverElement.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+    <value>6</value>
   </data>
   <data name="&gt;&gt;ucrReceiverElement.Name" xml:space="preserve">
     <value>ucrReceiverElement</value>
@@ -901,6 +988,6 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrReceiverElement.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>11</value>
   </data>
 </root>

--- a/instat/dlgHomogenization.resx
+++ b/instat/dlgHomogenization.resx
@@ -148,7 +148,115 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblElement.ZOrder" xml:space="preserve">
-    <value>11</value>
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;rdoCptMean.Name" xml:space="preserve">
+    <value>rdoCptMean</value>
+  </data>
+  <data name="&gt;&gt;rdoCptMean.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rdoCptMean.Parent" xml:space="preserve">
+    <value>grpMethods</value>
+  </data>
+  <data name="&gt;&gt;rdoCptMean.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;rdoCptMeanVariance.Name" xml:space="preserve">
+    <value>rdoCptMeanVariance</value>
+  </data>
+  <data name="&gt;&gt;rdoCptMeanVariance.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rdoCptMeanVariance.Parent" xml:space="preserve">
+    <value>grpMethods</value>
+  </data>
+  <data name="&gt;&gt;rdoCptMeanVariance.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;rdoCptVariance.Name" xml:space="preserve">
+    <value>rdoCptVariance</value>
+  </data>
+  <data name="&gt;&gt;rdoCptVariance.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rdoCptVariance.Parent" xml:space="preserve">
+    <value>grpMethods</value>
+  </data>
+  <data name="&gt;&gt;rdoCptVariance.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;rdoBuishand.Name" xml:space="preserve">
+    <value>rdoBuishand</value>
+  </data>
+  <data name="&gt;&gt;rdoBuishand.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rdoBuishand.Parent" xml:space="preserve">
+    <value>grpMethods</value>
+  </data>
+  <data name="&gt;&gt;rdoBuishand.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;rdoPettitt.Name" xml:space="preserve">
+    <value>rdoPettitt</value>
+  </data>
+  <data name="&gt;&gt;rdoPettitt.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rdoPettitt.Parent" xml:space="preserve">
+    <value>grpMethods</value>
+  </data>
+  <data name="&gt;&gt;rdoPettitt.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;rdoSnht.Name" xml:space="preserve">
+    <value>rdoSnht</value>
+  </data>
+  <data name="&gt;&gt;rdoSnht.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rdoSnht.Parent" xml:space="preserve">
+    <value>grpMethods</value>
+  </data>
+  <data name="&gt;&gt;rdoSnht.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlMethods.Name" xml:space="preserve">
+    <value>ucrPnlMethods</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlMethods.Type" xml:space="preserve">
+    <value>instat.UcrPanel, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlMethods.Parent" xml:space="preserve">
+    <value>grpMethods</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlMethods.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="grpMethods.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 243</value>
+  </data>
+  <data name="grpMethods.Size" type="System.Drawing.Size, System.Drawing">
+    <value>209, 104</value>
+  </data>
+  <data name="grpMethods.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="grpMethods.Text" xml:space="preserve">
+    <value>Methods</value>
+  </data>
+  <data name="&gt;&gt;grpMethods.Name" xml:space="preserve">
+    <value>grpMethods</value>
+  </data>
+  <data name="&gt;&gt;grpMethods.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;grpMethods.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;grpMethods.ZOrder" xml:space="preserve">
+    <value>9</value>
   </data>
   <data name="rdoCptMean.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -351,29 +459,197 @@
   <data name="&gt;&gt;ucrPnlMethods.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
-  <data name="grpMethods.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 243</value>
+  <data name="&gt;&gt;ucrInputComboMeanVarDistribution.Name" xml:space="preserve">
+    <value>ucrInputComboMeanVarDistribution</value>
   </data>
-  <data name="grpMethods.Size" type="System.Drawing.Size, System.Drawing">
-    <value>209, 104</value>
+  <data name="&gt;&gt;ucrInputComboMeanVarDistribution.Type" xml:space="preserve">
+    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="grpMethods.TabIndex" type="System.Int32, mscorlib">
+  <data name="&gt;&gt;ucrInputComboMeanVarDistribution.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMeanVarDistribution.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboVarDistribution.Name" xml:space="preserve">
+    <value>ucrInputComboVarDistribution</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboVarDistribution.Type" xml:space="preserve">
+    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboVarDistribution.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboVarDistribution.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;lblPenaltyValue.Name" xml:space="preserve">
+    <value>lblPenaltyValue</value>
+  </data>
+  <data name="&gt;&gt;lblPenaltyValue.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblPenaltyValue.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;lblPenaltyValue.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;ucrInputPenValue.Name" xml:space="preserve">
+    <value>ucrInputPenValue</value>
+  </data>
+  <data name="&gt;&gt;ucrInputPenValue.Type" xml:space="preserve">
+    <value>instat.ucrInputTextBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrInputPenValue.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrInputPenValue.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;lblMinSegLen.Name" xml:space="preserve">
+    <value>lblMinSegLen</value>
+  </data>
+  <data name="&gt;&gt;lblMinSegLen.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblMinSegLen.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;lblMinSegLen.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;lblQ.Name" xml:space="preserve">
+    <value>lblQ</value>
+  </data>
+  <data name="&gt;&gt;lblQ.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblQ.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;lblQ.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;lblPenalty.Name" xml:space="preserve">
+    <value>lblPenalty</value>
+  </data>
+  <data name="&gt;&gt;lblPenalty.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblPenalty.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;lblPenalty.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;Label2.Name" xml:space="preserve">
+    <value>Label2</value>
+  </data>
+  <data name="&gt;&gt;Label2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Label2.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;Label2.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;lblDistribution.Name" xml:space="preserve">
+    <value>lblDistribution</value>
+  </data>
+  <data name="&gt;&gt;lblDistribution.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblDistribution.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;lblDistribution.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;ucrNudMinSegLen.Name" xml:space="preserve">
+    <value>ucrNudMinSegLen</value>
+  </data>
+  <data name="&gt;&gt;ucrNudMinSegLen.Type" xml:space="preserve">
+    <value>instat.ucrNud, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrNudMinSegLen.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrNudMinSegLen.ZOrder" xml:space="preserve">
     <value>9</value>
   </data>
-  <data name="grpMethods.Text" xml:space="preserve">
-    <value>Methods</value>
+  <data name="&gt;&gt;ucrInputQ.Name" xml:space="preserve">
+    <value>ucrInputQ</value>
   </data>
-  <data name="&gt;&gt;grpMethods.Name" xml:space="preserve">
-    <value>grpMethods</value>
+  <data name="&gt;&gt;ucrInputQ.Type" xml:space="preserve">
+    <value>instat.ucrInputTextBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="&gt;&gt;grpMethods.Type" xml:space="preserve">
+  <data name="&gt;&gt;ucrInputQ.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrInputQ.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMeanDistribution.Name" xml:space="preserve">
+    <value>ucrInputComboMeanDistribution</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMeanDistribution.Type" xml:space="preserve">
+    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMeanDistribution.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMeanDistribution.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMethod.Name" xml:space="preserve">
+    <value>ucrInputComboMethod</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMethod.Type" xml:space="preserve">
+    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMethod.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMethod.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboPenalty.Name" xml:space="preserve">
+    <value>ucrInputComboPenalty</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboPenalty.Type" xml:space="preserve">
+    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboPenalty.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboPenalty.ZOrder" xml:space="preserve">
+    <value>13</value>
+  </data>
+  <data name="grpCptOptions.Location" type="System.Drawing.Point, System.Drawing">
+    <value>227, 243</value>
+  </data>
+  <data name="grpCptOptions.Size" type="System.Drawing.Size, System.Drawing">
+    <value>179, 170</value>
+  </data>
+  <data name="grpCptOptions.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="grpCptOptions.Text" xml:space="preserve">
+    <value>Change Point Options</value>
+  </data>
+  <data name="&gt;&gt;grpCptOptions.Name" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;grpCptOptions.Type" xml:space="preserve">
     <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;grpMethods.Parent" xml:space="preserve">
+  <data name="&gt;&gt;grpCptOptions.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;grpMethods.ZOrder" xml:space="preserve">
-    <value>10</value>
+  <data name="&gt;&gt;grpCptOptions.ZOrder" xml:space="preserve">
+    <value>8</value>
   </data>
   <data name="ucrInputComboMeanVarDistribution.Location" type="System.Drawing.Point, System.Drawing">
     <value>68, 67</value>
@@ -723,29 +999,53 @@
   <data name="&gt;&gt;ucrInputComboPenalty.ZOrder" xml:space="preserve">
     <value>13</value>
   </data>
-  <data name="grpCptOptions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>227, 243</value>
+  <data name="&gt;&gt;ucrChkPlot.Name" xml:space="preserve">
+    <value>ucrChkPlot</value>
   </data>
-  <data name="grpCptOptions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>179, 170</value>
+  <data name="&gt;&gt;ucrChkPlot.Type" xml:space="preserve">
+    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="grpCptOptions.TabIndex" type="System.Int32, mscorlib">
+  <data name="&gt;&gt;ucrChkPlot.Parent" xml:space="preserve">
+    <value>grpOutputOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrChkPlot.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;ucrChkSummary.Name" xml:space="preserve">
+    <value>ucrChkSummary</value>
+  </data>
+  <data name="&gt;&gt;ucrChkSummary.Type" xml:space="preserve">
+    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrChkSummary.Parent" xml:space="preserve">
+    <value>grpOutputOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrChkSummary.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="grpOutputOptions.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 353</value>
+  </data>
+  <data name="grpOutputOptions.Size" type="System.Drawing.Size, System.Drawing">
+    <value>209, 42</value>
+  </data>
+  <data name="grpOutputOptions.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
   </data>
-  <data name="grpCptOptions.Text" xml:space="preserve">
-    <value>Change Point Options</value>
+  <data name="grpOutputOptions.Text" xml:space="preserve">
+    <value>Output Options</value>
   </data>
-  <data name="&gt;&gt;grpCptOptions.Name" xml:space="preserve">
-    <value>grpCptOptions</value>
+  <data name="&gt;&gt;grpOutputOptions.Name" xml:space="preserve">
+    <value>grpOutputOptions</value>
   </data>
-  <data name="&gt;&gt;grpCptOptions.Type" xml:space="preserve">
+  <data name="&gt;&gt;grpOutputOptions.Type" xml:space="preserve">
     <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;grpCptOptions.Parent" xml:space="preserve">
+  <data name="&gt;&gt;grpOutputOptions.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;grpCptOptions.ZOrder" xml:space="preserve">
-    <value>9</value>
+  <data name="&gt;&gt;grpOutputOptions.ZOrder" xml:space="preserve">
+    <value>7</value>
   </data>
   <data name="ucrChkPlot.Location" type="System.Drawing.Point, System.Drawing">
     <value>10, 19</value>
@@ -789,30 +1089,6 @@
   <data name="&gt;&gt;ucrChkSummary.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="grpOutputOptions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 353</value>
-  </data>
-  <data name="grpOutputOptions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>209, 42</value>
-  </data>
-  <data name="grpOutputOptions.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
-  </data>
-  <data name="grpOutputOptions.Text" xml:space="preserve">
-    <value>Output Options</value>
-  </data>
-  <data name="&gt;&gt;grpOutputOptions.Name" xml:space="preserve">
-    <value>grpOutputOptions</value>
-  </data>
-  <data name="&gt;&gt;grpOutputOptions.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;grpOutputOptions.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;grpOutputOptions.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
   <metadata name="ttOptions.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
@@ -850,7 +1126,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;rdoSingle.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>3</value>
   </data>
   <data name="rdoMultiple.Appearance" type="System.Windows.Forms.Appearance, System.Windows.Forms">
     <value>Button</value>
@@ -886,7 +1162,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;rdoMultiple.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>4</value>
   </data>
   <data name="rdoNeighbouring.Appearance" type="System.Windows.Forms.Appearance, System.Windows.Forms">
     <value>Button</value>
@@ -922,7 +1198,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;rdoNeighbouring.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>2</value>
   </data>
   <data name="lblNeighbouring.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -952,123 +1228,6 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblNeighbouring.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="lblPeriod.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lblPeriod.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblPeriod.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 16</value>
-  </data>
-  <data name="lblPeriod.Size" type="System.Drawing.Size, System.Drawing">
-    <value>40, 13</value>
-  </data>
-  <data name="lblPeriod.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
-  </data>
-  <data name="lblPeriod.Text" xml:space="preserve">
-    <value>Period:</value>
-  </data>
-  <data name="&gt;&gt;lblPeriod.Name" xml:space="preserve">
-    <value>lblPeriod</value>
-  </data>
-  <data name="&gt;&gt;lblPeriod.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblPeriod.Parent" xml:space="preserve">
-    <value>grpSnhtOptions</value>
-  </data>
-  <data name="&gt;&gt;lblPeriod.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="ucrNudPeriod.Location" type="System.Drawing.Point, System.Drawing">
-    <value>49, 13</value>
-  </data>
-  <data name="ucrNudPeriod.Size" type="System.Drawing.Size, System.Drawing">
-    <value>50, 20</value>
-  </data>
-  <data name="ucrNudPeriod.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;ucrNudPeriod.Name" xml:space="preserve">
-    <value>ucrNudPeriod</value>
-  </data>
-  <data name="&gt;&gt;ucrNudPeriod.Type" xml:space="preserve">
-    <value>instat.ucrNud, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrNudPeriod.Parent" xml:space="preserve">
-    <value>grpSnhtOptions</value>
-  </data>
-  <data name="&gt;&gt;ucrNudPeriod.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="ucrChkRobust.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 61</value>
-  </data>
-  <data name="ucrChkRobust.Size" type="System.Drawing.Size, System.Drawing">
-    <value>93, 20</value>
-  </data>
-  <data name="ucrChkRobust.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;ucrChkRobust.Name" xml:space="preserve">
-    <value>ucrChkRobust</value>
-  </data>
-  <data name="&gt;&gt;ucrChkRobust.Type" xml:space="preserve">
-    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrChkRobust.Parent" xml:space="preserve">
-    <value>grpSnhtOptions</value>
-  </data>
-  <data name="&gt;&gt;ucrChkRobust.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="ucrChkScaled.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 37</value>
-  </data>
-  <data name="ucrChkScaled.Size" type="System.Drawing.Size, System.Drawing">
-    <value>93, 20</value>
-  </data>
-  <data name="ucrChkScaled.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;ucrChkScaled.Name" xml:space="preserve">
-    <value>ucrChkScaled</value>
-  </data>
-  <data name="&gt;&gt;ucrChkScaled.Type" xml:space="preserve">
-    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrChkScaled.Parent" xml:space="preserve">
-    <value>grpSnhtOptions</value>
-  </data>
-  <data name="&gt;&gt;ucrChkScaled.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="grpSnhtOptions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>227, 243</value>
-  </data>
-  <data name="grpSnhtOptions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>179, 104</value>
-  </data>
-  <data name="grpSnhtOptions.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="grpSnhtOptions.Text" xml:space="preserve">
-    <value>SNHT Options</value>
-  </data>
-  <data name="&gt;&gt;grpSnhtOptions.Name" xml:space="preserve">
-    <value>grpSnhtOptions</value>
-  </data>
-  <data name="&gt;&gt;grpSnhtOptions.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;grpSnhtOptions.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;grpSnhtOptions.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
@@ -1102,7 +1261,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrPnlOptions.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>5</value>
   </data>
   <data name="ucrSaveResult.Location" type="System.Drawing.Point, System.Drawing">
     <value>12, 413</value>
@@ -1111,10 +1270,10 @@
     <value>4, 5, 4, 5</value>
   </data>
   <data name="ucrSaveResult.Size" type="System.Drawing.Size, System.Drawing">
-    <value>237, 24</value>
+    <value>283, 24</value>
   </data>
   <data name="ucrSaveResult.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
+    <value>12</value>
   </data>
   <data name="&gt;&gt;ucrSaveResult.Name" xml:space="preserve">
     <value>ucrSaveResult</value>
@@ -1126,7 +1285,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrSaveResult.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>6</value>
   </data>
   <data name="ucrReceiverElement.Location" type="System.Drawing.Point, System.Drawing">
     <value>266, 96</value>
@@ -1150,7 +1309,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrReceiverElement.ZOrder" xml:space="preserve">
-    <value>12</value>
+    <value>11</value>
   </data>
   <data name="ucrSelectorHomogenization.Location" type="System.Drawing.Point, System.Drawing">
     <value>12, 58</value>
@@ -1174,7 +1333,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrSelectorHomogenization.ZOrder" xml:space="preserve">
-    <value>13</value>
+    <value>12</value>
   </data>
   <data name="ucrBase.Location" type="System.Drawing.Point, System.Drawing">
     <value>12, 440</value>
@@ -1183,7 +1342,7 @@
     <value>410, 52</value>
   </data>
   <data name="ucrBase.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
+    <value>13</value>
   </data>
   <data name="&gt;&gt;ucrBase.Name" xml:space="preserve">
     <value>ucrBase</value>
@@ -1195,7 +1354,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrBase.ZOrder" xml:space="preserve">
-    <value>14</value>
+    <value>13</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterScreen</value>
@@ -1237,6 +1396,6 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrReceiverNeighbour.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>1</value>
   </data>
 </root>

--- a/instat/dlgHomogenization.resx
+++ b/instat/dlgHomogenization.resx
@@ -150,96 +150,6 @@
   <data name="&gt;&gt;lblElement.ZOrder" xml:space="preserve">
     <value>11</value>
   </data>
-  <data name="rdoBuishand.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="rdoBuishand.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="rdoBuishand.Location" type="System.Drawing.Point, System.Drawing">
-    <value>131, 63</value>
-  </data>
-  <data name="rdoBuishand.Size" type="System.Drawing.Size, System.Drawing">
-    <value>69, 17</value>
-  </data>
-  <data name="rdoBuishand.TabIndex" type="System.Int32, mscorlib">
-    <value>16</value>
-  </data>
-  <data name="rdoBuishand.Text" xml:space="preserve">
-    <value>Buishand</value>
-  </data>
-  <data name="&gt;&gt;rdoBuishand.Name" xml:space="preserve">
-    <value>rdoBuishand</value>
-  </data>
-  <data name="&gt;&gt;rdoBuishand.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rdoBuishand.Parent" xml:space="preserve">
-    <value>grpMethods</value>
-  </data>
-  <data name="&gt;&gt;rdoBuishand.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="rdoPettitt.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="rdoPettitt.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="rdoPettitt.Location" type="System.Drawing.Point, System.Drawing">
-    <value>131, 40</value>
-  </data>
-  <data name="rdoPettitt.Size" type="System.Drawing.Size, System.Drawing">
-    <value>52, 17</value>
-  </data>
-  <data name="rdoPettitt.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
-  </data>
-  <data name="rdoPettitt.Text" xml:space="preserve">
-    <value>Pettitt</value>
-  </data>
-  <data name="&gt;&gt;rdoPettitt.Name" xml:space="preserve">
-    <value>rdoPettitt</value>
-  </data>
-  <data name="&gt;&gt;rdoPettitt.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rdoPettitt.Parent" xml:space="preserve">
-    <value>grpMethods</value>
-  </data>
-  <data name="&gt;&gt;rdoPettitt.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="rdoSnht.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="rdoSnht.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="rdoSnht.Location" type="System.Drawing.Point, System.Drawing">
-    <value>131, 17</value>
-  </data>
-  <data name="rdoSnht.Size" type="System.Drawing.Size, System.Drawing">
-    <value>55, 17</value>
-  </data>
-  <data name="rdoSnht.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
-  </data>
-  <data name="rdoSnht.Text" xml:space="preserve">
-    <value>SNHT</value>
-  </data>
-  <data name="&gt;&gt;rdoSnht.Name" xml:space="preserve">
-    <value>rdoSnht</value>
-  </data>
-  <data name="&gt;&gt;rdoSnht.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rdoSnht.Parent" xml:space="preserve">
-    <value>grpMethods</value>
-  </data>
-  <data name="&gt;&gt;rdoSnht.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="rdoCptMean.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -247,7 +157,7 @@
     <value>NoControl</value>
   </data>
   <data name="rdoCptMean.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 17</value>
+    <value>87, 23</value>
   </data>
   <data name="rdoCptMean.Size" type="System.Drawing.Size, System.Drawing">
     <value>52, 17</value>
@@ -268,7 +178,7 @@
     <value>grpMethods</value>
   </data>
   <data name="&gt;&gt;rdoCptMean.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>0</value>
   </data>
   <data name="rdoCptMeanVariance.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -277,7 +187,7 @@
     <value>NoControl</value>
   </data>
   <data name="rdoCptMeanVariance.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 63</value>
+    <value>87, 69</value>
   </data>
   <data name="rdoCptMeanVariance.Size" type="System.Drawing.Size, System.Drawing">
     <value>118, 17</value>
@@ -298,7 +208,7 @@
     <value>grpMethods</value>
   </data>
   <data name="&gt;&gt;rdoCptMeanVariance.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>1</value>
   </data>
   <data name="rdoCptVariance.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -307,7 +217,7 @@
     <value>NoControl</value>
   </data>
   <data name="rdoCptVariance.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 40</value>
+    <value>87, 46</value>
   </data>
   <data name="rdoCptVariance.Size" type="System.Drawing.Size, System.Drawing">
     <value>67, 17</value>
@@ -328,6 +238,96 @@
     <value>grpMethods</value>
   </data>
   <data name="&gt;&gt;rdoCptVariance.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="rdoBuishand.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="rdoBuishand.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="rdoBuishand.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 69</value>
+  </data>
+  <data name="rdoBuishand.Size" type="System.Drawing.Size, System.Drawing">
+    <value>69, 17</value>
+  </data>
+  <data name="rdoBuishand.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
+  </data>
+  <data name="rdoBuishand.Text" xml:space="preserve">
+    <value>Buishand</value>
+  </data>
+  <data name="&gt;&gt;rdoBuishand.Name" xml:space="preserve">
+    <value>rdoBuishand</value>
+  </data>
+  <data name="&gt;&gt;rdoBuishand.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rdoBuishand.Parent" xml:space="preserve">
+    <value>grpMethods</value>
+  </data>
+  <data name="&gt;&gt;rdoBuishand.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="rdoPettitt.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="rdoPettitt.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="rdoPettitt.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 46</value>
+  </data>
+  <data name="rdoPettitt.Size" type="System.Drawing.Size, System.Drawing">
+    <value>52, 17</value>
+  </data>
+  <data name="rdoPettitt.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="rdoPettitt.Text" xml:space="preserve">
+    <value>Pettitt</value>
+  </data>
+  <data name="&gt;&gt;rdoPettitt.Name" xml:space="preserve">
+    <value>rdoPettitt</value>
+  </data>
+  <data name="&gt;&gt;rdoPettitt.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rdoPettitt.Parent" xml:space="preserve">
+    <value>grpMethods</value>
+  </data>
+  <data name="&gt;&gt;rdoPettitt.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="rdoSnht.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="rdoSnht.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="rdoSnht.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 23</value>
+  </data>
+  <data name="rdoSnht.Size" type="System.Drawing.Size, System.Drawing">
+    <value>55, 17</value>
+  </data>
+  <data name="rdoSnht.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="rdoSnht.Text" xml:space="preserve">
+    <value>SNHT</value>
+  </data>
+  <data name="&gt;&gt;rdoSnht.Name" xml:space="preserve">
+    <value>rdoSnht</value>
+  </data>
+  <data name="&gt;&gt;rdoSnht.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rdoSnht.Parent" xml:space="preserve">
+    <value>grpMethods</value>
+  </data>
+  <data name="&gt;&gt;rdoSnht.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
   <data name="ucrPnlMethods.Location" type="System.Drawing.Point, System.Drawing">
@@ -374,198 +374,6 @@
   </data>
   <data name="&gt;&gt;grpMethods.ZOrder" xml:space="preserve">
     <value>10</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboMeanVarDistribution.Name" xml:space="preserve">
-    <value>ucrInputComboMeanVarDistribution</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboMeanVarDistribution.Type" xml:space="preserve">
-    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboMeanVarDistribution.Parent" xml:space="preserve">
-    <value>grpCptOptions</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboMeanVarDistribution.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboVarDistribution.Name" xml:space="preserve">
-    <value>ucrInputComboVarDistribution</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboVarDistribution.Type" xml:space="preserve">
-    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboVarDistribution.Parent" xml:space="preserve">
-    <value>grpCptOptions</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboVarDistribution.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;lblPenaltyValue.Name" xml:space="preserve">
-    <value>lblPenaltyValue</value>
-  </data>
-  <data name="&gt;&gt;lblPenaltyValue.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblPenaltyValue.Parent" xml:space="preserve">
-    <value>grpCptOptions</value>
-  </data>
-  <data name="&gt;&gt;lblPenaltyValue.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;ucrInputPenValue.Name" xml:space="preserve">
-    <value>ucrInputPenValue</value>
-  </data>
-  <data name="&gt;&gt;ucrInputPenValue.Type" xml:space="preserve">
-    <value>instat.ucrInputTextBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrInputPenValue.Parent" xml:space="preserve">
-    <value>grpCptOptions</value>
-  </data>
-  <data name="&gt;&gt;ucrInputPenValue.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;lblMinSegLen.Name" xml:space="preserve">
-    <value>lblMinSegLen</value>
-  </data>
-  <data name="&gt;&gt;lblMinSegLen.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblMinSegLen.Parent" xml:space="preserve">
-    <value>grpCptOptions</value>
-  </data>
-  <data name="&gt;&gt;lblMinSegLen.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;lblQ.Name" xml:space="preserve">
-    <value>lblQ</value>
-  </data>
-  <data name="&gt;&gt;lblQ.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblQ.Parent" xml:space="preserve">
-    <value>grpCptOptions</value>
-  </data>
-  <data name="&gt;&gt;lblQ.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;lblPenalty.Name" xml:space="preserve">
-    <value>lblPenalty</value>
-  </data>
-  <data name="&gt;&gt;lblPenalty.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblPenalty.Parent" xml:space="preserve">
-    <value>grpCptOptions</value>
-  </data>
-  <data name="&gt;&gt;lblPenalty.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;Label2.Name" xml:space="preserve">
-    <value>Label2</value>
-  </data>
-  <data name="&gt;&gt;Label2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label2.Parent" xml:space="preserve">
-    <value>grpCptOptions</value>
-  </data>
-  <data name="&gt;&gt;Label2.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;lblDistribution.Name" xml:space="preserve">
-    <value>lblDistribution</value>
-  </data>
-  <data name="&gt;&gt;lblDistribution.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblDistribution.Parent" xml:space="preserve">
-    <value>grpCptOptions</value>
-  </data>
-  <data name="&gt;&gt;lblDistribution.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;ucrNudMinSegLen.Name" xml:space="preserve">
-    <value>ucrNudMinSegLen</value>
-  </data>
-  <data name="&gt;&gt;ucrNudMinSegLen.Type" xml:space="preserve">
-    <value>instat.ucrNud, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrNudMinSegLen.Parent" xml:space="preserve">
-    <value>grpCptOptions</value>
-  </data>
-  <data name="&gt;&gt;ucrNudMinSegLen.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;ucrInputQ.Name" xml:space="preserve">
-    <value>ucrInputQ</value>
-  </data>
-  <data name="&gt;&gt;ucrInputQ.Type" xml:space="preserve">
-    <value>instat.ucrInputTextBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrInputQ.Parent" xml:space="preserve">
-    <value>grpCptOptions</value>
-  </data>
-  <data name="&gt;&gt;ucrInputQ.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboMeanDistribution.Name" xml:space="preserve">
-    <value>ucrInputComboMeanDistribution</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboMeanDistribution.Type" xml:space="preserve">
-    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboMeanDistribution.Parent" xml:space="preserve">
-    <value>grpCptOptions</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboMeanDistribution.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboMethod.Name" xml:space="preserve">
-    <value>ucrInputComboMethod</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboMethod.Type" xml:space="preserve">
-    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboMethod.Parent" xml:space="preserve">
-    <value>grpCptOptions</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboMethod.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboPenalty.Name" xml:space="preserve">
-    <value>ucrInputComboPenalty</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboPenalty.Type" xml:space="preserve">
-    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboPenalty.Parent" xml:space="preserve">
-    <value>grpCptOptions</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboPenalty.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
-  <data name="grpCptOptions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>227, 243</value>
-  </data>
-  <data name="grpCptOptions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>179, 170</value>
-  </data>
-  <data name="grpCptOptions.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="grpCptOptions.Text" xml:space="preserve">
-    <value>Change Point Options</value>
-  </data>
-  <data name="&gt;&gt;grpCptOptions.Name" xml:space="preserve">
-    <value>grpCptOptions</value>
-  </data>
-  <data name="&gt;&gt;grpCptOptions.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;grpCptOptions.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;grpCptOptions.ZOrder" xml:space="preserve">
-    <value>9</value>
   </data>
   <data name="ucrInputComboMeanVarDistribution.Location" type="System.Drawing.Point, System.Drawing">
     <value>68, 67</value>
@@ -915,53 +723,29 @@
   <data name="&gt;&gt;ucrInputComboPenalty.ZOrder" xml:space="preserve">
     <value>13</value>
   </data>
-  <data name="&gt;&gt;ucrChkPlot.Name" xml:space="preserve">
-    <value>ucrChkPlot</value>
+  <data name="grpCptOptions.Location" type="System.Drawing.Point, System.Drawing">
+    <value>227, 243</value>
   </data>
-  <data name="&gt;&gt;ucrChkPlot.Type" xml:space="preserve">
-    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  <data name="grpCptOptions.Size" type="System.Drawing.Size, System.Drawing">
+    <value>179, 170</value>
   </data>
-  <data name="&gt;&gt;ucrChkPlot.Parent" xml:space="preserve">
-    <value>grpOutputOptions</value>
-  </data>
-  <data name="&gt;&gt;ucrChkPlot.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;ucrChkSummary.Name" xml:space="preserve">
-    <value>ucrChkSummary</value>
-  </data>
-  <data name="&gt;&gt;ucrChkSummary.Type" xml:space="preserve">
-    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrChkSummary.Parent" xml:space="preserve">
-    <value>grpOutputOptions</value>
-  </data>
-  <data name="&gt;&gt;ucrChkSummary.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="grpOutputOptions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 353</value>
-  </data>
-  <data name="grpOutputOptions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>209, 42</value>
-  </data>
-  <data name="grpOutputOptions.TabIndex" type="System.Int32, mscorlib">
+  <data name="grpCptOptions.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
   </data>
-  <data name="grpOutputOptions.Text" xml:space="preserve">
-    <value>Output Options</value>
+  <data name="grpCptOptions.Text" xml:space="preserve">
+    <value>Change Point Options</value>
   </data>
-  <data name="&gt;&gt;grpOutputOptions.Name" xml:space="preserve">
-    <value>grpOutputOptions</value>
+  <data name="&gt;&gt;grpCptOptions.Name" xml:space="preserve">
+    <value>grpCptOptions</value>
   </data>
-  <data name="&gt;&gt;grpOutputOptions.Type" xml:space="preserve">
+  <data name="&gt;&gt;grpCptOptions.Type" xml:space="preserve">
     <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;grpOutputOptions.Parent" xml:space="preserve">
+  <data name="&gt;&gt;grpCptOptions.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;grpOutputOptions.ZOrder" xml:space="preserve">
-    <value>8</value>
+  <data name="&gt;&gt;grpCptOptions.ZOrder" xml:space="preserve">
+    <value>9</value>
   </data>
   <data name="ucrChkPlot.Location" type="System.Drawing.Point, System.Drawing">
     <value>10, 19</value>
@@ -1004,6 +788,30 @@
   </data>
   <data name="&gt;&gt;ucrChkSummary.ZOrder" xml:space="preserve">
     <value>1</value>
+  </data>
+  <data name="grpOutputOptions.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 353</value>
+  </data>
+  <data name="grpOutputOptions.Size" type="System.Drawing.Size, System.Drawing">
+    <value>209, 42</value>
+  </data>
+  <data name="grpOutputOptions.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="grpOutputOptions.Text" xml:space="preserve">
+    <value>Output Options</value>
+  </data>
+  <data name="&gt;&gt;grpOutputOptions.Name" xml:space="preserve">
+    <value>grpOutputOptions</value>
+  </data>
+  <data name="&gt;&gt;grpOutputOptions.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;grpOutputOptions.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;grpOutputOptions.ZOrder" xml:space="preserve">
+    <value>8</value>
   </data>
   <metadata name="ttOptions.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
@@ -1146,78 +954,6 @@
   <data name="&gt;&gt;lblNeighbouring.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="&gt;&gt;lblPeriod.Name" xml:space="preserve">
-    <value>lblPeriod</value>
-  </data>
-  <data name="&gt;&gt;lblPeriod.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblPeriod.Parent" xml:space="preserve">
-    <value>grpSnhtOptions</value>
-  </data>
-  <data name="&gt;&gt;lblPeriod.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;ucrNudPeriod.Name" xml:space="preserve">
-    <value>ucrNudPeriod</value>
-  </data>
-  <data name="&gt;&gt;ucrNudPeriod.Type" xml:space="preserve">
-    <value>instat.ucrNud, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrNudPeriod.Parent" xml:space="preserve">
-    <value>grpSnhtOptions</value>
-  </data>
-  <data name="&gt;&gt;ucrNudPeriod.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;ucrChkRobust.Name" xml:space="preserve">
-    <value>ucrChkRobust</value>
-  </data>
-  <data name="&gt;&gt;ucrChkRobust.Type" xml:space="preserve">
-    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrChkRobust.Parent" xml:space="preserve">
-    <value>grpSnhtOptions</value>
-  </data>
-  <data name="&gt;&gt;ucrChkRobust.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;ucrChkScaled.Name" xml:space="preserve">
-    <value>ucrChkScaled</value>
-  </data>
-  <data name="&gt;&gt;ucrChkScaled.Type" xml:space="preserve">
-    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrChkScaled.Parent" xml:space="preserve">
-    <value>grpSnhtOptions</value>
-  </data>
-  <data name="&gt;&gt;ucrChkScaled.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="grpSnhtOptions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>227, 243</value>
-  </data>
-  <data name="grpSnhtOptions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>179, 104</value>
-  </data>
-  <data name="grpSnhtOptions.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
-  </data>
-  <data name="grpSnhtOptions.Text" xml:space="preserve">
-    <value>SNHT Options</value>
-  </data>
-  <data name="&gt;&gt;grpSnhtOptions.Name" xml:space="preserve">
-    <value>grpSnhtOptions</value>
-  </data>
-  <data name="&gt;&gt;grpSnhtOptions.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;grpSnhtOptions.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;grpSnhtOptions.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="lblPeriod.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -1311,11 +1047,35 @@
   <data name="&gt;&gt;ucrChkScaled.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
+  <data name="grpSnhtOptions.Location" type="System.Drawing.Point, System.Drawing">
+    <value>227, 243</value>
+  </data>
+  <data name="grpSnhtOptions.Size" type="System.Drawing.Size, System.Drawing">
+    <value>179, 104</value>
+  </data>
+  <data name="grpSnhtOptions.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="grpSnhtOptions.Text" xml:space="preserve">
+    <value>SNHT Options</value>
+  </data>
+  <data name="&gt;&gt;grpSnhtOptions.Name" xml:space="preserve">
+    <value>grpSnhtOptions</value>
+  </data>
+  <data name="&gt;&gt;grpSnhtOptions.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;grpSnhtOptions.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;grpSnhtOptions.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>56</value>
+    <value>25</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>6, 13</value>
@@ -1354,7 +1114,7 @@
     <value>237, 24</value>
   </data>
   <data name="ucrSaveResult.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
+    <value>13</value>
   </data>
   <data name="&gt;&gt;ucrSaveResult.Name" xml:space="preserve">
     <value>ucrSaveResult</value>
@@ -1423,7 +1183,7 @@
     <value>410, 52</value>
   </data>
   <data name="ucrBase.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
+    <value>14</value>
   </data>
   <data name="&gt;&gt;ucrBase.Name" xml:space="preserve">
     <value>ucrBase</value>

--- a/instat/dlgHomogenization.resx
+++ b/instat/dlgHomogenization.resx
@@ -117,165 +117,15 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="ucrBase.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 409</value>
-  </data>
-  <data name="ucrBase.Size" type="System.Drawing.Size, System.Drawing">
-    <value>410, 52</value>
-  </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="ucrBase.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;ucrBase.Name" xml:space="preserve">
-    <value>ucrBase</value>
-  </data>
-  <data name="&gt;&gt;ucrBase.Type" xml:space="preserve">
-    <value>instat.ucrButtons, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrBase.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;ucrBase.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="ucrSelectorHomogenization.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 27</value>
-  </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="ucrSelectorHomogenization.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
-  </data>
-  <data name="ucrSelectorHomogenization.Size" type="System.Drawing.Size, System.Drawing">
-    <value>210, 180</value>
-  </data>
-  <data name="ucrSelectorHomogenization.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;ucrSelectorHomogenization.Name" xml:space="preserve">
-    <value>ucrSelectorHomogenization</value>
-  </data>
-  <data name="&gt;&gt;ucrSelectorHomogenization.Type" xml:space="preserve">
-    <value>instat.ucrSelectorByDataFrameAddRemove, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrSelectorHomogenization.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;ucrSelectorHomogenization.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
-  </data>
-  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>436, 467</value>
-  </data>
-  <data name="grpCptOptions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>222, 236</value>
-  </data>
-  <data name="grpCptOptions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>200, 141</value>
-  </data>
-  <data name="grpCptOptions.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="grpCptOptions.Text" xml:space="preserve">
-    <value>Change Point Options</value>
-  </data>
-  <data name="&gt;&gt;grpCptOptions.Name" xml:space="preserve">
-    <value>grpCptOptions</value>
-  </data>
-  <data name="&gt;&gt;grpCptOptions.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;grpCptOptions.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;grpCptOptions.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;rdoCptMean.Name" xml:space="preserve">
-    <value>rdoCptMean</value>
-  </data>
-  <data name="&gt;&gt;rdoCptMean.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rdoCptMean.Parent" xml:space="preserve">
-    <value>grpMethods</value>
-  </data>
-  <data name="&gt;&gt;rdoCptMean.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;rdoMeanVariance.Name" xml:space="preserve">
-    <value>rdoMeanVariance</value>
-  </data>
-  <data name="&gt;&gt;rdoMeanVariance.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rdoMeanVariance.Parent" xml:space="preserve">
-    <value>grpMethods</value>
-  </data>
-  <data name="&gt;&gt;rdoMeanVariance.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;rdoCptVariance.Name" xml:space="preserve">
-    <value>rdoCptVariance</value>
-  </data>
-  <data name="&gt;&gt;rdoCptVariance.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rdoCptVariance.Parent" xml:space="preserve">
-    <value>grpMethods</value>
-  </data>
-  <data name="&gt;&gt;rdoCptVariance.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;ucrPnlMethods.Name" xml:space="preserve">
-    <value>ucrPnlMethods</value>
-  </data>
-  <data name="&gt;&gt;ucrPnlMethods.Type" xml:space="preserve">
-    <value>instat.UcrPanel, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrPnlMethods.Parent" xml:space="preserve">
-    <value>grpMethods</value>
-  </data>
-  <data name="&gt;&gt;ucrPnlMethods.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="grpMethods.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 236</value>
-  </data>
-  <data name="grpMethods.Size" type="System.Drawing.Size, System.Drawing">
-    <value>200, 141</value>
-  </data>
-  <data name="grpMethods.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="grpMethods.Text" xml:space="preserve">
-    <value>Methods</value>
-  </data>
-  <data name="&gt;&gt;grpMethods.Name" xml:space="preserve">
-    <value>grpMethods</value>
-  </data>
-  <data name="&gt;&gt;grpMethods.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;grpMethods.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;grpMethods.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="lblElement.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="lblElement.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="lblElement.Location" type="System.Drawing.Point, System.Drawing">
     <value>264, 49</value>
   </data>
@@ -298,13 +148,583 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblElement.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="rdoCptMean.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="rdoCptMean.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="rdoCptMean.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 17</value>
+  </data>
+  <data name="rdoCptMean.Size" type="System.Drawing.Size, System.Drawing">
+    <value>52, 17</value>
+  </data>
+  <data name="rdoCptMean.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="rdoCptMean.Text" xml:space="preserve">
+    <value>Mean</value>
+  </data>
+  <data name="&gt;&gt;rdoCptMean.Name" xml:space="preserve">
+    <value>rdoCptMean</value>
+  </data>
+  <data name="&gt;&gt;rdoCptMean.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rdoCptMean.Parent" xml:space="preserve">
+    <value>grpMethods</value>
+  </data>
+  <data name="&gt;&gt;rdoCptMean.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="rdoMeanVariance.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="rdoMeanVariance.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="rdoMeanVariance.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 63</value>
+  </data>
+  <data name="rdoMeanVariance.Size" type="System.Drawing.Size, System.Drawing">
+    <value>118, 17</value>
+  </data>
+  <data name="rdoMeanVariance.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="rdoMeanVariance.Text" xml:space="preserve">
+    <value>Mean and Variance</value>
+  </data>
+  <data name="&gt;&gt;rdoMeanVariance.Name" xml:space="preserve">
+    <value>rdoMeanVariance</value>
+  </data>
+  <data name="&gt;&gt;rdoMeanVariance.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rdoMeanVariance.Parent" xml:space="preserve">
+    <value>grpMethods</value>
+  </data>
+  <data name="&gt;&gt;rdoMeanVariance.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="rdoCptVariance.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="rdoCptVariance.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="rdoCptVariance.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 40</value>
+  </data>
+  <data name="rdoCptVariance.Size" type="System.Drawing.Size, System.Drawing">
+    <value>67, 17</value>
+  </data>
+  <data name="rdoCptVariance.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="rdoCptVariance.Text" xml:space="preserve">
+    <value>Variance</value>
+  </data>
+  <data name="&gt;&gt;rdoCptVariance.Name" xml:space="preserve">
+    <value>rdoCptVariance</value>
+  </data>
+  <data name="&gt;&gt;rdoCptVariance.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rdoCptVariance.Parent" xml:space="preserve">
+    <value>grpMethods</value>
+  </data>
+  <data name="&gt;&gt;rdoCptVariance.ZOrder" xml:space="preserve">
     <value>2</value>
+  </data>
+  <data name="ucrPnlMethods.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 17</value>
+  </data>
+  <data name="ucrPnlMethods.Size" type="System.Drawing.Size, System.Drawing">
+    <value>122, 68</value>
+  </data>
+  <data name="ucrPnlMethods.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlMethods.Name" xml:space="preserve">
+    <value>ucrPnlMethods</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlMethods.Type" xml:space="preserve">
+    <value>instat.UcrPanel, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlMethods.Parent" xml:space="preserve">
+    <value>grpMethods</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlMethods.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="grpMethods.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 212</value>
+  </data>
+  <data name="grpMethods.Size" type="System.Drawing.Size, System.Drawing">
+    <value>209, 104</value>
+  </data>
+  <data name="grpMethods.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="grpMethods.Text" xml:space="preserve">
+    <value>Methods</value>
+  </data>
+  <data name="&gt;&gt;grpMethods.Name" xml:space="preserve">
+    <value>grpMethods</value>
+  </data>
+  <data name="&gt;&gt;grpMethods.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;grpMethods.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;grpMethods.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="lblMinSegLen.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblMinSegLen.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblMinSegLen.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 101</value>
+  </data>
+  <data name="lblMinSegLen.Size" type="System.Drawing.Size, System.Drawing">
+    <value>64, 13</value>
+  </data>
+  <data name="lblMinSegLen.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="lblMinSegLen.Text" xml:space="preserve">
+    <value>MinSegLen:</value>
+  </data>
+  <data name="&gt;&gt;lblMinSegLen.Name" xml:space="preserve">
+    <value>lblMinSegLen</value>
+  </data>
+  <data name="&gt;&gt;lblMinSegLen.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblMinSegLen.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;lblMinSegLen.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="lblQ.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblQ.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblQ.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 128</value>
+  </data>
+  <data name="lblQ.Size" type="System.Drawing.Size, System.Drawing">
+    <value>18, 13</value>
+  </data>
+  <data name="lblQ.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="lblQ.Text" xml:space="preserve">
+    <value>Q:</value>
+  </data>
+  <data name="&gt;&gt;lblQ.Name" xml:space="preserve">
+    <value>lblQ</value>
+  </data>
+  <data name="&gt;&gt;lblQ.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblQ.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;lblQ.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="lblPenalty.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblPenalty.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblPenalty.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 21</value>
+  </data>
+  <data name="lblPenalty.Size" type="System.Drawing.Size, System.Drawing">
+    <value>45, 13</value>
+  </data>
+  <data name="lblPenalty.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="lblPenalty.Text" xml:space="preserve">
+    <value>Penalty:</value>
+  </data>
+  <data name="&gt;&gt;lblPenalty.Name" xml:space="preserve">
+    <value>lblPenalty</value>
+  </data>
+  <data name="&gt;&gt;lblPenalty.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblPenalty.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;lblPenalty.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="Label2.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="Label2.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="Label2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 44</value>
+  </data>
+  <data name="Label2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>46, 13</value>
+  </data>
+  <data name="Label2.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="Label2.Text" xml:space="preserve">
+    <value>Method:</value>
+  </data>
+  <data name="&gt;&gt;Label2.Name" xml:space="preserve">
+    <value>Label2</value>
+  </data>
+  <data name="&gt;&gt;Label2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Label2.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;Label2.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="lblDistribution.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblDistribution.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblDistribution.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 69</value>
+  </data>
+  <data name="lblDistribution.Size" type="System.Drawing.Size, System.Drawing">
+    <value>62, 13</value>
+  </data>
+  <data name="lblDistribution.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="lblDistribution.Text" xml:space="preserve">
+    <value>Distribution:</value>
+  </data>
+  <data name="&gt;&gt;lblDistribution.Name" xml:space="preserve">
+    <value>lblDistribution</value>
+  </data>
+  <data name="&gt;&gt;lblDistribution.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblDistribution.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;lblDistribution.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="ucrNudMinSegLen.Location" type="System.Drawing.Point, System.Drawing">
+    <value>69, 99</value>
+  </data>
+  <data name="ucrNudMinSegLen.Size" type="System.Drawing.Size, System.Drawing">
+    <value>50, 20</value>
+  </data>
+  <data name="ucrNudMinSegLen.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;ucrNudMinSegLen.Name" xml:space="preserve">
+    <value>ucrNudMinSegLen</value>
+  </data>
+  <data name="&gt;&gt;ucrNudMinSegLen.Type" xml:space="preserve">
+    <value>instat.ucrNud, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrNudMinSegLen.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrNudMinSegLen.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="ucrInputQ.Location" type="System.Drawing.Point, System.Drawing">
+    <value>69, 125</value>
+  </data>
+  <data name="ucrInputQ.Size" type="System.Drawing.Size, System.Drawing">
+    <value>55, 21</value>
+  </data>
+  <data name="ucrInputQ.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;ucrInputQ.Name" xml:space="preserve">
+    <value>ucrInputQ</value>
+  </data>
+  <data name="&gt;&gt;ucrInputQ.Type" xml:space="preserve">
+    <value>instat.ucrInputTextBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrInputQ.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrInputQ.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="ucrInputComboDistribution.Location" type="System.Drawing.Point, System.Drawing">
+    <value>69, 67</value>
+  </data>
+  <data name="ucrInputComboDistribution.Size" type="System.Drawing.Size, System.Drawing">
+    <value>64, 21</value>
+  </data>
+  <data name="ucrInputComboDistribution.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboDistribution.Name" xml:space="preserve">
+    <value>ucrInputComboDistribution</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboDistribution.Type" xml:space="preserve">
+    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboDistribution.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboDistribution.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="ucrInputComboMethod.Location" type="System.Drawing.Point, System.Drawing">
+    <value>69, 43</value>
+  </data>
+  <data name="ucrInputComboMethod.Size" type="System.Drawing.Size, System.Drawing">
+    <value>64, 21</value>
+  </data>
+  <data name="ucrInputComboMethod.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMethod.Name" xml:space="preserve">
+    <value>ucrInputComboMethod</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMethod.Type" xml:space="preserve">
+    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMethod.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMethod.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="ucrInputComboPenalty.Location" type="System.Drawing.Point, System.Drawing">
+    <value>69, 19</value>
+  </data>
+  <data name="ucrInputComboPenalty.Size" type="System.Drawing.Size, System.Drawing">
+    <value>64, 21</value>
+  </data>
+  <data name="ucrInputComboPenalty.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboPenalty.Name" xml:space="preserve">
+    <value>ucrInputComboPenalty</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboPenalty.Type" xml:space="preserve">
+    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboPenalty.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboPenalty.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="grpCptOptions.Location" type="System.Drawing.Point, System.Drawing">
+    <value>227, 212</value>
+  </data>
+  <data name="grpCptOptions.Size" type="System.Drawing.Size, System.Drawing">
+    <value>179, 152</value>
+  </data>
+  <data name="grpCptOptions.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="grpCptOptions.Text" xml:space="preserve">
+    <value>Change Point Options</value>
+  </data>
+  <data name="&gt;&gt;grpCptOptions.Name" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;grpCptOptions.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;grpCptOptions.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;grpCptOptions.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="ucrChkPlot.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 19</value>
+  </data>
+  <data name="ucrChkPlot.Size" type="System.Drawing.Size, System.Drawing">
+    <value>100, 20</value>
+  </data>
+  <data name="ucrChkPlot.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;ucrChkPlot.Name" xml:space="preserve">
+    <value>ucrChkPlot</value>
+  </data>
+  <data name="&gt;&gt;ucrChkPlot.Type" xml:space="preserve">
+    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrChkPlot.Parent" xml:space="preserve">
+    <value>grpOutputOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrChkPlot.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="ucrChkSummary.Location" type="System.Drawing.Point, System.Drawing">
+    <value>110, 19</value>
+  </data>
+  <data name="ucrChkSummary.Size" type="System.Drawing.Size, System.Drawing">
+    <value>93, 20</value>
+  </data>
+  <data name="ucrChkSummary.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;ucrChkSummary.Name" xml:space="preserve">
+    <value>ucrChkSummary</value>
+  </data>
+  <data name="&gt;&gt;ucrChkSummary.Type" xml:space="preserve">
+    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrChkSummary.Parent" xml:space="preserve">
+    <value>grpOutputOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrChkSummary.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="grpOutputOptions.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 322</value>
+  </data>
+  <data name="grpOutputOptions.Size" type="System.Drawing.Size, System.Drawing">
+    <value>209, 42</value>
+  </data>
+  <data name="grpOutputOptions.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="grpOutputOptions.Text" xml:space="preserve">
+    <value>Output Options</value>
+  </data>
+  <data name="&gt;&gt;grpOutputOptions.Name" xml:space="preserve">
+    <value>grpOutputOptions</value>
+  </data>
+  <data name="&gt;&gt;grpOutputOptions.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;grpOutputOptions.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;grpOutputOptions.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="ucrSaveResult.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 377</value>
+  </data>
+  <data name="ucrSaveResult.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="ucrSaveResult.Size" type="System.Drawing.Size, System.Drawing">
+    <value>209, 24</value>
+  </data>
+  <data name="ucrSaveResult.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="&gt;&gt;ucrSaveResult.Name" xml:space="preserve">
+    <value>ucrSaveResult</value>
+  </data>
+  <data name="&gt;&gt;ucrSaveResult.Type" xml:space="preserve">
+    <value>instat.ucrSave, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrSaveResult.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrSaveResult.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>45</value>
+  </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>422, 467</value>
+  </data>
+  <data name="ucrSelectorHomogenization.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 27</value>
+  </data>
+  <data name="ucrSelectorHomogenization.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="ucrSelectorHomogenization.Size" type="System.Drawing.Size, System.Drawing">
+    <value>210, 180</value>
+  </data>
+  <data name="ucrSelectorHomogenization.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;ucrSelectorHomogenization.Name" xml:space="preserve">
+    <value>ucrSelectorHomogenization</value>
+  </data>
+  <data name="&gt;&gt;ucrSelectorHomogenization.Type" xml:space="preserve">
+    <value>instat.ucrSelectorByDataFrameAddRemove, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrSelectorHomogenization.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrSelectorHomogenization.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="ucrBase.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 409</value>
+  </data>
+  <data name="ucrBase.Size" type="System.Drawing.Size, System.Drawing">
+    <value>410, 52</value>
+  </data>
+  <data name="ucrBase.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;ucrBase.Name" xml:space="preserve">
+    <value>ucrBase</value>
+  </data>
+  <data name="&gt;&gt;ucrBase.Type" xml:space="preserve">
+    <value>instat.ucrButtons, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrBase.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrBase.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="$this.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterScreen</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
     <value>Homogenization (Change Point)</value>
+  </data>
+  <data name="&gt;&gt;ttQ.Name" xml:space="preserve">
+    <value>ttQ</value>
+  </data>
+  <data name="&gt;&gt;ttQ.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>dlgHomogenization</value>
@@ -334,117 +754,9 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrReceiverElement.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="ucrPnlMethods.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 29</value>
-  </data>
-  <data name="ucrPnlMethods.Size" type="System.Drawing.Size, System.Drawing">
-    <value>132, 84</value>
-  </data>
-  <data name="ucrPnlMethods.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;ucrPnlMethods.Name" xml:space="preserve">
-    <value>ucrPnlMethods</value>
-  </data>
-  <data name="&gt;&gt;ucrPnlMethods.Type" xml:space="preserve">
-    <value>instat.UcrPanel, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrPnlMethods.Parent" xml:space="preserve">
-    <value>grpMethods</value>
-  </data>
-  <data name="&gt;&gt;ucrPnlMethods.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="rdoCptVariance.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="rdoCptVariance.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="rdoCptVariance.Location" type="System.Drawing.Point, System.Drawing">
-    <value>20, 62</value>
-  </data>
-  <data name="rdoCptVariance.Size" type="System.Drawing.Size, System.Drawing">
-    <value>67, 17</value>
-  </data>
-  <data name="rdoCptVariance.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="rdoCptVariance.Text" xml:space="preserve">
-    <value>Variance</value>
-  </data>
-  <data name="&gt;&gt;rdoCptVariance.Name" xml:space="preserve">
-    <value>rdoCptVariance</value>
-  </data>
-  <data name="&gt;&gt;rdoCptVariance.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rdoCptVariance.Parent" xml:space="preserve">
-    <value>grpMethods</value>
-  </data>
-  <data name="&gt;&gt;rdoCptVariance.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="rdoMeanVariance.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="rdoMeanVariance.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="rdoMeanVariance.Location" type="System.Drawing.Point, System.Drawing">
-    <value>20, 85</value>
-  </data>
-  <data name="rdoMeanVariance.Size" type="System.Drawing.Size, System.Drawing">
-    <value>118, 17</value>
-  </data>
-  <data name="rdoMeanVariance.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
   </data>
-  <data name="rdoMeanVariance.Text" xml:space="preserve">
-    <value>Mean and Variance</value>
-  </data>
-  <data name="&gt;&gt;rdoMeanVariance.Name" xml:space="preserve">
-    <value>rdoMeanVariance</value>
-  </data>
-  <data name="&gt;&gt;rdoMeanVariance.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rdoMeanVariance.Parent" xml:space="preserve">
-    <value>grpMethods</value>
-  </data>
-  <data name="&gt;&gt;rdoMeanVariance.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="rdoCptMean.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="rdoCptMean.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="rdoCptMean.Location" type="System.Drawing.Point, System.Drawing">
-    <value>20, 39</value>
-  </data>
-  <data name="rdoCptMean.Size" type="System.Drawing.Size, System.Drawing">
-    <value>52, 17</value>
-  </data>
-  <data name="rdoCptMean.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="rdoCptMean.Text" xml:space="preserve">
-    <value>Mean</value>
-  </data>
-  <data name="&gt;&gt;rdoCptMean.Name" xml:space="preserve">
-    <value>rdoCptMean</value>
-  </data>
-  <data name="&gt;&gt;rdoCptMean.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rdoCptMean.Parent" xml:space="preserve">
-    <value>grpMethods</value>
-  </data>
-  <data name="&gt;&gt;rdoCptMean.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
+  <metadata name="ttQ.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>

--- a/instat/dlgHomogenization.resx
+++ b/instat/dlgHomogenization.resx
@@ -148,7 +148,37 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblElement.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>11</value>
+  </data>
+  <data name="rdoSnht.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="rdoSnht.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="rdoSnht.Location" type="System.Drawing.Point, System.Drawing">
+    <value>128, 17</value>
+  </data>
+  <data name="rdoSnht.Size" type="System.Drawing.Size, System.Drawing">
+    <value>55, 17</value>
+  </data>
+  <data name="rdoSnht.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="rdoSnht.Text" xml:space="preserve">
+    <value>SNHT</value>
+  </data>
+  <data name="&gt;&gt;rdoSnht.Name" xml:space="preserve">
+    <value>rdoSnht</value>
+  </data>
+  <data name="&gt;&gt;rdoSnht.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rdoSnht.Parent" xml:space="preserve">
+    <value>grpMethods</value>
+  </data>
+  <data name="&gt;&gt;rdoSnht.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="rdoCptMean.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -178,7 +208,7 @@
     <value>grpMethods</value>
   </data>
   <data name="&gt;&gt;rdoCptMean.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="rdoCptMeanVariance.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -208,7 +238,7 @@
     <value>grpMethods</value>
   </data>
   <data name="&gt;&gt;rdoCptMeanVariance.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="rdoCptVariance.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -238,7 +268,7 @@
     <value>grpMethods</value>
   </data>
   <data name="&gt;&gt;rdoCptVariance.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="ucrPnlMethods.Location" type="System.Drawing.Point, System.Drawing">
     <value>6, 17</value>
@@ -259,7 +289,7 @@
     <value>grpMethods</value>
   </data>
   <data name="&gt;&gt;ucrPnlMethods.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="grpMethods.Location" type="System.Drawing.Point, System.Drawing">
     <value>12, 243</value>
@@ -283,7 +313,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;grpMethods.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>10</value>
   </data>
   <data name="ucrInputComboMeanVarDistribution.Location" type="System.Drawing.Point, System.Drawing">
     <value>68, 67</value>
@@ -655,7 +685,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;grpCptOptions.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>9</value>
   </data>
   <data name="ucrChkPlot.Location" type="System.Drawing.Point, System.Drawing">
     <value>10, 19</value>
@@ -721,7 +751,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;grpOutputOptions.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>8</value>
   </data>
   <metadata name="ttOptions.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
@@ -760,7 +790,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;rdoSingle.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="rdoMultiple.Appearance" type="System.Windows.Forms.Appearance, System.Windows.Forms">
     <value>Button</value>
@@ -796,7 +826,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;rdoMultiple.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>5</value>
   </data>
   <data name="rdoNeighbouring.Appearance" type="System.Windows.Forms.Appearance, System.Windows.Forms">
     <value>Button</value>
@@ -832,7 +862,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;rdoNeighbouring.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="lblNeighbouring.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -862,6 +892,123 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblNeighbouring.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="lblPeriod.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblPeriod.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblPeriod.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 16</value>
+  </data>
+  <data name="lblPeriod.Size" type="System.Drawing.Size, System.Drawing">
+    <value>40, 13</value>
+  </data>
+  <data name="lblPeriod.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="lblPeriod.Text" xml:space="preserve">
+    <value>Period:</value>
+  </data>
+  <data name="&gt;&gt;lblPeriod.Name" xml:space="preserve">
+    <value>lblPeriod</value>
+  </data>
+  <data name="&gt;&gt;lblPeriod.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblPeriod.Parent" xml:space="preserve">
+    <value>grpSnhtOptions</value>
+  </data>
+  <data name="&gt;&gt;lblPeriod.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="ucrNudPeriod.Location" type="System.Drawing.Point, System.Drawing">
+    <value>49, 13</value>
+  </data>
+  <data name="ucrNudPeriod.Size" type="System.Drawing.Size, System.Drawing">
+    <value>50, 20</value>
+  </data>
+  <data name="ucrNudPeriod.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;ucrNudPeriod.Name" xml:space="preserve">
+    <value>ucrNudPeriod</value>
+  </data>
+  <data name="&gt;&gt;ucrNudPeriod.Type" xml:space="preserve">
+    <value>instat.ucrNud, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrNudPeriod.Parent" xml:space="preserve">
+    <value>grpSnhtOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrNudPeriod.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="ucrChkRobust.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 61</value>
+  </data>
+  <data name="ucrChkRobust.Size" type="System.Drawing.Size, System.Drawing">
+    <value>93, 20</value>
+  </data>
+  <data name="ucrChkRobust.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;ucrChkRobust.Name" xml:space="preserve">
+    <value>ucrChkRobust</value>
+  </data>
+  <data name="&gt;&gt;ucrChkRobust.Type" xml:space="preserve">
+    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrChkRobust.Parent" xml:space="preserve">
+    <value>grpSnhtOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrChkRobust.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="ucrChkScaled.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 37</value>
+  </data>
+  <data name="ucrChkScaled.Size" type="System.Drawing.Size, System.Drawing">
+    <value>93, 20</value>
+  </data>
+  <data name="ucrChkScaled.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;ucrChkScaled.Name" xml:space="preserve">
+    <value>ucrChkScaled</value>
+  </data>
+  <data name="&gt;&gt;ucrChkScaled.Type" xml:space="preserve">
+    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrChkScaled.Parent" xml:space="preserve">
+    <value>grpSnhtOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrChkScaled.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="grpSnhtOptions.Location" type="System.Drawing.Point, System.Drawing">
+    <value>227, 243</value>
+  </data>
+  <data name="grpSnhtOptions.Size" type="System.Drawing.Size, System.Drawing">
+    <value>179, 104</value>
+  </data>
+  <data name="grpSnhtOptions.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="grpSnhtOptions.Text" xml:space="preserve">
+    <value>SNHT Options</value>
+  </data>
+  <data name="&gt;&gt;grpSnhtOptions.Name" xml:space="preserve">
+    <value>grpSnhtOptions</value>
+  </data>
+  <data name="&gt;&gt;grpSnhtOptions.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;grpSnhtOptions.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;grpSnhtOptions.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
@@ -895,16 +1042,16 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrPnlOptions.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>6</value>
   </data>
   <data name="ucrSaveResult.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 408</value>
+    <value>12, 413</value>
   </data>
   <data name="ucrSaveResult.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>4, 5, 4, 5</value>
   </data>
   <data name="ucrSaveResult.Size" type="System.Drawing.Size, System.Drawing">
-    <value>209, 24</value>
+    <value>237, 24</value>
   </data>
   <data name="ucrSaveResult.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -919,7 +1066,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrSaveResult.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>7</value>
   </data>
   <data name="ucrReceiverElement.Location" type="System.Drawing.Point, System.Drawing">
     <value>266, 96</value>
@@ -943,7 +1090,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrReceiverElement.ZOrder" xml:space="preserve">
-    <value>11</value>
+    <value>12</value>
   </data>
   <data name="ucrSelectorHomogenization.Location" type="System.Drawing.Point, System.Drawing">
     <value>12, 58</value>
@@ -967,7 +1114,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrSelectorHomogenization.ZOrder" xml:space="preserve">
-    <value>12</value>
+    <value>13</value>
   </data>
   <data name="ucrBase.Location" type="System.Drawing.Point, System.Drawing">
     <value>12, 440</value>
@@ -988,7 +1135,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrBase.ZOrder" xml:space="preserve">
-    <value>13</value>
+    <value>14</value>
   </data>
   <data name="$this.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -1033,6 +1180,6 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrReceiverNeighbour.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
 </root>

--- a/instat/dlgHomogenization.resx
+++ b/instat/dlgHomogenization.resx
@@ -150,6 +150,36 @@
   <data name="&gt;&gt;lblElement.ZOrder" xml:space="preserve">
     <value>11</value>
   </data>
+  <data name="rdoPettitt.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="rdoPettitt.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="rdoPettitt.Location" type="System.Drawing.Point, System.Drawing">
+    <value>128, 40</value>
+  </data>
+  <data name="rdoPettitt.Size" type="System.Drawing.Size, System.Drawing">
+    <value>52, 17</value>
+  </data>
+  <data name="rdoPettitt.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="rdoPettitt.Text" xml:space="preserve">
+    <value>Pettitt</value>
+  </data>
+  <data name="&gt;&gt;rdoPettitt.Name" xml:space="preserve">
+    <value>rdoPettitt</value>
+  </data>
+  <data name="&gt;&gt;rdoPettitt.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rdoPettitt.Parent" xml:space="preserve">
+    <value>grpMethods</value>
+  </data>
+  <data name="&gt;&gt;rdoPettitt.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="rdoSnht.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -178,7 +208,7 @@
     <value>grpMethods</value>
   </data>
   <data name="&gt;&gt;rdoSnht.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="rdoCptMean.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -208,7 +238,7 @@
     <value>grpMethods</value>
   </data>
   <data name="&gt;&gt;rdoCptMean.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="rdoCptMeanVariance.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -238,7 +268,7 @@
     <value>grpMethods</value>
   </data>
   <data name="&gt;&gt;rdoCptMeanVariance.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="rdoCptVariance.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -268,7 +298,7 @@
     <value>grpMethods</value>
   </data>
   <data name="&gt;&gt;rdoCptVariance.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="ucrPnlMethods.Location" type="System.Drawing.Point, System.Drawing">
     <value>6, 17</value>
@@ -289,7 +319,7 @@
     <value>grpMethods</value>
   </data>
   <data name="&gt;&gt;ucrPnlMethods.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>5</value>
   </data>
   <data name="grpMethods.Location" type="System.Drawing.Point, System.Drawing">
     <value>12, 243</value>
@@ -315,15 +345,6 @@
   <data name="&gt;&gt;grpMethods.ZOrder" xml:space="preserve">
     <value>10</value>
   </data>
-  <data name="ucrInputComboMeanVarDistribution.Location" type="System.Drawing.Point, System.Drawing">
-    <value>68, 67</value>
-  </data>
-  <data name="ucrInputComboMeanVarDistribution.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 21</value>
-  </data>
-  <data name="ucrInputComboMeanVarDistribution.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
-  </data>
   <data name="&gt;&gt;ucrInputComboMeanVarDistribution.Name" xml:space="preserve">
     <value>ucrInputComboMeanVarDistribution</value>
   </data>
@@ -336,15 +357,6 @@
   <data name="&gt;&gt;ucrInputComboMeanVarDistribution.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="ucrInputComboVarDistribution.Location" type="System.Drawing.Point, System.Drawing">
-    <value>68, 67</value>
-  </data>
-  <data name="ucrInputComboVarDistribution.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 21</value>
-  </data>
-  <data name="ucrInputComboVarDistribution.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
-  </data>
   <data name="&gt;&gt;ucrInputComboVarDistribution.Name" xml:space="preserve">
     <value>ucrInputComboVarDistribution</value>
   </data>
@@ -356,6 +368,174 @@
   </data>
   <data name="&gt;&gt;ucrInputComboVarDistribution.ZOrder" xml:space="preserve">
     <value>1</value>
+  </data>
+  <data name="&gt;&gt;lblPenaltyValue.Name" xml:space="preserve">
+    <value>lblPenaltyValue</value>
+  </data>
+  <data name="&gt;&gt;lblPenaltyValue.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblPenaltyValue.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;lblPenaltyValue.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;ucrInputPenValue.Name" xml:space="preserve">
+    <value>ucrInputPenValue</value>
+  </data>
+  <data name="&gt;&gt;ucrInputPenValue.Type" xml:space="preserve">
+    <value>instat.ucrInputTextBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrInputPenValue.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrInputPenValue.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;lblMinSegLen.Name" xml:space="preserve">
+    <value>lblMinSegLen</value>
+  </data>
+  <data name="&gt;&gt;lblMinSegLen.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblMinSegLen.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;lblMinSegLen.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;lblQ.Name" xml:space="preserve">
+    <value>lblQ</value>
+  </data>
+  <data name="&gt;&gt;lblQ.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblQ.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;lblQ.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;lblPenalty.Name" xml:space="preserve">
+    <value>lblPenalty</value>
+  </data>
+  <data name="&gt;&gt;lblPenalty.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblPenalty.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;lblPenalty.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;Label2.Name" xml:space="preserve">
+    <value>Label2</value>
+  </data>
+  <data name="&gt;&gt;Label2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Label2.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;Label2.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;lblDistribution.Name" xml:space="preserve">
+    <value>lblDistribution</value>
+  </data>
+  <data name="&gt;&gt;lblDistribution.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblDistribution.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;lblDistribution.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;ucrNudMinSegLen.Name" xml:space="preserve">
+    <value>ucrNudMinSegLen</value>
+  </data>
+  <data name="&gt;&gt;ucrNudMinSegLen.Type" xml:space="preserve">
+    <value>instat.ucrNud, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrNudMinSegLen.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrNudMinSegLen.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;ucrInputQ.Name" xml:space="preserve">
+    <value>ucrInputQ</value>
+  </data>
+  <data name="&gt;&gt;ucrInputQ.Type" xml:space="preserve">
+    <value>instat.ucrInputTextBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrInputQ.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrInputQ.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMeanDistribution.Name" xml:space="preserve">
+    <value>ucrInputComboMeanDistribution</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMeanDistribution.Type" xml:space="preserve">
+    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMeanDistribution.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMeanDistribution.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMethod.Name" xml:space="preserve">
+    <value>ucrInputComboMethod</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMethod.Type" xml:space="preserve">
+    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMethod.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMethod.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboPenalty.Name" xml:space="preserve">
+    <value>ucrInputComboPenalty</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboPenalty.Type" xml:space="preserve">
+    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboPenalty.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboPenalty.ZOrder" xml:space="preserve">
+    <value>13</value>
+  </data>
+  <data name="grpCptOptions.Location" type="System.Drawing.Point, System.Drawing">
+    <value>227, 243</value>
+  </data>
+  <data name="grpCptOptions.Size" type="System.Drawing.Size, System.Drawing">
+    <value>179, 170</value>
+  </data>
+  <data name="grpCptOptions.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="grpCptOptions.Text" xml:space="preserve">
+    <value>Change Point Options</value>
+  </data>
+  <data name="&gt;&gt;grpCptOptions.Name" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;grpCptOptions.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;grpCptOptions.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;grpCptOptions.ZOrder" xml:space="preserve">
+    <value>9</value>
   </data>
   <data name="lblPenaltyValue.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -386,27 +566,6 @@
   </data>
   <data name="&gt;&gt;lblPenaltyValue.ZOrder" xml:space="preserve">
     <value>2</value>
-  </data>
-  <data name="ucrInputPenValue.Location" type="System.Drawing.Point, System.Drawing">
-    <value>68, 138</value>
-  </data>
-  <data name="ucrInputPenValue.Size" type="System.Drawing.Size, System.Drawing">
-    <value>55, 21</value>
-  </data>
-  <data name="ucrInputPenValue.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
-  </data>
-  <data name="&gt;&gt;ucrInputPenValue.Name" xml:space="preserve">
-    <value>ucrInputPenValue</value>
-  </data>
-  <data name="&gt;&gt;ucrInputPenValue.Type" xml:space="preserve">
-    <value>instat.ucrInputTextBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrInputPenValue.Parent" xml:space="preserve">
-    <value>grpCptOptions</value>
-  </data>
-  <data name="&gt;&gt;ucrInputPenValue.ZOrder" xml:space="preserve">
-    <value>3</value>
   </data>
   <data name="lblMinSegLen.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -558,144 +717,6 @@
   <data name="&gt;&gt;lblDistribution.ZOrder" xml:space="preserve">
     <value>8</value>
   </data>
-  <data name="ucrNudMinSegLen.Location" type="System.Drawing.Point, System.Drawing">
-    <value>68, 91</value>
-  </data>
-  <data name="ucrNudMinSegLen.Size" type="System.Drawing.Size, System.Drawing">
-    <value>50, 20</value>
-  </data>
-  <data name="ucrNudMinSegLen.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;ucrNudMinSegLen.Name" xml:space="preserve">
-    <value>ucrNudMinSegLen</value>
-  </data>
-  <data name="&gt;&gt;ucrNudMinSegLen.Type" xml:space="preserve">
-    <value>instat.ucrNud, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrNudMinSegLen.Parent" xml:space="preserve">
-    <value>grpCptOptions</value>
-  </data>
-  <data name="&gt;&gt;ucrNudMinSegLen.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="ucrInputQ.Location" type="System.Drawing.Point, System.Drawing">
-    <value>68, 114</value>
-  </data>
-  <data name="ucrInputQ.Size" type="System.Drawing.Size, System.Drawing">
-    <value>55, 21</value>
-  </data>
-  <data name="ucrInputQ.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;ucrInputQ.Name" xml:space="preserve">
-    <value>ucrInputQ</value>
-  </data>
-  <data name="&gt;&gt;ucrInputQ.Type" xml:space="preserve">
-    <value>instat.ucrInputTextBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrInputQ.Parent" xml:space="preserve">
-    <value>grpCptOptions</value>
-  </data>
-  <data name="&gt;&gt;ucrInputQ.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="ucrInputComboMeanDistribution.Location" type="System.Drawing.Point, System.Drawing">
-    <value>68, 67</value>
-  </data>
-  <data name="ucrInputComboMeanDistribution.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 21</value>
-  </data>
-  <data name="ucrInputComboMeanDistribution.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboMeanDistribution.Name" xml:space="preserve">
-    <value>ucrInputComboMeanDistribution</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboMeanDistribution.Type" xml:space="preserve">
-    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboMeanDistribution.Parent" xml:space="preserve">
-    <value>grpCptOptions</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboMeanDistribution.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="ucrInputComboMethod.Location" type="System.Drawing.Point, System.Drawing">
-    <value>68, 43</value>
-  </data>
-  <data name="ucrInputComboMethod.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 21</value>
-  </data>
-  <data name="ucrInputComboMethod.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboMethod.Name" xml:space="preserve">
-    <value>ucrInputComboMethod</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboMethod.Type" xml:space="preserve">
-    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboMethod.Parent" xml:space="preserve">
-    <value>grpCptOptions</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboMethod.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="ucrInputComboPenalty.Location" type="System.Drawing.Point, System.Drawing">
-    <value>68, 19</value>
-  </data>
-  <data name="ucrInputComboPenalty.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 21</value>
-  </data>
-  <data name="ucrInputComboPenalty.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboPenalty.Name" xml:space="preserve">
-    <value>ucrInputComboPenalty</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboPenalty.Type" xml:space="preserve">
-    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboPenalty.Parent" xml:space="preserve">
-    <value>grpCptOptions</value>
-  </data>
-  <data name="&gt;&gt;ucrInputComboPenalty.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
-  <data name="grpCptOptions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>227, 243</value>
-  </data>
-  <data name="grpCptOptions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>179, 170</value>
-  </data>
-  <data name="grpCptOptions.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="grpCptOptions.Text" xml:space="preserve">
-    <value>Change Point Options</value>
-  </data>
-  <data name="&gt;&gt;grpCptOptions.Name" xml:space="preserve">
-    <value>grpCptOptions</value>
-  </data>
-  <data name="&gt;&gt;grpCptOptions.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;grpCptOptions.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;grpCptOptions.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="ucrChkPlot.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 19</value>
-  </data>
-  <data name="ucrChkPlot.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 20</value>
-  </data>
-  <data name="ucrChkPlot.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
   <data name="&gt;&gt;ucrChkPlot.Name" xml:space="preserve">
     <value>ucrChkPlot</value>
   </data>
@@ -706,15 +727,6 @@
     <value>grpOutputOptions</value>
   </data>
   <data name="&gt;&gt;ucrChkPlot.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="ucrChkSummary.Location" type="System.Drawing.Point, System.Drawing">
-    <value>110, 19</value>
-  </data>
-  <data name="ucrChkSummary.Size" type="System.Drawing.Size, System.Drawing">
-    <value>93, 20</value>
-  </data>
-  <data name="ucrChkSummary.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
   <data name="&gt;&gt;ucrChkSummary.Name" xml:space="preserve">
@@ -894,6 +906,78 @@
   <data name="&gt;&gt;lblNeighbouring.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="&gt;&gt;lblPeriod.Name" xml:space="preserve">
+    <value>lblPeriod</value>
+  </data>
+  <data name="&gt;&gt;lblPeriod.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblPeriod.Parent" xml:space="preserve">
+    <value>grpSnhtOptions</value>
+  </data>
+  <data name="&gt;&gt;lblPeriod.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;ucrNudPeriod.Name" xml:space="preserve">
+    <value>ucrNudPeriod</value>
+  </data>
+  <data name="&gt;&gt;ucrNudPeriod.Type" xml:space="preserve">
+    <value>instat.ucrNud, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrNudPeriod.Parent" xml:space="preserve">
+    <value>grpSnhtOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrNudPeriod.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;ucrChkRobust.Name" xml:space="preserve">
+    <value>ucrChkRobust</value>
+  </data>
+  <data name="&gt;&gt;ucrChkRobust.Type" xml:space="preserve">
+    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrChkRobust.Parent" xml:space="preserve">
+    <value>grpSnhtOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrChkRobust.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;ucrChkScaled.Name" xml:space="preserve">
+    <value>ucrChkScaled</value>
+  </data>
+  <data name="&gt;&gt;ucrChkScaled.Type" xml:space="preserve">
+    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrChkScaled.Parent" xml:space="preserve">
+    <value>grpSnhtOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrChkScaled.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="grpSnhtOptions.Location" type="System.Drawing.Point, System.Drawing">
+    <value>227, 243</value>
+  </data>
+  <data name="grpSnhtOptions.Size" type="System.Drawing.Size, System.Drawing">
+    <value>179, 104</value>
+  </data>
+  <data name="grpSnhtOptions.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="grpSnhtOptions.Text" xml:space="preserve">
+    <value>SNHT Options</value>
+  </data>
+  <data name="&gt;&gt;grpSnhtOptions.Name" xml:space="preserve">
+    <value>grpSnhtOptions</value>
+  </data>
+  <data name="&gt;&gt;grpSnhtOptions.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;grpSnhtOptions.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;grpSnhtOptions.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="lblPeriod.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -986,30 +1070,6 @@
   </data>
   <data name="&gt;&gt;ucrChkScaled.ZOrder" xml:space="preserve">
     <value>3</value>
-  </data>
-  <data name="grpSnhtOptions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>227, 243</value>
-  </data>
-  <data name="grpSnhtOptions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>179, 104</value>
-  </data>
-  <data name="grpSnhtOptions.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
-  </data>
-  <data name="grpSnhtOptions.Text" xml:space="preserve">
-    <value>SNHT Options</value>
-  </data>
-  <data name="&gt;&gt;grpSnhtOptions.Name" xml:space="preserve">
-    <value>grpSnhtOptions</value>
-  </data>
-  <data name="&gt;&gt;grpSnhtOptions.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;grpSnhtOptions.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;grpSnhtOptions.ZOrder" xml:space="preserve">
-    <value>0</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -1181,5 +1241,215 @@
   </data>
   <data name="&gt;&gt;ucrReceiverNeighbour.ZOrder" xml:space="preserve">
     <value>2</value>
+  </data>
+  <data name="ucrChkPlot.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 19</value>
+  </data>
+  <data name="ucrChkPlot.Size" type="System.Drawing.Size, System.Drawing">
+    <value>100, 20</value>
+  </data>
+  <data name="ucrChkPlot.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;ucrChkPlot.Name" xml:space="preserve">
+    <value>ucrChkPlot</value>
+  </data>
+  <data name="&gt;&gt;ucrChkPlot.Type" xml:space="preserve">
+    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrChkPlot.Parent" xml:space="preserve">
+    <value>grpOutputOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrChkPlot.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="ucrChkSummary.Location" type="System.Drawing.Point, System.Drawing">
+    <value>110, 19</value>
+  </data>
+  <data name="ucrChkSummary.Size" type="System.Drawing.Size, System.Drawing">
+    <value>93, 20</value>
+  </data>
+  <data name="ucrChkSummary.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;ucrChkSummary.Name" xml:space="preserve">
+    <value>ucrChkSummary</value>
+  </data>
+  <data name="&gt;&gt;ucrChkSummary.Type" xml:space="preserve">
+    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrChkSummary.Parent" xml:space="preserve">
+    <value>grpOutputOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrChkSummary.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="ucrInputComboMeanVarDistribution.Location" type="System.Drawing.Point, System.Drawing">
+    <value>68, 67</value>
+  </data>
+  <data name="ucrInputComboMeanVarDistribution.Size" type="System.Drawing.Size, System.Drawing">
+    <value>64, 21</value>
+  </data>
+  <data name="ucrInputComboMeanVarDistribution.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMeanVarDistribution.Name" xml:space="preserve">
+    <value>ucrInputComboMeanVarDistribution</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMeanVarDistribution.Type" xml:space="preserve">
+    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMeanVarDistribution.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMeanVarDistribution.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="ucrInputComboVarDistribution.Location" type="System.Drawing.Point, System.Drawing">
+    <value>68, 67</value>
+  </data>
+  <data name="ucrInputComboVarDistribution.Size" type="System.Drawing.Size, System.Drawing">
+    <value>64, 21</value>
+  </data>
+  <data name="ucrInputComboVarDistribution.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboVarDistribution.Name" xml:space="preserve">
+    <value>ucrInputComboVarDistribution</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboVarDistribution.Type" xml:space="preserve">
+    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboVarDistribution.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboVarDistribution.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="ucrInputPenValue.Location" type="System.Drawing.Point, System.Drawing">
+    <value>68, 138</value>
+  </data>
+  <data name="ucrInputPenValue.Size" type="System.Drawing.Size, System.Drawing">
+    <value>55, 21</value>
+  </data>
+  <data name="ucrInputPenValue.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="&gt;&gt;ucrInputPenValue.Name" xml:space="preserve">
+    <value>ucrInputPenValue</value>
+  </data>
+  <data name="&gt;&gt;ucrInputPenValue.Type" xml:space="preserve">
+    <value>instat.ucrInputTextBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrInputPenValue.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrInputPenValue.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="ucrNudMinSegLen.Location" type="System.Drawing.Point, System.Drawing">
+    <value>68, 91</value>
+  </data>
+  <data name="ucrNudMinSegLen.Size" type="System.Drawing.Size, System.Drawing">
+    <value>50, 20</value>
+  </data>
+  <data name="ucrNudMinSegLen.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;ucrNudMinSegLen.Name" xml:space="preserve">
+    <value>ucrNudMinSegLen</value>
+  </data>
+  <data name="&gt;&gt;ucrNudMinSegLen.Type" xml:space="preserve">
+    <value>instat.ucrNud, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrNudMinSegLen.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrNudMinSegLen.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="ucrInputQ.Location" type="System.Drawing.Point, System.Drawing">
+    <value>68, 114</value>
+  </data>
+  <data name="ucrInputQ.Size" type="System.Drawing.Size, System.Drawing">
+    <value>55, 21</value>
+  </data>
+  <data name="ucrInputQ.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;ucrInputQ.Name" xml:space="preserve">
+    <value>ucrInputQ</value>
+  </data>
+  <data name="&gt;&gt;ucrInputQ.Type" xml:space="preserve">
+    <value>instat.ucrInputTextBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrInputQ.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrInputQ.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="ucrInputComboMeanDistribution.Location" type="System.Drawing.Point, System.Drawing">
+    <value>68, 67</value>
+  </data>
+  <data name="ucrInputComboMeanDistribution.Size" type="System.Drawing.Size, System.Drawing">
+    <value>64, 21</value>
+  </data>
+  <data name="ucrInputComboMeanDistribution.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMeanDistribution.Name" xml:space="preserve">
+    <value>ucrInputComboMeanDistribution</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMeanDistribution.Type" xml:space="preserve">
+    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMeanDistribution.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMeanDistribution.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="ucrInputComboMethod.Location" type="System.Drawing.Point, System.Drawing">
+    <value>68, 43</value>
+  </data>
+  <data name="ucrInputComboMethod.Size" type="System.Drawing.Size, System.Drawing">
+    <value>64, 21</value>
+  </data>
+  <data name="ucrInputComboMethod.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMethod.Name" xml:space="preserve">
+    <value>ucrInputComboMethod</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMethod.Type" xml:space="preserve">
+    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMethod.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboMethod.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="ucrInputComboPenalty.Location" type="System.Drawing.Point, System.Drawing">
+    <value>68, 19</value>
+  </data>
+  <data name="ucrInputComboPenalty.Size" type="System.Drawing.Size, System.Drawing">
+    <value>64, 21</value>
+  </data>
+  <data name="ucrInputComboPenalty.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboPenalty.Name" xml:space="preserve">
+    <value>ucrInputComboPenalty</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboPenalty.Type" xml:space="preserve">
+    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboPenalty.Parent" xml:space="preserve">
+    <value>grpCptOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboPenalty.ZOrder" xml:space="preserve">
+    <value>13</value>
   </data>
 </root>

--- a/instat/dlgHomogenization.vb
+++ b/instat/dlgHomogenization.vb
@@ -90,7 +90,6 @@ Public Class dlgHomogenization
         dctMethodOptions.Add("BinSeg", Chr(34) & "BinSeg" & Chr(34))
         ucrInputComboMethod.SetItems(dctMethodOptions)
         ucrInputComboMethod.SetDropDownStyleAsNonEditable()
-        ucrInputComboMethod.SetRDefault(Chr(34) & "BinSeg" & Chr(34))
 
         ucrInputComboDistribution.SetParameter(New RParameter("test.stat", 3))
         dctDistributionOptions.Add("Normal", Chr(34) & "Normal" & Chr(34))
@@ -120,7 +119,7 @@ Public Class dlgHomogenization
         ucrSaveResult.SetPrefix("Result")
         ucrSaveResult.SetAssignToIfUncheckedValue("last_result")
 
-        ucrInputComboPenalty.AddToLinkedControls(ucrInputPenValue, {"Asymptotic"}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
+        ucrInputComboPenalty.AddToLinkedControls(ucrInputPenValue, {"Asymptotic", "CROPS"}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
         ucrInputComboMethod.AddToLinkedControls(ucrInputQ, {"BinSeg"}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
         ucrPnlOptions.AddToLinkedControls(ucrReceiverNeighbour, {rdoNeighbouring}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
         ucrReceiverNeighbour.SetLinkedDisplayControl(lblNeighbouring)
@@ -149,6 +148,7 @@ Public Class dlgHomogenization
         clsCptMeanFunction.AddParameter("data", clsRFunctionParameter:=clsExcludeNAFunction, iPosition:=0)
         clsCptMeanFunction.AddParameter("Q", 5, iPosition:=5)
         clsCptMeanFunction.AddParameter("pen.value", 0, iPosition:=6)
+        clsCptMeanFunction.AddParameter("method", Chr(34) & "BinSeg" & Chr(34), iPosition:=2)
 
         clsCptVarianceFunction.SetPackageName("changepoint")
         clsCptVarianceFunction.SetRCommand("cpt.var")
@@ -165,6 +165,7 @@ Public Class dlgHomogenization
         clsSummaryFunction.SetRCommand("summary")
 
         ucrBase.clsRsyntax.ClearCodes()
+        AddPlotSummaryParameters()
         ucrBase.clsRsyntax.SetBaseRFunction(clsCptMeanFunction)
     End Sub
 
@@ -217,14 +218,22 @@ Public Class dlgHomogenization
     Private Sub ucrPnlMethods_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrPnlMethods.ControlValueChanged
         If rdoCptMean.Checked Then
             ucrBase.clsRsyntax.SetBaseRFunction(clsCptMeanFunction)
+        ElseIf rdoCptVariance.Checked Then
+            ucrBase.clsRsyntax.SetBaseRFunction(clsCptVarianceFunction)
+        ElseIf rdoMeanVariance.Checked Then
+            ucrBase.clsRsyntax.SetBaseRFunction(clsCptMeanVarianceFunction)
+        End If
+        AddPlotSummaryParameters()
+    End Sub
+
+    Private Sub AddPlotSummaryParameters()
+        If rdoCptMean.Checked Then
             clsPlotFunction.AddParameter("x", clsRFunctionParameter:=clsCptMeanFunction, iPosition:=0)
             clsSummaryFunction.AddParameter("object", clsRFunctionParameter:=clsCptMeanFunction, iPosition:=0)
         ElseIf rdoCptVariance.Checked Then
-            ucrBase.clsRsyntax.SetBaseRFunction(clsCptVarianceFunction)
             clsPlotFunction.AddParameter("x", clsRFunctionParameter:=clsCptVarianceFunction, iPosition:=0)
             clsSummaryFunction.AddParameter("object", clsRFunctionParameter:=clsCptVarianceFunction, iPosition:=0)
         ElseIf rdoMeanVariance.Checked Then
-            ucrBase.clsRsyntax.SetBaseRFunction(clsCptMeanVarianceFunction)
             clsPlotFunction.AddParameter("x", clsRFunctionParameter:=clsCptMeanVarianceFunction, iPosition:=0)
             clsSummaryFunction.AddParameter("object", clsRFunctionParameter:=clsCptMeanVarianceFunction, iPosition:=0)
         End If

--- a/instat/dlgHomogenization.vb
+++ b/instat/dlgHomogenization.vb
@@ -19,7 +19,7 @@ Imports instat.Translations
 Public Class dlgHomogenization
     Private bFirstLoad As Boolean = True
     Private bReset As Boolean = True
-    Private clsCptMeanFunction, clsCptVarianceFunction, clsCptMeanVarianceFunction, clsExcludeNAFunction, clsPlotFunction, clsSummaryFunction, clsSnhtFunction, clsPettittFunction As New RFunction
+    Private clsCptMeanFunction, clsCptVarianceFunction, clsCptMeanVarianceFunction, clsExcludeNAFunction, clsPlotFunction, clsSummaryFunction, clsSnhtFunction, clsPettittFunction, clsBuishandFunction As New RFunction
     Private Sub dlgHomogenization_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         autoTranslate(Me)
         If bFirstLoad Then
@@ -54,18 +54,20 @@ Public Class dlgHomogenization
         ucrPnlMethods.AddRadioButton(rdoCptMeanVariance)
         ucrPnlMethods.AddRadioButton(rdoSnht)
         ucrPnlMethods.AddRadioButton(rdoPettitt)
+        ucrPnlMethods.AddRadioButton(rdoBuishand)
         ucrPnlMethods.AddFunctionNamesCondition(rdoCptMean, "cpt.mean")
         ucrPnlMethods.AddFunctionNamesCondition(rdoCptVariance, "cpt.var")
         ucrPnlMethods.AddFunctionNamesCondition(rdoCptMeanVariance, "cpt.meanvar")
         ucrPnlMethods.AddFunctionNamesCondition(rdoSnht, "snht")
         ucrPnlMethods.AddFunctionNamesCondition(rdoPettitt, "pettitt.test")
+        ucrPnlMethods.AddFunctionNamesCondition(rdoBuishand, "br.test")
 
         ucrPnlOptions.AddRadioButton(rdoSingle)
         ucrPnlOptions.AddRadioButton(rdoNeighbouring)
         ucrPnlOptions.AddRadioButton(rdoMultiple)
-        ucrPnlOptions.AddFunctionNamesCondition(rdoSingle, {"cpt.mean", "cpt.var", "cpt.meanvar", "snht", "pettitt.test"})
-        ucrPnlOptions.AddFunctionNamesCondition(rdoNeighbouring, {"cpt.mean", "cpt.var", "cpt.meanvar", "snht", "pettitt.test"}, False)
-        ucrPnlOptions.AddFunctionNamesCondition(rdoMultiple, {"cpt.mean", "cpt.var", "cpt.meanvar", "snht", "pettitt.test"}, False)
+        ucrPnlOptions.AddFunctionNamesCondition(rdoSingle, {"cpt.mean", "cpt.var", "cpt.meanvar", "snht", "pettitt.test", "br.test"})
+        ucrPnlOptions.AddFunctionNamesCondition(rdoNeighbouring, {"cpt.mean", "cpt.var", "cpt.meanvar", "snht", "pettitt.test", "br.test"}, False)
+        ucrPnlOptions.AddFunctionNamesCondition(rdoMultiple, {"cpt.mean", "cpt.var", "cpt.meanvar", "snht", "pettitt.test", "br.test"}, False)
 
         ucrChkPlot.SetText("Plot")
         ucrChkPlot.AddRSyntaxContainsFunctionNamesCondition(True, {"plot"})
@@ -177,6 +179,7 @@ Public Class dlgHomogenization
         clsSummaryFunction = New RFunction
         clsSnhtFunction = New RFunction
         clsPettittFunction = New RFunction
+        clsBuishandFunction = New RFunction
 
         ucrSelectorHomogenization.Reset()
         ucrSaveResult.Reset()
@@ -211,6 +214,10 @@ Public Class dlgHomogenization
         clsPettittFunction.SetPackageName("trend")
         clsPettittFunction.SetRCommand("pettitt.test")
         clsPettittFunction.AddParameter("x", clsRFunctionParameter:=clsExcludeNAFunction, iPosition:=0)
+
+        clsBuishandFunction.SetPackageName("trend")
+        clsBuishandFunction.SetRCommand("br.test")
+        clsBuishandFunction.AddParameter("x", clsRFunctionParameter:=clsExcludeNAFunction, iPosition:=0)
 
         ucrBase.clsRsyntax.ClearCodes()
         AddPlotSummaryParameters()
@@ -279,6 +286,8 @@ Public Class dlgHomogenization
             ucrBase.clsRsyntax.SetBaseRFunction(clsSnhtFunction)
         ElseIf rdoPettitt.Checked Then
             ucrBase.clsRsyntax.SetBaseRFunction(clsPettittFunction)
+        ElseIf rdoBuishand.Checked Then
+            ucrBase.clsRsyntax.SetBaseRFunction(clsBuishandFunction)
         End If
         AddPlotSummaryParameters()
         ChangeSaveType()
@@ -300,11 +309,14 @@ Public Class dlgHomogenization
         ElseIf rdoPettitt.Checked Then
             clsPlotFunction.AddParameter("x", clsRFunctionParameter:=clsPettittFunction, iPosition:=0)
             clsSummaryFunction.AddParameter("object", clsRFunctionParameter:=clsPettittFunction, iPosition:=0)
+        ElseIf rdoBuishand.Checked Then
+            clsPlotFunction.AddParameter("x", clsRFunctionParameter:=clsBuishandFunction, iPosition:=0)
+            clsSummaryFunction.AddParameter("object", clsRFunctionParameter:=clsBuishandFunction, iPosition:=0)
         End If
     End Sub
 
     Private Sub ChangeSaveType()
-        If rdoCptMean.Checked OrElse rdoCptVariance.Checked OrElse rdoCptMeanVariance.Checked OrElse rdoPettitt.Checked Then
+        If rdoCptMean.Checked OrElse rdoCptVariance.Checked OrElse rdoCptMeanVariance.Checked OrElse rdoPettitt.Checked OrElse rdoBuishand.Checked Then
             ucrSaveResult.SetCheckBoxText("Save Result:")
             ucrSaveResult.SetSaveTypeAsModel()
             ucrSaveResult.SetIsComboBox()

--- a/instat/dlgHomogenization.vb
+++ b/instat/dlgHomogenization.vb
@@ -224,7 +224,7 @@ Public Class dlgHomogenization
 
         ucrBase.clsRsyntax.ClearCodes()
         AddPlotSummaryParameters()
-        ucrBase.clsRsyntax.SetBaseRFunction(clsCptMeanFunction)
+        ucrBase.clsRsyntax.SetBaseRFunction(clsSnhtFunction)
     End Sub
 
     Private Sub SetRcodeForControls(bReset As Boolean)

--- a/instat/dlgHomogenization.vb
+++ b/instat/dlgHomogenization.vb
@@ -19,7 +19,7 @@ Imports instat.Translations
 Public Class dlgHomogenization
     Private bFirstLoad As Boolean = True
     Private bReset As Boolean = True
-    Private clsCptMeanFunction, clsCptVarianceFunction, clsCptMeanVarianceFunction, clsExcludeNAFunction, clsPlotFunction, clsSummaryFunction, clsSnhtFunction As New RFunction
+    Private clsCptMeanFunction, clsCptVarianceFunction, clsCptMeanVarianceFunction, clsExcludeNAFunction, clsPlotFunction, clsSummaryFunction, clsSnhtFunction, clsPettittFunction As New RFunction
     Private Sub dlgHomogenization_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         autoTranslate(Me)
         If bFirstLoad Then
@@ -53,17 +53,19 @@ Public Class dlgHomogenization
         ucrPnlMethods.AddRadioButton(rdoCptVariance)
         ucrPnlMethods.AddRadioButton(rdoCptMeanVariance)
         ucrPnlMethods.AddRadioButton(rdoSnht)
+        ucrPnlMethods.AddRadioButton(rdoPettitt)
         ucrPnlMethods.AddFunctionNamesCondition(rdoCptMean, "cpt.mean")
         ucrPnlMethods.AddFunctionNamesCondition(rdoCptVariance, "cpt.var")
         ucrPnlMethods.AddFunctionNamesCondition(rdoCptMeanVariance, "cpt.meanvar")
         ucrPnlMethods.AddFunctionNamesCondition(rdoSnht, "snht")
+        ucrPnlMethods.AddFunctionNamesCondition(rdoPettitt, "pettitt.test")
 
         ucrPnlOptions.AddRadioButton(rdoSingle)
         ucrPnlOptions.AddRadioButton(rdoNeighbouring)
         ucrPnlOptions.AddRadioButton(rdoMultiple)
-        ucrPnlOptions.AddFunctionNamesCondition(rdoSingle, {"cpt.mean", "cpt.var", "cpt.meanvar", "snht"})
-        ucrPnlOptions.AddFunctionNamesCondition(rdoNeighbouring, {"cpt.mean", "cpt.var", "cpt.meanvar", "snht"}, False)
-        ucrPnlOptions.AddFunctionNamesCondition(rdoMultiple, {"cpt.mean", "cpt.var", "cpt.meanvar", "snht"}, False)
+        ucrPnlOptions.AddFunctionNamesCondition(rdoSingle, {"cpt.mean", "cpt.var", "cpt.meanvar", "snht", "pettitt.test"})
+        ucrPnlOptions.AddFunctionNamesCondition(rdoNeighbouring, {"cpt.mean", "cpt.var", "cpt.meanvar", "snht", "pettitt.test"}, False)
+        ucrPnlOptions.AddFunctionNamesCondition(rdoMultiple, {"cpt.mean", "cpt.var", "cpt.meanvar", "snht", "pettitt.test"}, False)
 
         ucrChkPlot.SetText("Plot")
         ucrChkPlot.AddRSyntaxContainsFunctionNamesCondition(True, {"plot"})
@@ -174,6 +176,7 @@ Public Class dlgHomogenization
         clsPlotFunction = New RFunction
         clsSummaryFunction = New RFunction
         clsSnhtFunction = New RFunction
+        clsPettittFunction = New RFunction
 
         ucrSelectorHomogenization.Reset()
         ucrSaveResult.Reset()
@@ -204,6 +207,10 @@ Public Class dlgHomogenization
         clsSnhtFunction.SetPackageName("snht")
         clsSnhtFunction.SetRCommand("snht")
         clsSnhtFunction.AddParameter("period", 10, iPosition:=1)
+
+        clsPettittFunction.SetPackageName("trend")
+        clsPettittFunction.SetRCommand("pettitt.test")
+        clsPettittFunction.AddParameter("x", clsRFunctionParameter:=clsExcludeNAFunction, iPosition:=0)
 
         ucrBase.clsRsyntax.ClearCodes()
         AddPlotSummaryParameters()
@@ -270,6 +277,8 @@ Public Class dlgHomogenization
             ucrBase.clsRsyntax.SetBaseRFunction(clsCptMeanVarianceFunction)
         ElseIf rdoSnht.Checked Then
             ucrBase.clsRsyntax.SetBaseRFunction(clsSnhtFunction)
+        ElseIf rdoPettitt.Checked Then
+            ucrBase.clsRsyntax.SetBaseRFunction(clsPettittFunction)
         End If
         AddPlotSummaryParameters()
         ChangeSaveType()
@@ -288,11 +297,14 @@ Public Class dlgHomogenization
         ElseIf rdoSnht.Checked Then
             clsPlotFunction.AddParameter("x", clsRFunctionParameter:=clsSnhtFunction, iPosition:=0)
             clsSummaryFunction.AddParameter("object", clsRFunctionParameter:=clsSnhtFunction, iPosition:=0)
+        ElseIf rdoPettitt.Checked Then
+            clsPlotFunction.AddParameter("x", clsRFunctionParameter:=clsPettittFunction, iPosition:=0)
+            clsSummaryFunction.AddParameter("object", clsRFunctionParameter:=clsPettittFunction, iPosition:=0)
         End If
     End Sub
 
     Private Sub ChangeSaveType()
-        If rdoCptMean.Checked OrElse rdoCptVariance.Checked OrElse rdoCptMeanVariance.Checked Then
+        If rdoCptMean.Checked OrElse rdoCptVariance.Checked OrElse rdoCptMeanVariance.Checked OrElse rdoPettitt.Checked Then
             ucrSaveResult.SetCheckBoxText("Save Result:")
             ucrSaveResult.SetSaveTypeAsModel()
             ucrSaveResult.SetIsComboBox()

--- a/instat/dlgHomogenization.vb
+++ b/instat/dlgHomogenization.vb
@@ -277,6 +277,7 @@ Public Class dlgHomogenization
             ucrBase.clsRsyntax.RemoveFromAfterCodes(clsPlotFunction)
         End If
     End Sub
+
     Private Sub ucrBase_ClickReset(sender As Object, e As EventArgs) Handles ucrBase.ClickReset
         SetDefaults()
         SetRcodeForControls(True)

--- a/instat/dlgHomogenization.vb
+++ b/instat/dlgHomogenization.vb
@@ -54,8 +54,18 @@ Public Class dlgHomogenization
         ucrPnlMethods.AddFunctionNamesCondition(rdoCptVariance, "cpt.var")
         ucrPnlMethods.AddFunctionNamesCondition(rdoMeanVariance, "cpt.meanvar")
 
+        ucrPnlOptions.AddRadioButton(rdoSingle)
+        ucrPnlOptions.AddRadioButton(rdoMultiple)
+        ucrPnlOptions.AddFunctionNamesCondition(rdoSingle, {"cpt.mean", "cpt.var", "cpt.meanvar"})
+        ucrPnlOptions.AddFunctionNamesCondition(rdoMultiple, {"cpt.mean", "cpt.var", "cpt.meanvar"}, False)
+
         ucrChkPlot.SetText("Plot")
+        ucrChkPlot.AddRSyntaxContainsFunctionNamesCondition(True, {"plot"})
+        ucrChkPlot.AddRSyntaxContainsFunctionNamesCondition(False, {"plot"}, False)
+
         ucrChkSummary.SetText("Summary")
+        ucrChkSummary.AddRSyntaxContainsFunctionNamesCondition(True, {"summary"})
+        ucrChkSummary.AddRSyntaxContainsFunctionNamesCondition(False, {"summary"}, False)
 
         ucrInputComboPenalty.SetParameter(New RParameter("penalty", 1))
         dctPenaltyOptions.Add("None", Chr(34) & "None" & Chr(34))
@@ -89,12 +99,19 @@ Public Class dlgHomogenization
 
         ucrNudMinSegLen.SetParameter(New RParameter("minseglen", 4))
         ucrNudMinSegLen.SetRDefault(1)
-        ttQ.SetToolTip(ucrNudMinSegLen, "Positive integer giving the minimum segment length (no. of observations between changes), default is the minimum allowed by theory.")
+        ttOptions.SetToolTip(ucrNudMinSegLen.nudUpDown, "Positive integer giving the minimum segment length (no. of observations between changes), default is the minimum allowed by theory.")
 
         ucrInputQ.SetParameter(New RParameter("Q", 5))
+        ucrInputQ.AddQuotesIfUnrecognised = False
         ucrInputQ.SetValidationTypeAsNumeric()
         ucrInputQ.SetRDefault(5)
-        ttQ.SetToolTip(ucrInputQ.txtInput, "The maximum number of changepoints to search for using the BinSeg method")
+        ttOptions.SetToolTip(ucrInputQ.txtInput, "The maximum number of changepoints to search for using the BinSeg method")
+
+        ucrInputPenValue.SetParameter(New RParameter("pen.value", 6))
+        ucrInputPenValue.AddQuotesIfUnrecognised = False
+        ucrInputPenValue.SetValidationTypeAsNumeric()
+        ucrInputPenValue.SetRDefault(0)
+        ttOptions.SetToolTip(ucrInputPenValue.txtInput, "The theoretical type I error e.g.0.05 when using the Asymptotic penalty. A vector of length 2 (min,max) if using the CROPS penalty")
 
         ucrSaveResult.SetLabelText("Save Result:")
         ucrSaveResult.SetDataFrameSelector(ucrSelectorHomogenization.ucrAvailableDataFrames)
@@ -102,6 +119,8 @@ Public Class dlgHomogenization
         ucrSaveResult.SetIsComboBox()
         ucrSaveResult.SetPrefix("Result")
         ucrSaveResult.SetAssignToIfUncheckedValue("last_result")
+
+        rdoMultiple.Enabled = False 'Not yet working!
     End Sub
 
     Private Sub SetDefaults()
@@ -146,12 +165,16 @@ Public Class dlgHomogenization
         ucrInputComboDistribution.SetRCode(ucrBase.clsRsyntax.clsBaseFunction, bReset)
         ucrNudMinSegLen.SetRCode(ucrBase.clsRsyntax.clsBaseFunction, bReset)
         ucrInputQ.SetRCode(ucrBase.clsRsyntax.clsBaseFunction, bReset)
+        ucrInputPenValue.SetRCode(ucrBase.clsRsyntax.clsBaseFunction, bReset)
         ucrPnlMethods.SetRCode(ucrBase.clsRsyntax.clsBaseFunction, bReset)
+        ucrPnlOptions.SetRCode(ucrBase.clsRsyntax.clsBaseFunction, bReset)
         ucrSaveResult.SetRCode(ucrBase.clsRsyntax.clsBaseFunction, bReset)
+        ucrChkPlot.SetRSyntax(ucrBase.clsRsyntax, bReset)
+        ucrChkSummary.SetRSyntax(ucrBase.clsRsyntax, bReset)
     End Sub
 
     Private Sub TestOkEnabled()
-        If ucrReceiverElement.IsEmpty Then
+        If ucrReceiverElement.IsEmpty OrElse Not ucrSaveResult.IsComplete OrElse ucrInputQ.IsEmpty OrElse ucrInputPenValue.IsEmpty OrElse ucrNudMinSegLen.GetText = "" Then
             ucrBase.OKEnabled(False)
         Else
             ucrBase.OKEnabled(True)
@@ -201,7 +224,7 @@ Public Class dlgHomogenization
         TestOkEnabled()
     End Sub
 
-    Private Sub Controls_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrReceiverElement.ControlContentsChanged
+    Private Sub Controls_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrReceiverElement.ControlContentsChanged, ucrSaveResult.ControlContentsChanged, ucrInputQ.ControlContentsChanged, ucrInputPenValue.ControlContentsChanged, ucrNudMinSegLen.ControlContentsChanged
         TestOkEnabled()
     End Sub
 End Class

--- a/instat/dlgHomogenization.vb
+++ b/instat/dlgHomogenization.vb
@@ -197,8 +197,10 @@ Public Class dlgHomogenization
         clsExcludeNAFunction.SetRCommand("na.exclude")
 
         clsPlotFunction.SetRCommand("plot")
+        clsPlotFunction.iCallType = 3
 
         clsSummaryFunction.SetRCommand("summary")
+        clsSummaryFunction.iCallType = 2
 
         clsSnhtFunction.SetPackageName("trend")
         clsSnhtFunction.SetRCommand("snh.test")
@@ -311,7 +313,6 @@ Public Class dlgHomogenization
     Private Sub ucrChkSummary_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrChkSummary.ControlValueChanged
         If ucrChkSummary.Checked Then
             ucrBase.clsRsyntax.AddToAfterCodes(clsSummaryFunction, iPosition:=0)
-            clsSummaryFunction.iCallType = 2
         Else
             ucrBase.clsRsyntax.RemoveFromAfterCodes(clsSummaryFunction)
         End If
@@ -320,7 +321,6 @@ Public Class dlgHomogenization
     Private Sub ucrChkPlot_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrChkPlot.ControlValueChanged
         If ucrChkPlot.Checked Then
             ucrBase.clsRsyntax.AddToAfterCodes(clsPlotFunction, iPosition:=1)
-            clsPlotFunction.iCallType = 3
         Else
             ucrBase.clsRsyntax.RemoveFromAfterCodes(clsPlotFunction)
         End If

--- a/instat/dlgHomogenization.vb
+++ b/instat/dlgHomogenization.vb
@@ -42,8 +42,9 @@ Public Class dlgHomogenization
         Dim dctVarDistribution As New Dictionary(Of String, String)
         Dim dctMeanVarDistribution As New Dictionary(Of String, String)
 
+        ucrBase.clsRsyntax.iCallType = 2
+        ucrBase.clsRsyntax.bExcludeAssignedFunctionOutput = False
         ucrReceiverElement.Selector = ucrSelectorHomogenization
-        'ucrBase.clsRsyntax.iCallType = 2
 
         ucrReceiverElement.SetParameter(New RParameter("object", 0))
         ucrReceiverElement.SetMeAsReceiver()
@@ -58,19 +59,19 @@ Public Class dlgHomogenization
         ucrPnlMethods.AddFunctionNamesCondition(rdoCptMean, "cpt.mean")
         ucrPnlMethods.AddFunctionNamesCondition(rdoCptVariance, "cpt.var")
         ucrPnlMethods.AddFunctionNamesCondition(rdoCptMeanVariance, "cpt.meanvar")
-        ucrPnlMethods.AddFunctionNamesCondition(rdoSnht, "snht")
+        ucrPnlMethods.AddFunctionNamesCondition(rdoSnht, "snh.test")
         ucrPnlMethods.AddFunctionNamesCondition(rdoPettitt, "pettitt.test")
         ucrPnlMethods.AddFunctionNamesCondition(rdoBuishand, "br.test")
-        ttOptions.SetToolTip(rdoSnht, "Performs a standard normal homogeneity test on the data supplied. This test searches the data for potential changepoints.")
+        ttOptions.SetToolTip(rdoSnht, "Performes the Standard Normal Homogeinity Test (SNHT) for change-point detection of a normal variate.")
         ttOptions.SetToolTip(rdoPettitt, "Performes a non-parametric test after Pettitt in order to test for a shift in the central tendency of a time series. The H0-hypothesis, no change, is tested against the HA-Hypothesis, change")
         ttOptions.SetToolTip(rdoBuishand, "Performes the Buishand range test for change-point detection of a normal variate.")
 
         ucrPnlOptions.AddRadioButton(rdoSingle)
         ucrPnlOptions.AddRadioButton(rdoNeighbouring)
         ucrPnlOptions.AddRadioButton(rdoMultiple)
-        ucrPnlOptions.AddFunctionNamesCondition(rdoSingle, {"cpt.mean", "cpt.var", "cpt.meanvar", "snht", "pettitt.test", "br.test"})
-        ucrPnlOptions.AddFunctionNamesCondition(rdoNeighbouring, {"cpt.mean", "cpt.var", "cpt.meanvar", "snht", "pettitt.test", "br.test"}, False)
-        ucrPnlOptions.AddFunctionNamesCondition(rdoMultiple, {"cpt.mean", "cpt.var", "cpt.meanvar", "snht", "pettitt.test", "br.test"}, False)
+        ucrPnlOptions.AddFunctionNamesCondition(rdoSingle, {"cpt.mean", "cpt.var", "cpt.meanvar", "snh.test", "pettitt.test", "br.test"})
+        ucrPnlOptions.AddFunctionNamesCondition(rdoNeighbouring, {"cpt.mean", "cpt.var", "cpt.meanvar", "snh.test", "pettitt.test", "br.test"}, False)
+        ucrPnlOptions.AddFunctionNamesCondition(rdoMultiple, {"cpt.mean", "cpt.var", "cpt.meanvar", "snh.test", "pettitt.test", "br.test"}, False)
 
         ucrChkPlot.SetText("Plot")
         ucrChkPlot.AddRSyntaxContainsFunctionNamesCondition(True, {"plot"})
@@ -140,6 +141,11 @@ Public Class dlgHomogenization
         ttOptions.SetToolTip(ucrInputPenValue.txtInput, "The theoretical type I error e.g.0.05 when using the Asymptotic penalty. A vector of length 2 (min,max) if using the CROPS penalty")
 
         ucrSaveResult.SetDataFrameSelector(ucrSelectorHomogenization.ucrAvailableDataFrames)
+        ucrSaveResult.SetCheckBoxText("Save Test Object:")
+        ucrSaveResult.SetSaveTypeAsModel()
+        ucrSaveResult.SetIsComboBox()
+        ucrSaveResult.SetPrefix("Test")
+        ucrSaveResult.SetAssignToIfUncheckedValue("last_model")
 
         ucrInputComboPenalty.AddToLinkedControls(ucrInputPenValue, {"Asymptotic", "CROPS"}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:=0)
         ucrInputComboMethod.AddToLinkedControls(ucrInputQ, {"SegNeigh", "BinSeg"}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:=5)
@@ -147,26 +153,11 @@ Public Class dlgHomogenization
         ucrPnlMethods.AddToLinkedControls(ucrInputComboMeanDistribution, {rdoCptMean}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
         ucrPnlMethods.AddToLinkedControls(ucrInputComboVarDistribution, {rdoCptVariance}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
         ucrPnlMethods.AddToLinkedControls(ucrInputComboMeanVarDistribution, {rdoCptMeanVariance}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
-        ucrPnlMethods.AddToLinkedControls(ucrNudPeriod, {rdoSnht}, bNewLinkedHideIfParameterMissing:=True)
         ucrPnlMethods.AddToLinkedControls(ucrInputComboMethod, {rdoCptMean, rdoCptVariance, rdoCptMeanVariance}, bNewLinkedHideIfParameterMissing:=True)
         ucrInputComboMethod.SetLinkedDisplayControl(grpCptOptions)
-        ucrNudPeriod.SetLinkedDisplayControl(grpSnhtOptions)
         ucrReceiverNeighbour.SetLinkedDisplayControl(lblNeighbouring)
         ucrInputPenValue.SetLinkedDisplayControl(lblPenaltyValue)
         ucrInputQ.SetLinkedDisplayControl(lblQ)
-
-        ucrNudPeriod.SetParameter(New RParameter("period", 1))
-        ucrNudPeriod.SetMinMax(1, Integer.MaxValue)
-
-        ucrChkRobust.SetParameter(New RParameter("robust", 2))
-        ucrChkRobust.SetValuesCheckedAndUnchecked("TRUE", "FALSE")
-        ucrChkRobust.SetRDefault("FALSE")
-        ucrChkRobust.SetText("Robust")
-
-        ucrChkScaled.SetParameter(New RParameter("scaled", 3))
-        ucrChkScaled.SetValuesCheckedAndUnchecked("TRUE", "FALSE")
-        ucrChkScaled.SetRDefault("TRUE")
-        ucrChkScaled.SetText("Scaled")
 
         'Not yet working!
         rdoMultiple.Enabled = False
@@ -186,7 +177,6 @@ Public Class dlgHomogenization
 
         ucrSelectorHomogenization.Reset()
         ucrSaveResult.Reset()
-        ucrBase.clsRsyntax.bExcludeAssignedFunctionOutput = False
 
         clsCptMeanFunction.SetPackageName("changepoint")
         clsCptMeanFunction.SetRCommand("cpt.mean")
@@ -210,9 +200,10 @@ Public Class dlgHomogenization
 
         clsSummaryFunction.SetRCommand("summary")
 
-        clsSnhtFunction.SetPackageName("snht")
-        clsSnhtFunction.SetRCommand("snht")
-        clsSnhtFunction.AddParameter("period", 10, iPosition:=1)
+        clsSnhtFunction.SetPackageName("trend")
+        clsSnhtFunction.SetRCommand("snh.test")
+        clsSnhtFunction.AddParameter("x", clsRFunctionParameter:=clsExcludeNAFunction, iPosition:=0)
+        clsSnhtFunction.AddParameter("m", 10, iPosition:=1)
 
         clsPettittFunction.SetPackageName("trend")
         clsPettittFunction.SetRCommand("pettitt.test")
@@ -221,6 +212,7 @@ Public Class dlgHomogenization
         clsBuishandFunction.SetPackageName("trend")
         clsBuishandFunction.SetRCommand("br.test")
         clsBuishandFunction.AddParameter("x", clsRFunctionParameter:=clsExcludeNAFunction, iPosition:=0)
+        clsBuishandFunction.AddParameter("m", 10, iPosition:=1)
 
         ucrBase.clsRsyntax.ClearCodes()
         AddPlotSummaryParameters()
@@ -228,7 +220,6 @@ Public Class dlgHomogenization
     End Sub
 
     Private Sub SetRcodeForControls(bReset As Boolean)
-        ucrReceiverElement.AddAdditionalCodeParameterPair(clsSnhtFunction, New RParameter("data", 0), iAdditionalPairNo:=1)
         ucrReceiverElement.SetRCode(clsExcludeNAFunction, bReset)
 
         ucrInputComboPenalty.AddAdditionalCodeParameterPair(clsCptVarianceFunction, ucrInputComboPenalty.GetParameter, iAdditionalPairNo:=1)
@@ -260,14 +251,14 @@ Public Class dlgHomogenization
 
         ucrSaveResult.AddAdditionalRCode(clsCptVarianceFunction, iAdditionalPairNo:=1)
         ucrSaveResult.AddAdditionalRCode(clsCptMeanVarianceFunction, iAdditionalPairNo:=2)
+        ucrSaveResult.AddAdditionalRCode(clsPettittFunction, iAdditionalPairNo:=3)
+        ucrSaveResult.AddAdditionalRCode(clsSnhtFunction, iAdditionalPairNo:=4)
+        ucrSaveResult.AddAdditionalRCode(clsBuishandFunction, iAdditionalPairNo:=5)
+
         ucrSaveResult.SetRCode(clsCptMeanFunction, bReset)
 
         ucrChkPlot.SetRSyntax(ucrBase.clsRsyntax, bReset)
         ucrChkSummary.SetRSyntax(ucrBase.clsRsyntax, bReset)
-
-        ucrNudPeriod.SetRCode(clsSnhtFunction, bReset)
-        ucrChkScaled.SetRCode(clsSnhtFunction, bReset)
-        ucrChkRobust.SetRCode(clsSnhtFunction, bReset)
     End Sub
 
     Private Sub TestOkEnabled()
@@ -293,7 +284,6 @@ Public Class dlgHomogenization
             ucrBase.clsRsyntax.SetBaseRFunction(clsBuishandFunction)
         End If
         AddPlotSummaryParameters()
-        ChangeSaveType()
     End Sub
 
     Private Sub AddPlotSummaryParameters()
@@ -315,24 +305,6 @@ Public Class dlgHomogenization
         ElseIf rdoBuishand.Checked Then
             clsPlotFunction.AddParameter("x", clsRFunctionParameter:=clsBuishandFunction, iPosition:=0)
             clsSummaryFunction.AddParameter("object", clsRFunctionParameter:=clsBuishandFunction, iPosition:=0)
-        End If
-    End Sub
-
-    Private Sub ChangeSaveType()
-        If rdoCptMean.Checked OrElse rdoCptVariance.Checked OrElse rdoCptMeanVariance.Checked OrElse rdoPettitt.Checked OrElse rdoBuishand.Checked Then
-            ucrSaveResult.SetCheckBoxText("Save Result:")
-            ucrSaveResult.SetSaveTypeAsModel()
-            ucrSaveResult.SetIsComboBox()
-            ucrSaveResult.SetPrefix("Result")
-            ucrSaveResult.SetAssignToIfUncheckedValue("last_result")
-            ucrBase.clsRsyntax.iCallType = 2
-        Else
-            ucrSaveResult.SetLabelText("New Dataframe Name:")
-            ucrSaveResult.SetSaveTypeAsDataFrame()
-            ucrSaveResult.SetIsTextBox()
-            ucrSaveResult.SetPrefix("Snht_dataframe")
-            ucrBase.clsRsyntax.iCallType = 0
-            clsSnhtFunction.SetAssignTo(strTemp:=ucrSelectorHomogenization.ucrAvailableDataFrames.cboAvailableDataFrames.Text, strTempDataframe:=ucrSaveResult.GetText)
         End If
     End Sub
 

--- a/instat/dlgHomogenization.vb
+++ b/instat/dlgHomogenization.vb
@@ -61,6 +61,9 @@ Public Class dlgHomogenization
         ucrPnlMethods.AddFunctionNamesCondition(rdoSnht, "snht")
         ucrPnlMethods.AddFunctionNamesCondition(rdoPettitt, "pettitt.test")
         ucrPnlMethods.AddFunctionNamesCondition(rdoBuishand, "br.test")
+        ttOptions.SetToolTip(rdoSnht, "Performs a standard normal homogeneity test on the data supplied. This test searches the data for potential changepoints.")
+        ttOptions.SetToolTip(rdoPettitt, "Performes a non-parametric test after Pettitt in order to test for a shift in the central tendency of a time series. The H0-hypothesis, no change, is tested against the HA-Hypothesis, change")
+        ttOptions.SetToolTip(rdoBuishand, "Performes the Buishand range test for change-point detection of a normal variate.")
 
         ucrPnlOptions.AddRadioButton(rdoSingle)
         ucrPnlOptions.AddRadioButton(rdoNeighbouring)

--- a/instat/dlgHomogenization.vb
+++ b/instat/dlgHomogenization.vb
@@ -14,8 +14,43 @@
 ' You should have received a copy of the GNU General Public License 
 ' along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+Imports instat.Translations
 Public Class dlgHomogenization
+    Private bFirstLoad As Boolean = True
+    Private bReset As Boolean = True
     Private Sub dlgHomogenization_Load(sender As Object, e As EventArgs) Handles MyBase.Load
+        If bFirstLoad Then
+            InitialiseDialog()
+            bFirstLoad = False
+        End If
 
+        If bReset Then
+            SetDefaults()
+        End If
+        SetRcodeForControls(bReset)
+        bReset = False
+        autoTranslate(Me)
+    End Sub
+
+    Private Sub InitialiseDialog()
+
+    End Sub
+
+    Private Sub SetDefaults()
+
+    End Sub
+
+    Private Sub SetRcodeForControls(bReset As Boolean)
+
+    End Sub
+
+    Private Sub TestOkEnabled()
+
+    End Sub
+
+    Private Sub ucrBase_ClickReset(sender As Object, e As EventArgs) Handles ucrBase.ClickReset
+        SetDefaults()
+        SetRcodeForControls(True)
+        TestOkEnabled()
     End Sub
 End Class

--- a/instat/dlgHomogenization.vb
+++ b/instat/dlgHomogenization.vb
@@ -217,8 +217,8 @@ Public Class dlgHomogenization
         clsBuishandFunction.AddParameter("m", 10, iPosition:=1)
 
         ucrBase.clsRsyntax.ClearCodes()
-        AddPlotSummaryParameters()
         ucrBase.clsRsyntax.SetBaseRFunction(clsSnhtFunction)
+        AddPlotSummaryParameters()
     End Sub
 
     Private Sub SetRcodeForControls(bReset As Boolean)
@@ -289,25 +289,8 @@ Public Class dlgHomogenization
     End Sub
 
     Private Sub AddPlotSummaryParameters()
-        If rdoCptMean.Checked Then
-            clsPlotFunction.AddParameter("x", clsRFunctionParameter:=clsCptMeanFunction, iPosition:=0)
-            clsSummaryFunction.AddParameter("object", clsRFunctionParameter:=clsCptMeanFunction, iPosition:=0)
-        ElseIf rdoCptVariance.Checked Then
-            clsPlotFunction.AddParameter("x", clsRFunctionParameter:=clsCptVarianceFunction, iPosition:=0)
-            clsSummaryFunction.AddParameter("object", clsRFunctionParameter:=clsCptVarianceFunction, iPosition:=0)
-        ElseIf rdoCptMeanVariance.Checked Then
-            clsPlotFunction.AddParameter("x", clsRFunctionParameter:=clsCptMeanVarianceFunction, iPosition:=0)
-            clsSummaryFunction.AddParameter("object", clsRFunctionParameter:=clsCptMeanVarianceFunction, iPosition:=0)
-        ElseIf rdoSnht.Checked Then
-            clsPlotFunction.AddParameter("x", clsRFunctionParameter:=clsSnhtFunction, iPosition:=0)
-            clsSummaryFunction.AddParameter("object", clsRFunctionParameter:=clsSnhtFunction, iPosition:=0)
-        ElseIf rdoPettitt.Checked Then
-            clsPlotFunction.AddParameter("x", clsRFunctionParameter:=clsPettittFunction, iPosition:=0)
-            clsSummaryFunction.AddParameter("object", clsRFunctionParameter:=clsPettittFunction, iPosition:=0)
-        ElseIf rdoBuishand.Checked Then
-            clsPlotFunction.AddParameter("x", clsRFunctionParameter:=clsBuishandFunction, iPosition:=0)
-            clsSummaryFunction.AddParameter("object", clsRFunctionParameter:=clsBuishandFunction, iPosition:=0)
-        End If
+        clsPlotFunction.AddParameter("x", clsRFunctionParameter:=ucrBase.clsRsyntax.clsBaseFunction, iPosition:=0)
+        clsSummaryFunction.AddParameter("object", clsRFunctionParameter:=ucrBase.clsRsyntax.clsBaseFunction, iPosition:=0)
     End Sub
 
     Private Sub ucrChkSummary_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrChkSummary.ControlValueChanged

--- a/instat/dlgHomogenization.vb
+++ b/instat/dlgHomogenization.vb
@@ -15,10 +15,13 @@
 ' along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 Imports instat.Translations
+
 Public Class dlgHomogenization
     Private bFirstLoad As Boolean = True
     Private bReset As Boolean = True
+    Private clsCptMeanFunction, clsCptVarianceFunction, clsCptMeanVarianceFunction, clsExcludeNAFunction, clsPlotFunction, clsSummaryFunction As New RFunction
     Private Sub dlgHomogenization_Load(sender As Object, e As EventArgs) Handles MyBase.Load
+        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -29,28 +32,176 @@ Public Class dlgHomogenization
         End If
         SetRcodeForControls(bReset)
         bReset = False
-        autoTranslate(Me)
+        TestOkEnabled()
     End Sub
 
     Private Sub InitialiseDialog()
+        Dim dctPenaltyOptions As New Dictionary(Of String, String)
+        Dim dctMethodOptions As New Dictionary(Of String, String)
+        Dim dctDistributionOptions As New Dictionary(Of String, String)
 
+        ucrReceiverElement.Selector = ucrSelectorHomogenization
+        ucrBase.clsRsyntax.iCallType = 2
+
+        ucrReceiverElement.SetParameter(New RParameter("object", 0))
+        ucrReceiverElement.SetMeAsReceiver()
+        ucrReceiverElement.SetParameterIsRFunction()
+
+        ucrPnlMethods.AddRadioButton(rdoCptMean)
+        ucrPnlMethods.AddRadioButton(rdoCptVariance)
+        ucrPnlMethods.AddRadioButton(rdoMeanVariance)
+        ucrPnlMethods.AddFunctionNamesCondition(rdoCptMean, "cpt.mean")
+        ucrPnlMethods.AddFunctionNamesCondition(rdoCptVariance, "cpt.var")
+        ucrPnlMethods.AddFunctionNamesCondition(rdoMeanVariance, "cpt.meanvar")
+
+        ucrChkPlot.SetText("Plot")
+        ucrChkSummary.SetText("Summary")
+
+        ucrInputComboPenalty.SetParameter(New RParameter("penalty", 1))
+        dctPenaltyOptions.Add("None", Chr(34) & "None" & Chr(34))
+        dctPenaltyOptions.Add("SIC", Chr(34) & "SIC" & Chr(34))
+        dctPenaltyOptions.Add("BIC", Chr(34) & "BIC" & Chr(34))
+        dctPenaltyOptions.Add("MBIC", Chr(34) & "MBIC" & Chr(34))
+        dctPenaltyOptions.Add("AIC", Chr(34) & "AIC" & Chr(34))
+        dctPenaltyOptions.Add("Hannan-Quinn", Chr(34) & "Hannan-Quinn" & Chr(34))
+        dctPenaltyOptions.Add("Asymptotic", Chr(34) & "Asymptotic" & Chr(34))
+        dctPenaltyOptions.Add("Manual", Chr(34) & "Manual" & Chr(34))
+        dctPenaltyOptions.Add("CROPS", Chr(34) & "CROPS" & Chr(34))
+        ucrInputComboPenalty.SetItems(dctPenaltyOptions)
+        ucrInputComboPenalty.SetDropDownStyleAsNonEditable()
+        ucrInputComboPenalty.SetRDefault(Chr(34) & "None" & Chr(34))
+
+        ucrInputComboMethod.SetParameter(New RParameter("method", 2))
+        dctMethodOptions.Add("AMOC", Chr(34) & "AMOC" & Chr(34))
+        dctMethodOptions.Add("PELT", Chr(34) & "PELT" & Chr(34))
+        dctMethodOptions.Add("SegNeigh", Chr(34) & "SegNeigh" & Chr(34))
+        dctMethodOptions.Add("BinSeg", Chr(34) & "BinSeg" & Chr(34))
+        ucrInputComboMethod.SetItems(dctMethodOptions)
+        ucrInputComboMethod.SetDropDownStyleAsNonEditable()
+        ucrInputComboMethod.SetRDefault(Chr(34) & "AMOC" & Chr(34))
+
+        ucrInputComboDistribution.SetParameter(New RParameter("test.stat", 3))
+        dctDistributionOptions.Add("Normal", Chr(34) & "Normal" & Chr(34))
+        dctDistributionOptions.Add("CUSUM", Chr(34) & "CUSUM" & Chr(34))
+        ucrInputComboDistribution.SetItems(dctDistributionOptions)
+        ucrInputComboDistribution.SetDropDownStyleAsNonEditable()
+        ucrInputComboDistribution.SetRDefault(Chr(34) & "Normal" & Chr(34))
+
+        ucrNudMinSegLen.SetParameter(New RParameter("minseglen", 4))
+        ucrNudMinSegLen.SetRDefault(1)
+        ttQ.SetToolTip(ucrNudMinSegLen, "Positive integer giving the minimum segment length (no. of observations between changes), default is the minimum allowed by theory.")
+
+        ucrInputQ.SetParameter(New RParameter("Q", 5))
+        ucrInputQ.SetValidationTypeAsNumeric()
+        ucrInputQ.SetRDefault(5)
+        ttQ.SetToolTip(ucrInputQ.txtInput, "The maximum number of changepoints to search for using the BinSeg method")
+
+        ucrSaveResult.SetLabelText("Save Result:")
+        ucrSaveResult.SetDataFrameSelector(ucrSelectorHomogenization.ucrAvailableDataFrames)
+        ucrSaveResult.SetSaveTypeAsModel()
+        ucrSaveResult.SetIsComboBox()
+        ucrSaveResult.SetPrefix("Result")
+        ucrSaveResult.SetAssignToIfUncheckedValue("last_result")
     End Sub
 
     Private Sub SetDefaults()
+        clsCptMeanFunction = New RFunction
+        clsCptVarianceFunction = New RFunction
+        clsCptMeanVarianceFunction = New RFunction
+        clsExcludeNAFunction = New RFunction
+        clsPlotFunction = New RFunction
+        clsSummaryFunction = New RFunction
 
+        ucrSelectorHomogenization.Reset()
+        ucrSaveResult.Reset()
+        ucrBase.clsRsyntax.bExcludeAssignedFunctionOutput = False
+
+        clsCptMeanFunction.SetPackageName("changepoint")
+        clsCptMeanFunction.SetRCommand("cpt.mean")
+        clsCptMeanFunction.AddParameter("data", clsRFunctionParameter:=clsExcludeNAFunction, iPosition:=0)
+
+        clsCptVarianceFunction.SetPackageName("changepoint")
+        clsCptVarianceFunction.SetRCommand("cpt.var")
+        clsCptVarianceFunction.AddParameter("data", clsRFunctionParameter:=clsExcludeNAFunction, iPosition:=0)
+
+        clsCptMeanVarianceFunction.SetPackageName("changepoint")
+        clsCptMeanVarianceFunction.SetRCommand("cpt.meanvar")
+        clsCptMeanVarianceFunction.AddParameter("data", clsRFunctionParameter:=clsExcludeNAFunction, iPosition:=0)
+
+        clsExcludeNAFunction.SetRCommand("na.exclude")
+
+        clsPlotFunction.SetRCommand("plot")
+
+        clsSummaryFunction.SetRCommand("summary")
+
+        ucrBase.clsRsyntax.ClearCodes()
+        SetBaseFunction()
+        ucrBase.clsRsyntax.SetBaseRFunction(clsCptMeanFunction)
     End Sub
 
     Private Sub SetRcodeForControls(bReset As Boolean)
-
+        ucrReceiverElement.SetRCode(clsExcludeNAFunction, bReset)
+        ucrInputComboPenalty.SetRCode(ucrBase.clsRsyntax.clsBaseFunction, bReset)
+        ucrInputComboMethod.SetRCode(ucrBase.clsRsyntax.clsBaseFunction, bReset)
+        ucrInputComboDistribution.SetRCode(ucrBase.clsRsyntax.clsBaseFunction, bReset)
+        ucrNudMinSegLen.SetRCode(ucrBase.clsRsyntax.clsBaseFunction, bReset)
+        ucrInputQ.SetRCode(ucrBase.clsRsyntax.clsBaseFunction, bReset)
+        ucrPnlMethods.SetRCode(ucrBase.clsRsyntax.clsBaseFunction, bReset)
+        ucrSaveResult.SetRCode(ucrBase.clsRsyntax.clsBaseFunction, bReset)
     End Sub
 
     Private Sub TestOkEnabled()
-
+        If ucrReceiverElement.IsEmpty Then
+            ucrBase.OKEnabled(False)
+        Else
+            ucrBase.OKEnabled(True)
+        End If
     End Sub
 
+    Private Sub SetBaseFunction()
+        If rdoCptMean.Checked Then
+            ucrBase.clsRsyntax.SetBaseRFunction(clsCptMeanFunction)
+            clsPlotFunction.AddParameter("x", clsRFunctionParameter:=clsCptMeanFunction, iPosition:=0)
+            clsSummaryFunction.AddParameter("object", clsRFunctionParameter:=clsCptMeanFunction, iPosition:=0)
+        ElseIf rdoCptVariance.Checked Then
+            ucrBase.clsRsyntax.SetBaseRFunction(clsCptVarianceFunction)
+            clsPlotFunction.AddParameter("x", clsRFunctionParameter:=clsCptVarianceFunction, iPosition:=0)
+            clsSummaryFunction.AddParameter("object", clsRFunctionParameter:=clsCptVarianceFunction, iPosition:=0)
+        ElseIf rdoMeanVariance.Checked Then
+            ucrBase.clsRsyntax.SetBaseRFunction(clsCptMeanVarianceFunction)
+            clsPlotFunction.AddParameter("x", clsRFunctionParameter:=clsCptMeanVarianceFunction, iPosition:=0)
+            clsSummaryFunction.AddParameter("object", clsRFunctionParameter:=clsCptMeanVarianceFunction, iPosition:=0)
+        End If
+    End Sub
+
+    Private Sub ucrPnlMethods_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrPnlMethods.ControlValueChanged
+        SetBaseFunction()
+    End Sub
+
+    Private Sub ucrChkSummary_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrChkSummary.ControlValueChanged
+        If ucrChkSummary.Checked Then
+            ucrBase.clsRsyntax.AddToAfterCodes(clsSummaryFunction, iPosition:=0)
+            clsSummaryFunction.iCallType = 2
+        Else
+            ucrBase.clsRsyntax.RemoveFromAfterCodes(clsSummaryFunction)
+        End If
+    End Sub
+
+    Private Sub ucrChkPlot_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrChkPlot.ControlValueChanged
+        If ucrChkPlot.Checked Then
+            ucrBase.clsRsyntax.AddToAfterCodes(clsPlotFunction, iPosition:=1)
+            clsPlotFunction.iCallType = 3
+        Else
+            ucrBase.clsRsyntax.RemoveFromAfterCodes(clsPlotFunction)
+        End If
+    End Sub
     Private Sub ucrBase_ClickReset(sender As Object, e As EventArgs) Handles ucrBase.ClickReset
         SetDefaults()
         SetRcodeForControls(True)
+        TestOkEnabled()
+    End Sub
+
+    Private Sub Controls_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrReceiverElement.ControlContentsChanged
         TestOkEnabled()
     End Sub
 End Class

--- a/instat/dlgHomogenization.vb
+++ b/instat/dlgHomogenization.vb
@@ -55,8 +55,10 @@ Public Class dlgHomogenization
         ucrPnlMethods.AddFunctionNamesCondition(rdoMeanVariance, "cpt.meanvar")
 
         ucrPnlOptions.AddRadioButton(rdoSingle)
+        ucrPnlOptions.AddRadioButton(rdoNeighbouring)
         ucrPnlOptions.AddRadioButton(rdoMultiple)
         ucrPnlOptions.AddFunctionNamesCondition(rdoSingle, {"cpt.mean", "cpt.var", "cpt.meanvar"})
+        ucrPnlOptions.AddFunctionNamesCondition(rdoNeighbouring, {"cpt.mean", "cpt.var", "cpt.meanvar"}, False)
         ucrPnlOptions.AddFunctionNamesCondition(rdoMultiple, {"cpt.mean", "cpt.var", "cpt.meanvar"}, False)
 
         ucrChkPlot.SetText("Plot")
@@ -120,10 +122,14 @@ Public Class dlgHomogenization
 
         ucrInputComboPenalty.AddToLinkedControls(ucrInputPenValue, {"Asymptotic"}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
         ucrInputComboMethod.AddToLinkedControls(ucrInputQ, {"BinSeg"}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
+        ucrPnlOptions.AddToLinkedControls(ucrReceiverNeighbour, {rdoNeighbouring}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
+        ucrReceiverNeighbour.SetLinkedDisplayControl(lblNeighbouring)
         ucrInputPenValue.SetLinkedDisplayControl(lblPenaltyValue)
         ucrInputQ.SetLinkedDisplayControl(lblQ)
 
-        rdoMultiple.Enabled = False 'Not yet working!
+        'Not yet working!
+        rdoMultiple.Enabled = False
+        rdoNeighbouring.Enabled = False
     End Sub
 
     Private Sub SetDefaults()

--- a/instat/dlgHomogenization.vb
+++ b/instat/dlgHomogenization.vb
@@ -38,7 +38,9 @@ Public Class dlgHomogenization
     Private Sub InitialiseDialog()
         Dim dctPenaltyOptions As New Dictionary(Of String, String)
         Dim dctMethodOptions As New Dictionary(Of String, String)
-        Dim dctDistributionOptions As New Dictionary(Of String, String)
+        Dim dctMeanDistribution As New Dictionary(Of String, String)
+        Dim dctVarDistribution As New Dictionary(Of String, String)
+        Dim dctMeanVarDistribution As New Dictionary(Of String, String)
 
         ucrReceiverElement.Selector = ucrSelectorHomogenization
         ucrBase.clsRsyntax.iCallType = 2
@@ -49,10 +51,10 @@ Public Class dlgHomogenization
 
         ucrPnlMethods.AddRadioButton(rdoCptMean)
         ucrPnlMethods.AddRadioButton(rdoCptVariance)
-        ucrPnlMethods.AddRadioButton(rdoMeanVariance)
+        ucrPnlMethods.AddRadioButton(rdoCptMeanVariance)
         ucrPnlMethods.AddFunctionNamesCondition(rdoCptMean, "cpt.mean")
         ucrPnlMethods.AddFunctionNamesCondition(rdoCptVariance, "cpt.var")
-        ucrPnlMethods.AddFunctionNamesCondition(rdoMeanVariance, "cpt.meanvar")
+        ucrPnlMethods.AddFunctionNamesCondition(rdoCptMeanVariance, "cpt.meanvar")
 
         ucrPnlOptions.AddRadioButton(rdoSingle)
         ucrPnlOptions.AddRadioButton(rdoNeighbouring)
@@ -81,7 +83,6 @@ Public Class dlgHomogenization
         dctPenaltyOptions.Add("CROPS", Chr(34) & "CROPS" & Chr(34))
         ucrInputComboPenalty.SetItems(dctPenaltyOptions)
         ucrInputComboPenalty.SetDropDownStyleAsNonEditable()
-        ucrInputComboPenalty.SetRDefault(Chr(34) & "None" & Chr(34))
 
         ucrInputComboMethod.SetParameter(New RParameter("method", 2))
         dctMethodOptions.Add("AMOC", Chr(34) & "AMOC" & Chr(34))
@@ -91,12 +92,28 @@ Public Class dlgHomogenization
         ucrInputComboMethod.SetItems(dctMethodOptions)
         ucrInputComboMethod.SetDropDownStyleAsNonEditable()
 
-        ucrInputComboDistribution.SetParameter(New RParameter("test.stat", 3))
-        dctDistributionOptions.Add("Normal", Chr(34) & "Normal" & Chr(34))
-        dctDistributionOptions.Add("CUSUM", Chr(34) & "CUSUM" & Chr(34))
-        ucrInputComboDistribution.SetItems(dctDistributionOptions)
-        ucrInputComboDistribution.SetDropDownStyleAsNonEditable()
-        ucrInputComboDistribution.SetRDefault(Chr(34) & "Normal" & Chr(34))
+        ucrInputComboMeanDistribution.SetParameter(New RParameter("test.stat", 3))
+        dctMeanDistribution.Add("Normal", Chr(34) & "Normal" & Chr(34))
+        dctMeanDistribution.Add("CUSUM", Chr(34) & "CUSUM" & Chr(34))
+        ucrInputComboMeanDistribution.SetItems(dctMeanDistribution)
+        ucrInputComboMeanDistribution.SetDropDownStyleAsNonEditable()
+        ucrInputComboMeanDistribution.SetRDefault(Chr(34) & "Normal" & Chr(34))
+
+        ucrInputComboVarDistribution.SetParameter(New RParameter("test.stat", 3))
+        dctVarDistribution.Add("Normal", Chr(34) & "Normal" & Chr(34))
+        dctVarDistribution.Add("CSS", Chr(34) & "CSS" & Chr(34))
+        ucrInputComboVarDistribution.SetItems(dctVarDistribution)
+        ucrInputComboVarDistribution.SetDropDownStyleAsNonEditable()
+        ucrInputComboVarDistribution.SetRDefault(Chr(34) & "Normal" & Chr(34))
+
+        ucrInputComboMeanVarDistribution.SetParameter(New RParameter("test.stat", 3))
+        dctMeanVarDistribution.Add("Normal", Chr(34) & "Normal" & Chr(34))
+        dctMeanVarDistribution.Add("Gamma", Chr(34) & "Gamma" & Chr(34))
+        dctMeanVarDistribution.Add("Exponential", Chr(34) & "Exponential" & Chr(34))
+        dctMeanVarDistribution.Add("Poisson", Chr(34) & "Poisson" & Chr(34))
+        ucrInputComboMeanVarDistribution.SetItems(dctMeanVarDistribution)
+        ucrInputComboMeanVarDistribution.SetDropDownStyleAsNonEditable()
+        ucrInputComboMeanVarDistribution.SetRDefault(Chr(34) & "Normal" & Chr(34))
 
         ucrNudMinSegLen.SetParameter(New RParameter("minseglen", 4))
         ucrNudMinSegLen.SetRDefault(1)
@@ -119,9 +136,12 @@ Public Class dlgHomogenization
         ucrSaveResult.SetPrefix("Result")
         ucrSaveResult.SetAssignToIfUncheckedValue("last_result")
 
-        ucrInputComboPenalty.AddToLinkedControls(ucrInputPenValue, {"Asymptotic", "CROPS"}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
-        ucrInputComboMethod.AddToLinkedControls(ucrInputQ, {"BinSeg"}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
+        ucrInputComboPenalty.AddToLinkedControls(ucrInputPenValue, {"Asymptotic", "CROPS"}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:=0)
+        ucrInputComboMethod.AddToLinkedControls(ucrInputQ, {"SegNeigh", "BinSeg"}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:=5)
         ucrPnlOptions.AddToLinkedControls(ucrReceiverNeighbour, {rdoNeighbouring}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
+        ucrPnlMethods.AddToLinkedControls(ucrInputComboMeanDistribution, {rdoCptMean}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
+        ucrPnlMethods.AddToLinkedControls(ucrInputComboVarDistribution, {rdoCptVariance}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
+        ucrPnlMethods.AddToLinkedControls(ucrInputComboMeanVarDistribution, {rdoCptMeanVariance}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
         ucrReceiverNeighbour.SetLinkedDisplayControl(lblNeighbouring)
         ucrInputPenValue.SetLinkedDisplayControl(lblPenaltyValue)
         ucrInputQ.SetLinkedDisplayControl(lblQ)
@@ -148,6 +168,7 @@ Public Class dlgHomogenization
         clsCptMeanFunction.AddParameter("data", clsRFunctionParameter:=clsExcludeNAFunction, iPosition:=0)
         clsCptMeanFunction.AddParameter("Q", 5, iPosition:=5)
         clsCptMeanFunction.AddParameter("pen.value", 0, iPosition:=6)
+        clsCptMeanFunction.AddParameter("penalty", Chr(34) & "None" & Chr(34), iPosition:=1)
         clsCptMeanFunction.AddParameter("method", Chr(34) & "BinSeg" & Chr(34), iPosition:=2)
 
         clsCptVarianceFunction.SetPackageName("changepoint")
@@ -173,16 +194,16 @@ Public Class dlgHomogenization
         ucrReceiverElement.SetRCode(clsExcludeNAFunction, bReset)
 
         ucrInputComboPenalty.AddAdditionalCodeParameterPair(clsCptVarianceFunction, ucrInputComboPenalty.GetParameter, iAdditionalPairNo:=1)
-        ucrInputComboPenalty.AddAdditionalCodeParameterPair(clsCptMeanVarianceFunction, ucrInputComboPenalty.GetParameter, iAdditionalPairNo:=1)
+        ucrInputComboPenalty.AddAdditionalCodeParameterPair(clsCptMeanVarianceFunction, ucrInputComboPenalty.GetParameter, iAdditionalPairNo:=2)
         ucrInputComboPenalty.SetRCode(clsCptMeanFunction, bReset)
 
         ucrInputComboMethod.AddAdditionalCodeParameterPair(clsCptVarianceFunction, ucrInputComboMethod.GetParameter, iAdditionalPairNo:=1)
         ucrInputComboMethod.AddAdditionalCodeParameterPair(clsCptMeanVarianceFunction, ucrInputComboMethod.GetParameter, iAdditionalPairNo:=2)
         ucrInputComboMethod.SetRCode(clsCptMeanFunction, bReset)
 
-        ucrInputComboDistribution.AddAdditionalCodeParameterPair(clsCptVarianceFunction, ucrInputComboDistribution.GetParameter, iAdditionalPairNo:=1)
-        ucrInputComboDistribution.AddAdditionalCodeParameterPair(clsCptMeanVarianceFunction, ucrInputComboDistribution.GetParameter, iAdditionalPairNo:=2)
-        ucrInputComboDistribution.SetRCode(clsCptMeanFunction, bReset)
+        ucrInputComboMeanDistribution.SetRCode(clsCptMeanFunction, bReset)
+        ucrInputComboVarDistribution.SetRCode(clsCptVarianceFunction, bReset)
+        ucrInputComboMeanVarDistribution.SetRCode(clsCptMeanVarianceFunction, bReset)
 
         ucrNudMinSegLen.AddAdditionalCodeParameterPair(clsCptVarianceFunction, ucrNudMinSegLen.GetParameter, iAdditionalPairNo:=1)
         ucrNudMinSegLen.AddAdditionalCodeParameterPair(clsCptMeanVarianceFunction, ucrNudMinSegLen.GetParameter, iAdditionalPairNo:=2)
@@ -220,7 +241,7 @@ Public Class dlgHomogenization
             ucrBase.clsRsyntax.SetBaseRFunction(clsCptMeanFunction)
         ElseIf rdoCptVariance.Checked Then
             ucrBase.clsRsyntax.SetBaseRFunction(clsCptVarianceFunction)
-        ElseIf rdoMeanVariance.Checked Then
+        ElseIf rdoCptMeanVariance.Checked Then
             ucrBase.clsRsyntax.SetBaseRFunction(clsCptMeanVarianceFunction)
         End If
         AddPlotSummaryParameters()
@@ -233,7 +254,7 @@ Public Class dlgHomogenization
         ElseIf rdoCptVariance.Checked Then
             clsPlotFunction.AddParameter("x", clsRFunctionParameter:=clsCptVarianceFunction, iPosition:=0)
             clsSummaryFunction.AddParameter("object", clsRFunctionParameter:=clsCptVarianceFunction, iPosition:=0)
-        ElseIf rdoMeanVariance.Checked Then
+        ElseIf rdoCptMeanVariance.Checked Then
             clsPlotFunction.AddParameter("x", clsRFunctionParameter:=clsCptMeanVarianceFunction, iPosition:=0)
             clsSummaryFunction.AddParameter("object", clsRFunctionParameter:=clsCptMeanVarianceFunction, iPosition:=0)
         End If


### PR DESCRIPTION
Fixes #5461. @rdstern this contains an initial implementation of homogenization. This implements the three core functions from `changepoint` package i.e `cpt.mean(), cpt.var` and `cpt.meanvar()`. I did initial testing using the datasets from the `changepoint` package although some of these datasets are not well labelled. I also used Dodoma data at some point to check how these methods work in our area of application (Climate). But first I aggregate the data into Annual using climatic summaries for the reasons I outline below. So for this case, I obtained annual rainfall totals for testing.

My understanding is that homogenization of daily and sub-daily data is still an active area of research therefore applying homogenization methods is still not recommended. This is because daily data is generally "noisy" and also daily data is mostly used to study extremes which make detecting changepoints difficult because it is not easy to distinguish extremes and inhomogeneities. I am still looking into the to be released WMO guide you shared to check if they now have recommendations based on recent advancements. In the previous guide, they only made recommendations on aggregated data.

I, therefore, envisage that the main use of this dialog will be on aggregated data, monthly, annual, seasonal, dekadal etc. However, the user is not restricted to apply these methods into daily and sub-daily data.

I made `BinSeg` the default method of detecting inhomogeneities because this method allows for multiple changepoints detection defined by `Q` which looks sensible in climatology. A previous check with Rija (CDT) is that he was planning to change his algorithms in CDT to use this method.

Below are some output results;
```

Class 'cpt' : Changepoint Object
       ~~   : S4 class containing 14 slots with names
              cpts.full pen.value.full data.set cpttype method test.stat pen.type pen.value minseglen cpts ncpts.max param.est date version 

Created on  : Sat Sep 21 05:12:37 2019 

summary(.)  :
----------
Created Using changepoint version 2.2.2 
Changepoint type      : Change in mean 
Method of analysis    : BinSeg 
Test Statistic  : Normal 
Type of penalty       : MBIC with value, 13.03 
Minimum Segment Length : 1 
Maximum no. of cpts   : 5 
Changepoint Locations : 11 12 13 20 49 
Range of segmentations:
     [,1] [,2] [,3] [,4] [,5]
[1,]   13   NA   NA   NA   NA
[2,]   13   12   NA   NA   NA
[3,]   13   12   11   NA   NA
[4,]   13   12   11   20   NA
[5,]   13   12   11   20   49

 For penalty values: 48032 48032 48032 48032 38714 
```
![image](https://user-images.githubusercontent.com/26301973/84588604-879c0100-ae31-11ea-82eb-b96746182724.png)
