### PR TITLE
Popup Component and dlgEnter Implementation

### DIFF
--- a/instat/clsPopup.vb
+++ b/instat/clsPopup.vb
@@ -1,0 +1,3 @@
+﻿Public Class clsPopup
+
+End Class

--- a/instat/clsPopup.vb
+++ b/instat/clsPopup.vb
@@ -13,19 +13,51 @@
 '
 ' You should have received a copy of the GNU General Public License 
 ' along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+'''--------------------------------------------------------------------------------------------
+''' <summary>
+''' An object of this class represents a popup component that's used and displayed as a control.
+''' <list type="bullet">
+'''     <item><description>
+'''                  set contents control of the popup
+'''     </description></item>
+'''     <item><description>
+'''                  set size of the popup
+'''     </description></item>
+'''     <item><description>
+'''                  specify the display position of the popup relative to the owner. Default is top
+'''     </description></item>
+'''     <item><description>
+'''                  attach the owner control and show the popup
+'''     </description></item>
+'''  </list>
+''' </summary>
+'''--------------------------------------------------------------------------------------------
 Public Class clsPopup
-    ''' <summary> Event raised when the contents control loses focus. 
-    '''           This indicates that the popup is closing. </summary>
+    ''' <summary> 
+    ''' Event raised when the contents control loses focus. 
+    ''' This indicates that the popup is closing. 
+    '''</summary>
     Public Event Closing()
 
+    ''' <summary>
+    ''' Container used as the 'frame' of the popup component
+    ''' </summary>
     Private ReadOnly frm As Form
-    'specifies if the popup should hide automatically on lost focus or not
+
+    ''' <summary>
+    ''' specifies if the popup should hide automatically on lost focus or not
+    ''' </summary>
     Public Property AutoHide As Boolean
 
-    'specifies the position of the popup relative to the owner(control)
+    ''' <summary>
+    ''' specifies the position of the popup relative to the owner(control)
+    ''' </summary> 
     Public Property Position As PopupPosition
 
-    'enumeration of allowable popup positions
+    ''' <summary>
+    ''' enumeration of allowable popup positions
+    ''' </summary>
     Public Enum PopupPosition
         Top
         Below

