### PR TITLE
Using multiple stations and multiple levels for aggregate option when infilling missing values

### DIFF
--- a/instat/dlgInfillMissingValues.Designer.vb
+++ b/instat/dlgInfillMissingValues.Designer.vb
@@ -36,11 +36,11 @@ Partial Class dlgInfillMissingValues
         Me.grpMethods = New System.Windows.Forms.GroupBox()
         Me.ucrPnlMethods = New instat.UcrPanel()
         Me.grpStartEnd = New System.Windows.Forms.GroupBox()
-        Me.lblValue = New System.Windows.Forms.Label()
-        Me.ucrInputConstant = New instat.ucrInputTextBox()
         Me.rdoExtendFill = New System.Windows.Forms.RadioButton()
         Me.rdoLeaveAsMissing = New System.Windows.Forms.RadioButton()
         Me.ucrPnlStartEnd = New instat.UcrPanel()
+        Me.lblValue = New System.Windows.Forms.Label()
+        Me.ucrInputConstant = New instat.ucrInputTextBox()
         Me.lblFunction = New System.Windows.Forms.Label()
         Me.lblRows = New System.Windows.Forms.Label()
         Me.ucrChkSetSeed = New instat.ucrCheck()
@@ -166,19 +166,6 @@ Partial Class dlgInfillMissingValues
         Me.grpStartEnd.Name = "grpStartEnd"
         Me.grpStartEnd.TabStop = False
         '
-        'lblValue
-        '
-        resources.ApplyResources(Me.lblValue, "lblValue")
-        Me.lblValue.Name = "lblValue"
-        '
-        'ucrInputConstant
-        '
-        Me.ucrInputConstant.AddQuotesIfUnrecognised = True
-        Me.ucrInputConstant.IsMultiline = False
-        Me.ucrInputConstant.IsReadOnly = False
-        resources.ApplyResources(Me.ucrInputConstant, "ucrInputConstant")
-        Me.ucrInputConstant.Name = "ucrInputConstant"
-        '
         'rdoExtendFill
         '
         resources.ApplyResources(Me.rdoExtendFill, "rdoExtendFill")
@@ -197,6 +184,19 @@ Partial Class dlgInfillMissingValues
         '
         resources.ApplyResources(Me.ucrPnlStartEnd, "ucrPnlStartEnd")
         Me.ucrPnlStartEnd.Name = "ucrPnlStartEnd"
+        '
+        'lblValue
+        '
+        resources.ApplyResources(Me.lblValue, "lblValue")
+        Me.lblValue.Name = "lblValue"
+        '
+        'ucrInputConstant
+        '
+        Me.ucrInputConstant.AddQuotesIfUnrecognised = True
+        Me.ucrInputConstant.IsMultiline = False
+        Me.ucrInputConstant.IsReadOnly = False
+        resources.ApplyResources(Me.ucrInputConstant, "ucrInputConstant")
+        Me.ucrInputConstant.Name = "ucrInputConstant"
         '
         'lblFunction
         '

--- a/instat/dlgInfillMissingValues.Designer.vb
+++ b/instat/dlgInfillMissingValues.Designer.vb
@@ -34,26 +34,30 @@ Partial Class dlgInfillMissingValues
         Me.rdoMultiple = New System.Windows.Forms.RadioButton()
         Me.rdoNeighbouring = New System.Windows.Forms.RadioButton()
         Me.grpMethods = New System.Windows.Forms.GroupBox()
-        Me.rdoInsertConstant = New System.Windows.Forms.RadioButton()
+        Me.ucrPnlMethods = New instat.UcrPanel()
         Me.grpStartEnd = New System.Windows.Forms.GroupBox()
+        Me.lblValue = New System.Windows.Forms.Label()
+        Me.ucrInputConstant = New instat.ucrInputTextBox()
         Me.rdoExtendFill = New System.Windows.Forms.RadioButton()
         Me.rdoLeaveAsMissing = New System.Windows.Forms.RadioButton()
+        Me.ucrPnlStartEnd = New instat.UcrPanel()
         Me.lblFunction = New System.Windows.Forms.Label()
         Me.lblRows = New System.Windows.Forms.Label()
+        Me.ucrChkSetSeed = New instat.ucrCheck()
+        Me.ucrNudSetSeed = New instat.ucrNud()
         Me.ucrNudMaximum = New instat.ucrNud()
         Me.ucrChkMaxGap = New instat.ucrCheck()
-        Me.ucrReceiverByFactor = New instat.ucrReceiverSingle()
         Me.ucrChkBy = New instat.ucrCheck()
         Me.ucrChkCopyFromAbove = New instat.ucrCheck()
-        Me.ucrInputConstant = New instat.ucrInputTextBox()
-        Me.ucrPnlStartEnd = New instat.UcrPanel()
         Me.ucrSaveNewColumn = New instat.ucrSave()
         Me.ucrInputComboFunction = New instat.ucrInputComboBox()
         Me.ucrReceiverElement = New instat.ucrReceiverSingle()
         Me.ucrBase = New instat.ucrButtons()
         Me.ucrSelectorInfillMissing = New instat.ucrSelectorByDataFrameAddRemove()
         Me.ucrPnlOptions = New instat.UcrPanel()
-        Me.ucrPnlMethods = New instat.UcrPanel()
+        Me.ucrReceiverStation = New instat.ucrReceiverSingle()
+        Me.ucrReceiverByFactor = New instat.ucrReceiverMultiple()
+        Me.lblStation = New System.Windows.Forms.Label()
         Me.grpMethods.SuspendLayout()
         Me.grpStartEnd.SuspendLayout()
         Me.SuspendLayout()
@@ -148,23 +152,34 @@ Partial Class dlgInfillMissingValues
         Me.grpMethods.Name = "grpMethods"
         Me.grpMethods.TabStop = False
         '
-        'rdoInsertConstant
+        'ucrPnlMethods
         '
-        resources.ApplyResources(Me.rdoInsertConstant, "rdoInsertConstant")
-        Me.rdoInsertConstant.Name = "rdoInsertConstant"
-        Me.rdoInsertConstant.TabStop = True
-        Me.rdoInsertConstant.UseVisualStyleBackColor = True
+        resources.ApplyResources(Me.ucrPnlMethods, "ucrPnlMethods")
+        Me.ucrPnlMethods.Name = "ucrPnlMethods"
         '
         'grpStartEnd
         '
+        Me.grpStartEnd.Controls.Add(Me.lblValue)
         Me.grpStartEnd.Controls.Add(Me.ucrInputConstant)
         Me.grpStartEnd.Controls.Add(Me.rdoExtendFill)
-        Me.grpStartEnd.Controls.Add(Me.rdoInsertConstant)
         Me.grpStartEnd.Controls.Add(Me.rdoLeaveAsMissing)
         Me.grpStartEnd.Controls.Add(Me.ucrPnlStartEnd)
         resources.ApplyResources(Me.grpStartEnd, "grpStartEnd")
         Me.grpStartEnd.Name = "grpStartEnd"
         Me.grpStartEnd.TabStop = False
+        '
+        'lblValue
+        '
+        resources.ApplyResources(Me.lblValue, "lblValue")
+        Me.lblValue.Name = "lblValue"
+        '
+        'ucrInputConstant
+        '
+        Me.ucrInputConstant.AddQuotesIfUnrecognised = True
+        Me.ucrInputConstant.IsMultiline = False
+        Me.ucrInputConstant.IsReadOnly = False
+        resources.ApplyResources(Me.ucrInputConstant, "ucrInputConstant")
+        Me.ucrInputConstant.Name = "ucrInputConstant"
         '
         'rdoExtendFill
         '
@@ -180,6 +195,11 @@ Partial Class dlgInfillMissingValues
         Me.rdoLeaveAsMissing.TabStop = True
         Me.rdoLeaveAsMissing.UseVisualStyleBackColor = True
         '
+        'ucrPnlStartEnd
+        '
+        resources.ApplyResources(Me.ucrPnlStartEnd, "ucrPnlStartEnd")
+        Me.ucrPnlStartEnd.Name = "ucrPnlStartEnd"
+        '
         'lblFunction
         '
         resources.ApplyResources(Me.lblFunction, "lblFunction")
@@ -189,6 +209,22 @@ Partial Class dlgInfillMissingValues
         '
         resources.ApplyResources(Me.lblRows, "lblRows")
         Me.lblRows.Name = "lblRows"
+        '
+        'ucrChkSetSeed
+        '
+        Me.ucrChkSetSeed.Checked = False
+        resources.ApplyResources(Me.ucrChkSetSeed, "ucrChkSetSeed")
+        Me.ucrChkSetSeed.Name = "ucrChkSetSeed"
+        '
+        'ucrNudSetSeed
+        '
+        Me.ucrNudSetSeed.DecimalPlaces = New Decimal(New Integer() {0, 0, 0, 0})
+        Me.ucrNudSetSeed.Increment = New Decimal(New Integer() {1, 0, 0, 0})
+        resources.ApplyResources(Me.ucrNudSetSeed, "ucrNudSetSeed")
+        Me.ucrNudSetSeed.Maximum = New Decimal(New Integer() {100, 0, 0, 0})
+        Me.ucrNudSetSeed.Minimum = New Decimal(New Integer() {0, 0, 0, 0})
+        Me.ucrNudSetSeed.Name = "ucrNudSetSeed"
+        Me.ucrNudSetSeed.Value = New Decimal(New Integer() {0, 0, 0, 0})
         '
         'ucrNudMaximum
         '
@@ -206,15 +242,6 @@ Partial Class dlgInfillMissingValues
         resources.ApplyResources(Me.ucrChkMaxGap, "ucrChkMaxGap")
         Me.ucrChkMaxGap.Name = "ucrChkMaxGap"
         '
-        'ucrReceiverByFactor
-        '
-        Me.ucrReceiverByFactor.frmParent = Me
-        resources.ApplyResources(Me.ucrReceiverByFactor, "ucrReceiverByFactor")
-        Me.ucrReceiverByFactor.Name = "ucrReceiverByFactor"
-        Me.ucrReceiverByFactor.Selector = Nothing
-        Me.ucrReceiverByFactor.strNcFilePath = ""
-        Me.ucrReceiverByFactor.ucrSelector = Nothing
-        '
         'ucrChkBy
         '
         Me.ucrChkBy.Checked = False
@@ -226,19 +253,6 @@ Partial Class dlgInfillMissingValues
         Me.ucrChkCopyFromAbove.Checked = False
         resources.ApplyResources(Me.ucrChkCopyFromAbove, "ucrChkCopyFromAbove")
         Me.ucrChkCopyFromAbove.Name = "ucrChkCopyFromAbove"
-        '
-        'ucrInputConstant
-        '
-        Me.ucrInputConstant.AddQuotesIfUnrecognised = True
-        Me.ucrInputConstant.IsMultiline = False
-        Me.ucrInputConstant.IsReadOnly = False
-        resources.ApplyResources(Me.ucrInputConstant, "ucrInputConstant")
-        Me.ucrInputConstant.Name = "ucrInputConstant"
-        '
-        'ucrPnlStartEnd
-        '
-        resources.ApplyResources(Me.ucrPnlStartEnd, "ucrPnlStartEnd")
-        Me.ucrPnlStartEnd.Name = "ucrPnlStartEnd"
         '
         'ucrSaveNewColumn
         '
