### PR TITLE
Minor bug fix in the R-code for `$make_inventory_plot`

### DIFF
--- a/instat/static/InstatObject/R/data_object_R6.R
+++ b/instat/static/InstatObject/R/data_object_R6.R
@@ -2467,7 +2467,7 @@ DataSheet$set("public","make_inventory_plot", function(date_col, station_col = N
     if(is.null(year_col)) {
       if(is_climatic) {
         if(is.null(self$get_climatic_column_name(year_label))) {
-          self$split_date(col_name = date_col, year = TRUE)
+          self$split_date(col_name = date_col, year_val = TRUE)
         }
         year_col <- self$get_climatic_column_name(year_label)
       }


### PR DESCRIPTION
Fixes #6000 

@africanmathsinitiative/developers this is ready for review.

This fixes a bug in the R-code used in the dlgInventory dialog

1. Go to `File > Import from Library ...` and import the `ghana_two_stations.RDS` data set. This data set has a date column and not a year column. The bug was present in a data set without a year column (or without a year column defined in the climatic define dialog).
2. Go to `Climatic > Check Data > Inventory ...`
3. Enter the `Date` and `Elements`, and select `DOY-Year Plot` on the radio buttons
4. There used to be an error at this point. This PR fixes this error so that the code now runs.