### PR TITLE
Check box text property

### DIFF
--- a/instat/ucrCheck.vb
+++ b/instat/ucrCheck.vb
@@ -23,6 +23,15 @@ Public Class ucrCheck
     Private strValueIfChecked As String = "TRUE"
     Private strValueIfUnchecked As String = "FALSE"
 
+    Public Overrides Property Text() As String
+        Get
+            Return chkCheck.Text
+        End Get
+        Set(value As String)
+            chkCheck.Text = value
+        End Set
+    End Property
+
     Public Sub SetValueIfChecked(strNewValueIfChecked As String)
         Dim clsTempCond As New Condition
 


### PR DESCRIPTION
Partly Fixes , issue #5838. (More controls to await such enhancements)

@africanmathsinitiative/developers this is ready for review.

Currently to set the text of the checkbox, developers have to call `ucrCheck.SetText()`. This sometimes increases substantially the number of lines needed to write and during peer reviewing the team has to go through these lines which are basically more or less "labels" of the checkboxes. To take advantage of visual studio and have it write such trivial code for us, this subroutine has to be rewritten or complemented with a VB.NET property. The VB.NET property Text will now appear in the design properties panel of visual studio. 

Another critical advantage of this enhancement is, when designing the dialog the developers can now see the size that the text will occupy on the dialog, without necessarily having to run the application, all they need to do is find the property in the design view and set the text.

@lloyddewit If this is merged before PR #5847, @shadrackkibet could take advantage of this in labelling the many checkboxes on those dialogs.