### PR TITLE
Empty clsPopup

### DIFF
--- a/instat/clsPopup.vb
+++ b/instat/clsPopup.vb
@@ -1,0 +1,3 @@
+﻿Public Class clsPopup
+
+End Class

--- a/instat/instat.vbproj
+++ b/instat/instat.vbproj
@@ -179,6 +179,7 @@
     <Compile Include="clsCustomRenderer.vb" />
     <Compile Include="clsGgplotDefaults.vb" />
     <Compile Include="clsInstatOptionsDefaults.vb" />
+    <Compile Include="clsPopup.vb" />
     <Compile Include="clsQualityControl.vb" />
     <Compile Include="clsRCodeStructure.vb" />
     <Compile Include="clsRegressionDefaults.vb" />


### PR DESCRIPTION
@lloyddewit @maxwellfundi this is an empty `class` meant to hold the code that will be creating the popup used in several dialogs. 

Since I last created such a popup for the comment section, github issues have been created demanding more use of it (currently there is another dialog that needs this feature outlined by @rdstern in issue #5596 and possibly more will arise). Because of this we had discussed with @dannyparsons to have this as a reusable component that can be used in any dialog without much of re-implementation( and copy paste). Check out more about this `component` in issue #5876 . 

So I have added an empty class so that this can be merged quickly and avoid conflicts incase another item is added to the R-Instat `solution`. After this is merged I'll push the code needed to create the actual popup and demonstrate how this `class` can be used to dynamically create the `component`.