### PR TITLE
File Export Dialogs - design 

### DIFF
--- a/instat/dlgExportDataset.resx
+++ b/instat/dlgExportDataset.resx
@@ -123,10 +123,10 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="cmdBrowse.Location" type="System.Drawing.Point, System.Drawing">
-    <value>429, 48</value>
+    <value>332, 55</value>
   </data>
   <data name="cmdBrowse.Size" type="System.Drawing.Size, System.Drawing">
-    <value>62, 23</value>
+    <value>75, 23</value>
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="cmdBrowse.TabIndex" type="System.Int32, mscorlib">
@@ -151,13 +151,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblExport.Location" type="System.Drawing.Point, System.Drawing">
-    <value>2, 53</value>
+    <value>9, 60</value>
   </data>
   <data name="lblExport.Size" type="System.Drawing.Size, System.Drawing">
     <value>91, 13</value>
   </data>
   <data name="lblExport.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
+    <value>1</value>
   </data>
   <data name="lblExport.Text" xml:space="preserve">
     <value>Export File:</value>
@@ -181,7 +181,7 @@
     <value>NoControl</value>
   </data>
   <data name="lblConfirmText.Location" type="System.Drawing.Point, System.Drawing">
-    <value>75, 87</value>
+    <value>85, 85</value>
   </data>
   <data name="lblConfirmText.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 0, 2, 0</value>
@@ -190,7 +190,7 @@
     <value>148, 13</value>
   </data>
   <data name="lblConfirmText.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
+    <value>4</value>
   </data>
   <data name="lblConfirmText.Text" xml:space="preserve">
     <value>Click Ok to Confirm the Export</value>
@@ -208,13 +208,13 @@
     <value>0</value>
   </data>
   <data name="ucrInputExportFile.Location" type="System.Drawing.Point, System.Drawing">
-    <value>102, 50</value>
+    <value>90, 56</value>
   </data>
   <data name="ucrInputExportFile.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>6, 8, 6, 8</value>
   </data>
   <data name="ucrInputExportFile.Size" type="System.Drawing.Size, System.Drawing">
-    <value>325, 21</value>
+    <value>240, 21</value>
   </data>
   <data name="ucrInputExportFile.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -232,7 +232,7 @@
     <value>2</value>
   </data>
   <data name="ucrAvailableSheets.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 4</value>
+    <value>10, 10</value>
   </data>
   <data name="ucrAvailableSheets.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
@@ -265,7 +265,7 @@
     <value>405, 53</value>
   </data>
   <data name="ucrBase.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
+    <value>5</value>
   </data>
   <data name="&gt;&gt;ucrBase.Name" xml:space="preserve">
     <value>ucrBase</value>
@@ -289,7 +289,7 @@
     <value>True</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>494, 165</value>
+    <value>414, 165</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterScreen</value>

--- a/instat/dlgExportGraphAsImage.resx
+++ b/instat/dlgExportGraphAsImage.resx
@@ -123,7 +123,7 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="lblSelectedGraph.Location" type="System.Drawing.Point, System.Drawing">
-    <value>265, 45</value>
+    <value>264, 45</value>
   </data>
   <data name="lblSelectedGraph.Size" type="System.Drawing.Size, System.Drawing">
     <value>84, 13</value>
@@ -147,13 +147,13 @@
     <value>3</value>
   </data>
   <data name="cmdBrowse.Location" type="System.Drawing.Point, System.Drawing">
-    <value>380, 194</value>
+    <value>334, 194</value>
   </data>
   <data name="cmdBrowse.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 23</value>
   </data>
   <data name="cmdBrowse.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
+    <value>5</value>
   </data>
   <data name="cmdBrowse.Text" xml:space="preserve">
     <value>Browse</value>
@@ -180,20 +180,20 @@
     <value>True</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>455, 280</value>
+    <value>418, 280</value>
   </data>
   <data name="ucrInputFile.Location" type="System.Drawing.Point, System.Drawing">
-    <value>128, 195</value>
+    <value>92, 195</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="ucrInputFile.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>6, 8, 6, 8</value>
   </data>
   <data name="ucrInputFile.Size" type="System.Drawing.Size, System.Drawing">
-    <value>246, 21</value>
+    <value>240, 21</value>
   </data>
   <data name="ucrInputFile.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
+    <value>4</value>
   </data>
   <data name="&gt;&gt;ucrInputFile.Name" xml:space="preserve">
     <value>ucrInputFile</value>
@@ -208,13 +208,13 @@
     <value>0</value>
   </data>
   <data name="lblExport.Location" type="System.Drawing.Point, System.Drawing">
-    <value>7, 199</value>
+    <value>9, 199</value>
   </data>
   <data name="lblExport.Size" type="System.Drawing.Size, System.Drawing">
     <value>115, 13</value>
   </data>
   <data name="lblExport.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
+    <value>3</value>
   </data>
   <data name="lblExport.Text" xml:space="preserve">
     <value>Export File:</value>
@@ -265,7 +265,7 @@
     <value>404, 52</value>
   </data>
   <data name="ucrBase.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
+    <value>6</value>
   </data>
   <data name="&gt;&gt;ucrBase.Name" xml:space="preserve">
     <value>ucrBase</value>

--- a/instat/dlgExportRObjects.resx
+++ b/instat/dlgExportRObjects.resx
@@ -123,7 +123,7 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="lblObjects.Location" type="System.Drawing.Point, System.Drawing">
-    <value>264, 45</value>
+    <value>266, 45</value>
   </data>
   <data name="lblObjects.Size" type="System.Drawing.Size, System.Drawing">
     <value>91, 13</value>