--- a/instat/clsPopup.vb
+++ b/instat/clsPopup.vb
@@ -1,3 +1,119 @@
-﻿Public Class clsPopup
+﻿' R- Instat
+' Copyright (C) 2015-2017
+'
+' This program is free software: you can redistribute it and/or modify
+' it under the terms of the GNU General Public License as published by
+' the Free Software Foundation, either version 3 of the License, or
+' (at your option) any later version.
+'
+' This program is distributed in the hope that it will be useful,
+' but WITHOUT ANY WARRANTY; without even the implied warranty of
+' MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+' GNU General Public License for more details.
+'
+' You should have received a copy of the GNU General Public License 
+' along with this program.  If not, see <http://www.gnu.org/licenses/>.
+Public Class clsPopup
+    'event raised when the contents control loses focus. Indeicates that the popup is closing
+    Public Event Closing()
+
+    Private ReadOnly frm As Form
+    'specifies if the popup should hide automatically on lost focus or not
+    Public Property AutoHide As Boolean
+
+    'specifies the position of the popup relative to the owner(control)
+    Public Property Position As PopupPosition
+
+    'enumeration of allowable popup positions
+    Public Enum PopupPosition
+        Top
+        Below
+    End Enum
+
+    Sub New()
+        'initialise variables and set defaults
+        frm = New Form With {
+            .ShowInTaskbar = False,
+            .FormBorderStyle = FormBorderStyle.None,
+            .StartPosition = FormStartPosition.Manual
+        }
+        'set default popup behaviours
+        AutoHide = True
+        Position = PopupPosition.Top
+    End Sub
+
+    Public Sub SetSize(width As Integer, height As Integer)
+        SetSize(New Size(width, height))
+    End Sub
+
+    Public Sub SetSize(size As Size)
+        frm.Size = size
+    End Sub
+
+    Public Sub SetLocation(x As Integer, y As Integer)
+        SetLocation(New Point(x, y))
+    End Sub
+
+    Public Sub SetLocation(point As Point)
+        frm.Location = point
+    End Sub
+
+    ''' <summary>
+    ''' sets the specified control as the contents control of the popup
+    ''' </summary>
+    ''' <param name="ctr">The System.Windows.Forms.Control to set as the control contained in the popup</param>
+    Public Sub SetContentControl(ctr As Control)
+        frm.Controls.Clear() 'remove any existing control first
+        frm.Controls.Add(ctr)
+        ctr.Dock = DockStyle.Fill 'the control will always be same size as the from
+
+        'attach the event handler that will determine auto closing
+        AddHandler ctr.LostFocus, Sub()
+                                      If AutoHide Then
+                                          Hide()
+                                      End If
+                                  End Sub
+    End Sub
+
+    ''' <summary>
+    ''' shows the popup relative to the location of the specified control(owner) 
+    ''' and the position specified
+    ''' </summary>
+    ''' <param name="owner">The System.Windows.Forms.Control to set popup location based on</param>
+    ''' <param name="position">PopupPosition to set the position of the popup</param>
+    Public Sub Show(owner As Control, position As PopupPosition)
+        Me.Position = position
+        Show(owner)
+    End Sub
+
+    ''' <summary>
+    ''' shows the popup relative to the location of the specified control(owner) 
+    '''  and the position set
+    ''' </summary>
+    ''' <param name="owner">The System.Windows.Forms.Control to set popup location based on</param> 
+    Public Sub Show(owner As Control)
+        'compute and get the location of the specified control relative to screen coordinates
+        'Don't use Point.Empty, it's not function so use Point(0, 0)
+        Dim ctrPos As Point = owner.PointToScreen(New Point(0, 0))
+
+        'then set location of the popup relative to the position specified
+        Select Case Position
+            Case PopupPosition.Top
+                SetLocation(ctrPos.X - 2, ctrPos.Y - frm.Height - 2)
+            Case PopupPosition.Below
+                SetLocation(ctrPos.X - 2, ctrPos.Y + owner.Height - 2)
+        End Select
+
+        'then show popup
+        frm.Show()
+    End Sub
+
+    ''' <summary>
+    ''' raises popup hiding event then hides the popup
+    ''' </summary>
+    Public Sub Hide()
+        RaiseEvent Closing()
+        frm.Close()
+    End Sub
 
 End Class

--- a/instat/clsPopup.vb
+++ b/instat/clsPopup.vb
@@ -14,7 +14,8 @@
 ' You should have received a copy of the GNU General Public License 
 ' along with this program.  If not, see <http://www.gnu.org/licenses/>.
 Public Class clsPopup
-    'event raised when the contents control loses focus. Indeicates that the popup is closing
+    ''' <summary> Event raised when the contents control loses focus. 
+    '''           This indicates that the popup is closing. </summary>
     Public Event Closing()
 
     Private ReadOnly frm As Form

--- a/instat/dlgEnter.Designer.vb
+++ b/instat/dlgEnter.Designer.vb
@@ -322,6 +322,7 @@ Partial Class dlgEnter
         'ucrSaveEnterResultInto
         '
         Me.ucrSaveEnterResultInto.AddQuotesIfUnrecognised = True
+        Me.ucrSaveEnterResultInto.GetSetSelectedIndex = -1
         Me.ucrSaveEnterResultInto.IsReadOnly = False
         resources.ApplyResources(Me.ucrSaveEnterResultInto, "ucrSaveEnterResultInto")
         Me.ucrSaveEnterResultInto.Name = "ucrSaveEnterResultInto"

--- a/instat/dlgEnter.Designer.vb
+++ b/instat/dlgEnter.Designer.vb
@@ -78,6 +78,7 @@ Partial Class dlgEnter
         Me.ucrReceiverForEnterCalculation = New instat.ucrReceiverExpression()
         Me.ucrBase = New instat.ucrButtons()
         Me.ucrTryModelling = New instat.ucrTry()
+        Me.btnExample = New System.Windows.Forms.Button()
         Me.grpEnterKeybord1.SuspendLayout()
         Me.grpEnterKeyboard2.SuspendLayout()
         Me.SuspendLayout()