@@ -279,19 +293,41 @@ Partial Class dlgInfillMissingValues
         resources.ApplyResources(Me.ucrPnlOptions, "ucrPnlOptions")
         Me.ucrPnlOptions.Name = "ucrPnlOptions"
         '
-        'ucrPnlMethods
+        'ucrReceiverStation
         '
-        resources.ApplyResources(Me.ucrPnlMethods, "ucrPnlMethods")
-        Me.ucrPnlMethods.Name = "ucrPnlMethods"
+        Me.ucrReceiverStation.frmParent = Me
+        resources.ApplyResources(Me.ucrReceiverStation, "ucrReceiverStation")
+        Me.ucrReceiverStation.Name = "ucrReceiverStation"
+        Me.ucrReceiverStation.Selector = Nothing
+        Me.ucrReceiverStation.strNcFilePath = ""
+        Me.ucrReceiverStation.ucrSelector = Nothing
+        '
+        'ucrReceiverByFactor
+        '
+        Me.ucrReceiverByFactor.frmParent = Me
+        resources.ApplyResources(Me.ucrReceiverByFactor, "ucrReceiverByFactor")
+        Me.ucrReceiverByFactor.Name = "ucrReceiverByFactor"
+        Me.ucrReceiverByFactor.Selector = Nothing
+        Me.ucrReceiverByFactor.strNcFilePath = ""
+        Me.ucrReceiverByFactor.ucrSelector = Nothing
+        '
+        'lblStation
+        '
+        resources.ApplyResources(Me.lblStation, "lblStation")
+        Me.lblStation.Name = "lblStation"
         '
         'dlgInfillMissingValues
         '
         resources.ApplyResources(Me, "$this")
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.Controls.Add(Me.lblStation)
+        Me.Controls.Add(Me.ucrReceiverByFactor)
+        Me.Controls.Add(Me.ucrReceiverStation)
+        Me.Controls.Add(Me.ucrChkSetSeed)
+        Me.Controls.Add(Me.ucrNudSetSeed)
         Me.Controls.Add(Me.lblRows)
         Me.Controls.Add(Me.ucrNudMaximum)
         Me.Controls.Add(Me.ucrChkMaxGap)
-        Me.Controls.Add(Me.ucrReceiverByFactor)
         Me.Controls.Add(Me.ucrChkBy)
         Me.Controls.Add(Me.ucrChkCopyFromAbove)
         Me.Controls.Add(Me.grpStartEnd)
@@ -344,11 +380,15 @@ Partial Class dlgInfillMissingValues
     Friend WithEvents ucrInputComboFunction As ucrInputComboBox
     Friend WithEvents lblFunction As Label
     Friend WithEvents ucrChkCopyFromAbove As ucrCheck
-    Friend WithEvents rdoInsertConstant As RadioButton
     Friend WithEvents ucrInputConstant As ucrInputTextBox
     Friend WithEvents ucrChkBy As ucrCheck
-    Friend WithEvents ucrReceiverByFactor As ucrReceiverSingle
     Friend WithEvents ucrChkMaxGap As ucrCheck
     Friend WithEvents ucrNudMaximum As ucrNud
     Friend WithEvents lblRows As Label
+    Friend WithEvents ucrNudSetSeed As ucrNud
+    Friend WithEvents lblValue As Label
+    Friend WithEvents ucrChkSetSeed As ucrCheck
+    Friend WithEvents lblStation As Label
+    Friend WithEvents ucrReceiverByFactor As ucrReceiverMultiple
+    Friend WithEvents ucrReceiverStation As ucrReceiverSingle
 End Class

--- a/instat/dlgInfillMissingValues.Designer.vb
+++ b/instat/dlgInfillMissingValues.Designer.vb
@@ -48,7 +48,7 @@ Partial Class dlgInfillMissingValues
         Me.ucrNudMaximum = New instat.ucrNud()
         Me.ucrChkMaxGap = New instat.ucrCheck()
         Me.ucrChkBy = New instat.ucrCheck()
-        Me.ucrChkCopyFromAbove = New instat.ucrCheck()
+        Me.ucrChkCopyFromBelow = New instat.ucrCheck()
         Me.ucrSaveNewColumn = New instat.ucrSave()
         Me.ucrInputComboFunction = New instat.ucrInputComboBox()
         Me.ucrReceiverElement = New instat.ucrReceiverSingle()
@@ -246,11 +246,11 @@ Partial Class dlgInfillMissingValues
         resources.ApplyResources(Me.ucrChkBy, "ucrChkBy")
         Me.ucrChkBy.Name = "ucrChkBy"
         '
-        'ucrChkCopyFromAbove
+        'ucrChkCopyFromBelow
         '
-        Me.ucrChkCopyFromAbove.Checked = False
-        resources.ApplyResources(Me.ucrChkCopyFromAbove, "ucrChkCopyFromAbove")
-        Me.ucrChkCopyFromAbove.Name = "ucrChkCopyFromAbove"
+        Me.ucrChkCopyFromBelow.Checked = False
+        resources.ApplyResources(Me.ucrChkCopyFromBelow, "ucrChkCopyFromBelow")
+        Me.ucrChkCopyFromBelow.Name = "ucrChkCopyFromBelow"
         '
         'ucrSaveNewColumn
         '
@@ -329,7 +329,7 @@ Partial Class dlgInfillMissingValues
         Me.Controls.Add(Me.ucrNudMaximum)
         Me.Controls.Add(Me.ucrChkMaxGap)
         Me.Controls.Add(Me.ucrChkBy)
-        Me.Controls.Add(Me.ucrChkCopyFromAbove)
+        Me.Controls.Add(Me.ucrChkCopyFromBelow)
         Me.Controls.Add(Me.grpStartEnd)
         Me.Controls.Add(Me.lblFunction)
         Me.Controls.Add(Me.ucrSaveNewColumn)
@@ -379,7 +379,7 @@ Partial Class dlgInfillMissingValues
     Friend WithEvents ucrPnlStartEnd As UcrPanel
     Friend WithEvents ucrInputComboFunction As ucrInputComboBox
     Friend WithEvents lblFunction As Label
-    Friend WithEvents ucrChkCopyFromAbove As ucrCheck
+    Friend WithEvents ucrChkCopyFromBelow As ucrCheck
     Friend WithEvents ucrInputConstant As ucrInputTextBox
     Friend WithEvents ucrChkBy As ucrCheck
     Friend WithEvents ucrChkMaxGap As ucrCheck

--- a/instat/dlgInfillMissingValues.Designer.vb
+++ b/instat/dlgInfillMissingValues.Designer.vb
@@ -159,8 +159,6 @@ Partial Class dlgInfillMissingValues
         '
         'grpStartEnd
         '
-        Me.grpStartEnd.Controls.Add(Me.lblValue)
-        Me.grpStartEnd.Controls.Add(Me.ucrInputConstant)
         Me.grpStartEnd.Controls.Add(Me.rdoExtendFill)
         Me.grpStartEnd.Controls.Add(Me.rdoLeaveAsMissing)
         Me.grpStartEnd.Controls.Add(Me.ucrPnlStartEnd)
@@ -320,7 +318,9 @@ Partial Class dlgInfillMissingValues
         '
         resources.ApplyResources(Me, "$this")
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.Controls.Add(Me.lblValue)
         Me.Controls.Add(Me.lblStation)
+        Me.Controls.Add(Me.ucrInputConstant)
         Me.Controls.Add(Me.ucrReceiverByFactor)
         Me.Controls.Add(Me.ucrReceiverStation)
         Me.Controls.Add(Me.ucrChkSetSeed)

--- a/instat/dlgInfillMissingValues.resx
+++ b/instat/dlgInfillMissingValues.resx
@@ -328,7 +328,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblElement.ZOrder" xml:space="preserve">
-    <value>17</value>
+    <value>19</value>
   </data>
   <data name="rdoSingle.Appearance" type="System.Windows.Forms.Appearance, System.Windows.Forms">
     <value>Button</value>
@@ -364,7 +364,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;rdoSingle.ZOrder" xml:space="preserve">
-    <value>16</value>
+    <value>18</value>
   </data>
   <data name="rdoMultiple.Appearance" type="System.Windows.Forms.Appearance, System.Windows.Forms">
     <value>Button</value>
@@ -400,7 +400,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;rdoMultiple.ZOrder" xml:space="preserve">
-    <value>15</value>
+    <value>17</value>
   </data>
   <data name="rdoNeighbouring.Appearance" type="System.Windows.Forms.Appearance, System.Windows.Forms">
     <value>Button</value>
@@ -436,16 +436,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;rdoNeighbouring.ZOrder" xml:space="preserve">
-    <value>14</value>
-  </data>
-  <data name="ucrPnlMethods.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 15</value>
-  </data>
-  <data name="ucrPnlMethods.Size" type="System.Drawing.Size, System.Drawing">
-    <value>177, 71</value>
-  </data>
-  <data name="ucrPnlMethods.TabIndex" type="System.Int32, mscorlib">
-    <value>17</value>
+    <value>16</value>
   </data>
   <data name="&gt;&gt;ucrPnlMethods.Name" xml:space="preserve">
     <value>ucrPnlMethods</value>
@@ -481,7 +472,88 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;grpMethods.ZOrder" xml:space="preserve">
-    <value>22</value>
+    <value>24</value>
+  </data>
+  <data name="ucrPnlMethods.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 15</value>
+  </data>
+  <data name="ucrPnlMethods.Size" type="System.Drawing.Size, System.Drawing">
+    <value>177, 71</value>
+  </data>
+  <data name="ucrPnlMethods.TabIndex" type="System.Int32, mscorlib">
+    <value>17</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlMethods.Name" xml:space="preserve">
+    <value>ucrPnlMethods</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlMethods.Type" xml:space="preserve">
+    <value>instat.UcrPanel, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlMethods.Parent" xml:space="preserve">
+    <value>grpMethods</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlMethods.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;rdoExtendFill.Name" xml:space="preserve">
+    <value>rdoExtendFill</value>
+  </data>
+  <data name="&gt;&gt;rdoExtendFill.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rdoExtendFill.Parent" xml:space="preserve">
+    <value>grpStartEnd</value>
+  </data>
+  <data name="&gt;&gt;rdoExtendFill.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;rdoLeaveAsMissing.Name" xml:space="preserve">
+    <value>rdoLeaveAsMissing</value>
+  </data>
+  <data name="&gt;&gt;rdoLeaveAsMissing.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rdoLeaveAsMissing.Parent" xml:space="preserve">
+    <value>grpStartEnd</value>
+  </data>
+  <data name="&gt;&gt;rdoLeaveAsMissing.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlStartEnd.Name" xml:space="preserve">
+    <value>ucrPnlStartEnd</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlStartEnd.Type" xml:space="preserve">
+    <value>instat.UcrPanel, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlStartEnd.Parent" xml:space="preserve">
+    <value>grpStartEnd</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlStartEnd.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="grpStartEnd.Location" type="System.Drawing.Point, System.Drawing">
+    <value>228, 317</value>
+  </data>
+  <data name="grpStartEnd.Size" type="System.Drawing.Size, System.Drawing">
+    <value>181, 66</value>
+  </data>
+  <data name="grpStartEnd.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="grpStartEnd.Text" xml:space="preserve">
+    <value>Start and End</value>
+  </data>
+  <data name="&gt;&gt;grpStartEnd.Name" xml:space="preserve">
+    <value>grpStartEnd</value>
+  </data>
+  <data name="&gt;&gt;grpStartEnd.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;grpStartEnd.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;grpStartEnd.ZOrder" xml:space="preserve">
+    <value>12</value>
   </data>
   <data name="lblValue.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -490,7 +562,7 @@
     <value>NoControl</value>
   </data>
   <data name="lblValue.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 65</value>
