### PR TITLE
Adding options to delete filters and calculations - delete objects dialog

### DIFF
--- a/instat/dlgDeleteObjects.Designer.vb
+++ b/instat/dlgDeleteObjects.Designer.vb
@@ -43,6 +43,8 @@ Partial Class dlgDeleteObjects
         Me.ucrReceiverObjectsToDelete = New instat.ucrReceiverMultiple()
         Me.ucrSelectorDeleteObject = New instat.ucrSelectorByDataFrameAddRemove()
         Me.ucrBase = New instat.ucrButtons()
+        Me.ucrInputComboType = New instat.ucrInputComboBox()
+        Me.lblType = New System.Windows.Forms.Label()
         Me.SuspendLayout()
         '
         'lblObjectsToDelete
@@ -62,6 +64,7 @@ Partial Class dlgDeleteObjects
         '
         'ucrSelectorDeleteObject
         '
+        Me.ucrSelectorDeleteObject.bDropUnusedFilterLevels = False
         Me.ucrSelectorDeleteObject.bShowHiddenColumns = False
         Me.ucrSelectorDeleteObject.bUseCurrentFilter = True
         resources.ApplyResources(Me.ucrSelectorDeleteObject, "ucrSelectorDeleteObject")
@@ -72,10 +75,24 @@ Partial Class dlgDeleteObjects
         resources.ApplyResources(Me.ucrBase, "ucrBase")
         Me.ucrBase.Name = "ucrBase"
         '
+        'ucrInputComboType
+        '
+        Me.ucrInputComboType.AddQuotesIfUnrecognised = True
+        Me.ucrInputComboType.IsReadOnly = False
+        resources.ApplyResources(Me.ucrInputComboType, "ucrInputComboType")
+        Me.ucrInputComboType.Name = "ucrInputComboType"
+        '
+        'lblType
+        '
+        resources.ApplyResources(Me.lblType, "lblType")
+        Me.lblType.Name = "lblType"
+        '
         'dlgDeleteObjects
         '
         resources.ApplyResources(Me, "$this")
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.Controls.Add(Me.lblType)
+        Me.Controls.Add(Me.ucrInputComboType)
         Me.Controls.Add(Me.ucrReceiverObjectsToDelete)
         Me.Controls.Add(Me.lblObjectsToDelete)
         Me.Controls.Add(Me.ucrSelectorDeleteObject)
@@ -94,4 +111,6 @@ Partial Class dlgDeleteObjects
     Friend WithEvents ucrSelectorDeleteObject As ucrSelectorByDataFrameAddRemove
     Friend WithEvents lblObjectsToDelete As Label
     Friend WithEvents ucrReceiverObjectsToDelete As ucrReceiverMultiple
+    Friend WithEvents lblType As Label
+    Friend WithEvents ucrInputComboType As ucrInputComboBox
 End Class

--- a/instat/dlgDeleteObjects.resx
+++ b/instat/dlgDeleteObjects.resx
@@ -123,7 +123,7 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="lblObjectsToDelete.Location" type="System.Drawing.Point, System.Drawing">
-    <value>254, 45</value>
+    <value>251, 24</value>
   </data>
   <data name="lblObjectsToDelete.Size" type="System.Drawing.Size, System.Drawing">
     <value>92, 13</value>
@@ -144,7 +144,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblObjectsToDelete.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>3</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -154,6 +154,54 @@
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
     <value>416, 260</value>
+  </data>
+  <data name="lblType.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblType.Location" type="System.Drawing.Point, System.Drawing">
+    <value>251, 149</value>
+  </data>
+  <data name="lblType.Size" type="System.Drawing.Size, System.Drawing">
+    <value>34, 13</value>
+  </data>
+  <data name="lblType.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="lblType.Text" xml:space="preserve">
+    <value>Type:</value>
+  </data>
+  <data name="&gt;&gt;lblType.Name" xml:space="preserve">
+    <value>lblType</value>
+  </data>
+  <data name="&gt;&gt;lblType.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblType.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;lblType.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="ucrInputComboType.Location" type="System.Drawing.Point, System.Drawing">
+    <value>254, 165</value>
+  </data>
+  <data name="ucrInputComboType.Size" type="System.Drawing.Size, System.Drawing">
+    <value>92, 21</value>
+  </data>
+  <data name="ucrInputComboType.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboType.Name" xml:space="preserve">
+    <value>ucrInputComboType</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboType.Type" xml:space="preserve">
+    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboType.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrInputComboType.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="ucrSelectorDeleteObject.Location" type="System.Drawing.Point, System.Drawing">
     <value>10, 10</value>
