### PR TITLE
Retaining an operator(==,> etc) on filter input

### DIFF
--- a/instat/ucrFilter.vb
+++ b/instat/ucrFilter.vb
@@ -160,8 +160,7 @@ Public Class ucrFilter
 
     Private Sub ucrFilterReceiver_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrFilterByReceiver.ControlContentsChanged
         'for logical columns add {"==", "is.na", "!is.na"} only
-        Dim selectedIndex As Integer
-        selectedIndex = ucrFilterOperation.cboInput.SelectedIndex
+        Dim selectedIndex As Integer = ucrFilterOperation.cboInput.SelectedIndex
         ucrFilterOperation.SetItems(If(ucrFilterByReceiver.strCurrDataType.ToLower = "logical", {"==", "is.na", "! is.na"}, {"==", "<", "<=", ">", ">=", "!=", "is.na", "! is.na"}))
         If ucrFilterByReceiver.strCurrDataType.ToLower = "logical" AndAlso selectedIndex > 2 Then
             ucrFilterOperation.cboInput.SelectedIndex = 0

--- a/instat/ucrFilter.vb
+++ b/instat/ucrFilter.vb
@@ -160,9 +160,14 @@ Public Class ucrFilter
 
     Private Sub ucrFilterReceiver_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrFilterByReceiver.ControlContentsChanged
         'for logical columns add {"==", "is.na", "!is.na"} only
+        Dim selectedIndex As Integer
+        selectedIndex = ucrFilterOperation.cboInput.SelectedIndex
         ucrFilterOperation.SetItems(If(ucrFilterByReceiver.strCurrDataType.ToLower = "logical", {"==", "is.na", "! is.na"}, {"==", "<", "<=", ">", ">=", "!=", "is.na", "! is.na"}))
-        ucrFilterOperation.cboInput.SelectedIndex = 0
-
+        If ucrFilterByReceiver.strCurrDataType.ToLower = "logical" AndAlso selectedIndex > 2 Then
+            ucrFilterOperation.cboInput.SelectedIndex = 0
+        Else
+            ucrFilterOperation.cboInput.SelectedIndex = selectedIndex
+        End If
         VariableTypeProperties()
         CheckAddEnabled()
     End Sub

--- a/instat/ucrFilter.vb
+++ b/instat/ucrFilter.vb
@@ -162,11 +162,10 @@ Public Class ucrFilter
         'for logical columns add {"==", "is.na", "!is.na"} only
         Dim selectedIndex As Integer = ucrFilterOperation.GetSetSelectedIndex
         ucrFilterOperation.SetItems(If(ucrFilterByReceiver.strCurrDataType.ToLower = "logical", {"==", "is.na", "! is.na"}, {"==", "<", "<=", ">", ">=", "!=", "is.na", "! is.na"}))
-        Dim ItemsCount As Integer = ucrFilterOperation.GetItemsCount()
-        If ucrFilterByReceiver.strCurrDataType.ToLower = "logical" AndAlso selectedIndex > ItemsCount Then
-            ucrFilterOperation.GetSetSelectedIndex = 0
-        Else
+        If ucrFilterByReceiver.strCurrDataType.ToLower IsNot "logical" OrElse selectedIndex < ucrFilterOperation.GetItemsCount Then
             ucrFilterOperation.GetSetSelectedIndex = selectedIndex
+        Else
+            ucrFilterOperation.GetSetSelectedIndex = 0
         End If
         VariableTypeProperties()
         CheckAddEnabled()

--- a/instat/ucrFilter.vb
+++ b/instat/ucrFilter.vb
@@ -229,7 +229,6 @@ Public Class ucrFilter
         lstFilters.Columns(1).Width = -2
         ucrFilterPreview.SetName(clsFilterView.ToScript())
         ucrFilterByReceiver.Clear()
-        ucrReceiverExpression.Clear()
         RaiseEvent FilterChanged()
     End Sub
 

--- a/instat/ucrFilter.vb
+++ b/instat/ucrFilter.vb
@@ -162,7 +162,7 @@ Public Class ucrFilter
         'for logical columns add {"==", "is.na", "!is.na"} only
         Dim selectedIndex As Integer = ucrFilterOperation.GetSetSelectedIndex
         ucrFilterOperation.SetItems(If(ucrFilterByReceiver.strCurrDataType.ToLower = "logical", {"==", "is.na", "! is.na"}, {"==", "<", "<=", ">", ">=", "!=", "is.na", "! is.na"}))