@@ -351,10 +352,17 @@ Partial Class dlgEnter
         resources.ApplyResources(Me.ucrTryModelling, "ucrTryModelling")
         Me.ucrTryModelling.Name = "ucrTryModelling"
         '
+        'btnExample
+        '
+        resources.ApplyResources(Me.btnExample, "btnExample")
+        Me.btnExample.Name = "btnExample"
+        Me.btnExample.UseVisualStyleBackColor = True
+        '
         'dlgEnter
         '
         resources.ApplyResources(Me, "$this")
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.Controls.Add(Me.btnExample)
         Me.Controls.Add(Me.ucrTryModelling)
         Me.Controls.Add(Me.grpEnterKeyboard2)
         Me.Controls.Add(Me.ucrSaveEnterResultInto)
@@ -415,4 +423,5 @@ Partial Class dlgEnter
     Friend WithEvents cmdColon As Button
     Friend WithEvents grpEnterKeyboard2 As GroupBox
     Friend WithEvents ucrTryModelling As ucrTry
+    Friend WithEvents btnExample As Button
 End Class

--- a/instat/dlgEnter.Designer.vb
+++ b/instat/dlgEnter.Designer.vb
@@ -322,7 +322,6 @@ Partial Class dlgEnter
         'ucrSaveEnterResultInto
         '
         Me.ucrSaveEnterResultInto.AddQuotesIfUnrecognised = True
-        Me.ucrSaveEnterResultInto.GetSetSelectedIndex = -1
         Me.ucrSaveEnterResultInto.IsReadOnly = False
         resources.ApplyResources(Me.ucrSaveEnterResultInto, "ucrSaveEnterResultInto")
         Me.ucrSaveEnterResultInto.Name = "ucrSaveEnterResultInto"

--- a/instat/dlgEnter.resx
+++ b/instat/dlgEnter.resx
@@ -150,20 +150,20 @@
     <value>True</value>
   </data>
   <data name="lblData.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 26</value>
+    <value>10, 25</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="lblData.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 0, 2, 0</value>
   </data>
   <data name="lblData.Size" type="System.Drawing.Size, System.Drawing">
-    <value>30, 13</value>
+    <value>33, 13</value>
   </data>
   <data name="lblData.TabIndex" type="System.Int32, mscorlib">
     <value>152</value>
   </data>
   <data name="lblData.Text" xml:space="preserve">
-    <value>Data</value>
+    <value>Data:</value>
   </data>
   <data name="&gt;&gt;lblData.Name" xml:space="preserve">
     <value>lblData</value>
@@ -1187,9 +1187,6 @@
   </data>
   <data name="&gt;&gt;ucrBase.ZOrder" xml:space="preserve">
     <value>10</value>
-  </data>
-  <data name="$this.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterScreen</value>

--- a/instat/dlgEnter.resx
+++ b/instat/dlgEnter.resx
@@ -123,7 +123,7 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="chkShowEnterArguments.Location" type="System.Drawing.Point, System.Drawing">
-    <value>371, 23</value>
+    <value>371, 18</value>
   </data>
   <data name="chkShowEnterArguments.Size" type="System.Drawing.Size, System.Drawing">
     <value>106, 17</value>
@@ -150,7 +150,7 @@
     <value>True</value>
   </data>
   <data name="lblData.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 25</value>
+    <value>10, 20</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="lblData.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
@@ -178,19 +178,19 @@
     <value>8</value>
   </data>
   <data name="chkSaveEnterResultInto.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 259</value>
+    <value>11, 248</value>
   </data>
   <data name="chkSaveEnterResultInto.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 3, 2, 3</value>
   </data>
   <data name="chkSaveEnterResultInto.Size" type="System.Drawing.Size, System.Drawing">
-    <value>174, 17</value>
+    <value>110, 17</value>
   </data>
   <data name="chkSaveEnterResultInto.TabIndex" type="System.Int32, mscorlib">
     <value>157</value>
   </data>
   <data name="chkSaveEnterResultInto.Text" xml:space="preserve">
