### PR TITLE
Removed automatic selection of the first level of a factor when filtering and elsewhere

### DIFF
--- a/instat/ucrFactor.vb
+++ b/instat/ucrFactor.vb
@@ -279,7 +279,7 @@ Public Class ucrFactor
                 If strSelectedLevels IsNot Nothing AndAlso strSelectedLevels.Count > 0 Then
                     bSelect = strSelectedLevels.Contains(shtCurrSheet(i, 0))
                 Else
-                    bSelect = (i = 0)
+                    bSelect = False
                 End If
                 shtCurrSheet(i, iSelectorColumnIndex) = bSelect
             Next


### PR DESCRIPTION
@rdstern I didn't find an issue for this but I remember this is something you mentioned at some point during our discussions. This change removes the selection of the first level of a factor when filtering for convenience purpose. Please test.

**Note:** This affects other places where this control is used, my assumption is that we do not need to always select the first level.