-        If ucrFilterByReceiver.strCurrDataType.ToLower IsNot "logical" OrElse selectedIndex < ucrFilterOperation.GetItemsCount Then
+        If ucrFilterByReceiver.strCurrDataType.ToLower IsNot "logical" AndAlso selectedIndex < ucrFilterOperation.GetItemsCount Then
             ucrFilterOperation.GetSetSelectedIndex = selectedIndex
         Else
             ucrFilterOperation.GetSetSelectedIndex = 0

--- a/instat/ucrFilter.vb
+++ b/instat/ucrFilter.vb
@@ -160,12 +160,13 @@ Public Class ucrFilter
 
     Private Sub ucrFilterReceiver_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrFilterByReceiver.ControlContentsChanged
         'for logical columns add {"==", "is.na", "!is.na"} only
-        Dim selectedIndex As Integer = ucrFilterOperation.cboInput.SelectedIndex
+        Dim selectedIndex As Integer = ucrFilterOperation.GetSetSelectedIndex
         ucrFilterOperation.SetItems(If(ucrFilterByReceiver.strCurrDataType.ToLower = "logical", {"==", "is.na", "! is.na"}, {"==", "<", "<=", ">", ">=", "!=", "is.na", "! is.na"}))
-        If ucrFilterByReceiver.strCurrDataType.ToLower = "logical" AndAlso selectedIndex > 2 Then
-            ucrFilterOperation.cboInput.SelectedIndex = 0
+        Dim ItemsCount As Integer = ucrFilterOperation.GetItemsCount()
+        If ucrFilterByReceiver.strCurrDataType.ToLower = "logical" AndAlso selectedIndex > ItemsCount Then
+            ucrFilterOperation.GetSetSelectedIndex = 0
         Else
-            ucrFilterOperation.cboInput.SelectedIndex = selectedIndex
+            ucrFilterOperation.GetSetSelectedIndex = selectedIndex
         End If
         VariableTypeProperties()
         CheckAddEnabled()

--- a/instat/ucrFilter.vb
+++ b/instat/ucrFilter.vb
@@ -229,6 +229,7 @@ Public Class ucrFilter
         lstFilters.Columns(1).Width = -2
         ucrFilterPreview.SetName(clsFilterView.ToScript())
         ucrFilterByReceiver.Clear()
+        ucrReceiverExpression.AddtoCombobox(ucrReceiverExpression.GetText)
         RaiseEvent FilterChanged()
     End Sub
 

--- a/instat/ucrInputComboBox.vb
+++ b/instat/ucrInputComboBox.vb
@@ -161,6 +161,19 @@ Public Class ucrInputComboBox
         End If
     End Function
 
+    Public Property GetSetSelectedIndex As Integer
+        Get
+            Return cboInput.SelectedIndex
+        End Get
+        Set(value As Integer)
+            cboInput.SelectedIndex = value
+        End Set
+    End Property
+
+    Public Function GetItemsCount() As Integer
+        Return cboInput.Items.Count
+    End Function
+
     Public Sub SetItems(Optional strItems As String() = Nothing, Optional bClearExisting As Boolean = True, Optional bAddConditions As Boolean = False, Optional bAddQuotes As Boolean = True)
         Dim dctValues As New Dictionary(Of String, String)
         If bAddConditions Then

--- a/instat/ucrInputComboBox.vb
+++ b/instat/ucrInputComboBox.vb
@@ -170,9 +170,11 @@ Public Class ucrInputComboBox
         End Set
     End Property
 
-    Public Function GetItemsCount() As Integer
-        Return cboInput.Items.Count
-    End Function
+    Public ReadOnly Property GetItemsCount As Integer
+        Get
+            Return cboInput.Items.Count
+        End Get
+    End Property
 
     Public Sub SetItems(Optional strItems As String() = Nothing, Optional bClearExisting As Boolean = True, Optional bAddConditions As Boolean = False, Optional bAddQuotes As Boolean = True)
         Dim dctValues As New Dictionary(Of String, String)

--- a/instat/ucrReceiverExpression.vb
+++ b/instat/ucrReceiverExpression.vb
@@ -128,8 +128,9 @@ Public Class ucrReceiverExpression
     End Function
 
     Public Sub AddtoCombobox(strNew As String)
-        cboExpression.Items.Insert(0, strNew)
-
+        If Not cboExpression.Items.Contains(strNew) Then
+            cboExpression.Items.Insert(0, strNew)
+        End If
     End Sub
 
     Private Sub cboExpression_KeyUp(sender As Object, e As KeyEventArgs) Handles cboExpression.KeyUp


### PR DESCRIPTION
@rdstern this PR fixes a small issue you reported in PR #5914. Please check, I might have misunderstood your statement below.

> Sounds good. Will check. One other (smaller) item in the filter sub-dialogue is that the control with the function ==, > etc doesn't get remembered between successive uses of the dialogue.