### PR TITLE
Enabling use of & and | operators in the filter 

### DIFF
--- a/instat/dlgRestrict.resx
+++ b/instat/dlgRestrict.resx
@@ -361,7 +361,7 @@
     <value>10, 197</value>
   </data>
   <data name="grpApplyOptions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>378, 53</value>
+    <value>396, 53</value>
   </data>
   <data name="grpApplyOptions.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -382,10 +382,10 @@
     <value>3</value>
   </data>
   <data name="ucrInputFilterPreview.Location" type="System.Drawing.Point, System.Drawing">
-    <value>163, 284</value>
+    <value>129, 284</value>
   </data>
   <data name="ucrInputFilterPreview.Size" type="System.Drawing.Size, System.Drawing">
-    <value>246, 42</value>
+    <value>277, 43</value>
   </data>
   <data name="ucrInputFilterPreview.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -406,7 +406,7 @@
     <value>10, 285</value>
   </data>
   <data name="lblFilterPreview.Size" type="System.Drawing.Size, System.Drawing">
-    <value>147, 13</value>
+    <value>118, 22</value>
   </data>
   <data name="lblFilterPreview.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>

--- a/instat/dlgRestrict.vb
+++ b/instat/dlgRestrict.vb
@@ -68,10 +68,10 @@ Public Class dlgRestrict
         'rdoApplyAsSubset.Enabled = False
 
         ' ucrSave
-        ucrNewDataFrameName.SetIsTextBox()
         ucrNewDataFrameName.SetSaveTypeAsDataFrame()
         ucrNewDataFrameName.SetLabelText("New Data Frame Name:")
         ucrNewDataFrameName.SetDataFrameSelector(ucrSelectorFilter.ucrAvailableDataFrames)
+        ucrNewDataFrameName.SetIsTextBox()
     End Sub
 
     Private Sub SetDefaults()

--- a/instat/static/InstatObject/R/data_object_R6.R
+++ b/instat/static/InstatObject/R/data_object_R6.R
@@ -1468,7 +1468,7 @@ DataSheet$set("public", "set_protected_columns", function(col_names) {
 }
 )
 