@@ -153,17 +153,17 @@
     <value>6, 13</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>428, 288</value>
+    <value>420, 288</value>
   </data>
   <data name="ucrInputExportFile.Location" type="System.Drawing.Point, System.Drawing">
-    <value>100, 204</value>
+    <value>92, 204</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="ucrInputExportFile.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>6, 8, 6, 8</value>
   </data>
   <data name="ucrInputExportFile.Size" type="System.Drawing.Size, System.Drawing">
-    <value>251, 21</value>
+    <value>240, 23</value>
   </data>
   <data name="ucrInputExportFile.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -181,10 +181,10 @@
     <value>0</value>
   </data>
   <data name="cmdBrowse.Location" type="System.Drawing.Point, System.Drawing">
-    <value>355, 203</value>
+    <value>333, 203</value>
   </data>
   <data name="cmdBrowse.Size" type="System.Drawing.Size, System.Drawing">
-    <value>62, 23</value>
+    <value>75, 23</value>
   </data>
   <data name="cmdBrowse.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -205,7 +205,7 @@
     <value>1</value>
   </data>
   <data name="lblExportFile.Location" type="System.Drawing.Point, System.Drawing">
-    <value>-1, 206</value>
+    <value>9, 206</value>
   </data>
   <data name="lblExportFile.Size" type="System.Drawing.Size, System.Drawing">
     <value>95, 13</value>
@@ -289,7 +289,7 @@
     <value>System.Windows.Forms.Form, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="ucrReceiverObjects.Location" type="System.Drawing.Point, System.Drawing">
-    <value>264, 60</value>
+    <value>267, 60</value>
   </data>
   <data name="ucrReceiverObjects.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>

--- a/instat/dlgExportRWorkspace.resx
+++ b/instat/dlgExportRWorkspace.resx
@@ -119,10 +119,10 @@
   </resheader>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="cmdBrowse.Location" type="System.Drawing.Point, System.Drawing">
-    <value>357, 251</value>
+    <value>333, 247</value>
   </data>
   <data name="cmdBrowse.Size" type="System.Drawing.Size, System.Drawing">
-    <value>81, 23</value>
+    <value>75, 23</value>
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="cmdBrowse.TabIndex" type="System.Int32, mscorlib">
@@ -144,13 +144,13 @@
     <value>3</value>
   </data>
   <data name="lblExport.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 255</value>
+    <value>9, 251</value>
   </data>
   <data name="lblExport.Size" type="System.Drawing.Size, System.Drawing">
     <value>100, 13</value>
   </data>
   <data name="lblExport.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
+    <value>7</value>
   </data>
   <data name="lblExport.Text" xml:space="preserve">
     <value>Export File:</value>
@@ -171,7 +171,7 @@
     <value>True</value>
   </data>
   <data name="lblDataFrames.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 13</value>
+    <value>10, 15</value>
   </data>
   <data name="lblDataFrames.Size" type="System.Drawing.Size, System.Drawing">
     <value>76, 13</value>
@@ -247,13 +247,13 @@
     <value>10</value>
   </data>
   <data name="ucrInputExportFile.Location" type="System.Drawing.Point, System.Drawing">
-    <value>112, 252</value>
+    <value>92, 248</value>
   </data>
   <data name="ucrInputExportFile.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>6, 8, 6, 8</value>
   </data>
   <data name="ucrInputExportFile.Size" type="System.Drawing.Size, System.Drawing">
-    <value>244, 23</value>
+    <value>240, 23</value>
   </data>
   <data name="ucrInputExportFile.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -271,7 +271,7 @@
     <value>2</value>
   </data>
   <data name="ucrChkGraphs.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 199</value>
+    <value>10, 193</value>
   </data>
   <data name="ucrChkGraphs.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>4, 5, 4, 5</value>
@@ -295,7 +295,7 @@
     <value>5</value>
   </data>
   <data name="ucrChkModels.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 225</value>
+    <value>10, 219</value>
   </data>
   <data name="ucrChkModels.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>4, 5, 4, 5</value>
@@ -319,7 +319,7 @@
     <value>6</value>
   </data>
   <data name="ucrChkMetadata.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 173</value>
+    <value>10, 167</value>
   </data>
   <data name="ucrChkMetadata.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>4, 5, 4, 5</value>
@@ -352,10 +352,10 @@
     <value>True</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>440, 338</value>
+    <value>417, 335</value>
   </data>
   <data name="ucrBase.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 281</value>
+    <value>10, 278</value>
   </data>
   <data name="ucrBase.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>4, 5, 4, 5</value>
@@ -391,7 +391,7 @@
     <value>System.Windows.Forms.Form, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="ucrReceiverMultiple.Location" type="System.Drawing.Point, System.Drawing">
-    <value>247, 60</value>
+    <value>250, 60</value>
   </data>
   <data name="ucrReceiverMultiple.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>


### PR DESCRIPTION
@africanmathsinitiative/developers this is ready for review

Fixes #5879 

Minor design changes to the "File > Export" dialogs:
* Tab order
* Receiver/Browse button aligned with ucrBase
* "Export File" label moved.

To see "before" screenshots, see #5879 

![image](https://user-images.githubusercontent.com/21180424/86461262-a2231500-bd21-11ea-9968-138221466ca8.png)

![image](https://user-images.githubusercontent.com/21180424/86461318-b7983f00-bd21-11ea-86ac-4a593fe2e0f6.png)

![image](https://user-images.githubusercontent.com/21180424/86461356-c848b500-bd21-11ea-9f12-05f2833cfd91.png)

![image](https://user-images.githubusercontent.com/21180424/86461375-d4347700-bd21-11ea-994d-86df60398a1d.png)