+    <value>236, 387</value>
   </data>
   <data name="lblValue.Size" type="System.Drawing.Size, System.Drawing">
     <value>37, 13</value>
@@ -508,13 +580,13 @@
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;lblValue.Parent" xml:space="preserve">
-    <value>grpStartEnd</value>
+    <value>$this</value>
   </data>
   <data name="&gt;&gt;lblValue.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
   <data name="ucrInputConstant.Location" type="System.Drawing.Point, System.Drawing">
-    <value>80, 63</value>
+    <value>279, 384</value>
   </data>
   <data name="ucrInputConstant.Size" type="System.Drawing.Size, System.Drawing">
     <value>47, 21</value>
@@ -529,10 +601,10 @@
     <value>instat.ucrInputTextBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ucrInputConstant.Parent" xml:space="preserve">
-    <value>grpStartEnd</value>
+    <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrInputConstant.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="rdoExtendFill.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -562,7 +634,7 @@
     <value>grpStartEnd</value>
   </data>
   <data name="&gt;&gt;rdoExtendFill.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>0</value>
   </data>
   <data name="rdoLeaveAsMissing.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -592,7 +664,7 @@
     <value>grpStartEnd</value>
   </data>
   <data name="&gt;&gt;rdoLeaveAsMissing.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>1</value>
   </data>
   <data name="ucrPnlStartEnd.Location" type="System.Drawing.Point, System.Drawing">
     <value>6, 15</value>
@@ -613,31 +685,7 @@
     <value>grpStartEnd</value>
   </data>
   <data name="&gt;&gt;ucrPnlStartEnd.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="grpStartEnd.Location" type="System.Drawing.Point, System.Drawing">
-    <value>228, 317</value>
-  </data>
-  <data name="grpStartEnd.Size" type="System.Drawing.Size, System.Drawing">
-    <value>181, 99</value>
-  </data>
-  <data name="grpStartEnd.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
-  </data>
-  <data name="grpStartEnd.Text" xml:space="preserve">
-    <value>Start and End</value>
-  </data>
-  <data name="&gt;&gt;grpStartEnd.Name" xml:space="preserve">
-    <value>grpStartEnd</value>
-  </data>
-  <data name="&gt;&gt;grpStartEnd.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;grpStartEnd.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;grpStartEnd.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>2</value>
   </data>
   <data name="lblFunction.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -667,7 +715,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblFunction.ZOrder" xml:space="preserve">
-    <value>11</value>
+    <value>13</value>
   </data>
   <data name="lblRows.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -697,7 +745,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblRows.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>7</value>
   </data>
   <data name="ucrChkSetSeed.Location" type="System.Drawing.Point, System.Drawing">
     <value>146, 427</value>
@@ -718,7 +766,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrChkSetSeed.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>5</value>
   </data>
   <data name="ucrNudSetSeed.Location" type="System.Drawing.Point, System.Drawing">
     <value>223, 427</value>
@@ -739,7 +787,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrNudSetSeed.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>6</value>
   </data>
   <data name="ucrNudMaximum.Location" type="System.Drawing.Point, System.Drawing">
     <value>92, 279</value>
@@ -760,7 +808,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrNudMaximum.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>8</value>
   </data>
   <data name="ucrChkMaxGap.Location" type="System.Drawing.Point, System.Drawing">
     <value>12, 280</value>
@@ -781,7 +829,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrChkMaxGap.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>9</value>
   </data>
   <data name="ucrChkBy.Location" type="System.Drawing.Point, System.Drawing">
     <value>281, 184</value>
@@ -802,7 +850,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrChkBy.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>10</value>
   </data>
   <data name="ucrChkCopyFromAbove.Location" type="System.Drawing.Point, System.Drawing">
     <value>12, 427</value>
@@ -823,7 +871,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrChkCopyFromAbove.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>11</value>
   </data>
   <data name="ucrSaveNewColumn.Location" type="System.Drawing.Point, System.Drawing">
     <value>12, 455</value>
@@ -847,7 +895,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrSaveNewColumn.ZOrder" xml:space="preserve">
-    <value>12</value>
+    <value>14</value>
   </data>
   <data name="ucrInputComboFunction.Location" type="System.Drawing.Point, System.Drawing">
     <value>66, 426</value>
@@ -868,7 +916,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrInputComboFunction.ZOrder" xml:space="preserve">
-    <value>13</value>
+    <value>15</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -907,7 +955,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblStation.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="ucrReceiverByFactor.Location" type="System.Drawing.Point, System.Drawing">
     <value>281, 207</value>
@@ -931,7 +979,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrReceiverByFactor.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>3</value>
   </data>
   <data name="ucrReceiverStation.Location" type="System.Drawing.Point, System.Drawing">
     <value>281, 98</value>
@@ -955,7 +1003,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrReceiverStation.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>4</value>
   </data>
   <data name="ucrBase.Location" type="System.Drawing.Point, System.Drawing">
     <value>12, 483</value>
@@ -976,7 +1024,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrBase.ZOrder" xml:space="preserve">
-    <value>19</value>
+    <value>21</value>
   </data>
   <data name="ucrSelectorInfillMissing.Location" type="System.Drawing.Point, System.Drawing">
     <value>12, 75</value>
@@ -1000,7 +1048,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrSelectorInfillMissing.ZOrder" xml:space="preserve">
-    <value>20</value>
+    <value>22</value>
   </data>
   <data name="ucrPnlOptions.Location" type="System.Drawing.Point, System.Drawing">
     <value>49, 12</value>
@@ -1021,7 +1069,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrPnlOptions.ZOrder" xml:space="preserve">
-    <value>21</value>
+    <value>23</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterScreen</value>
@@ -1057,6 +1105,6 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrReceiverElement.ZOrder" xml:space="preserve">
-    <value>18</value>
+    <value>20</value>
   </data>
 </root>

--- a/instat/dlgInfillMissingValues.resx
+++ b/instat/dlgInfillMissingValues.resx
@@ -250,13 +250,13 @@
     <value>9, 42</value>
   </data>
   <data name="rdoNaAggregate.Size" type="System.Drawing.Size, System.Drawing">
-    <value>65, 17</value>
+    <value>59, 17</value>
   </data>
   <data name="rdoNaAggregate.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
   </data>
   <data name="rdoNaAggregate.Text" xml:space="preserve">
-    <value>Average</value>
+    <value>Typical</value>
   </data>
   <data name="&gt;&gt;rdoNaAggregate.Name" xml:space="preserve">
     <value>rdoNaAggregate</value>
@@ -438,6 +438,15 @@
   <data name="&gt;&gt;rdoNeighbouring.ZOrder" xml:space="preserve">
     <value>16</value>
   </data>
+  <data name="ucrPnlMethods.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 15</value>
+  </data>
+  <data name="ucrPnlMethods.Size" type="System.Drawing.Size, System.Drawing">
+    <value>177, 71</value>
+  </data>
+  <data name="ucrPnlMethods.TabIndex" type="System.Int32, mscorlib">
+    <value>17</value>
+  </data>
   <data name="&gt;&gt;ucrPnlMethods.Name" xml:space="preserve">
     <value>ucrPnlMethods</value>
   </data>
@@ -474,26 +483,23 @@
   <data name="&gt;&gt;grpMethods.ZOrder" xml:space="preserve">
     <value>24</value>
   </data>
-  <data name="ucrPnlMethods.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 15</value>
+  <data name="rdoExtendFill.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
-  <data name="ucrPnlMethods.Size" type="System.Drawing.Size, System.Drawing">
-    <value>177, 71</value>
+  <data name="rdoExtendFill.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
-  <data name="ucrPnlMethods.TabIndex" type="System.Int32, mscorlib">
-    <value>17</value>
+  <data name="rdoExtendFill.Location" type="System.Drawing.Point, System.Drawing">
+    <value>11, 39</value>
   </data>
-  <data name="&gt;&gt;ucrPnlMethods.Name" xml:space="preserve">
-    <value>ucrPnlMethods</value>
+  <data name="rdoExtendFill.Size" type="System.Drawing.Size, System.Drawing">
+    <value>73, 17</value>
   </data>
-  <data name="&gt;&gt;ucrPnlMethods.Type" xml:space="preserve">
-    <value>instat.UcrPanel, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  <data name="rdoExtendFill.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
   </data>
-  <data name="&gt;&gt;ucrPnlMethods.Parent" xml:space="preserve">
-    <value>grpMethods</value>
-  </data>
-  <data name="&gt;&gt;ucrPnlMethods.ZOrder" xml:space="preserve">
-    <value>6</value>
+  <data name="rdoExtendFill.Text" xml:space="preserve">
+    <value>Extend Fill</value>
   </data>
   <data name="&gt;&gt;rdoExtendFill.Name" xml:space="preserve">
     <value>rdoExtendFill</value>
@@ -507,6 +513,24 @@
   <data name="&gt;&gt;rdoExtendFill.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
+  <data name="rdoLeaveAsMissing.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="rdoLeaveAsMissing.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="rdoLeaveAsMissing.Location" type="System.Drawing.Point, System.Drawing">
+    <value>11, 16</value>
+  </data>
+  <data name="rdoLeaveAsMissing.Size" type="System.Drawing.Size, System.Drawing">
+    <value>107, 17</value>
+  </data>
+  <data name="rdoLeaveAsMissing.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="rdoLeaveAsMissing.Text" xml:space="preserve">
+    <value>Leave as Missing</value>
+  </data>
   <data name="&gt;&gt;rdoLeaveAsMissing.Name" xml:space="preserve">
     <value>rdoLeaveAsMissing</value>
   </data>
@@ -518,6 +542,15 @@
   </data>
   <data name="&gt;&gt;rdoLeaveAsMissing.ZOrder" xml:space="preserve">
     <value>1</value>
+  </data>
+  <data name="ucrPnlStartEnd.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 15</value>
+  </data>
+  <data name="ucrPnlStartEnd.Size" type="System.Drawing.Size, System.Drawing">
+    <value>118, 44</value>
+  </data>
+  <data name="ucrPnlStartEnd.TabIndex" type="System.Int32, mscorlib">
+    <value>18</value>
   </data>
   <data name="&gt;&gt;ucrPnlStartEnd.Name" xml:space="preserve">
     <value>ucrPnlStartEnd</value>