@@ -178,7 +226,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrSelectorDeleteObject.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>4</value>
   </data>
   <data name="ucrBase.Location" type="System.Drawing.Point, System.Drawing">
     <value>10, 204</value>
@@ -187,7 +235,7 @@
     <value>410, 52</value>
   </data>
   <data name="ucrBase.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
+    <value>5</value>
   </data>
   <data name="&gt;&gt;ucrBase.Name" xml:space="preserve">
     <value>ucrBase</value>
@@ -199,7 +247,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrBase.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>5</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterScreen</value>
@@ -214,7 +262,7 @@
     <value>System.Windows.Forms.Form, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="ucrReceiverObjectsToDelete.Location" type="System.Drawing.Point, System.Drawing">
-    <value>254, 60</value>
+    <value>254, 39</value>
   </data>
   <data name="ucrReceiverObjectsToDelete.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
@@ -235,6 +283,6 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrReceiverObjectsToDelete.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>2</value>
   </data>
 </root>

--- a/instat/dlgDeleteObjects.vb
+++ b/instat/dlgDeleteObjects.vb
@@ -96,18 +96,12 @@ Public Class dlgDeleteObjects
     End Sub
 
     Private Sub ucrInputComboType_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrInputComboType.ControlValueChanged
-        Dim value As String
-        Dim key As String
+        Dim key As String = dctTypes.Keys(ucrInputComboType.cboInput.SelectedIndex)
+        Dim value As String = ""
 
-        If dctTypes.Count <> 0 Then
-            value = dctTypes.Values(ucrInputComboType.cboInput.SelectedIndex)
-            key = dctTypes.Keys(ucrInputComboType.cboInput.SelectedIndex)
-            If (dctTypes.ContainsKey(key) AndAlso dctTypes.ContainsValue(value)) Then
-                ucrReceiverObjectsToDelete.SetItemType(value.Replace(Chr(34), ""))
-                ucrReceiverObjectsToDelete.strSelectorHeading = key
-            End If
-        Else
-            Exit Sub
+        If key IsNot Nothing AndAlso dctTypes.TryGetValue(key, value) Then
+            ucrReceiverObjectsToDelete.strSelectorHeading = key
+            ucrReceiverObjectsToDelete.SetItemType(value.Replace(Chr(34), ""))
         End If
     End Sub
 

--- a/instat/dlgDeleteObjects.vb
+++ b/instat/dlgDeleteObjects.vb
@@ -16,7 +16,8 @@
 
 Imports instat.Translations
 Public Class dlgDeleteObjects
-    Public bFirstLoad As Boolean = True
+    Private bFirstLoad As Boolean = True
+    Private dctTypes As New Dictionary(Of String, String)
     Private bReset As Boolean = True
     Private clsDefaultFunction As New RFunction
 
@@ -37,7 +38,6 @@ Public Class dlgDeleteObjects
     End Sub
 
     Private Sub InitialiseDialog()
-        Dim dctTypes As New Dictionary(Of String, String)
         ucrBase.iHelpTopicID = 352
 
         ' Selector
@@ -96,26 +96,19 @@ Public Class dlgDeleteObjects
     End Sub
 
     Private Sub ucrInputComboType_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrInputComboType.ControlValueChanged