-    <value>Save Result into</value>
+    <value>Save Result Into:</value>
   </data>
   <data name="&gt;&gt;chkSaveEnterResultInto.Name" xml:space="preserve">
     <value>chkSaveEnterResultInto</value>
@@ -616,7 +616,7 @@
     <value>0</value>
   </data>
   <data name="grpEnterKeybord1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>163, 58</value>
+    <value>163, 48</value>
   </data>
   <data name="grpEnterKeybord1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 3, 2, 3</value>
@@ -1033,7 +1033,7 @@
     <value>0</value>
   </data>
   <data name="grpEnterKeyboard2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>364, 58</value>
+    <value>364, 48</value>
   </data>
   <data name="grpEnterKeyboard2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 3, 2, 3</value>
@@ -1060,13 +1060,13 @@
     <value>2</value>
   </data>
   <data name="ucrSaveEnterResultInto.Location" type="System.Drawing.Point, System.Drawing">
-    <value>195, 254</value>
+    <value>124, 244</value>
   </data>
   <data name="ucrSaveEnterResultInto.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 3, 2, 3</value>
   </data>
   <data name="ucrSaveEnterResultInto.Size" type="System.Drawing.Size, System.Drawing">
-    <value>288, 22</value>
+    <value>266, 22</value>
   </data>
   <data name="ucrSaveEnterResultInto.TabIndex" type="System.Int32, mscorlib">
     <value>158</value>
@@ -1084,7 +1084,7 @@
     <value>3</value>
   </data>
   <data name="ucrDataFrameEnter.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 65</value>
+    <value>11, 55</value>
   </data>
   <data name="ucrDataFrameEnter.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
@@ -1114,13 +1114,13 @@
     <value>6, 13</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>573, 346</value>
+    <value>573, 336</value>
   </data>
   <data name="btnExample.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="btnExample.Location" type="System.Drawing.Point, System.Drawing">
-    <value>301, 21</value>
+    <value>301, 16</value>
   </data>
   <data name="btnExample.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 2, 2, 2</value>
@@ -1147,7 +1147,7 @@
     <value>0</value>
   </data>
   <data name="ucrTryModelling.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 215</value>
+    <value>3, 202</value>
   </data>
   <data name="ucrTryModelling.Size" type="System.Drawing.Size, System.Drawing">
     <value>480, 33</value>
@@ -1168,7 +1168,7 @@
     <value>1</value>
   </data>
   <data name="ucrBase.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 286</value>
+    <value>11, 278</value>
   </data>
   <data name="ucrBase.Size" type="System.Drawing.Size, System.Drawing">
     <value>452, 52</value>
@@ -1201,7 +1201,7 @@
     <value>System.Windows.Forms.Form, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="ucrReceiverForEnterCalculation.Location" type="System.Drawing.Point, System.Drawing">
-    <value>44, 21</value>
+    <value>44, 16</value>
   </data>
   <data name="ucrReceiverForEnterCalculation.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 3, 2, 3</value>

--- a/instat/dlgEnter.resx
+++ b/instat/dlgEnter.resx
@@ -123,7 +123,7 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="chkShowEnterArguments.Location" type="System.Drawing.Point, System.Drawing">
-    <value>347, 26</value>
+    <value>371, 23</value>
   </data>
   <data name="chkShowEnterArguments.Size" type="System.Drawing.Size, System.Drawing">
     <value>106, 17</value>
@@ -144,7 +144,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;chkShowEnterArguments.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>6</value>
   </data>
   <data name="lblData.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -175,10 +175,10 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblData.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>8</value>
   </data>
   <data name="chkSaveEnterResultInto.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 280</value>
+    <value>11, 259</value>
   </data>
   <data name="chkSaveEnterResultInto.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 3, 2, 3</value>
@@ -202,7 +202,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;chkSaveEnterResultInto.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="cmd1.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 76</value>
@@ -640,7 +640,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;grpEnterKeybord1.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>7</value>
   </data>
   <data name="cmdMissingValues.Location" type="System.Drawing.Point, System.Drawing">
     <value>106, 14</value>
@@ -1057,10 +1057,10 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;grpEnterKeyboard2.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="ucrSaveEnterResultInto.Location" type="System.Drawing.Point, System.Drawing">
-    <value>195, 275</value>
+    <value>195, 254</value>
   </data>
   <data name="ucrSaveEnterResultInto.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 3, 2, 3</value>