@@ -604,87 +637,6 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrInputConstant.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="rdoExtendFill.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="rdoExtendFill.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="rdoExtendFill.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 39</value>
-  </data>
-  <data name="rdoExtendFill.Size" type="System.Drawing.Size, System.Drawing">
-    <value>73, 17</value>
-  </data>
-  <data name="rdoExtendFill.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
-  </data>
-  <data name="rdoExtendFill.Text" xml:space="preserve">
-    <value>Extend Fill</value>
-  </data>
-  <data name="&gt;&gt;rdoExtendFill.Name" xml:space="preserve">
-    <value>rdoExtendFill</value>
-  </data>
-  <data name="&gt;&gt;rdoExtendFill.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rdoExtendFill.Parent" xml:space="preserve">
-    <value>grpStartEnd</value>
-  </data>
-  <data name="&gt;&gt;rdoExtendFill.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="rdoLeaveAsMissing.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="rdoLeaveAsMissing.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="rdoLeaveAsMissing.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 16</value>
-  </data>
-  <data name="rdoLeaveAsMissing.Size" type="System.Drawing.Size, System.Drawing">
-    <value>107, 17</value>
-  </data>
-  <data name="rdoLeaveAsMissing.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
-  </data>
-  <data name="rdoLeaveAsMissing.Text" xml:space="preserve">
-    <value>Leave as Missing</value>
-  </data>
-  <data name="&gt;&gt;rdoLeaveAsMissing.Name" xml:space="preserve">
-    <value>rdoLeaveAsMissing</value>
-  </data>
-  <data name="&gt;&gt;rdoLeaveAsMissing.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rdoLeaveAsMissing.Parent" xml:space="preserve">
-    <value>grpStartEnd</value>
-  </data>
-  <data name="&gt;&gt;rdoLeaveAsMissing.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="ucrPnlStartEnd.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 15</value>
-  </data>
-  <data name="ucrPnlStartEnd.Size" type="System.Drawing.Size, System.Drawing">
-    <value>118, 44</value>
-  </data>
-  <data name="ucrPnlStartEnd.TabIndex" type="System.Int32, mscorlib">
-    <value>18</value>
-  </data>
-  <data name="&gt;&gt;ucrPnlStartEnd.Name" xml:space="preserve">
-    <value>ucrPnlStartEnd</value>
-  </data>
-  <data name="&gt;&gt;ucrPnlStartEnd.Type" xml:space="preserve">
-    <value>instat.UcrPanel, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrPnlStartEnd.Parent" xml:space="preserve">
-    <value>grpStartEnd</value>
-  </data>
-  <data name="&gt;&gt;ucrPnlStartEnd.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
   <data name="lblFunction.AutoSize" type="System.Boolean, mscorlib">

--- a/instat/dlgInfillMissingValues.resx
+++ b/instat/dlgInfillMissingValues.resx
@@ -307,13 +307,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblElement.Location" type="System.Drawing.Point, System.Drawing">
-    <value>285, 97</value>
+    <value>281, 132</value>
   </data>
   <data name="lblElement.Size" type="System.Drawing.Size, System.Drawing">
     <value>48, 13</value>
   </data>
   <data name="lblElement.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
+    <value>7</value>
   </data>
   <data name="lblElement.Text" xml:space="preserve">
     <value>Element:</value>
@@ -328,7 +328,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblElement.ZOrder" xml:space="preserve">
-    <value>13</value>
+    <value>17</value>
   </data>
   <data name="rdoSingle.Appearance" type="System.Windows.Forms.Appearance, System.Windows.Forms">
     <value>Button</value>
@@ -364,7 +364,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;rdoSingle.ZOrder" xml:space="preserve">
-    <value>12</value>
+    <value>16</value>
   </data>
   <data name="rdoMultiple.Appearance" type="System.Windows.Forms.Appearance, System.Windows.Forms">
     <value>Button</value>
@@ -400,7 +400,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;rdoMultiple.ZOrder" xml:space="preserve">
-    <value>11</value>
+    <value>15</value>
   </data>
   <data name="rdoNeighbouring.Appearance" type="System.Windows.Forms.Appearance, System.Windows.Forms">
     <value>Button</value>
@@ -436,7 +436,16 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;rdoNeighbouring.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>14</value>
+  </data>
+  <data name="ucrPnlMethods.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 15</value>
+  </data>
+  <data name="ucrPnlMethods.Size" type="System.Drawing.Size, System.Drawing">
+    <value>177, 71</value>
+  </data>
+  <data name="ucrPnlMethods.TabIndex" type="System.Int32, mscorlib">
+    <value>17</value>
   </data>
   <data name="&gt;&gt;ucrPnlMethods.Name" xml:space="preserve">
     <value>ucrPnlMethods</value>
@@ -451,13 +460,13 @@
     <value>6</value>
   </data>
   <data name="grpMethods.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 264</value>
+    <value>12, 317</value>
   </data>
   <data name="grpMethods.Size" type="System.Drawing.Size, System.Drawing">
     <value>210, 99</value>
   </data>
   <data name="grpMethods.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
+    <value>14</value>
   </data>
   <data name="grpMethods.Text" xml:space="preserve">
     <value>Methods</value>
@@ -472,37 +481,46 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;grpMethods.ZOrder" xml:space="preserve">
-    <value>18</value>
+    <value>22</value>
   </data>
-  <data name="rdoInsertConstant.AutoSize" type="System.Boolean, mscorlib">
+  <data name="lblValue.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="rdoInsertConstant.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="lblValue.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="rdoInsertConstant.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 64</value>
+  <data name="lblValue.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 65</value>
   </data>
-  <data name="rdoInsertConstant.Size" type="System.Drawing.Size, System.Drawing">
-    <value>55, 17</value>
+  <data name="lblValue.Size" type="System.Drawing.Size, System.Drawing">
+    <value>37, 13</value>
   </data>
-  <data name="rdoInsertConstant.TabIndex" type="System.Int32, mscorlib">
-    <value>18</value>
+  <data name="lblValue.TabIndex" type="System.Int32, mscorlib">
+    <value>28</value>
   </data>
-  <data name="rdoInsertConstant.Text" xml:space="preserve">
+  <data name="lblValue.Text" xml:space="preserve">
     <value>Value:</value>
   </data>
-  <data name="&gt;&gt;rdoInsertConstant.Name" xml:space="preserve">
-    <value>rdoInsertConstant</value>
+  <data name="&gt;&gt;lblValue.Name" xml:space="preserve">
+    <value>lblValue</value>
   </data>
-  <data name="&gt;&gt;rdoInsertConstant.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;lblValue.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;rdoInsertConstant.Parent" xml:space="preserve">
+  <data name="&gt;&gt;lblValue.Parent" xml:space="preserve">
     <value>grpStartEnd</value>
   </data>
-  <data name="&gt;&gt;rdoInsertConstant.ZOrder" xml:space="preserve">
-    <value>2</value>
+  <data name="&gt;&gt;lblValue.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="ucrInputConstant.Location" type="System.Drawing.Point, System.Drawing">
+    <value>80, 63</value>
+  </data>
+  <data name="ucrInputConstant.Size" type="System.Drawing.Size, System.Drawing">
+    <value>47, 21</value>
+  </data>
+  <data name="ucrInputConstant.TabIndex" type="System.Int32, mscorlib">
+    <value>19</value>
   </data>
   <data name="&gt;&gt;ucrInputConstant.Name" xml:space="preserve">
     <value>ucrInputConstant</value>
@@ -514,67 +532,7 @@
     <value>grpStartEnd</value>
   </data>
   <data name="&gt;&gt;ucrInputConstant.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;rdoExtendFill.Name" xml:space="preserve">
-    <value>rdoExtendFill</value>
-  </data>
-  <data name="&gt;&gt;rdoExtendFill.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rdoExtendFill.Parent" xml:space="preserve">
-    <value>grpStartEnd</value>
-  </data>
-  <data name="&gt;&gt;rdoExtendFill.ZOrder" xml:space="preserve">
     <value>1</value>
-  </data>
-  <data name="&gt;&gt;rdoLeaveAsMissing.Name" xml:space="preserve">
-    <value>rdoLeaveAsMissing</value>
-  </data>
-  <data name="&gt;&gt;rdoLeaveAsMissing.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rdoLeaveAsMissing.Parent" xml:space="preserve">
-    <value>grpStartEnd</value>
-  </data>
-  <data name="&gt;&gt;rdoLeaveAsMissing.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;ucrPnlStartEnd.Name" xml:space="preserve">
-    <value>ucrPnlStartEnd</value>
-  </data>
-  <data name="&gt;&gt;ucrPnlStartEnd.Type" xml:space="preserve">
-    <value>instat.UcrPanel, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrPnlStartEnd.Parent" xml:space="preserve">
-    <value>grpStartEnd</value>
-  </data>
-  <data name="&gt;&gt;ucrPnlStartEnd.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="grpStartEnd.Location" type="System.Drawing.Point, System.Drawing">
-    <value>228, 264</value>
-  </data>
-  <data name="grpStartEnd.Size" type="System.Drawing.Size, System.Drawing">
-    <value>181, 99</value>
-  </data>
-  <data name="grpStartEnd.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="grpStartEnd.Text" xml:space="preserve">
-    <value>Start and End</value>
-  </data>
-  <data name="&gt;&gt;grpStartEnd.Name" xml:space="preserve">
-    <value>grpStartEnd</value>
-  </data>
-  <data name="&gt;&gt;grpStartEnd.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;grpStartEnd.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;grpStartEnd.ZOrder" xml:space="preserve">
-    <value>6</value>
   </data>
   <data name="rdoExtendFill.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -604,7 +562,7 @@
     <value>grpStartEnd</value>
   </data>
   <data name="&gt;&gt;rdoExtendFill.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="rdoLeaveAsMissing.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -636,6 +594,51 @@
   <data name="&gt;&gt;rdoLeaveAsMissing.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
+  <data name="ucrPnlStartEnd.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 15</value>
+  </data>
+  <data name="ucrPnlStartEnd.Size" type="System.Drawing.Size, System.Drawing">
+    <value>118, 44</value>
+  </data>
+  <data name="ucrPnlStartEnd.TabIndex" type="System.Int32, mscorlib">
+    <value>18</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlStartEnd.Name" xml:space="preserve">
+    <value>ucrPnlStartEnd</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlStartEnd.Type" xml:space="preserve">
+    <value>instat.UcrPanel, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlStartEnd.Parent" xml:space="preserve">
+    <value>grpStartEnd</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlStartEnd.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="grpStartEnd.Location" type="System.Drawing.Point, System.Drawing">
+    <value>228, 317</value>
+  </data>
+  <data name="grpStartEnd.Size" type="System.Drawing.Size, System.Drawing">
+    <value>181, 99</value>
+  </data>
+  <data name="grpStartEnd.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="grpStartEnd.Text" xml:space="preserve">
+    <value>Start and End</value>
+  </data>
+  <data name="&gt;&gt;grpStartEnd.Name" xml:space="preserve">
+    <value>grpStartEnd</value>
+  </data>
+  <data name="&gt;&gt;grpStartEnd.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;grpStartEnd.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;grpStartEnd.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
   <data name="lblFunction.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -643,7 +646,7 @@
     <value>NoControl</value>
   </data>
   <data name="lblFunction.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 377</value>