-        Select Case ucrInputComboType.GetValue()
-            Case "Objects"
-                ucrReceiverObjectsToDelete.SetItemType("object")
-                ucrReceiverObjectsToDelete.strSelectorHeading = "Objects"
-            Case "Filters"
-                ucrReceiverObjectsToDelete.SetItemType("filter")
-                ucrReceiverObjectsToDelete.strSelectorHeading = "Filters"
-            Case "Calculations"
-                ucrReceiverObjectsToDelete.SetItemType("calculation")
-                ucrReceiverObjectsToDelete.strSelectorHeading = "Calculations"
-            Case "Tables"
-                ucrReceiverObjectsToDelete.SetItemType("table")
-                ucrReceiverObjectsToDelete.strSelectorHeading = "Tables"
-            Case "Graphs"
-                ucrReceiverObjectsToDelete.SetItemType("graph")
-                ucrReceiverObjectsToDelete.strSelectorHeading = "Graphs"
-            Case "Models"
-                ucrReceiverObjectsToDelete.SetItemType("model")
-                ucrReceiverObjectsToDelete.strSelectorHeading = "Models"
-        End Select
+        Dim value As String
+        Dim key As String
+
+        If dctTypes.Count <> 0 Then
+            value = dctTypes.Values(ucrInputComboType.cboInput.SelectedIndex)
+            key = dctTypes.Keys(ucrInputComboType.cboInput.SelectedIndex)
+            If (dctTypes.ContainsKey(key) AndAlso dctTypes.ContainsValue(value)) Then
+                ucrReceiverObjectsToDelete.SetItemType(value.Replace(Chr(34), ""))
+                ucrReceiverObjectsToDelete.strSelectorHeading = key
+            End If
+        Else
+            Exit Sub
+        End If
     End Sub
 
     Private Sub ucrReceiverObjectsToDelete_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrReceiverObjectsToDelete.ControlContentsChanged

--- a/instat/dlgDeleteObjects.vb
+++ b/instat/dlgDeleteObjects.vb
@@ -37,6 +37,7 @@ Public Class dlgDeleteObjects
     End Sub
 
     Private Sub InitialiseDialog()
+        Dim dctTypes As New Dictionary(Of String, String)
         ucrBase.iHelpTopicID = 352
 
         ' Selector
@@ -48,8 +49,16 @@ Public Class dlgDeleteObjects
         ucrReceiverObjectsToDelete.SetParameterIsString()
         ucrReceiverObjectsToDelete.Selector = ucrSelectorDeleteObject
         ucrReceiverObjectsToDelete.SetMeAsReceiver()
-        ucrReceiverObjectsToDelete.SetItemType("object")
-        ucrReceiverObjectsToDelete.strSelectorHeading = "Objects"
+
+        ucrInputComboType.SetParameter(New RParameter("object_type", 2))
+        dctTypes.Add("Objects", Chr(34) & "object" & Chr(34))
+        dctTypes.Add("Filters", Chr(34) & "filter" & Chr(34))
+        dctTypes.Add("Calculations", Chr(34) & "calculation" & Chr(34))
+        dctTypes.Add("Tables", Chr(34) & "table" & Chr(34))
+        dctTypes.Add("Graphs", Chr(34) & "graph" & Chr(34))
+        dctTypes.Add("Models", Chr(34) & "model" & Chr(34))
+        ucrInputComboType.SetItems(dctTypes)
+        ucrInputComboType.SetDropDownStyleAsNonEditable()
 
     End Sub
 
@@ -59,6 +68,8 @@ Public Class dlgDeleteObjects
         ucrSelectorDeleteObject.Reset()
 
         clsDefaultFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$delete_objects")
+        clsDefaultFunction.AddParameter("object_type", Chr(34) & "object" & Chr(34), iPosition:=2)
+
         ucrBase.clsRsyntax.SetBaseRFunction(clsDefaultFunction)
     End Sub
 
@@ -82,6 +93,29 @@ Public Class dlgDeleteObjects
         SetDefaults()
         SetRCodeforControls(True)
         TestOKEnabled()
+    End Sub
+
+    Private Sub ucrInputComboType_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrInputComboType.ControlValueChanged
+        Select Case ucrInputComboType.GetValue()
+            Case "Objects"
+                ucrReceiverObjectsToDelete.SetItemType("object")
+                ucrReceiverObjectsToDelete.strSelectorHeading = "Objects"
+            Case "Filters"
+                ucrReceiverObjectsToDelete.SetItemType("filter")
+                ucrReceiverObjectsToDelete.strSelectorHeading = "Filters"
+            Case "Calculations"
+                ucrReceiverObjectsToDelete.SetItemType("calculation")
+                ucrReceiverObjectsToDelete.strSelectorHeading = "Calculations"
+            Case "Tables"
+                ucrReceiverObjectsToDelete.SetItemType("table")
+                ucrReceiverObjectsToDelete.strSelectorHeading = "Tables"
+            Case "Graphs"
+                ucrReceiverObjectsToDelete.SetItemType("graph")
+                ucrReceiverObjectsToDelete.strSelectorHeading = "Graphs"
+            Case "Models"
+                ucrReceiverObjectsToDelete.SetItemType("model")
+                ucrReceiverObjectsToDelete.strSelectorHeading = "Models"
+        End Select
     End Sub
 
     Private Sub ucrReceiverObjectsToDelete_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrReceiverObjectsToDelete.ControlContentsChanged