@@ -1081,7 +1081,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrSaveEnterResultInto.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="ucrDataFrameEnter.Location" type="System.Drawing.Point, System.Drawing">
     <value>11, 65</value>
@@ -1105,7 +1105,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrDataFrameEnter.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>5</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -1114,10 +1114,40 @@
     <value>6, 13</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>573, 376</value>
+    <value>573, 346</value>
+  </data>
+  <data name="btnExample.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnExample.Location" type="System.Drawing.Point, System.Drawing">
+    <value>301, 21</value>
+  </data>
+  <data name="btnExample.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
+  </data>
+  <data name="btnExample.Size" type="System.Drawing.Size, System.Drawing">
+    <value>64, 22</value>
+  </data>
+  <data name="btnExample.TabIndex" type="System.Int32, mscorlib">
+    <value>161</value>
+  </data>
+  <data name="btnExample.Text" xml:space="preserve">
+    <value>Examples</value>
+  </data>
+  <data name="&gt;&gt;btnExample.Name" xml:space="preserve">
+    <value>btnExample</value>
+  </data>
+  <data name="&gt;&gt;btnExample.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnExample.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;btnExample.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="ucrTryModelling.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 236</value>
+    <value>3, 215</value>
   </data>
   <data name="ucrTryModelling.Size" type="System.Drawing.Size, System.Drawing">
     <value>480, 33</value>
@@ -1135,10 +1165,10 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrTryModelling.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="ucrBase.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 307</value>
+    <value>11, 286</value>
   </data>
   <data name="ucrBase.Size" type="System.Drawing.Size, System.Drawing">
     <value>452, 52</value>
@@ -1156,7 +1186,10 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrBase.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>10</value>
+  </data>
+  <data name="$this.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterScreen</value>
@@ -1171,7 +1204,7 @@
     <value>System.Windows.Forms.Form, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="ucrReceiverForEnterCalculation.Location" type="System.Drawing.Point, System.Drawing">
-    <value>65, 26</value>
+    <value>44, 21</value>
   </data>
   <data name="ucrReceiverForEnterCalculation.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 3, 2, 3</value>
@@ -1192,6 +1225,6 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrReceiverForEnterCalculation.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>9</value>
   </data>
 </root>

--- a/instat/dlgEnter.vb
+++ b/instat/dlgEnter.vb
@@ -305,20 +305,21 @@ Public Class dlgEnter
 
         'add rows of sample commands
         lstView.Items.Add(New ListViewItem({"seq(9 )"}))
-        lstView.Items.Item(0).ToolTipText = "todo. sensible tooltip here."
+        lstView.Items.Item(0).ToolTipText = "seq(9 )" 'todo. sensible tooltip here.
 
         lstView.Items.Add(New ListViewItem({"LETTERS"}))
-        lstView.Items.Item(1).ToolTipText = "todo. sensible tooltip here."
+        lstView.Items.Item(1).ToolTipText = "LETTERS" 'todo. sensible tooltip here.
 
         lstView.Items.Add(New ListViewItem({"month.name"}))
-        lstView.Items.Item(2).ToolTipText = "todo. sensible tooltip here"
+        lstView.Items.Item(2).ToolTipText = "month.name" 'todo. sensible tooltip here.
 
         lstView.Items.Add(New ListViewItem({"month.abb"}))
-        lstView.Items.Item(2).ToolTipText = "todo. sensible tooltip here"
+        lstView.Items.Item(2).ToolTipText = "month.abb" 'todo. sensible tooltip here.
 
 
         AddHandler lstView.DoubleClick, Sub()
-                                            If lstView.SelectedItems.Count > 1 Then
+                                            If lstView.SelectedItems.Count > 0 Then
+                                                ucrReceiverForEnterCalculation.Clear()
                                                 ucrReceiverForEnterCalculation.AddToReceiverAtCursorPosition(lstView.SelectedItems.Item(0).SubItems(0).Text)
                                                 objPopup.Hide()
                                             End If