+    <value>12, 430</value>
   </data>
   <data name="lblFunction.Size" type="System.Drawing.Size, System.Drawing">
     <value>51, 13</value>
@@ -664,7 +667,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblFunction.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>11</value>
   </data>
   <data name="lblRows.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -673,13 +676,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblRows.Location" type="System.Drawing.Point, System.Drawing">
-    <value>334, 241</value>
+    <value>141, 283</value>
   </data>
   <data name="lblRows.Size" type="System.Drawing.Size, System.Drawing">
     <value>35, 13</value>
   </data>
   <data name="lblRows.TabIndex" type="System.Int32, mscorlib">
-    <value>25</value>
+    <value>13</value>
   </data>
   <data name="lblRows.Text" xml:space="preserve">
     <value>row(s)</value>
@@ -694,16 +697,58 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblRows.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>5</value>
+  </data>
+  <data name="ucrChkSetSeed.Location" type="System.Drawing.Point, System.Drawing">
+    <value>146, 427</value>
+  </data>
+  <data name="ucrChkSetSeed.Size" type="System.Drawing.Size, System.Drawing">
+    <value>76, 20</value>
+  </data>
+  <data name="ucrChkSetSeed.TabIndex" type="System.Int32, mscorlib">
+    <value>18</value>
+  </data>
+  <data name="&gt;&gt;ucrChkSetSeed.Name" xml:space="preserve">
+    <value>ucrChkSetSeed</value>
+  </data>
+  <data name="&gt;&gt;ucrChkSetSeed.Type" xml:space="preserve">
+    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrChkSetSeed.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrChkSetSeed.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="ucrNudSetSeed.Location" type="System.Drawing.Point, System.Drawing">
+    <value>223, 427</value>
+  </data>
+  <data name="ucrNudSetSeed.Size" type="System.Drawing.Size, System.Drawing">
+    <value>48, 20</value>
+  </data>
+  <data name="ucrNudSetSeed.TabIndex" type="System.Int32, mscorlib">
+    <value>19</value>
+  </data>
+  <data name="&gt;&gt;ucrNudSetSeed.Name" xml:space="preserve">
+    <value>ucrNudSetSeed</value>
+  </data>
+  <data name="&gt;&gt;ucrNudSetSeed.Type" xml:space="preserve">
+    <value>instat.ucrNud, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrNudSetSeed.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrNudSetSeed.ZOrder" xml:space="preserve">
+    <value>4</value>
   </data>
   <data name="ucrNudMaximum.Location" type="System.Drawing.Point, System.Drawing">
-    <value>285, 237</value>
+    <value>92, 279</value>
   </data>
   <data name="ucrNudMaximum.Size" type="System.Drawing.Size, System.Drawing">
     <value>48, 20</value>
   </data>
   <data name="ucrNudMaximum.TabIndex" type="System.Int32, mscorlib">
-    <value>24</value>
+    <value>12</value>
   </data>
   <data name="&gt;&gt;ucrNudMaximum.Name" xml:space="preserve">
     <value>ucrNudMaximum</value>
@@ -715,16 +760,16 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrNudMaximum.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>6</value>
   </data>
   <data name="ucrChkMaxGap.Location" type="System.Drawing.Point, System.Drawing">
-    <value>285, 216</value>
+    <value>12, 280</value>
   </data>
   <data name="ucrChkMaxGap.Size" type="System.Drawing.Size, System.Drawing">
     <value>76, 20</value>
   </data>
   <data name="ucrChkMaxGap.TabIndex" type="System.Int32, mscorlib">
-    <value>23</value>
+    <value>11</value>
   </data>
   <data name="&gt;&gt;ucrChkMaxGap.Name" xml:space="preserve">
     <value>ucrChkMaxGap</value>
@@ -736,25 +781,16 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrChkMaxGap.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
-  </data>
-  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>421, 487</value>
+    <value>7</value>
   </data>
   <data name="ucrChkBy.Location" type="System.Drawing.Point, System.Drawing">
-    <value>285, 153</value>
+    <value>281, 184</value>
   </data>
   <data name="ucrChkBy.Size" type="System.Drawing.Size, System.Drawing">
     <value>103, 20</value>
   </data>
   <data name="ucrChkBy.TabIndex" type="System.Int32, mscorlib">
-    <value>21</value>
+    <value>9</value>
   </data>
   <data name="&gt;&gt;ucrChkBy.Name" xml:space="preserve">
     <value>ucrChkBy</value>
@@ -766,16 +802,16 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrChkBy.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>8</value>
   </data>
   <data name="ucrChkCopyFromAbove.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 374</value>
+    <value>12, 427</value>
   </data>
   <data name="ucrChkCopyFromAbove.Size" type="System.Drawing.Size, System.Drawing">
     <value>110, 20</value>
   </data>
   <data name="ucrChkCopyFromAbove.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
+    <value>16</value>
   </data>
   <data name="&gt;&gt;ucrChkCopyFromAbove.Name" xml:space="preserve">
     <value>ucrChkCopyFromAbove</value>
@@ -787,10 +823,10 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrChkCopyFromAbove.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>9</value>
   </data>
   <data name="ucrSaveNewColumn.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 402</value>
+    <value>12, 455</value>
   </data>
   <data name="ucrSaveNewColumn.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>4, 5, 4, 5</value>
@@ -799,7 +835,7 @@
     <value>302, 25</value>
   </data>
   <data name="ucrSaveNewColumn.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
+    <value>20</value>
   </data>
   <data name="&gt;&gt;ucrSaveNewColumn.Name" xml:space="preserve">
     <value>ucrSaveNewColumn</value>
@@ -811,16 +847,16 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrSaveNewColumn.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>12</value>
   </data>
   <data name="ucrInputComboFunction.Location" type="System.Drawing.Point, System.Drawing">
-    <value>66, 373</value>
+    <value>66, 426</value>
   </data>
   <data name="ucrInputComboFunction.Size" type="System.Drawing.Size, System.Drawing">
     <value>66, 21</value>
   </data>
   <data name="ucrInputComboFunction.TabIndex" type="System.Int32, mscorlib">
-    <value>19</value>
+    <value>17</value>
   </data>
   <data name="&gt;&gt;ucrInputComboFunction.Name" xml:space="preserve">
     <value>ucrInputComboFunction</value>
@@ -832,40 +868,103 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrInputComboFunction.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>13</value>
   </data>
-  <data name="ucrReceiverElement.Location" type="System.Drawing.Point, System.Drawing">
-    <value>285, 113</value>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
   </data>
-  <data name="ucrReceiverElement.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>421, 540</value>
   </data>
-  <data name="ucrReceiverElement.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 20</value>
+  <data name="lblStation.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
-  <data name="ucrReceiverElement.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
+  <data name="lblStation.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
-  <data name="&gt;&gt;ucrReceiverElement.Name" xml:space="preserve">
-    <value>ucrReceiverElement</value>
+  <data name="lblStation.Location" type="System.Drawing.Point, System.Drawing">
+    <value>281, 82</value>
   </data>
-  <data name="&gt;&gt;ucrReceiverElement.Type" xml:space="preserve">
-    <value>instat.ucrReceiverSingle, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  <data name="lblStation.Size" type="System.Drawing.Size, System.Drawing">
+    <value>43, 13</value>
   </data>
-  <data name="&gt;&gt;ucrReceiverElement.Parent" xml:space="preserve">
+  <data name="lblStation.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="lblStation.Text" xml:space="preserve">
+    <value>Station:</value>
+  </data>
+  <data name="&gt;&gt;lblStation.Name" xml:space="preserve">
+    <value>lblStation</value>
+  </data>
+  <data name="&gt;&gt;lblStation.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblStation.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;ucrReceiverElement.ZOrder" xml:space="preserve">
-    <value>14</value>
+  <data name="&gt;&gt;lblStation.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="ucrReceiverByFactor.Location" type="System.Drawing.Point, System.Drawing">
+    <value>281, 207</value>
+  </data>
+  <data name="ucrReceiverByFactor.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="ucrReceiverByFactor.Size" type="System.Drawing.Size, System.Drawing">
+    <value>120, 100</value>
+  </data>
+  <data name="ucrReceiverByFactor.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverByFactor.Name" xml:space="preserve">
+    <value>ucrReceiverByFactor</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverByFactor.Type" xml:space="preserve">
+    <value>instat.ucrReceiverMultiple, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverByFactor.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverByFactor.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="ucrReceiverStation.Location" type="System.Drawing.Point, System.Drawing">
+    <value>281, 98</value>
+  </data>
+  <data name="ucrReceiverStation.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="ucrReceiverStation.Size" type="System.Drawing.Size, System.Drawing">
+    <value>120, 20</value>
+  </data>
+  <data name="ucrReceiverStation.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverStation.Name" xml:space="preserve">
+    <value>ucrReceiverStation</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverStation.Type" xml:space="preserve">
+    <value>instat.ucrReceiverSingle, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverStation.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverStation.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <data name="ucrBase.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 430</value>
+    <value>12, 483</value>
   </data>
   <data name="ucrBase.Size" type="System.Drawing.Size, System.Drawing">
     <value>410, 52</value>
   </data>
   <data name="ucrBase.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
+    <value>21</value>
   </data>
   <data name="&gt;&gt;ucrBase.Name" xml:space="preserve">
     <value>ucrBase</value>
@@ -877,7 +976,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrBase.ZOrder" xml:space="preserve">
-    <value>15</value>
+    <value>19</value>
   </data>
   <data name="ucrSelectorInfillMissing.Location" type="System.Drawing.Point, System.Drawing">
     <value>12, 75</value>
@@ -901,7 +1000,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrSelectorInfillMissing.ZOrder" xml:space="preserve">
-    <value>16</value>
+    <value>20</value>
   </data>
   <data name="ucrPnlOptions.Location" type="System.Drawing.Point, System.Drawing">
     <value>49, 12</value>
@@ -922,10 +1021,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrPnlOptions.ZOrder" xml:space="preserve">
-    <value>17</value>
-  </data>
-  <data name="$this.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
+    <value>21</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterScreen</value>
@@ -939,91 +1035,28 @@
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
     <value>System.Windows.Forms.Form, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="ucrReceiverByFactor.Location" type="System.Drawing.Point, System.Drawing">
-    <value>285, 175</value>
+  <data name="ucrReceiverElement.Location" type="System.Drawing.Point, System.Drawing">
+    <value>281, 149</value>
   </data>
-  <data name="ucrReceiverByFactor.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="ucrReceiverElement.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
   </data>
-  <data name="ucrReceiverByFactor.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="ucrReceiverElement.Size" type="System.Drawing.Size, System.Drawing">
     <value>120, 20</value>
   </data>
-  <data name="ucrReceiverByFactor.TabIndex" type="System.Int32, mscorlib">
-    <value>22</value>
+  <data name="ucrReceiverElement.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
   </data>