--- a/instat/static/InstatObject/R/data_object_R6.R
+++ b/instat/static/InstatObject/R/data_object_R6.R
@@ -1723,7 +1723,8 @@ DataSheet$set("public", "delete_objects", function(data_name, object_names, obje
     }else if(object_type == "filter"){
       if(!all(object_names %in% names(private$filters))) stop(object_names, " not found in filters list.")
       if("no_filter" %in% object_names) stop("no_filter cannot be deleted.")
-      if(any(private$.current_filter$name %in% object_names))stop(private$.current_filter$name, " is a current filter it cannot deleted.")
+      if(any(private$.current_filter$name %in% object_names))stop(private$.current_filter$name, " is currently in use and cannot be deleted.")
+
       private$filters[names(private$filters) %in% object_names] <- NULL
     }else if(object_type == "calculation"){
       if(!object_names %in% names(private$calculations)) stop(object_names, " not found in calculations list.")

--- a/instat/static/InstatObject/R/data_object_R6.R
+++ b/instat/static/InstatObject/R/data_object_R6.R
@@ -1724,7 +1724,6 @@ DataSheet$set("public", "delete_objects", function(data_name, object_names, obje
       if(!all(object_names %in% names(private$filters))) stop(object_names, " not found in filters list.")
       if("no_filter" %in% object_names) stop("no_filter cannot be deleted.")
       if(any(private$.current_filter$name %in% object_names))stop(private$.current_filter$name, " is currently in use and cannot be deleted.")
-
       private$filters[names(private$filters) %in% object_names] <- NULL
     }else if(object_type == "calculation"){
       if(!object_names %in% names(private$calculations)) stop(object_names, " not found in calculations list.")

--- a/instat/static/InstatObject/R/data_object_R6.R
+++ b/instat/static/InstatObject/R/data_object_R6.R
@@ -1715,16 +1715,18 @@ DataSheet$set("public", "rename_object", function(object_name, new_name, object_
 )
 
 DataSheet$set("public", "delete_objects", function(data_name, object_names, object_type = "object") {
-  if(!object_type %in% c("object", "graph", "table","model","filter", "calculation")) stop(object_type, " must be either object (graph, table or model), filter or a calculation")
+  if(!object_type %in% c("object", "graph", "table","model","filter", "calculation")) stop(object_type, " must be either object (graph, table or model), filter or a calculation.")
   if(any(object_type == c("object", "graph", "table","model"))){
-      if(!all(object_names %in% names(private$objects))) stop("Not all object_names found in overall objects list")
-      private$objects[names(private$objects) == object_names] <- NULL
+      if(!all(object_names %in% names(private$objects))) stop("Not all object_names found in overall objects list.")
+      private$objects[names(private$objects) %in% object_names] <- NULL
     }else if(object_type == "filter"){
-      if(!object_names %in% names(private$filters)) stop(object_names, " not found in filters list")
-      private$filters[names(private$filters) == object_names] <- NULL
+      if(!all(object_names %in% names(private$filters))) stop(object_names, " not found in filters list.")
+      if("no_filter" %in% object_names) stop("no_filter cannot be deleted.")
+      if(any(private$.current_filter$name %in% object_names))stop(private$.current_filter$name, " is a current filter it cannot deleted.")
+      private$filters[names(private$filters) %in% object_names] <- NULL
     }else if(object_type == "calculation"){
-      if(!object_names %in% names(private$calculations)) stop(object_names, " not found in calculations list")
-      private$calculations[names(private$calculations) == object_names] <- NULL
+      if(!object_names %in% names(private$calculations)) stop(object_names, " not found in calculations list.")
+      private$calculations[names(private$calculations) %in% object_names] <- NULL
     }
   if(!is.null(private$.last_graph) && length(private$.last_graph) == 2 && private$.last_graph[1] == data_name && private$.last_graph[2] %in% object_names) {
     private$.last_graph <- NULL

--- a/instat/static/InstatObject/R/data_object_R6.R
+++ b/instat/static/InstatObject/R/data_object_R6.R
@@ -1714,6 +1714,24 @@ DataSheet$set("public", "rename_object", function(object_name, new_name, object_
 }
 )
 
+DataSheet$set("public", "delete_objects", function(data_name, object_names, object_type = "object") {
+  if(!object_type %in% c("object", "graph", "table","model","filter", "calculation")) stop(object_type, " must be either object (graph, table or model), filter or a calculation")
+  if(any(object_type == c("object", "graph", "table","model"))){
+      if(!all(object_names %in% names(private$objects))) stop("Not all object_names found in overall objects list")
+      private$objects[names(private$objects) == object_names] <- NULL
+    }else if(object_type == "filter"){
+      if(!object_names %in% names(private$filters)) stop(object_names, " not found in filters list")
+      private$filters[names(private$filters) == object_names] <- NULL
+    }else if(object_type == "calculation"){
+      if(!object_names %in% names(private$calculations)) stop(object_names, " not found in calculations list")
+      private$calculations[names(private$calculations) == object_names] <- NULL
+    }
+  if(!is.null(private$.last_graph) && length(private$.last_graph) == 2 && private$.last_graph[1] == data_name && private$.last_graph[2] %in% object_names) {
+    private$.last_graph <- NULL
+  }
+}
+)
+
 DataSheet$set("public", "reorder_objects", function(new_order) {
   if(length(new_order) != length(private$objects) || !setequal(new_order, names(private$objects))) stop("new_order must be a permutation of the current object names.")
   self$set_objects(private$objects[new_order])

--- a/instat/static/InstatObject/R/data_object_R6.R
+++ b/instat/static/InstatObject/R/data_object_R6.R
@@ -1693,7 +1693,7 @@ DataSheet$set("public", "get_last_graph", function() {
 )
 
 DataSheet$set("public", "rename_object", function(object_name, new_name, object_type = "object") {
-  if(!object_type %in% c("object", "filter", "calculation", "graph", "table","model")) stop(object_type, " must be either object (graph, table or model), filter or a calculation")
+  if(!object_type %in% c("object", "filter", "calculation", "graph", "table","model")) stop(object_type, " must be either object (graph, table or model), filter or a calculation.")
   #Temp fix:: added graph, table and model so as to distinguish this when implementing it in the dialog. Otherwise they remain as objects
   if (object_type %in% c("object", "graph", "table","model")){
     if(!object_name %in% names(private$objects)) stop(object_name, " not found in objects list")
@@ -1703,6 +1703,7 @@ DataSheet$set("public", "rename_object", function(object_name, new_name, object_
   else if (object_type == "filter"){
     if(!object_name %in% names(private$filters)) stop(object_name, " not found in filters list")
     if(new_name %in% names(private$filters)) stop(new_name, " is already a filter name. Cannot rename ", object_name, " to ", new_name)
+    if("no_filter" == object_name) stop("Renaming no_filter is not allowed.")
     names(private$filters)[names(private$filters) == object_name] <- new_name
     if(private$.current_filter$name == object_name){private$.current_filter$name <- new_name}
   } 

--- a/instat/static/InstatObject/R/instat_object_R6.R
+++ b/instat/static/InstatObject/R/instat_object_R6.R
@@ -598,15 +598,11 @@ DataBook$set("public", "rename_object", function(data_name, object_name, new_nam
 }
 )
 
-DataBook$set("public", "delete_objects", function(data_name, object_names) {
+DataBook$set("public", "delete_objects", function(data_name, object_names, object_type = "object") {
   if(missing(data_name) || data_name == overall_label) {
     if(!all(object_names %in% names(private$.objects))) stop("Not all object_names found in overall objects list")
-    private$.objects[names(private$.objects) == object_names] <- NULL
   }
-  else self$get_data_objects(data_name)$delete_objects(object_names = object_names)
-  if(!is.null(private$.last_graph) && length(private$.last_graph) == 2 && private$.last_graph[1] == data_name && private$.last_graph[2] %in% object_names) {
-    private$.last_graph <- NULL
-  }
+  else self$get_data_objects(data_name)$delete_objects(object_names = object_names, object_type = object_type)
 }
 )
 


### PR DESCRIPTION
Fixes #5792. @rdstern this is now working please test. I am concerned that we are enabling the user to delete a current filter and also "no_filter" this will cause bugs. One option is to hide them from the selector so that the user does not delete it or stop the user from deleting and give notification that it is not allowed.