--- a/instat/dlgEnter.vb
+++ b/instat/dlgEnter.vb
@@ -290,4 +290,42 @@ Public Class dlgEnter
         End If
         SaveResults()
     End Sub
+
+    Private Sub btnExample_Click(sender As Object, e As EventArgs) Handles btnExample.Click
+        Dim objPopup As New clsPopup
+        Dim lstView As New ListView With {
+            .Scrollable = True,
+            .View = View.Details,
+            .FullRowSelect = True,
+            .ShowItemToolTips = True
+        }
+
+        'add a single column
+        lstView.Columns.Add("Commands", 450)
+
+        'add rows of sample commands
+        lstView.Items.Add(New ListViewItem({"seq(9 )"}))
+        lstView.Items.Item(0).ToolTipText = "todo. sensible tooltip here."
+
+        lstView.Items.Add(New ListViewItem({"LETTERS"}))
+        lstView.Items.Item(1).ToolTipText = "todo. sensible tooltip here."
+
+        lstView.Items.Add(New ListViewItem({"month.name"}))
+        lstView.Items.Item(2).ToolTipText = "todo. sensible tooltip here"
+
+        lstView.Items.Add(New ListViewItem({"month.abb"}))
+        lstView.Items.Item(2).ToolTipText = "todo. sensible tooltip here"
+
+
+        AddHandler lstView.DoubleClick, Sub()
+                                            If lstView.SelectedItems.Count > 1 Then
+                                                ucrReceiverForEnterCalculation.AddToReceiverAtCursorPosition(lstView.SelectedItems.Item(0).SubItems(0).Text)
+                                                objPopup.Hide()
+                                            End If
+                                        End Sub
+
+        objPopup.SetContentControl(lstView)
+        objPopup.SetSize(ucrReceiverForEnterCalculation.Width, ucrReceiverForEnterCalculation.Height + 100)
+        objPopup.Show(ucrReceiverForEnterCalculation)
+    End Sub
 End Class

--- a/instat/dlgEnter.vb
+++ b/instat/dlgEnter.vb
@@ -291,6 +291,11 @@ Public Class dlgEnter
         SaveResults()
     End Sub
 
+    ''' <summary>
+    ''' displays a popup with example commands just above the input receiver
+    ''' </summary>
+    ''' <param name="sender"></param>
+    ''' <param name="e"></param>
     Private Sub btnExample_Click(sender As Object, e As EventArgs) Handles btnExample.Click
         Dim objPopup As New clsPopup
         Dim lstView As New ListView With {

--- a/instat/dlgEnter.vb
+++ b/instat/dlgEnter.vb
@@ -314,7 +314,7 @@ Public Class dlgEnter
         lstView.Items.Item(2).ToolTipText = "month.name" 'todo. sensible tooltip here.
 
         lstView.Items.Add(New ListViewItem({"month.abb"}))
-        lstView.Items.Item(2).ToolTipText = "month.abb" 'todo. sensible tooltip here.
+        lstView.Items.Item(3).ToolTipText = "month.abb" 'todo. sensible tooltip here.
 
 
         AddHandler lstView.DoubleClick, Sub()

--- a/instat/instat.vbproj
+++ b/instat/instat.vbproj
@@ -179,6 +179,7 @@
     <Compile Include="clsCustomRenderer.vb" />
     <Compile Include="clsGgplotDefaults.vb" />
     <Compile Include="clsInstatOptionsDefaults.vb" />
+    <Compile Include="clsPopup.vb" />
     <Compile Include="clsQualityControl.vb" />
     <Compile Include="clsRCodeStructure.vb" />
     <Compile Include="clsRegressionDefaults.vb" />


### PR DESCRIPTION
Fixes #5596 . Fixes #5876.

@africanmathsinitiative/developers this is ready for review.

This issue implements the popup component and also demonstrates through dlgEnter how other dialogs can use it. It's a continuation of PR #5877(which should be merged first) which has an empty class that represents the popup component. 

Once merged, the other dialogs that currently have code that is implemented in this component, can be amended to use it. 

@rdstern as discussed in issue #5596 the only thing waiting in the dialog are the samples and their tooltips. I will add them as soon as I get your feedback. 