-  <data name="&gt;&gt;ucrReceiverByFactor.Name" xml:space="preserve">
-    <value>ucrReceiverByFactor</value>
+  <data name="&gt;&gt;ucrReceiverElement.Name" xml:space="preserve">
+    <value>ucrReceiverElement</value>
   </data>
-  <data name="&gt;&gt;ucrReceiverByFactor.Type" xml:space="preserve">
+  <data name="&gt;&gt;ucrReceiverElement.Type" xml:space="preserve">
     <value>instat.ucrReceiverSingle, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="&gt;&gt;ucrReceiverByFactor.Parent" xml:space="preserve">
+  <data name="&gt;&gt;ucrReceiverElement.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;ucrReceiverByFactor.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="ucrInputConstant.Location" type="System.Drawing.Point, System.Drawing">
-    <value>113, 63</value>
-  </data>
-  <data name="ucrInputConstant.Size" type="System.Drawing.Size, System.Drawing">
-    <value>47, 21</value>
-  </data>
-  <data name="ucrInputConstant.TabIndex" type="System.Int32, mscorlib">
-    <value>19</value>
-  </data>
-  <data name="&gt;&gt;ucrInputConstant.Name" xml:space="preserve">
-    <value>ucrInputConstant</value>
-  </data>
-  <data name="&gt;&gt;ucrInputConstant.Type" xml:space="preserve">
-    <value>instat.ucrInputTextBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrInputConstant.Parent" xml:space="preserve">
-    <value>grpStartEnd</value>
-  </data>
-  <data name="&gt;&gt;ucrInputConstant.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="ucrPnlStartEnd.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 15</value>
-  </data>
-  <data name="ucrPnlStartEnd.Size" type="System.Drawing.Size, System.Drawing">
-    <value>118, 75</value>
-  </data>
-  <data name="ucrPnlStartEnd.TabIndex" type="System.Int32, mscorlib">
+  <data name="&gt;&gt;ucrReceiverElement.ZOrder" xml:space="preserve">
     <value>18</value>
-  </data>
-  <data name="&gt;&gt;ucrPnlStartEnd.Name" xml:space="preserve">
-    <value>ucrPnlStartEnd</value>
-  </data>
-  <data name="&gt;&gt;ucrPnlStartEnd.Type" xml:space="preserve">
-    <value>instat.UcrPanel, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrPnlStartEnd.Parent" xml:space="preserve">
-    <value>grpStartEnd</value>
-  </data>
-  <data name="&gt;&gt;ucrPnlStartEnd.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="ucrPnlMethods.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 15</value>
-  </data>
-  <data name="ucrPnlMethods.Size" type="System.Drawing.Size, System.Drawing">
-    <value>177, 71</value>
-  </data>
-  <data name="ucrPnlMethods.TabIndex" type="System.Int32, mscorlib">
-    <value>17</value>
-  </data>
-  <data name="&gt;&gt;ucrPnlMethods.Name" xml:space="preserve">
-    <value>ucrPnlMethods</value>
-  </data>
-  <data name="&gt;&gt;ucrPnlMethods.Type" xml:space="preserve">
-    <value>instat.UcrPanel, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrPnlMethods.Parent" xml:space="preserve">
-    <value>grpMethods</value>
-  </data>
-  <data name="&gt;&gt;ucrPnlMethods.ZOrder" xml:space="preserve">
-    <value>6</value>
   </data>
 </root>

--- a/instat/dlgInfillMissingValues.resx
+++ b/instat/dlgInfillMissingValues.resx
@@ -804,25 +804,25 @@
   <data name="&gt;&gt;ucrChkBy.ZOrder" xml:space="preserve">
     <value>10</value>
   </data>
-  <data name="ucrChkCopyFromAbove.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="ucrChkCopyFromBelow.Location" type="System.Drawing.Point, System.Drawing">
     <value>12, 427</value>
   </data>
-  <data name="ucrChkCopyFromAbove.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="ucrChkCopyFromBelow.Size" type="System.Drawing.Size, System.Drawing">
     <value>110, 20</value>
   </data>
-  <data name="ucrChkCopyFromAbove.TabIndex" type="System.Int32, mscorlib">
+  <data name="ucrChkCopyFromBelow.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
   </data>
-  <data name="&gt;&gt;ucrChkCopyFromAbove.Name" xml:space="preserve">
-    <value>ucrChkCopyFromAbove</value>
+  <data name="&gt;&gt;ucrChkCopyFromBelow.Name" xml:space="preserve">
+    <value>ucrChkCopyFromBelow</value>
   </data>
-  <data name="&gt;&gt;ucrChkCopyFromAbove.Type" xml:space="preserve">
+  <data name="&gt;&gt;ucrChkCopyFromBelow.Type" xml:space="preserve">
     <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="&gt;&gt;ucrChkCopyFromAbove.Parent" xml:space="preserve">
+  <data name="&gt;&gt;ucrChkCopyFromBelow.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;ucrChkCopyFromAbove.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;ucrChkCopyFromBelow.ZOrder" xml:space="preserve">
     <value>11</value>
   </data>
   <data name="ucrSaveNewColumn.Location" type="System.Drawing.Point, System.Drawing">

--- a/instat/dlgInfillMissingValues.vb
+++ b/instat/dlgInfillMissingValues.vb
@@ -83,10 +83,10 @@ Public Class dlgInfillMissingValues
         ucrInputComboFunction.SetItems(dctFunctionNames)
         ucrInputComboFunction.SetDropDownStyleAsNonEditable()
 
-        ucrChkCopyFromAbove.SetParameter(New RParameter("fromLast", 1))
-        ucrChkCopyFromAbove.SetValuesCheckedAndUnchecked("FALSE", "TRUE")
-        ucrChkCopyFromAbove.SetText("Copy from Above")
-        ucrChkCopyFromAbove.SetRDefault("FALSE")
+        ucrChkCopyFromBelow.SetParameter(New RParameter("fromLast", 1))
+        ucrChkCopyFromBelow.SetValuesCheckedAndUnchecked("TRUE", "FALSE")
+        ucrChkCopyFromBelow.SetText("Copy from Below")
+        ucrChkCopyFromBelow.SetRDefault("FALSE")
 
         ucrChkBy.SetText("By:")
         ucrChkBy.AddParameterPresentCondition(True, "by")