-DataSheet$set("public", "add_filter", function(filter, filter_name = "", replace = TRUE, set_as_current = FALSE, na.rm = TRUE, is_no_filter = FALSE) {
+DataSheet$set("public", "add_filter", function(filter, filter_name = "", replace = TRUE, set_as_current = FALSE, na.rm = TRUE, is_no_filter = FALSE, and_or = "and") {
   if(missing(filter)) stop("filter is required")
   if(filter_name == "") filter_name = next_default_item("Filter", names(private$filters))
   
@@ -1483,7 +1483,7 @@ DataSheet$set("public", "add_filter", function(filter, filter_name = "", replace
   }
   else {
     if(filter_name %in% names(private$filters)) message("A filter named ", filter_name, " already exists. It will be replaced by the new filter.")
-    filter_calc = calculation$new(type = "filter", filter_conditions = filter, name = filter_name, parameters = list(na.rm = na.rm, is_no_filter = is_no_filter))
+    filter_calc = calculation$new(type = "filter", filter_conditions = filter, name = filter_name, parameters = list(na.rm = na.rm, is_no_filter = is_no_filter, and_or = and_or))
     private$filters[[filter_name]] <- filter_calc
     self$append_to_changes(list(Added_filter, filter_name))
     if(set_as_current) {
@@ -1550,7 +1550,11 @@ DataSheet$set("public", "get_filter_as_logical", function(filter_name) {
       }
       i = i + 1
     }
-    out <- apply(result, 1, all)
+    and_or <- curr_filter$parameters[["and_or"]] 
+    if(is.null(and_or)) and_or <- "and"
+    if(and_or == "and") out <- apply(result, 1, all) 
+    else if (and_or == "or") out <- apply(result, 1, any)
+    else stop(and_or, " should be and or or.")
     out[is.na(out)] <- !curr_filter$parameters[["na.rm"]]
   }
   return(out)

--- a/instat/static/InstatObject/R/data_object_R6.R
+++ b/instat/static/InstatObject/R/data_object_R6.R
@@ -1468,7 +1468,7 @@ DataSheet$set("public", "set_protected_columns", function(col_names) {
 }
 )
 
-DataSheet$set("public", "add_filter", function(filter, filter_name = "", replace = TRUE, set_as_current = FALSE, na.rm = TRUE, is_no_filter = FALSE, and_or = "and") {
+DataSheet$set("public", "add_filter", function(filter, filter_name = "", replace = TRUE, set_as_current = FALSE, na.rm = TRUE, is_no_filter = FALSE, and_or = "&") {
   if(missing(filter)) stop("filter is required")
   if(filter_name == "") filter_name = next_default_item("Filter", names(private$filters))
   
@@ -1551,10 +1551,10 @@ DataSheet$set("public", "get_filter_as_logical", function(filter_name) {
       i = i + 1
     }
     and_or <- curr_filter$parameters[["and_or"]] 
-    if(is.null(and_or)) and_or <- "and"
-    if(and_or == "and") out <- apply(result, 1, all) 
-    else if (and_or == "or") out <- apply(result, 1, any)
-    else stop(and_or, " should be and or or.")
+    if(is.null(and_or)) and_or <- "&"
+    if(and_or == "&") out <- apply(result, 1, all) 
+    else if (and_or == "|") out <- apply(result, 1, any)
+    else stop(and_or, " should be & or |.")
     out[is.na(out)] <- !curr_filter$parameters[["na.rm"]]
   }
   return(out)
@@ -1594,7 +1594,7 @@ DataSheet$set("public", "filter_string", function(filter_name) {
   out = "("
   i = 1
   for(condition in curr_filter$filter_conditions) {
-    if(i != 1) out = paste(out, "&")
+    if(i != 1) out = paste(out, curr_filter$parameters[["and_or"]])
     out = paste0(out, " (", condition[["column"]], " ", condition[["operation"]])
     if(condition[["operation"]] == "%in%") out = paste0(out, " c(", paste(paste0("'", condition[["value"]], "'"), collapse = ","), ")")
     else out = paste(out, condition[["value"]])

--- a/instat/static/InstatObject/R/instat_object_R6.R
+++ b/instat/static/InstatObject/R/instat_object_R6.R
@@ -712,9 +712,9 @@ DataBook$set("public", "get_table_names", function(data_name, include_overall = 
 }
 )
 
-DataBook$set("public", "add_filter", function(data_name, filter, filter_name = "", replace = TRUE, set_as_current_filter = FALSE, na.rm = TRUE, is_no_filter = FALSE) {
+DataBook$set("public", "add_filter", function(data_name, filter, filter_name = "", replace = TRUE, set_as_current_filter = FALSE, na.rm = TRUE, is_no_filter = FALSE, and_or = "and") {
   if(missing(filter)) stop("filter is required")
-  self$get_data_objects(data_name)$add_filter(filter, filter_name, replace, set_as_current_filter, na.rm = na.rm, is_no_filter = is_no_filter)
+  self$get_data_objects(data_name)$add_filter(filter, filter_name, replace, set_as_current_filter, na.rm = na.rm, is_no_filter = is_no_filter, and_or = and_or)
 }
 ) 
 

--- a/instat/static/InstatObject/R/instat_object_R6.R
+++ b/instat/static/InstatObject/R/instat_object_R6.R
@@ -712,7 +712,7 @@ DataBook$set("public", "get_table_names", function(data_name, include_overall = 
 }
 )
 
-DataBook$set("public", "add_filter", function(data_name, filter, filter_name = "", replace = TRUE, set_as_current_filter = FALSE, na.rm = TRUE, is_no_filter = FALSE, and_or = "and") {
+DataBook$set("public", "add_filter", function(data_name, filter, filter_name = "", replace = TRUE, set_as_current_filter = FALSE, na.rm = TRUE, is_no_filter = FALSE, and_or = "&") {
   if(missing(filter)) stop("filter is required")
   self$get_data_objects(data_name)$add_filter(filter, filter_name, replace, set_as_current_filter, na.rm = na.rm, is_no_filter = is_no_filter, and_or = and_or)
 }

--- a/instat/ucrFilter.Designer.vb
+++ b/instat/ucrFilter.Designer.vb
@@ -38,6 +38,7 @@ Partial Class ucrFilter
     'Do not modify it using the code editor.
     <System.Diagnostics.DebuggerStepThrough()> _
     Private Sub InitializeComponent()
+        Me.components = New System.ComponentModel.Container()
         Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(ucrFilter))
         Me.lblSelectLevels = New System.Windows.Forms.Label()
         Me.cmdAddCondition = New System.Windows.Forms.Button()
@@ -78,7 +79,8 @@ Partial Class ucrFilter
         Me.ucrFactorLevels = New instat.ucrFactor()
         Me.ucrFilterByReceiver = New instat.ucrReceiverSingle()
         Me.ucrSelectorForFitler = New instat.ucrSelectorByDataFrameAddRemove()
-        Me.Button1 = New System.Windows.Forms.Button()
+        Me.cmdCombineWithAndOr = New System.Windows.Forms.Button()
+        Me.ttpCombineWithAndOr = New System.Windows.Forms.ToolTip(Me.components)
         Me.grpNumeric.SuspendLayout()
         Me.SuspendLayout()
         '
@@ -295,6 +297,7 @@ Partial Class ucrFilter
         'ucrLogicalCombobox
         '
         Me.ucrLogicalCombobox.AddQuotesIfUnrecognised = True
+        Me.ucrLogicalCombobox.GetSetSelectedIndex = -1
         Me.ucrLogicalCombobox.IsReadOnly = False
         resources.ApplyResources(Me.ucrLogicalCombobox, "ucrLogicalCombobox")
         Me.ucrLogicalCombobox.Name = "ucrLogicalCombobox"
@@ -309,6 +312,7 @@ Partial Class ucrFilter
         'ucrInputFilterName
         '
         Me.ucrInputFilterName.AddQuotesIfUnrecognised = True
+        Me.ucrInputFilterName.GetSetSelectedIndex = -1
         Me.ucrInputFilterName.IsReadOnly = False
         resources.ApplyResources(Me.ucrInputFilterName, "ucrInputFilterName")
         Me.ucrInputFilterName.Name = "ucrInputFilterName"
@@ -324,6 +328,7 @@ Partial Class ucrFilter
         'ucrFilterOperation
         '
         Me.ucrFilterOperation.AddQuotesIfUnrecognised = True
+        Me.ucrFilterOperation.GetSetSelectedIndex = -1
         Me.ucrFilterOperation.IsReadOnly = False
         resources.ApplyResources(Me.ucrFilterOperation, "ucrFilterOperation")
         Me.ucrFilterOperation.Name = "ucrFilterOperation"
@@ -354,18 +359,18 @@ Partial Class ucrFilter
         resources.ApplyResources(Me.ucrSelectorForFitler, "ucrSelectorForFitler")
         Me.ucrSelectorForFitler.Name = "ucrSelectorForFitler"
         '
-        'Button1
+        'cmdCombineWithAndOr
         '
-        resources.ApplyResources(Me.Button1, "Button1")
-        Me.Button1.Name = "Button1"
-        Me.Button1.Tag = "Clear_Conditions"
-        Me.Button1.UseVisualStyleBackColor = True
+        resources.ApplyResources(Me.cmdCombineWithAndOr, "cmdCombineWithAndOr")
+        Me.cmdCombineWithAndOr.Name = "cmdCombineWithAndOr"
+        Me.cmdCombineWithAndOr.Tag = "Clear_Conditions"
+        Me.cmdCombineWithAndOr.UseVisualStyleBackColor = True
         '
         'ucrFilter
         '
         resources.ApplyResources(Me, "$this")
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
-        Me.Controls.Add(Me.Button1)
+        Me.Controls.Add(Me.cmdCombineWithAndOr)
         Me.Controls.Add(Me.ucrReceiverExpression)
         Me.Controls.Add(Me.grpNumeric)
         Me.Controls.Add(Me.ucrLogicalCombobox)
@@ -432,5 +437,6 @@ Partial Class ucrFilter
     Friend WithEvents cmd0 As Button
     Friend WithEvents cmd1 As Button
     Friend WithEvents ucrReceiverExpression As ucrReceiverExpression
-    Friend WithEvents Button1 As Button
+    Friend WithEvents cmdCombineWithAndOr As Button
+    Friend WithEvents ttpCombineWithAndOr As ToolTip
 End Class

--- a/instat/ucrFilter.resx
+++ b/instat/ucrFilter.resx
@@ -151,7 +151,7 @@
     <value>17</value>
   </data>
   <data name="cmdAddCondition.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Microsoft Sans Serif, 9pt, style=Bold</value>
+    <value>Microsoft Sans Serif, 8.25pt</value>
   </data>
   <data name="cmdAddCondition.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -160,7 +160,7 @@
     <value>278, 64</value>
   </data>
   <data name="cmdAddCondition.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 27</value>
+    <value>110, 29</value>
   </data>
   <data name="cmdAddCondition.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -211,7 +211,7 @@
     <value>5, 195</value>
   </data>
   <data name="lstFilters.Size" type="System.Drawing.Size, System.Drawing">
-    <value>251, 132</value>
+    <value>271, 132</value>
   </data>
   <data name="lstFilters.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -262,7 +262,7 @@
     <value>NoControl</value>
   </data>
   <data name="lblFilterBy.Location" type="System.Drawing.Point, System.Drawing">
-    <value>278, 27</value>
+    <value>281, 27</value>
   </data>
   <data name="lblFilterBy.Size" type="System.Drawing.Size, System.Drawing">
     <value>47, 13</value>
@@ -289,10 +289,10 @@
     <value>NoControl</value>
   </data>
   <data name="cmdClearConditions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>256, 298</value>
+    <value>277, 298</value>
   </data>
   <data name="cmdClearConditions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>149, 29</value>
+    <value>110, 29</value>
   </data>
   <data name="cmdClearConditions.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -319,10 +319,10 @@
     <value>NoControl</value>
   </data>
   <data name="mcdEditCondition.Location" type="System.Drawing.Point, System.Drawing">
-    <value>256, 230</value>
+    <value>277, 230</value>
   </data>
   <data name="mcdEditCondition.Size" type="System.Drawing.Size, System.Drawing">
-    <value>149, 29</value>
+    <value>110, 29</value>
   </data>
   <data name="mcdEditCondition.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -349,10 +349,10 @@
     <value>NoControl</value>
   </data>
   <data name="cmdRemoveCondition.Location" type="System.Drawing.Point, System.Drawing">
-    <value>256, 264</value>
+    <value>277, 264</value>
   </data>
   <data name="cmdRemoveCondition.Size" type="System.Drawing.Size, System.Drawing">
-    <value>149, 29</value>
+    <value>110, 29</value>
   </data>
   <data name="cmdRemoveCondition.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
@@ -991,7 +991,7 @@
     <value>18</value>
   </data>
   <data name="grpNumeric.Location" type="System.Drawing.Point, System.Drawing">
-    <value>419, 68</value>
+    <value>398, 66</value>
   </data>
   <data name="grpNumeric.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 3, 2, 3</value>
@@ -1123,7 +1123,7 @@
     <value>7, 6, 7, 6</value>
   </data>
   <data name="ucrFilterPreview.Size" type="System.Drawing.Size, System.Drawing">
-    <value>275, 21</value>
+    <value>280, 21</value>
   </data>
   <data name="ucrFilterPreview.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -1168,7 +1168,7 @@
     <value>True</value>
   </data>
   <data name="ucrFactorLevels.Location" type="System.Drawing.Point, System.Drawing">
-    <value>413, 65</value>
+    <value>398, 65</value>
   </data>
   <data name="ucrFactorLevels.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>5, 5, 5, 5</value>
@@ -1192,7 +1192,7 @@
     <value>18</value>
   </data>
   <data name="ucrFilterByReceiver.Location" type="System.Drawing.Point, System.Drawing">
-    <value>278, 42</value>
+    <value>278, 43</value>
   </data>
   <data name="ucrFilterByReceiver.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
@@ -1240,16 +1240,16 @@
     <value>20</value>
   </data>
   <data name="cmdCombineWithAndOr.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Microsoft Sans Serif, 9pt, style=Bold</value>
+    <value>Microsoft Sans Serif, 8.25pt</value>
   </data>
   <data name="cmdCombineWithAndOr.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="cmdCombineWithAndOr.Location" type="System.Drawing.Point, System.Drawing">
-    <value>256, 196</value>
+    <value>277, 196</value>
   </data>
   <data name="cmdCombineWithAndOr.Size" type="System.Drawing.Size, System.Drawing">
-    <value>149, 29</value>
+    <value>110, 29</value>
   </data>
   <data name="cmdCombineWithAndOr.TabIndex" type="System.Int32, mscorlib">
     <value>182</value>

--- a/instat/ucrFilter.resx
+++ b/instat/ucrFilter.resx
@@ -127,7 +127,7 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="lblSelectLevels.Location" type="System.Drawing.Point, System.Drawing">
-    <value>413, 42</value>
+    <value>413, 48</value>
   </data>
   <data name="lblSelectLevels.Size" type="System.Drawing.Size, System.Drawing">
     <value>74, 13</value>
@@ -150,6 +150,9 @@
   <data name="&gt;&gt;lblSelectLevels.ZOrder" xml:space="preserve">
     <value>17</value>
   </data>
+  <data name="cmdAddCondition.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Microsoft Sans Serif, 9pt, style=Bold</value>
+  </data>
   <data name="cmdAddCondition.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -157,7 +160,7 @@
     <value>278, 64</value>
   </data>
   <data name="cmdAddCondition.Size" type="System.Drawing.Size, System.Drawing">
-    <value>93, 23</value>
+    <value>120, 27</value>
   </data>
   <data name="cmdAddCondition.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -205,10 +208,10 @@
     <value>14</value>
   </data>
   <data name="lstFilters.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 195</value>
+    <value>5, 195</value>
   </data>
   <data name="lstFilters.Size" type="System.Drawing.Size, System.Drawing">
-    <value>268, 132</value>
+    <value>251, 132</value>
   </data>
   <data name="lstFilters.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -232,7 +235,7 @@
     <value>5, 339</value>
   </data>
   <data name="lblFilterPreview.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 13</value>
+    <value>91, 19</value>
   </data>
   <data name="lblFilterPreview.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -286,10 +289,10 @@
     <value>NoControl</value>
   </data>
   <data name="cmdClearConditions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>272, 298</value>
+    <value>256, 298</value>
   </data>
   <data name="cmdClearConditions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>110, 23</value>
+    <value>149, 29</value>
   </data>
   <data name="cmdClearConditions.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -316,10 +319,10 @@
     <value>NoControl</value>
   </data>
   <data name="mcdEditCondition.Location" type="System.Drawing.Point, System.Drawing">
-    <value>272, 230</value>
+    <value>256, 230</value>
   </data>
   <data name="mcdEditCondition.Size" type="System.Drawing.Size, System.Drawing">
-    <value>110, 23</value>
+    <value>149, 29</value>
   </data>
   <data name="mcdEditCondition.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -346,10 +349,10 @@
     <value>NoControl</value>
   </data>
   <data name="cmdRemoveCondition.Location" type="System.Drawing.Point, System.Drawing">
-    <value>272, 264</value>
+    <value>256, 264</value>
   </data>
   <data name="cmdRemoveCondition.Size" type="System.Drawing.Size, System.Drawing">
-    <value>110, 23</value>
+    <value>149, 29</value>
   </data>
   <data name="cmdRemoveCondition.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
@@ -376,7 +379,7 @@
     <value>5, 366</value>
   </data>
   <data name="lblNewFilterName.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 13</value>
+    <value>91, 19</value>
   </data>
   <data name="lblNewFilterName.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -395,264 +398,6 @@
   </data>
   <data name="&gt;&gt;lblNewFilterName.ZOrder" xml:space="preserve">
     <value>6</value>
-  </data>
-  <data name="&gt;&gt;cmdClear.Name" xml:space="preserve">
-    <value>cmdClear</value>
-  </data>
-  <data name="&gt;&gt;cmdClear.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cmdClear.Parent" xml:space="preserve">
-    <value>grpNumeric</value>
-  </data>
-  <data name="&gt;&gt;cmdClear.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;cmdComma.Name" xml:space="preserve">
-    <value>cmdComma</value>
-  </data>
-  <data name="&gt;&gt;cmdComma.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cmdComma.Parent" xml:space="preserve">
-    <value>grpNumeric</value>
-  </data>
-  <data name="&gt;&gt;cmdComma.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;cmdBrackets.Name" xml:space="preserve">
-    <value>cmdBrackets</value>
-  </data>
-  <data name="&gt;&gt;cmdBrackets.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cmdBrackets.Parent" xml:space="preserve">
-    <value>grpNumeric</value>
-  </data>
-  <data name="&gt;&gt;cmdBrackets.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;cmdPower.Name" xml:space="preserve">
-    <value>cmdPower</value>
-  </data>
-  <data name="&gt;&gt;cmdPower.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cmdPower.Parent" xml:space="preserve">
-    <value>grpNumeric</value>
-  </data>
-  <data name="&gt;&gt;cmdPower.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;cmdDivide.Name" xml:space="preserve">
-    <value>cmdDivide</value>
-  </data>
-  <data name="&gt;&gt;cmdDivide.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cmdDivide.Parent" xml:space="preserve">
-    <value>grpNumeric</value>
-  </data>
-  <data name="&gt;&gt;cmdDivide.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;cmdPlus.Name" xml:space="preserve">
-    <value>cmdPlus</value>
-  </data>
-  <data name="&gt;&gt;cmdPlus.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cmdPlus.Parent" xml:space="preserve">
-    <value>grpNumeric</value>
-  </data>
-  <data name="&gt;&gt;cmdPlus.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;cmdMinus.Name" xml:space="preserve">
-    <value>cmdMinus</value>
-  </data>
-  <data name="&gt;&gt;cmdMinus.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cmdMinus.Parent" xml:space="preserve">
-    <value>grpNumeric</value>
-  </data>
-  <data name="&gt;&gt;cmdMinus.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;cmdMultiply.Name" xml:space="preserve">
-    <value>cmdMultiply</value>
-  </data>
-  <data name="&gt;&gt;cmdMultiply.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cmdMultiply.Parent" xml:space="preserve">
-    <value>grpNumeric</value>
-  </data>
-  <data name="&gt;&gt;cmdMultiply.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;cmdDot.Name" xml:space="preserve">
-    <value>cmdDot</value>
-  </data>
-  <data name="&gt;&gt;cmdDot.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cmdDot.Parent" xml:space="preserve">
-    <value>grpNumeric</value>
-  </data>
-  <data name="&gt;&gt;cmdDot.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;cmd9.Name" xml:space="preserve">
-    <value>cmd9</value>
-  </data>
-  <data name="&gt;&gt;cmd9.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cmd9.Parent" xml:space="preserve">
-    <value>grpNumeric</value>
-  </data>
-  <data name="&gt;&gt;cmd9.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;cmd8.Name" xml:space="preserve">
-    <value>cmd8</value>
-  </data>
-  <data name="&gt;&gt;cmd8.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cmd8.Parent" xml:space="preserve">
-    <value>grpNumeric</value>
-  </data>
-  <data name="&gt;&gt;cmd8.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;cmd7.Name" xml:space="preserve">
-    <value>cmd7</value>
-  </data>
-  <data name="&gt;&gt;cmd7.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cmd7.Parent" xml:space="preserve">
-    <value>grpNumeric</value>
-  </data>
-  <data name="&gt;&gt;cmd7.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="&gt;&gt;cmd6.Name" xml:space="preserve">
-    <value>cmd6</value>
-  </data>
-  <data name="&gt;&gt;cmd6.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cmd6.Parent" xml:space="preserve">
-    <value>grpNumeric</value>
-  </data>
-  <data name="&gt;&gt;cmd6.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="&gt;&gt;cmd5.Name" xml:space="preserve">
-    <value>cmd5</value>
-  </data>
-  <data name="&gt;&gt;cmd5.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cmd5.Parent" xml:space="preserve">
-    <value>grpNumeric</value>
-  </data>
-  <data name="&gt;&gt;cmd5.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
-  <data name="&gt;&gt;cmd4.Name" xml:space="preserve">
-    <value>cmd4</value>
-  </data>
-  <data name="&gt;&gt;cmd4.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cmd4.Parent" xml:space="preserve">
-    <value>grpNumeric</value>
-  </data>
-  <data name="&gt;&gt;cmd4.ZOrder" xml:space="preserve">
-    <value>14</value>
-  </data>
-  <data name="&gt;&gt;cmd3.Name" xml:space="preserve">
-    <value>cmd3</value>
-  </data>
-  <data name="&gt;&gt;cmd3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cmd3.Parent" xml:space="preserve">
-    <value>grpNumeric</value>
-  </data>
-  <data name="&gt;&gt;cmd3.ZOrder" xml:space="preserve">
-    <value>15</value>
-  </data>
-  <data name="&gt;&gt;cmd2.Name" xml:space="preserve">
-    <value>cmd2</value>
-  </data>
-  <data name="&gt;&gt;cmd2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cmd2.Parent" xml:space="preserve">
-    <value>grpNumeric</value>
-  </data>
-  <data name="&gt;&gt;cmd2.ZOrder" xml:space="preserve">
-    <value>16</value>
-  </data>
-  <data name="&gt;&gt;cmd0.Name" xml:space="preserve">
-    <value>cmd0</value>
-  </data>
-  <data name="&gt;&gt;cmd0.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cmd0.Parent" xml:space="preserve">
-    <value>grpNumeric</value>
-  </data>
-  <data name="&gt;&gt;cmd0.ZOrder" xml:space="preserve">
-    <value>17</value>
-  </data>
-  <data name="&gt;&gt;cmd1.Name" xml:space="preserve">
-    <value>cmd1</value>
-  </data>
-  <data name="&gt;&gt;cmd1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cmd1.Parent" xml:space="preserve">
-    <value>grpNumeric</value>
-  </data>
-  <data name="&gt;&gt;cmd1.ZOrder" xml:space="preserve">
-    <value>18</value>
-  </data>
-  <data name="grpNumeric.Location" type="System.Drawing.Point, System.Drawing">
-    <value>424, 84</value>
-  </data>
-  <data name="grpNumeric.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>2, 3, 2, 3</value>
-  </data>
-  <data name="grpNumeric.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>2, 3, 2, 3</value>
-  </data>
-  <data name="grpNumeric.Size" type="System.Drawing.Size, System.Drawing">
-    <value>205, 134</value>
-  </data>
-  <data name="grpNumeric.TabIndex" type="System.Int32, mscorlib">
-    <value>180</value>
-  </data>
-  <data name="grpNumeric.Text" xml:space="preserve">
-    <value>Numeric</value>
-  </data>
-  <data name="&gt;&gt;grpNumeric.Name" xml:space="preserve">
-    <value>grpNumeric</value>
-  </data>
-  <data name="&gt;&gt;grpNumeric.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;grpNumeric.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;grpNumeric.ZOrder" xml:space="preserve">
-    <value>2</value>
   </data>
   <data name="cmdClear.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -1245,8 +990,38 @@
   <data name="&gt;&gt;cmd1.ZOrder" xml:space="preserve">
     <value>18</value>
   </data>
+  <data name="grpNumeric.Location" type="System.Drawing.Point, System.Drawing">
+    <value>419, 68</value>
+  </data>
+  <data name="grpNumeric.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 3, 2, 3</value>
+  </data>
+  <data name="grpNumeric.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 3, 2, 3</value>
+  </data>
+  <data name="grpNumeric.Size" type="System.Drawing.Size, System.Drawing">
+    <value>205, 134</value>
+  </data>
+  <data name="grpNumeric.TabIndex" type="System.Int32, mscorlib">
+    <value>180</value>
+  </data>
+  <data name="grpNumeric.Text" xml:space="preserve">
+    <value>Numeric</value>
+  </data>
+  <data name="&gt;&gt;grpNumeric.Name" xml:space="preserve">
+    <value>grpNumeric</value>
+  </data>
+  <data name="&gt;&gt;grpNumeric.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;grpNumeric.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;grpNumeric.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
   <data name="ucrReceiverExpression.Location" type="System.Drawing.Point, System.Drawing">
-    <value>488, 40</value>
+    <value>456, 42</value>
   </data>
   <data name="ucrReceiverExpression.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>5, 5, 5, 5</value>
@@ -1270,7 +1045,7 @@
     <value>1</value>
   </data>
   <data name="ucrLogicalCombobox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>489, 39</value>
+    <value>455, 40</value>
   </data>
   <data name="ucrLogicalCombobox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>7, 6, 7, 6</value>
@@ -1294,7 +1069,7 @@
     <value>3</value>
   </data>
   <data name="ucrDatePicker.Location" type="System.Drawing.Point, System.Drawing">
-    <value>489, 40</value>
+    <value>456, 40</value>
   </data>
   <data name="ucrDatePicker.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>5, 5, 5, 5</value>
@@ -1318,7 +1093,7 @@
     <value>4</value>
   </data>
   <data name="ucrInputFilterName.Location" type="System.Drawing.Point, System.Drawing">
-    <value>131, 364</value>
+    <value>100, 364</value>
   </data>
   <data name="ucrInputFilterName.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>7, 6, 7, 6</value>
@@ -1342,7 +1117,7 @@
     <value>5</value>
   </data>
   <data name="ucrFilterPreview.Location" type="System.Drawing.Point, System.Drawing">
-    <value>131, 337</value>
+    <value>100, 337</value>
   </data>
   <data name="ucrFilterPreview.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>7, 6, 7, 6</value>
@@ -1366,7 +1141,7 @@
     <value>11</value>
   </data>
   <data name="ucrFilterOperation.Location" type="System.Drawing.Point, System.Drawing">
-    <value>413, 40</value>
+    <value>399, 42</value>
   </data>
   <data name="ucrFilterOperation.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>7, 6, 7, 6</value>
@@ -1393,7 +1168,7 @@
     <value>True</value>
   </data>
   <data name="ucrFactorLevels.Location" type="System.Drawing.Point, System.Drawing">
-    <value>413, 61</value>
+    <value>413, 65</value>
   </data>
   <data name="ucrFactorLevels.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>5, 5, 5, 5</value>
@@ -1423,7 +1198,7 @@
     <value>0, 0, 0, 0</value>
   </data>
   <data name="ucrFilterByReceiver.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 20</value>
+    <value>120, 21</value>
   </data>
   <data name="ucrFilterByReceiver.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -1441,7 +1216,7 @@
     <value>19</value>
   </data>
   <data name="ucrSelectorForFitler.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 4</value>
+    <value>5, 4</value>
   </data>
   <data name="ucrSelectorForFitler.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
@@ -1464,36 +1239,39 @@
   <data name="&gt;&gt;ucrSelectorForFitler.ZOrder" xml:space="preserve">
     <value>20</value>
   </data>
-  <data name="Button1.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
+  <data name="cmdCombineWithAndOr.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Microsoft Sans Serif, 9pt, style=Bold</value>
   </data>
-  <data name="Button1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="cmdCombineWithAndOr.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="Button1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>272, 196</value>
+  <data name="cmdCombineWithAndOr.Location" type="System.Drawing.Point, System.Drawing">
+    <value>256, 196</value>
   </data>
-  <data name="Button1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>110, 23</value>
+  <data name="cmdCombineWithAndOr.Size" type="System.Drawing.Size, System.Drawing">
+    <value>149, 29</value>
   </data>
-  <data name="Button1.TabIndex" type="System.Int32, mscorlib">
+  <data name="cmdCombineWithAndOr.TabIndex" type="System.Int32, mscorlib">
     <value>182</value>
   </data>
-  <data name="Button1.Text" xml:space="preserve">
-    <value>Combine with &amp;&amp;</value>
+  <data name="cmdCombineWithAndOr.Text" xml:space="preserve">
+    <value>All Combined with &amp;&amp;</value>
   </data>
-  <data name="&gt;&gt;Button1.Name" xml:space="preserve">
-    <value>Button1</value>
+  <data name="&gt;&gt;cmdCombineWithAndOr.Name" xml:space="preserve">
+    <value>cmdCombineWithAndOr</value>
   </data>
-  <data name="&gt;&gt;Button1.Type" xml:space="preserve">
+  <data name="&gt;&gt;cmdCombineWithAndOr.Type" xml:space="preserve">
     <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;Button1.Parent" xml:space="preserve">
+  <data name="&gt;&gt;cmdCombineWithAndOr.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;Button1.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;cmdCombineWithAndOr.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
+  <metadata name="ttpCombineWithAndOr.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
@@ -1502,6 +1280,12 @@
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
     <value>772, 395</value>
+  </data>
+  <data name="&gt;&gt;ttpCombineWithAndOr.Name" xml:space="preserve">
+    <value>ttpCombineWithAndOr</value>
+  </data>
+  <data name="&gt;&gt;ttpCombineWithAndOr.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>ucrFilter</value>

--- a/instat/ucrFilter.vb
+++ b/instat/ucrFilter.vb
@@ -369,7 +369,13 @@ Public Class ucrFilter
         ucrReceiverExpression.Clear()
     End Sub
 
-    ''' <summary> Handles event triggered when cmdCombineWithAndOr Button is clicked.</summary>
+    ''' <summary> Handles event triggered when cmdCombineWithAndOr Button is clicked.
+    ''' The purpose of this button is to change the filter operator which to either AND(&amp;) or OR(|).
+    ''' The user clicks the button to trigger a change in the operator. 
+    ''' This subroutine changes the oparator, passes "and_or" parameter into clsFilterFunction, updates the button label and set the tooltip text for the button.
+    ''' Filter preview is also updated.
+    ''' Button text and the tooltip displayed on hover is changed whenever the button is clicked.
+    ''' </summary>
     ''' <param name="sender"> Not used. </param>
     ''' <param name="e"> Not used. </param>
     Private Sub cmdCombineWithAndOr_Click(sender As Object, e As EventArgs) Handles cmdCombineWithAndOr.Click

--- a/instat/ucrFilter.vb
+++ b/instat/ucrFilter.vb
@@ -372,7 +372,8 @@ Public Class ucrFilter
     ''' <summary> Handles event triggered when cmdCombineWithAndOr Button is clicked.
     ''' The purpose of this button is to change the filter operator to either AND(&amp;) or OR(|).
     ''' The user clicks the button to trigger a change in the operator. 
-    ''' This subroutine changes the oparator, passes "and_or" parameter into clsFilterFunction, updates the button label and set the tooltip text for the button.
+    ''' This subroutine changes the oparator, passes "and_or" parameter into clsFilterFunction, 
+    ''' updates the button label and set the tooltip text for the button.
     ''' Filter preview is also updated.
     ''' Button text and the tooltip displayed on hover is changed whenever the button is clicked.
     ''' </summary>

--- a/instat/ucrFilter.vb
+++ b/instat/ucrFilter.vb
@@ -77,6 +77,7 @@ Public Class ucrFilter
         ucrSelectorForFitler.btnDataOptions.Visible = False
         ucrLogicalCombobox.SetItems({"TRUE", "FALSE"})
         ucrLogicalCombobox.SetDropDownStyleAsNonEditable()
+        ttpCombineWithAndOr.SetToolTip(cmdCombineWithAndOr, "With more than one condition, e.g. (year > 1990) & (year < 2021) they have all to be TRUE.")
     End Sub
 
     Private Sub SetDefaults()
@@ -120,12 +121,11 @@ Public Class ucrFilter
     End Sub
 
     Private Sub CheckAddEnabled()
-        If ucrFilterByReceiver.IsEmpty() AndAlso ucrReceiverExpression.IsEmpty() Then
+        If (ucrFilterByReceiver.IsEmpty() AndAlso ucrReceiverExpression.bIsVisible AndAlso ucrReceiverExpression.IsEmpty()) OrElse ucrFilterByReceiver.IsEmpty() Then
             cmdAddCondition.Enabled = False
         Else
             If ucrFilterByReceiver.strCurrDataType.ToLower.Contains("factor") Then
                 cmdAddCondition.Enabled = Not String.IsNullOrEmpty(ucrFactorLevels.GetSelectedLevels())
-
             Else
                 Select Case ucrFilterOperation.GetText()
                     Case "is.na", "! is.na"
@@ -367,5 +367,21 @@ Public Class ucrFilter
 
     Private Sub cmdClear_Click(sender As Object, e As EventArgs) Handles cmdClear.Click
         ucrReceiverExpression.Clear()
+    End Sub
+
+    Private Sub cmdCombineWithAndOr_Click(sender As Object, e As EventArgs) Handles cmdCombineWithAndOr.Click
+        If cmdCombineWithAndOr.Text.Contains("All combined with |") Then
+            clsFilterView.strOperation = "&"
+            ucrFilterPreview.SetName(clsFilterView.ToScript())
+            clsFilterFunction.AddParameter("and_or", Chr(34) & "and" & Chr(34), iPosition:=3)
+            cmdCombineWithAndOr.Text = " All combined with &&"
+            ttpCombineWithAndOr.SetToolTip(cmdCombineWithAndOr, "With more than one condition, e.g. (year > 1990) & (year < 2021) they have all to be TRUE.")
+        Else
+            clsFilterView.strOperation = "|"
+            ucrFilterPreview.SetName(clsFilterView.ToScript())
+            clsFilterFunction.AddParameter("and_or", Chr(34) & "or" & Chr(34), iPosition:=3)
+            cmdCombineWithAndOr.Text = "All combined with |"
+            ttpCombineWithAndOr.SetToolTip(cmdCombineWithAndOr, "With more than one condition, e.g. (sunhrs >14) | (sunhrs <0) then just one need be TRUE.")
+        End If
     End Sub
 End Class

--- a/instat/ucrFilter.vb
+++ b/instat/ucrFilter.vb
@@ -369,6 +369,9 @@ Public Class ucrFilter
         ucrReceiverExpression.Clear()
     End Sub
 
+    ''' <summary> Handles event triggered when cmdCombineWithAndOr Button is clicked.</summary>
+    ''' <param name="sender"> Not used. </param>
+    ''' <param name="e"> Not used. </param>
     Private Sub cmdCombineWithAndOr_Click(sender As Object, e As EventArgs) Handles cmdCombineWithAndOr.Click
         If cmdCombineWithAndOr.Text.Contains("All combined with |") Then
             clsFilterView.strOperation = "&"

--- a/instat/ucrFilter.vb
+++ b/instat/ucrFilter.vb
@@ -372,16 +372,15 @@ Public Class ucrFilter
     Private Sub cmdCombineWithAndOr_Click(sender As Object, e As EventArgs) Handles cmdCombineWithAndOr.Click
         If cmdCombineWithAndOr.Text.Contains("All combined with |") Then
             clsFilterView.strOperation = "&"
-            ucrFilterPreview.SetName(clsFilterView.ToScript())
             clsFilterFunction.AddParameter("and_or", Chr(34) & "&" & Chr(34), iPosition:=3)
             cmdCombineWithAndOr.Text = " All combined with &&"
             ttpCombineWithAndOr.SetToolTip(cmdCombineWithAndOr, "With more than one condition, e.g. (year > 1990) & (year < 2021) they have all to be TRUE.")
         Else
             clsFilterView.strOperation = "|"
-            ucrFilterPreview.SetName(clsFilterView.ToScript())
             clsFilterFunction.AddParameter("and_or", Chr(34) & "|" & Chr(34), iPosition:=3)
             cmdCombineWithAndOr.Text = "All combined with |"
             ttpCombineWithAndOr.SetToolTip(cmdCombineWithAndOr, "With more than one condition, e.g. (sunhrs >14) | (sunhrs <0) then just one need be TRUE.")
         End If
+        ucrFilterPreview.SetName(clsFilterView.ToScript())
     End Sub
 End Class

--- a/instat/ucrFilter.vb
+++ b/instat/ucrFilter.vb
@@ -370,7 +370,7 @@ Public Class ucrFilter
     End Sub
 
     ''' <summary> Handles event triggered when cmdCombineWithAndOr Button is clicked.
-    ''' The purpose of this button is to change the filter operator which to either AND(&amp;) or OR(|).
+    ''' The purpose of this button is to change the filter operator to either AND(&amp;) or OR(|).
     ''' The user clicks the button to trigger a change in the operator. 
     ''' This subroutine changes the oparator, passes "and_or" parameter into clsFilterFunction, updates the button label and set the tooltip text for the button.
     ''' Filter preview is also updated.

--- a/instat/ucrFilter.vb
+++ b/instat/ucrFilter.vb
@@ -373,13 +373,13 @@ Public Class ucrFilter
         If cmdCombineWithAndOr.Text.Contains("All combined with |") Then
             clsFilterView.strOperation = "&"
             ucrFilterPreview.SetName(clsFilterView.ToScript())
-            clsFilterFunction.AddParameter("and_or", Chr(34) & "and" & Chr(34), iPosition:=3)
+            clsFilterFunction.AddParameter("and_or", Chr(34) & "&" & Chr(34), iPosition:=3)
             cmdCombineWithAndOr.Text = " All combined with &&"
             ttpCombineWithAndOr.SetToolTip(cmdCombineWithAndOr, "With more than one condition, e.g. (year > 1990) & (year < 2021) they have all to be TRUE.")
         Else
             clsFilterView.strOperation = "|"
             ucrFilterPreview.SetName(clsFilterView.ToScript())
-            clsFilterFunction.AddParameter("and_or", Chr(34) & "or" & Chr(34), iPosition:=3)
+            clsFilterFunction.AddParameter("and_or", Chr(34) & "|" & Chr(34), iPosition:=3)
             cmdCombineWithAndOr.Text = "All combined with |"
             ttpCombineWithAndOr.SetToolTip(cmdCombineWithAndOr, "With more than one condition, e.g. (sunhrs >14) | (sunhrs <0) then just one need be TRUE.")
         End If


### PR DESCRIPTION
Fixes #5791. @rdstern this is ready for you to test. This is the implementation of the use of **&** and **|** operators in the filter.