@@ -117,7 +117,7 @@ Public Class dlgInfillMissingValues
         ucrPnlMethods.AddToLinkedControls(ucrInputComboFunction, {rdoNaAggregate}, bNewLinkedHideIfParameterMissing:=True)
         ucrPnlMethods.AddToLinkedControls(ucrReceiverStation, {rdoNaApproximate, rdoNaFill, rdoNaSpline, rdoNaLocf, rdoNaStructTS}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
         ucrPnlMethods.AddToLinkedControls(ucrPnlStartEnd, {rdoNaFill}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
-        ucrPnlMethods.AddToLinkedControls(ucrChkCopyFromAbove, {rdoNaLocf}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
+        ucrPnlMethods.AddToLinkedControls(ucrChkCopyFromBelow, {rdoNaLocf}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
         ucrPnlMethods.AddToLinkedControls(ucrChkBy, {rdoNaAggregate}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
         ucrChkBy.AddToLinkedControls(ucrReceiverByFactor, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
         ucrChkMaxGap.AddToLinkedControls(ucrNudMaximum, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:=1)
@@ -167,7 +167,7 @@ Public Class dlgInfillMissingValues
         clsSetSeedFunction.SetRCommand("set.seed")
 
         clsNaLocfFunction.SetPackageName("zoo")
-        clsNaLocfFunction.SetRCommand("na.locf")
+        clsNaLocfFunction.SetRCommand("na.locf0")
         clsNaLocfFunction.AddParameter("x", "x", iPosition:=0, bIncludeArgumentName:=False)
 
         clsSplineFunction.SetPackageName("zoo")
@@ -215,7 +215,7 @@ Public Class dlgInfillMissingValues
         ucrPnlOptions.SetRCode(ucrBase.clsRsyntax.clsBaseFunction, bReset)
         'ucrPnlMethods.SetRCode(clsNewObject, bReset)
         ucrInputComboFunction.SetRCode(clsAggregateFunction, bReset)
-        ucrChkCopyFromAbove.SetRCode(clsNaLocfFunction, bReset)
+        ucrChkCopyFromBelow.SetRCode(clsNaLocfFunction, bReset)
         ucrChkBy.SetRCode(clsAggregateFunction, bReset)
         ucrNudMaximum.SetRCode(clsApproximateFunction, bReset)
         ucrChkMaxGap.SetRCode(ucrBase.clsRsyntax.clsBaseFunction, bReset)
@@ -235,7 +235,7 @@ Public Class dlgInfillMissingValues
             clsBracketOperator.AddParameter("right", clsRFunctionParameter:=clsApproximateFunction, iPosition:=1)
         ElseIf rdoNaAggregate.Checked Then
             ucrReceiverElement.SetMeAsReceiver()
-            ucrSaveNewColumn.SetPrefix("Agg_" & ucrReceiverElement.GetVariableNames(False))
+            ucrSaveNewColumn.SetPrefix("Typ_" & ucrReceiverElement.GetVariableNames(False))
             ucrBase.clsRsyntax.SetBaseRFunction(clsAggregateFunction)
             clsNewObject = clsAggregateFunction
         ElseIf rdoNaFill.Checked Then

--- a/instat/dlgInfillMissingValues.vb
+++ b/instat/dlgInfillMissingValues.vb
@@ -19,7 +19,9 @@ Imports instat.Translations
 Public Class dlgInfillMissingValues
     Private bFirstLoad As Boolean = True
     Private bReset As Boolean = True
-    Private clsApproximateFunction, clsAggregateFunction, clsNaLocfFunction, clsSplineFunction, clsNaFillFunction, clsStructTSFunction, clsZooRegFunction As New RFunction
+    Private clsApproximateFunction, clsAggregateFunction, clsNaLocfFunction, clsSplineFunction, clsNaFillFunction, clsStructTSFunction, clsZooRegFunction, clsSetSeedFunction, clsAveFunction As New RFunction
+    Private clsBracketOperator As New ROperator
+    Private clsNewObject As New RCodeStructure
     Private Sub dlgInfillMissingValues_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         autoTranslate(Me)
         If bFirstLoad Then
@@ -56,18 +58,20 @@ Public Class dlgInfillMissingValues
         ucrPnlMethods.AddFunctionNamesCondition(rdoNaStructTS, "na.StructTS")
         ucrPnlMethods.AddFunctionNamesCondition(rdoNaSpline, "na.spline")
 
-        ucrPnlStartEnd.SetParameter(New RParameter("fill", 1))
-        ucrPnlStartEnd.AddRadioButton(rdoLeaveAsMissing, "list(NA, ""extend"", NA)")
-        ucrPnlStartEnd.AddRadioButton(rdoExtendFill, Chr(34) & "extend" & Chr(34))
-        ucrPnlStartEnd.AddRadioButton(rdoInsertConstant)
-        ucrPnlStartEnd.AddParameterValuesCondition(rdoLeaveAsMissing, "fill", "list(NA, ""extend"", NA)")
-        ucrPnlStartEnd.AddParameterValuesCondition(rdoExtendFill, "fill", Chr(34) & "extend" & Chr(34))
-        ucrPnlStartEnd.AddParameterValuesCondition(rdoInsertConstant, "fill", {"list(NA, ""extend"", NA)", Chr(34) & "extend" & Chr(34)}, False)
+        ucrPnlStartEnd.AddRadioButton(rdoLeaveAsMissing)
+        ucrPnlStartEnd.AddRadioButton(rdoExtendFill)
 
-        ucrReceiverElement.SetParameter(New RParameter("object", 0))
+        ucrReceiverElement.SetParameter(New RParameter("x", 0))
         ucrReceiverElement.Selector = ucrSelectorInfillMissing
         ucrReceiverElement.SetParameterIsRFunction()
         ucrReceiverElement.bUseFilteredData = False
+
+        ucrReceiverStation.SetParameter(New RParameter("factor", 1, bNewIncludeArgumentName:=False))
+        ucrReceiverStation.Selector = ucrSelectorInfillMissing
+        ucrReceiverStation.SetParameterIsRFunction()
+        ucrReceiverStation.SetClimaticType("station")
+        ucrReceiverStation.bUseFilteredData = False
+        ucrReceiverStation.bAutoFill = True
 
         ucrInputConstant.SetValidationTypeAsNumeric()
         ucrInputConstant.AddQuotesIfUnrecognised = False
@@ -75,6 +79,7 @@ Public Class dlgInfillMissingValues
         ucrInputComboFunction.SetParameter(New RParameter("FUN", 2))
         dctFunctionNames.Add("Mean", "mean")
         dctFunctionNames.Add("Median", "median")
+        dctFunctionNames.Add("Sample", "sample")
         ucrInputComboFunction.SetItems(dctFunctionNames)
         ucrInputComboFunction.SetDropDownStyleAsNonEditable()
         ucrInputComboFunction.SetRDefault("mean")
@@ -92,27 +97,37 @@ Public Class dlgInfillMissingValues
         ucrChkMaxGap.AddParameterPresentCondition(True, "maxgap")
         ucrChkMaxGap.AddParameterPresentCondition(False, "maxgap", False)
 
-        ucrReceiverByFactor.SetParameter(New RParameter("by", 1))
+        ucrReceiverByFactor.SetParameter(New RParameter("by", 1, bNewIncludeArgumentName:=False))
         ucrReceiverByFactor.Selector = ucrSelectorInfillMissing
         ucrReceiverByFactor.SetParameterIsRFunction()
         ucrReceiverByFactor.SetIncludedDataTypes({"factor", "character"}, bStrict:=True)
-        ucrReceiverByFactor.strSelectorHeading = "Factors"
+        ucrReceiverByFactor.strSelectorHeading = "Factors and Characters"
         ucrReceiverByFactor.SetClimaticType("month")
         ucrReceiverByFactor.bAutoFill = True
 
         ucrNudMaximum.SetParameter(New RParameter("maxgap", 5))
         ucrNudMaximum.SetMinMax(iNewMin:=1, iNewMax:=Integer.MaxValue)
 
-        ucrPnlStartEnd.AddToLinkedControls(ucrInputConstant, {rdoInsertConstant}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:=0)
+        ucrNudSetSeed.SetParameter(New RParameter("seed", 0))
+
+        ucrChkSetSeed.SetText("Set Seed:")
+        ucrChkSetSeed.AddRSyntaxContainsFunctionNamesCondition(True, {"set.seed"})
+        ucrChkSetSeed.AddRSyntaxContainsFunctionNamesCondition(False, {"set.seed"}, False)
+
+        ucrPnlStartEnd.AddToLinkedControls(ucrInputConstant, {rdoLeaveAsMissing, rdoExtendFill}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:=0)
         ucrPnlMethods.AddToLinkedControls(ucrInputComboFunction, {rdoNaAggregate}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
+        ucrPnlMethods.AddToLinkedControls(ucrReceiverStation, {rdoNaApproximate, rdoNaFill, rdoNaSpline, rdoNaLocf, rdoNaStructTS}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
         ucrPnlMethods.AddToLinkedControls(ucrPnlStartEnd, {rdoNaFill}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
         ucrPnlMethods.AddToLinkedControls(ucrChkCopyFromAbove, {rdoNaLocf}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
         ucrPnlMethods.AddToLinkedControls(ucrChkBy, {rdoNaAggregate}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
         ucrChkBy.AddToLinkedControls(ucrReceiverByFactor, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
         ucrChkMaxGap.AddToLinkedControls(ucrNudMaximum, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:=1)
+        ucrInputComboFunction.AddToLinkedControls(ucrChkSetSeed, {"Sample"}, bNewLinkedHideIfParameterMissing:=True)
+        ucrChkSetSeed.AddToLinkedControls(ucrNudSetSeed, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:=1)
         ucrInputComboFunction.SetLinkedDisplayControl(lblFunction)
         ucrPnlStartEnd.SetLinkedDisplayControl(grpStartEnd)
         ucrNudMaximum.SetLinkedDisplayControl(lblRows)
+        ucrReceiverStation.SetLinkedDisplayControl(lblStation)
         ucrSaveNewColumn.SetDataFrameSelector(ucrSelectorInfillMissing.ucrAvailableDataFrames)
         ucrSaveNewColumn.SetSaveTypeAsColumn()
         ucrSaveNewColumn.SetIsComboBox()
@@ -127,29 +142,40 @@ Public Class dlgInfillMissingValues
         clsNaFillFunction = New RFunction
         clsStructTSFunction = New RFunction
         clsZooRegFunction = New RFunction
+        clsSetSeedFunction = New RFunction
+        clsAveFunction = New RFunction
+
+        clsBracketOperator = New ROperator
 
         ucrSelectorInfillMissing.Reset()
-        ucrReceiverElement.SetMeAsReceiver()
+        ucrReceiverStation.SetMeAsReceiver()
         ucrSaveNewColumn.Reset()
         'Temp fix: Set panel conditions properly!
+        rdoSingle.Checked = True
         rdoLeaveAsMissing.Checked = True
+        rdoNaApproximate.Checked = True
 
         clsApproximateFunction.SetPackageName("zoo")
         clsApproximateFunction.SetRCommand("na.approx")
+        clsApproximateFunction.AddParameter("x", "x", iPosition:=0, bIncludeArgumentName:=False)
         clsApproximateFunction.AddParameter("rule", 2, iPosition:=1)
 
         clsAggregateFunction.SetPackageName("zoo")
         clsAggregateFunction.SetRCommand("na.aggregate")
 
+        clsSetSeedFunction.SetRCommand("set.seed")
+
         clsNaLocfFunction.SetPackageName("zoo")
         clsNaLocfFunction.SetRCommand("na.locf")
+        clsNaLocfFunction.AddParameter("x", "x", iPosition:=0, bIncludeArgumentName:=False)
 
         clsSplineFunction.SetPackageName("zoo")
         clsSplineFunction.SetRCommand("na.spline")
+        clsSplineFunction.AddParameter("x", "x", iPosition:=0, bIncludeArgumentName:=False)
 
         clsNaFillFunction.SetPackageName("zoo")
         clsNaFillFunction.SetRCommand("na.fill")
-        clsNaFillFunction.AddParameter("fill", "list(NA, ""extend"", NA)", iPosition:=1)
+        clsNaFillFunction.AddParameter("x", "x", iPosition:=0, bIncludeArgumentName:=False)
 
         clsStructTSFunction.SetPackageName("zoo")
         clsStructTSFunction.SetRCommand("na.StructTS")
@@ -158,16 +184,27 @@ Public Class dlgInfillMissingValues
         clsZooRegFunction.SetPackageName("zoo")
         clsZooRegFunction.SetRCommand("zooreg")
         clsZooRegFunction.AddParameter("frequency", 2, iPosition:=0)
+        clsZooRegFunction.AddParameter("x", "x", iPosition:=0, bIncludeArgumentName:=False)
 
-        ucrBase.clsRsyntax.SetBaseRFunction(clsApproximateFunction)
+        clsAveFunction.SetPackageName("stats")
+        clsAveFunction.SetRCommand("ave")
+
+        clsBracketOperator.SetOperation(")")
+        clsBracketOperator.AddParameter("left", "function(x", iPosition:=0)
+        clsBracketOperator.bBrackets = False
+        clsBracketOperator.bSpaceAroundOperation = False
+
+        ucrBase.clsRsyntax.ClearCodes()
+        clsNewObject = clsAggregateFunction
+        ucrBase.clsRsyntax.SetBaseRFunction(clsAveFunction)
     End Sub
 
     Private Sub SetRcodeForControls(bReset As Boolean)
-        ucrReceiverElement.AddAdditionalCodeParameterPair(clsAggregateFunction, ucrReceiverElement.GetParameter(), iAdditionalPairNo:=1)
-        ucrReceiverElement.AddAdditionalCodeParameterPair(clsSplineFunction, ucrReceiverElement.GetParameter(), iAdditionalPairNo:=2)
-        ucrReceiverElement.AddAdditionalCodeParameterPair(clsNaLocfFunction, ucrReceiverElement.GetParameter(), iAdditionalPairNo:=3)
-        ucrReceiverElement.AddAdditionalCodeParameterPair(clsNaFillFunction, ucrReceiverElement.GetParameter(), iAdditionalPairNo:=4)
-        ucrReceiverElement.AddAdditionalCodeParameterPair(clsZooRegFunction, New RParameter("data", 0), iAdditionalPairNo:=5)
+        ucrReceiverElement.AddAdditionalCodeParameterPair(clsAggregateFunction, New RParameter("object", 0), iAdditionalPairNo:=1)
+        'ucrReceiverElement.AddAdditionalCodeParameterPair(clsSplineFunction, ucrReceiverElement.GetParameter(), iAdditionalPairNo:=2)
+        'ucrReceiverElement.AddAdditionalCodeParameterPair(clsNaLocfFunction, ucrReceiverElement.GetParameter(), iAdditionalPairNo:=3)
+        'ucrReceiverElement.AddAdditionalCodeParameterPair(clsNaFillFunction, ucrReceiverElement.GetParameter(), iAdditionalPairNo:=4)
+        'ucrReceiverElement.AddAdditionalCodeParameterPair(clsZooRegFunction, New RParameter("data", 0), iAdditionalPairNo:=5)
 
         ucrNudMaximum.AddAdditionalCodeParameterPair(clsAggregateFunction, ucrNudMaximum.GetParameter(), iAdditionalPairNo:=1)
         ucrNudMaximum.AddAdditionalCodeParameterPair(clsSplineFunction, ucrNudMaximum.GetParameter(), iAdditionalPairNo:=2)
@@ -175,51 +212,62 @@ Public Class dlgInfillMissingValues
         ucrNudMaximum.AddAdditionalCodeParameterPair(clsNaFillFunction, ucrNudMaximum.GetParameter(), iAdditionalPairNo:=4)
         ucrNudMaximum.AddAdditionalCodeParameterPair(clsStructTSFunction, ucrNudMaximum.GetParameter(), iAdditionalPairNo:=5)
 
-        ucrReceiverElement.SetRCode(clsApproximateFunction, bReset)
+        ucrReceiverElement.SetRCode(clsAveFunction, bReset)
+        ucrReceiverStation.SetRCode(clsAveFunction, bReset)
         ucrReceiverByFactor.SetRCode(clsAggregateFunction, bReset)
-        ucrPnlOptions.SetRCode(ucrBase.clsRsyntax.clsBaseFunction, bReset)
-        ucrPnlMethods.SetRCode(ucrBase.clsRsyntax.clsBaseFunction, bReset)
+        'ucrPnlOptions.SetRCode(ucrBase.clsRsyntax.clsBaseFunction, bReset)
+        'ucrPnlMethods.SetRCode(clsNewObject, bReset)
         ucrInputComboFunction.SetRCode(clsAggregateFunction, bReset)
         ucrChkCopyFromAbove.SetRCode(clsNaLocfFunction, bReset)
-        ucrPnlStartEnd.SetRCode(clsNaFillFunction, bReset)
         ucrChkBy.SetRCode(clsAggregateFunction, bReset)
         ucrNudMaximum.SetRCode(clsApproximateFunction, bReset)
         ucrChkMaxGap.SetRCode(ucrBase.clsRsyntax.clsBaseFunction, bReset)
+        ucrNudSetSeed.SetRCode(clsSetSeedFunction, bReset)
+        ucrChkSetSeed.SetRSyntax(ucrBase.clsRsyntax, bReset)
 
         ucrSaveNewColumn.AddAdditionalRCode(clsAggregateFunction, iAdditionalPairNo:=1)
-        ucrSaveNewColumn.AddAdditionalRCode(clsSplineFunction, iAdditionalPairNo:=2)
-        ucrSaveNewColumn.AddAdditionalRCode(clsNaLocfFunction, iAdditionalPairNo:=3)
-        ucrSaveNewColumn.AddAdditionalRCode(clsNaFillFunction, iAdditionalPairNo:=4)
-        ucrSaveNewColumn.AddAdditionalRCode(clsStructTSFunction, iAdditionalPairNo:=5)
+        'ucrSaveNewColumn.AddAdditionalRCode(clsSplineFunction, iAdditionalPairNo:=2)
+        'ucrSaveNewColumn.AddAdditionalRCode(clsNaLocfFunction, iAdditionalPairNo:=3)
+        'ucrSaveNewColumn.AddAdditionalRCode(clsNaFillFunction, iAdditionalPairNo:=4)
+        'ucrSaveNewColumn.AddAdditionalRCode(clsStructTSFunction, iAdditionalPairNo:=5)
 
-        ucrSaveNewColumn.SetRCode(clsApproximateFunction, bReset)
+        ucrSaveNewColumn.SetRCode(clsAveFunction, bReset)
     End Sub
 
     Private Sub ucrPnlMethods_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrPnlMethods.ControlValueChanged, ucrReceiverElement.ControlValueChanged
+        ucrBase.clsRsyntax.SetBaseRFunction(clsAveFunction)
+        clsNewObject = clsBracketOperator
         If rdoNaApproximate.Checked Then
             ucrSaveNewColumn.SetPrefix("Int_" & ucrReceiverElement.GetVariableNames(False))
-            ucrBase.clsRsyntax.SetBaseRFunction(clsApproximateFunction)
+            clsBracketOperator.AddParameter("right", clsRFunctionParameter:=clsApproximateFunction, iPosition:=1)
         ElseIf rdoNaAggregate.Checked Then
-            ucrSaveNewColumn.SetPrefix("Ave_" & ucrReceiverElement.GetVariableNames(False))
+            ucrReceiverElement.SetMeAsReceiver()
+            ucrSaveNewColumn.SetPrefix("Agg_" & ucrReceiverElement.GetVariableNames(False))
             ucrBase.clsRsyntax.SetBaseRFunction(clsAggregateFunction)
+            clsNewObject = clsAggregateFunction
         ElseIf rdoNaFill.Checked Then
             ucrSaveNewColumn.SetPrefix("Con_" & ucrReceiverElement.GetVariableNames(False))
-            ucrBase.clsRsyntax.SetBaseRFunction(clsNaFillFunction)
+            clsBracketOperator.AddParameter("right", clsRFunctionParameter:=clsNaFillFunction, iPosition:=1)
         ElseIf rdoNaStructTS.Checked Then
             ucrSaveNewColumn.SetPrefix("Str_" & ucrReceiverElement.GetVariableNames(False))
-            ucrBase.clsRsyntax.SetBaseRFunction(clsStructTSFunction)
+            clsBracketOperator.AddParameter("right", clsRFunctionParameter:=clsStructTSFunction, iPosition:=1)
         ElseIf rdoNaSpline.Checked Then
             ucrSaveNewColumn.SetPrefix("Spl_" & ucrReceiverElement.GetVariableNames(False))
-            ucrBase.clsRsyntax.SetBaseRFunction(clsSplineFunction)
+            clsBracketOperator.AddParameter("right", clsRFunctionParameter:=clsSplineFunction, iPosition:=1)
         ElseIf rdoNaLocf.Checked Then
             ucrSaveNewColumn.SetPrefix("Cop_" & ucrReceiverElement.GetVariableNames(False))
-            ucrBase.clsRsyntax.SetBaseRFunction(clsNaLocfFunction)
+            clsBracketOperator.AddParameter("right", clsRFunctionParameter:=clsNaLocfFunction, iPosition:=1)
         End If
+        clsAveFunction.AddParameter("FUN", clsROperatorParameter:=clsBracketOperator, iPosition:=2)
     End Sub
 
     Private Sub ucrPnlStartEnd_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrPnlStartEnd.ControlValueChanged, ucrInputConstant.ControlValueChanged
-        If rdoInsertConstant.Checked Then
-            clsNaFillFunction.AddParameter("fill", ucrInputConstant.GetText(), iPosition:=1)
+        If rdoLeaveAsMissing.Checked Then
+            clsNaFillFunction.AddParameter("fill", "list(" & "NA," & ucrInputConstant.GetValue() & ",NA" & ")", iPosition:=1)
+        ElseIf rdoExtendFill.Checked Then
+            clsNaFillFunction.AddParameter("fill", "list(" & Chr(34) & "extend" & Chr(34) & "," & ucrInputConstant.GetValue() & "," & Chr(34) & "extend" & Chr(34) & ")", iPosition:=1)
+        Else
+            clsNaFillFunction.RemoveParameterByName("fill")
         End If
     End Sub
 
@@ -231,8 +279,25 @@ Public Class dlgInfillMissingValues
         End If
     End Sub
 
+    Private Sub ucrInputComboFunction_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrInputComboFunction.ControlValueChanged, ucrPnlMethods.ControlValueChanged, ucrChkSetSeed.ControlValueChanged
+        If rdoNaAggregate.Checked Then
+            If ucrChkSetSeed.Checked Then
+                Select Case ucrInputComboFunction.GetValue()
+                    Case "Sample"
+                        ucrBase.clsRsyntax.AddToBeforeCodes(clsSetSeedFunction, 0)
+                    Case Else
+                        ucrBase.clsRsyntax.RemoveFromBeforeCodes(clsSetSeedFunction)
+                End Select
+            Else
+                ucrBase.clsRsyntax.RemoveFromBeforeCodes(clsSetSeedFunction)
+            End If
+        Else
+            ucrBase.clsRsyntax.RemoveFromBeforeCodes(clsSetSeedFunction)
+        End If
+    End Sub
+
     Private Sub TestOkEnabled()
-        If ucrReceiverElement.IsEmpty OrElse Not ucrSaveNewColumn.IsComplete Then
+        If ucrReceiverElement.IsEmpty OrElse Not ucrSaveNewColumn.IsComplete OrElse (rdoNaFill.Checked AndAlso ((rdoLeaveAsMissing.Checked OrElse rdoExtendFill.Checked) AndAlso ucrInputConstant.IsEmpty)) Then
             ucrBase.OKEnabled(False)
         Else
             ucrBase.OKEnabled(True)
@@ -245,7 +310,7 @@ Public Class dlgInfillMissingValues
         TestOkEnabled()
     End Sub
 
-    Private Sub ucrReceiverElement_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrReceiverElement.ControlContentsChanged, ucrSaveNewColumn.ControlContentsChanged
+    Private Sub ucrReceiverElement_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrReceiverElement.ControlContentsChanged, ucrSaveNewColumn.ControlContentsChanged, ucrPnlStartEnd.ControlContentsChanged, ucrInputConstant.ControlContentsChanged, ucrPnlMethods.ControlContentsChanged
         TestOkEnabled()
     End Sub
 End Class

--- a/instat/dlgInfillMissingValues.vb
+++ b/instat/dlgInfillMissingValues.vb
@@ -127,6 +127,7 @@ Public Class dlgInfillMissingValues
         ucrPnlStartEnd.SetLinkedDisplayControl(grpStartEnd)
         ucrNudMaximum.SetLinkedDisplayControl(lblRows)
         ucrReceiverStation.SetLinkedDisplayControl(lblStation)
+        ucrInputConstant.SetLinkedDisplayControl(lblValue)
         ucrSaveNewColumn.SetDataFrameSelector(ucrSelectorInfillMissing.ucrAvailableDataFrames)
         ucrSaveNewColumn.SetSaveTypeAsColumn()
         ucrSaveNewColumn.SetIsComboBox()

--- a/instat/static/InstatObject/R/stand_alone_functions.R
+++ b/instat/static/InstatObject/R/stand_alone_functions.R
@@ -1276,3 +1276,7 @@ in_top_n <- function(x, n = 10, wt, fun = sum) {
   else dat <- dat %>% count(x, sort = TRUE, name = "fq")
   return(x %in% dat$x[1:n])
 }
+
+summary_sample <- function(x, size = 1, replace = FALSE){
+  if(length(x)==0){return(NA)}else{sample(x = x, size = size, replace = replace)}
+}

--- a/instat/static/InstatObject/R/stand_alone_functions.R
+++ b/instat/static/InstatObject/R/stand_alone_functions.R
@@ -1277,6 +1277,8 @@ in_top_n <- function(x, n = 10, wt, fun = sum) {
   return(x %in% dat$x[1:n])
 }
 
-summary_sample <- function(x, size = 1, replace = FALSE){
-  if(length(x)==0){return(NA)}else{sample(x = x, size = size, replace = replace)}
+summary_sample <- function(x, size, replace = FALSE){
+  if(length(x)==0){return(NA)}
+  else if(length(x)==1){return(x)}
+  else{sample(x = x, size = size, replace = replace)}
 }


### PR DESCRIPTION
@rdstern I am putting up this for testing. I think I have been able to implement these methods for multiple stations and also the Average option can now use a multiple receiver, which means you can use multiple levels at a time. Please also check the start and end options under constant option if it works as discussed. I also added the `sample` as a function to be selected under average option dropdown (I think we need to rename this option to accommodate sample function but I am not sure what to call it now).


**NOTE** This is not ready for code checking.