### PR TITLE
Tidy climatic data dialog improvements

### DIFF
--- a/instat/dlgTidyDailyData.Designer.vb
+++ b/instat/dlgTidyDailyData.Designer.vb
@@ -36,12 +36,16 @@ Partial Class dlgTidyDailyData
         Me.lblColumnstoStack = New System.Windows.Forms.Label()
         Me.lblMultipleElement = New System.Windows.Forms.Label()
         Me.grpElements = New System.Windows.Forms.GroupBox()
+        Me.ucrChkUnstackElements = New instat.ucrCheck()
         Me.lblOr = New System.Windows.Forms.Label()
         Me.ucrTextBoxElementName = New instat.ucrInputTextBox()
         Me.ucrReceiverElement = New instat.ucrReceiverSingle()
         Me.grpOptions = New System.Windows.Forms.GroupBox()
         Me.ucrChkIgnoreInvalid = New instat.ucrCheck()
         Me.ucrChkSilent = New instat.ucrCheck()
+        Me.lblNewDataFrameName = New System.Windows.Forms.Label()
+        Me.ttReshapeType = New System.Windows.Forms.ToolTip(Me.components)
+        Me.ucrInputNewDataFrame = New instat.ucrInputTextBox()
         Me.ucrReceiverMultipleStack = New instat.ucrReceiverMultiple()
         Me.ucrReceiverMonth = New instat.ucrReceiverSingle()
         Me.ucrReceiverDayofMonth = New instat.ucrReceiverSingle()
@@ -50,9 +54,7 @@ Partial Class dlgTidyDailyData
         Me.ucrSelectorTidyDailyData = New instat.ucrSelectorByDataFrameAddRemove()
         Me.ucrReceiverStation = New instat.ucrReceiverSingle()
         Me.ucrBase = New instat.ucrButtons()
-        Me.ucrInputNewDataFrame = New instat.ucrInputTextBox()
-        Me.lblNewDataFrameName = New System.Windows.Forms.Label()
-        Me.ttReshapeType = New System.Windows.Forms.ToolTip(Me.components)
+        Me.lblNColumns = New System.Windows.Forms.Label()
         Me.grpElements.SuspendLayout()
         Me.grpOptions.SuspendLayout()
         Me.SuspendLayout()
@@ -129,6 +131,7 @@ Partial Class dlgTidyDailyData
         '
         'grpElements
         '
+        Me.grpElements.Controls.Add(Me.ucrChkUnstackElements)
         Me.grpElements.Controls.Add(Me.lblOr)
         Me.grpElements.Controls.Add(Me.lblElementName)
         Me.grpElements.Controls.Add(Me.ucrTextBoxElementName)
@@ -137,6 +140,12 @@ Partial Class dlgTidyDailyData
         resources.ApplyResources(Me.grpElements, "grpElements")
         Me.grpElements.Name = "grpElements"
         Me.grpElements.TabStop = False
+        '
+        'ucrChkUnstackElements
+        '
+        Me.ucrChkUnstackElements.Checked = False
+        resources.ApplyResources(Me.ucrChkUnstackElements, "ucrChkUnstackElements")
+        Me.ucrChkUnstackElements.Name = "ucrChkUnstackElements"
         '
         'lblOr
         '
@@ -179,6 +188,19 @@ Partial Class dlgTidyDailyData
         Me.ucrChkSilent.Checked = False
         resources.ApplyResources(Me.ucrChkSilent, "ucrChkSilent")
         Me.ucrChkSilent.Name = "ucrChkSilent"
+        '
+        'lblNewDataFrameName
+        '
+        resources.ApplyResources(Me.lblNewDataFrameName, "lblNewDataFrameName")
+        Me.lblNewDataFrameName.Name = "lblNewDataFrameName"
+        '
+        'ucrInputNewDataFrame
+        '
+        Me.ucrInputNewDataFrame.AddQuotesIfUnrecognised = True
+        Me.ucrInputNewDataFrame.IsMultiline = False
+        Me.ucrInputNewDataFrame.IsReadOnly = False
+        resources.ApplyResources(Me.ucrInputNewDataFrame, "ucrInputNewDataFrame")
+        Me.ucrInputNewDataFrame.Name = "ucrInputNewDataFrame"
         '
         'ucrReceiverMultipleStack
         '
@@ -243,23 +265,17 @@ Partial Class dlgTidyDailyData
         resources.ApplyResources(Me.ucrBase, "ucrBase")
         Me.ucrBase.Name = "ucrBase"
         '
-        'ucrInputNewDataFrame
+        'lblNColumns
         '
-        Me.ucrInputNewDataFrame.AddQuotesIfUnrecognised = True
-        Me.ucrInputNewDataFrame.IsMultiline = False
-        Me.ucrInputNewDataFrame.IsReadOnly = False
-        resources.ApplyResources(Me.ucrInputNewDataFrame, "ucrInputNewDataFrame")
-        Me.ucrInputNewDataFrame.Name = "ucrInputNewDataFrame"
-        '
-        'lblNewDataFrameName
-        '
-        resources.ApplyResources(Me.lblNewDataFrameName, "lblNewDataFrameName")
-        Me.lblNewDataFrameName.Name = "lblNewDataFrameName"
+        resources.ApplyResources(Me.lblNColumns, "lblNColumns")
+        Me.lblNColumns.ForeColor = System.Drawing.Color.Red
+        Me.lblNColumns.Name = "lblNColumns"
         '
         'dlgTidyDailyData
         '
         resources.ApplyResources(Me, "$this")
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.Controls.Add(Me.lblNColumns)
         Me.Controls.Add(Me.lblNewDataFrameName)
         Me.Controls.Add(Me.ucrInputNewDataFrame)
         Me.Controls.Add(Me.grpOptions)
@@ -322,4 +338,6 @@ Partial Class dlgTidyDailyData
     Friend WithEvents lblNewDataFrameName As Label
     Friend WithEvents ucrInputNewDataFrame As ucrInputTextBox
     Friend WithEvents ttReshapeType As ToolTip
+    Friend WithEvents ucrChkUnstackElements As ucrCheck
+    Friend WithEvents lblNColumns As Label
 End Class

--- a/instat/dlgTidyDailyData.Designer.vb
+++ b/instat/dlgTidyDailyData.Designer.vb
@@ -22,6 +22,7 @@ Partial Class dlgTidyDailyData
     'Do not modify it using the code editor.
     <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
+        Me.components = New System.ComponentModel.Container()
         Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(dlgTidyDailyData))
         Me.lblColumnPer = New System.Windows.Forms.Label()
         Me.rdoDay = New System.Windows.Forms.RadioButton()
@@ -51,6 +52,7 @@ Partial Class dlgTidyDailyData
         Me.ucrBase = New instat.ucrButtons()
         Me.ucrInputNewDataFrame = New instat.ucrInputTextBox()
         Me.lblNewDataFrameName = New System.Windows.Forms.Label()
+        Me.ttReshapeType = New System.Windows.Forms.ToolTip(Me.components)
         Me.grpElements.SuspendLayout()
         Me.grpOptions.SuspendLayout()
         Me.SuspendLayout()
@@ -319,4 +321,5 @@ Partial Class dlgTidyDailyData
     Friend WithEvents grpOptions As GroupBox
     Friend WithEvents lblNewDataFrameName As Label
     Friend WithEvents ucrInputNewDataFrame As ucrInputTextBox
+    Friend WithEvents ttReshapeType As ToolTip
 End Class

--- a/instat/dlgTidyDailyData.resx
+++ b/instat/dlgTidyDailyData.resx
@@ -145,7 +145,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblColumnPer.ZOrder" xml:space="preserve">
-    <value>17</value>
+    <value>18</value>
   </data>
   <data name="rdoDay.Appearance" type="System.Windows.Forms.Appearance, System.Windows.Forms">
     <value>Button</value>
@@ -157,7 +157,7 @@
     <value>NoControl</value>
   </data>
   <data name="rdoDay.Location" type="System.Drawing.Point, System.Drawing">
-    <value>284, 30</value>
+    <value>284, 17</value>
   </data>
   <data name="rdoDay.Size" type="System.Drawing.Size, System.Drawing">
     <value>120, 27</value>
@@ -181,7 +181,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;rdoDay.ZOrder" xml:space="preserve">
-    <value>13</value>
+    <value>14</value>
   </data>
   <data name="rdoMonth.Appearance" type="System.Windows.Forms.Appearance, System.Windows.Forms">
     <value>Button</value>
@@ -193,7 +193,7 @@
     <value>NoControl</value>
   </data>
   <data name="rdoMonth.Location" type="System.Drawing.Point, System.Drawing">
-    <value>166, 30</value>
+    <value>166, 17</value>
   </data>
   <data name="rdoMonth.Size" type="System.Drawing.Size, System.Drawing">
     <value>120, 27</value>
@@ -217,7 +217,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;rdoMonth.ZOrder" xml:space="preserve">
-    <value>14</value>
+    <value>15</value>
   </data>
   <data name="rdoYear.Appearance" type="System.Windows.Forms.Appearance, System.Windows.Forms">
     <value>Button</value>
@@ -229,7 +229,7 @@
     <value>NoControl</value>
   </data>
   <data name="rdoYear.Location" type="System.Drawing.Point, System.Drawing">
-    <value>48, 30</value>
+    <value>48, 17</value>
   </data>
   <data name="rdoYear.Size" type="System.Drawing.Size, System.Drawing">
     <value>120, 27</value>
@@ -253,7 +253,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;rdoYear.ZOrder" xml:space="preserve">
-    <value>15</value>
+    <value>16</value>
   </data>
   <data name="lblMonth.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -262,7 +262,7 @@
     <value>NoControl</value>
   </data>
   <data name="lblMonth.Location" type="System.Drawing.Point, System.Drawing">
-    <value>279, 258</value>
+    <value>279, 239</value>
   </data>
   <data name="lblMonth.Size" type="System.Drawing.Size, System.Drawing">
     <value>40, 13</value>
@@ -283,7 +283,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblMonth.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>9</value>
   </data>
   <data name="lblYear.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -292,7 +292,7 @@
     <value>NoControl</value>
   </data>
   <data name="lblYear.Location" type="System.Drawing.Point, System.Drawing">
-    <value>279, 210</value>
+    <value>279, 191</value>
   </data>
   <data name="lblYear.Size" type="System.Drawing.Size, System.Drawing">
     <value>32, 13</value>
@@ -313,7 +313,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblYear.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>11</value>
   </data>
   <data name="lblDayofMonth.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -322,7 +322,7 @@
     <value>NoControl</value>
   </data>
   <data name="lblDayofMonth.Location" type="System.Drawing.Point, System.Drawing">
-    <value>279, 258</value>
+    <value>279, 239</value>
   </data>
   <data name="lblDayofMonth.Size" type="System.Drawing.Size, System.Drawing">
     <value>76, 13</value>
@@ -343,7 +343,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblDayofMonth.ZOrder" xml:space="preserve">
-    <value>11</value>
+    <value>12</value>
   </data>
   <data name="lblStation.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -352,7 +352,7 @@
     <value>NoControl</value>
   </data>
   <data name="lblStation.Location" type="System.Drawing.Point, System.Drawing">
-    <value>279, 307</value>
+    <value>279, 288</value>
   </data>
   <data name="lblStation.Size" type="System.Drawing.Size, System.Drawing">
     <value>43, 13</value>
@@ -373,7 +373,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblStation.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>7</value>
   </data>
   <data name="lblElementName.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -403,7 +403,7 @@
     <value>grpElements</value>
   </data>
   <data name="&gt;&gt;lblElementName.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="lblColumnstoStack.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -412,7 +412,7 @@
     <value>NoControl</value>
   </data>
   <data name="lblColumnstoStack.Location" type="System.Drawing.Point, System.Drawing">
-    <value>279, 80</value>
+    <value>279, 61</value>
   </data>
   <data name="lblColumnstoStack.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 13</value>
@@ -433,7 +433,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblColumnstoStack.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>5</value>
   </data>
   <data name="lblMultipleElement.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -463,7 +463,28 @@
     <value>grpElements</value>
   </data>
   <data name="&gt;&gt;lblMultipleElement.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
+  </data>
+  <data name="ucrChkUnstackElements.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 126</value>
+  </data>
+  <data name="ucrChkUnstackElements.Size" type="System.Drawing.Size, System.Drawing">
+    <value>120, 20</value>
+  </data>
+  <data name="ucrChkUnstackElements.TabIndex" type="System.Int32, mscorlib">
+    <value>21</value>
+  </data>
+  <data name="&gt;&gt;ucrChkUnstackElements.Name" xml:space="preserve">
+    <value>ucrChkUnstackElements</value>
+  </data>
+  <data name="&gt;&gt;ucrChkUnstackElements.Type" xml:space="preserve">
+    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrChkUnstackElements.Parent" xml:space="preserve">
+    <value>grpElements</value>
+  </data>
+  <data name="&gt;&gt;ucrChkUnstackElements.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="lblOr.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -493,7 +514,7 @@
     <value>grpElements</value>
   </data>
   <data name="&gt;&gt;lblOr.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="ucrTextBoxElementName.Location" type="System.Drawing.Point, System.Drawing">
     <value>13, 32</value>
@@ -514,7 +535,7 @@
     <value>grpElements</value>
   </data>
   <data name="&gt;&gt;ucrTextBoxElementName.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -525,8 +546,41 @@
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
     <value>452, 578</value>
   </data>
+  <data name="lblNColumns.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblNColumns.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblNColumns.Location" type="System.Drawing.Point, System.Drawing">
+    <value>385, 61</value>
+  </data>
+  <data name="lblNColumns.Size" type="System.Drawing.Size, System.Drawing">
+    <value>19, 13</value>
+  </data>
+  <data name="lblNColumns.TabIndex" type="System.Int32, mscorlib">
+    <value>28</value>
+  </data>
+  <data name="lblNColumns.Text" xml:space="preserve">
+    <value>(0)</value>
+  </data>
+  <data name="&gt;&gt;lblNColumns.Name" xml:space="preserve">
+    <value>lblNColumns</value>
+  </data>
+  <data name="&gt;&gt;lblNColumns.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblNColumns.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;lblNColumns.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="lblNewDataFrameName.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
+  </data>
+  <data name="lblNewDataFrameName.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
   <data name="lblNewDataFrameName.Location" type="System.Drawing.Point, System.Drawing">
     <value>12, 498</value>
@@ -550,7 +604,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblNewDataFrameName.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="ucrInputNewDataFrame.Location" type="System.Drawing.Point, System.Drawing">
     <value>134, 495</value>
@@ -571,7 +625,304 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrInputNewDataFrame.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;ucrChkIgnoreInvalid.Name" xml:space="preserve">
+    <value>ucrChkIgnoreInvalid</value>
+  </data>
+  <data name="&gt;&gt;ucrChkIgnoreInvalid.Type" xml:space="preserve">
+    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrChkIgnoreInvalid.Parent" xml:space="preserve">
+    <value>grpOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrChkIgnoreInvalid.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;ucrChkSilent.Name" xml:space="preserve">
+    <value>ucrChkSilent</value>
+  </data>
+  <data name="&gt;&gt;ucrChkSilent.Type" xml:space="preserve">
+    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrChkSilent.Parent" xml:space="preserve">
+    <value>grpOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrChkSilent.ZOrder" xml:space="preserve">
     <value>1</value>
+  </data>
+  <data name="grpOptions.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 270</value>
+  </data>
+  <data name="grpOptions.Size" type="System.Drawing.Size, System.Drawing">
+    <value>223, 83</value>
+  </data>
+  <data name="grpOptions.TabIndex" type="System.Int32, mscorlib">
+    <value>21</value>
+  </data>
+  <data name="grpOptions.Text" xml:space="preserve">
+    <value>Options</value>
+  </data>
+  <data name="&gt;&gt;grpOptions.Name" xml:space="preserve">
+    <value>grpOptions</value>
+  </data>
+  <data name="&gt;&gt;grpOptions.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;grpOptions.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;grpOptions.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="ucrReceiverMultipleStack.Location" type="System.Drawing.Point, System.Drawing">
+    <value>282, 79</value>
+  </data>
+  <data name="ucrReceiverMultipleStack.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="ucrReceiverMultipleStack.Size" type="System.Drawing.Size, System.Drawing">
+    <value>120, 100</value>
+  </data>
+  <data name="ucrReceiverMultipleStack.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverMultipleStack.Name" xml:space="preserve">
+    <value>ucrReceiverMultipleStack</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverMultipleStack.Type" xml:space="preserve">
+    <value>instat.ucrReceiverMultiple, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverMultipleStack.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverMultipleStack.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="ucrReceiverMonth.Location" type="System.Drawing.Point, System.Drawing">
+    <value>282, 257</value>
+  </data>
+  <data name="ucrReceiverMonth.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="ucrReceiverMonth.Size" type="System.Drawing.Size, System.Drawing">
+    <value>120, 20</value>
+  </data>
+  <data name="ucrReceiverMonth.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverMonth.Name" xml:space="preserve">
+    <value>ucrReceiverMonth</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverMonth.Type" xml:space="preserve">
+    <value>instat.ucrReceiverSingle, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverMonth.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverMonth.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="ucrReceiverDayofMonth.Location" type="System.Drawing.Point, System.Drawing">
+    <value>282, 257</value>
+  </data>
+  <data name="ucrReceiverDayofMonth.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="ucrReceiverDayofMonth.Size" type="System.Drawing.Size, System.Drawing">
+    <value>120, 20</value>
+  </data>
+  <data name="ucrReceiverDayofMonth.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverDayofMonth.Name" xml:space="preserve">
+    <value>ucrReceiverDayofMonth</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverDayofMonth.Type" xml:space="preserve">
+    <value>instat.ucrReceiverSingle, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverDayofMonth.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverDayofMonth.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="ucrReceiverYear.Location" type="System.Drawing.Point, System.Drawing">
+    <value>282, 209</value>
+  </data>
+  <data name="ucrReceiverYear.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="ucrReceiverYear.Size" type="System.Drawing.Size, System.Drawing">
+    <value>120, 20</value>
+  </data>
+  <data name="ucrReceiverYear.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverYear.Name" xml:space="preserve">
+    <value>ucrReceiverYear</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverYear.Type" xml:space="preserve">
+    <value>instat.ucrReceiverSingle, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverYear.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverYear.ZOrder" xml:space="preserve">
+    <value>13</value>
+  </data>
+  <data name="ucrPnlReshapeClimaticData.Location" type="System.Drawing.Point, System.Drawing">
+    <value>41, 13</value>
+  </data>
+  <data name="ucrPnlReshapeClimaticData.Size" type="System.Drawing.Size, System.Drawing">
+    <value>372, 35</value>
+  </data>
+  <data name="ucrPnlReshapeClimaticData.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlReshapeClimaticData.Name" xml:space="preserve">
+    <value>ucrPnlReshapeClimaticData</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlReshapeClimaticData.Type" xml:space="preserve">
+    <value>instat.UcrPanel, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlReshapeClimaticData.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlReshapeClimaticData.ZOrder" xml:space="preserve">
+    <value>17</value>
+  </data>
+  <data name="ucrSelectorTidyDailyData.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 66</value>
+  </data>
+  <data name="ucrSelectorTidyDailyData.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="ucrSelectorTidyDailyData.Size" type="System.Drawing.Size, System.Drawing">
+    <value>210, 180</value>
+  </data>
+  <data name="ucrSelectorTidyDailyData.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;ucrSelectorTidyDailyData.Name" xml:space="preserve">
+    <value>ucrSelectorTidyDailyData</value>
+  </data>
+  <data name="&gt;&gt;ucrSelectorTidyDailyData.Type" xml:space="preserve">
+    <value>instat.ucrSelectorByDataFrameAddRemove, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrSelectorTidyDailyData.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrSelectorTidyDailyData.ZOrder" xml:space="preserve">
+    <value>19</value>
+  </data>
+  <data name="ucrReceiverStation.Location" type="System.Drawing.Point, System.Drawing">
+    <value>282, 306</value>
+  </data>
+  <data name="ucrReceiverStation.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="ucrReceiverStation.Size" type="System.Drawing.Size, System.Drawing">
+    <value>120, 20</value>
+  </data>
+  <data name="ucrReceiverStation.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverStation.Name" xml:space="preserve">
+    <value>ucrReceiverStation</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverStation.Type" xml:space="preserve">
+    <value>instat.ucrReceiverSingle, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverStation.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverStation.ZOrder" xml:space="preserve">
+    <value>20</value>
+  </data>
+  <data name="ucrBase.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 524</value>
+  </data>
+  <data name="ucrBase.Size" type="System.Drawing.Size, System.Drawing">
+    <value>410, 52</value>
+  </data>
+  <data name="ucrBase.TabIndex" type="System.Int32, mscorlib">
+    <value>25</value>
+  </data>
+  <data name="&gt;&gt;ucrBase.Name" xml:space="preserve">
+    <value>ucrBase</value>
+  </data>
+  <data name="&gt;&gt;ucrBase.Type" xml:space="preserve">
+    <value>instat.ucrButtons, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrBase.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrBase.ZOrder" xml:space="preserve">
+    <value>21</value>
+  </data>
+  <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
+    <value>CenterScreen</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>Tidy Daily Data</value>
+  </data>
+  <data name="&gt;&gt;ttReshapeType.Name" xml:space="preserve">
+    <value>ttReshapeType</value>
+  </data>
+  <data name="&gt;&gt;ttReshapeType.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>dlgTidyDailyData</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Form, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="ucrReceiverElement.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 98</value>
+  </data>
+  <data name="ucrReceiverElement.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="ucrReceiverElement.Size" type="System.Drawing.Size, System.Drawing">
+    <value>120, 20</value>
+  </data>
+  <data name="ucrReceiverElement.TabIndex" type="System.Int32, mscorlib">
+    <value>20</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverElement.Name" xml:space="preserve">
+    <value>ucrReceiverElement</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverElement.Type" xml:space="preserve">
+    <value>instat.ucrReceiverSingle, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverElement.Parent" xml:space="preserve">
+    <value>grpElements</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverElement.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="grpElements.Location" type="System.Drawing.Point, System.Drawing">
+    <value>269, 337</value>
+  </data>
+  <data name="grpElements.Size" type="System.Drawing.Size, System.Drawing">
+    <value>144, 152</value>
+  </data>
+  <data name="grpElements.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="&gt;&gt;grpElements.Name" xml:space="preserve">
+    <value>grpElements</value>
+  </data>
+  <data name="&gt;&gt;grpElements.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;grpElements.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;grpElements.ZOrder" xml:space="preserve">
+    <value>4</value>
   </data>
   <data name="ucrChkIgnoreInvalid.Location" type="System.Drawing.Point, System.Drawing">
     <value>8, 19</value>
@@ -614,279 +965,6 @@
   </data>
   <data name="&gt;&gt;ucrChkSilent.ZOrder" xml:space="preserve">
     <value>1</value>
-  </data>
-  <data name="grpOptions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 289</value>
-  </data>
-  <data name="grpOptions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>223, 83</value>
-  </data>
-  <data name="grpOptions.TabIndex" type="System.Int32, mscorlib">
-    <value>21</value>
-  </data>
-  <data name="grpOptions.Text" xml:space="preserve">
-    <value>Options</value>
-  </data>
-  <data name="&gt;&gt;grpOptions.Name" xml:space="preserve">
-    <value>grpOptions</value>
-  </data>
-  <data name="&gt;&gt;grpOptions.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;grpOptions.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;grpOptions.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="ucrReceiverMultipleStack.Location" type="System.Drawing.Point, System.Drawing">
-    <value>282, 98</value>
-  </data>
-  <data name="ucrReceiverMultipleStack.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
-  </data>
-  <data name="ucrReceiverMultipleStack.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 100</value>
-  </data>
-  <data name="ucrReceiverMultipleStack.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverMultipleStack.Name" xml:space="preserve">
-    <value>ucrReceiverMultipleStack</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverMultipleStack.Type" xml:space="preserve">
-    <value>instat.ucrReceiverMultiple, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverMultipleStack.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverMultipleStack.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="ucrReceiverMonth.Location" type="System.Drawing.Point, System.Drawing">
-    <value>282, 276</value>
-  </data>
-  <data name="ucrReceiverMonth.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
-  </data>
-  <data name="ucrReceiverMonth.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 20</value>
-  </data>
-  <data name="ucrReceiverMonth.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverMonth.Name" xml:space="preserve">
-    <value>ucrReceiverMonth</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverMonth.Type" xml:space="preserve">
-    <value>instat.ucrReceiverSingle, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverMonth.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverMonth.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="ucrReceiverDayofMonth.Location" type="System.Drawing.Point, System.Drawing">
-    <value>282, 276</value>
-  </data>
-  <data name="ucrReceiverDayofMonth.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
-  </data>
-  <data name="ucrReceiverDayofMonth.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 20</value>
-  </data>
-  <data name="ucrReceiverDayofMonth.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverDayofMonth.Name" xml:space="preserve">
-    <value>ucrReceiverDayofMonth</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverDayofMonth.Type" xml:space="preserve">
-    <value>instat.ucrReceiverSingle, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverDayofMonth.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverDayofMonth.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="ucrReceiverYear.Location" type="System.Drawing.Point, System.Drawing">
-    <value>282, 228</value>
-  </data>
-  <data name="ucrReceiverYear.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
-  </data>
-  <data name="ucrReceiverYear.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 20</value>
-  </data>
-  <data name="ucrReceiverYear.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverYear.Name" xml:space="preserve">
-    <value>ucrReceiverYear</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverYear.Type" xml:space="preserve">
-    <value>instat.ucrReceiverSingle, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverYear.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverYear.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="ucrPnlReshapeClimaticData.Location" type="System.Drawing.Point, System.Drawing">
-    <value>41, 26</value>
-  </data>
-  <data name="ucrPnlReshapeClimaticData.Size" type="System.Drawing.Size, System.Drawing">
-    <value>372, 35</value>
-  </data>
-  <data name="ucrPnlReshapeClimaticData.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;ucrPnlReshapeClimaticData.Name" xml:space="preserve">
-    <value>ucrPnlReshapeClimaticData</value>
-  </data>
-  <data name="&gt;&gt;ucrPnlReshapeClimaticData.Type" xml:space="preserve">
-    <value>instat.UcrPanel, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrPnlReshapeClimaticData.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;ucrPnlReshapeClimaticData.ZOrder" xml:space="preserve">
-    <value>16</value>
-  </data>
-  <data name="ucrSelectorTidyDailyData.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 85</value>
-  </data>
-  <data name="ucrSelectorTidyDailyData.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
-  </data>
-  <data name="ucrSelectorTidyDailyData.Size" type="System.Drawing.Size, System.Drawing">
-    <value>210, 180</value>
-  </data>
-  <data name="ucrSelectorTidyDailyData.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;ucrSelectorTidyDailyData.Name" xml:space="preserve">
-    <value>ucrSelectorTidyDailyData</value>
-  </data>
-  <data name="&gt;&gt;ucrSelectorTidyDailyData.Type" xml:space="preserve">
-    <value>instat.ucrSelectorByDataFrameAddRemove, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrSelectorTidyDailyData.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;ucrSelectorTidyDailyData.ZOrder" xml:space="preserve">
-    <value>18</value>
-  </data>
-  <data name="ucrReceiverStation.Location" type="System.Drawing.Point, System.Drawing">
-    <value>282, 325</value>
-  </data>
-  <data name="ucrReceiverStation.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
-  </data>
-  <data name="ucrReceiverStation.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 20</value>
-  </data>
-  <data name="ucrReceiverStation.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverStation.Name" xml:space="preserve">
-    <value>ucrReceiverStation</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverStation.Type" xml:space="preserve">
-    <value>instat.ucrReceiverSingle, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverStation.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverStation.ZOrder" xml:space="preserve">
-    <value>19</value>
-  </data>
-  <data name="ucrBase.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 524</value>
-  </data>
-  <data name="ucrBase.Size" type="System.Drawing.Size, System.Drawing">
-    <value>410, 52</value>
-  </data>
-  <data name="ucrBase.TabIndex" type="System.Int32, mscorlib">
-    <value>25</value>
-  </data>
-  <data name="&gt;&gt;ucrBase.Name" xml:space="preserve">
-    <value>ucrBase</value>
-  </data>
-  <data name="&gt;&gt;ucrBase.Type" xml:space="preserve">
-    <value>instat.ucrButtons, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrBase.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;ucrBase.ZOrder" xml:space="preserve">
-    <value>20</value>
-  </data>
-  <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
-    <value>CenterScreen</value>
-  </data>
-  <data name="$this.Text" xml:space="preserve">
-    <value>Tidy Daily Data</value>
-  </data>
-  <data name="&gt;&gt;ttReshapeType.Name" xml:space="preserve">
-    <value>ttReshapeType</value>
-  </data>
-  <data name="&gt;&gt;ttReshapeType.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;$this.Name" xml:space="preserve">
-    <value>dlgTidyDailyData</value>
-  </data>
-  <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Form, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="ucrReceiverElement.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 98</value>
-  </data>
-  <data name="ucrReceiverElement.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
-  </data>
-  <data name="ucrReceiverElement.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 20</value>
-  </data>
-  <data name="ucrReceiverElement.TabIndex" type="System.Int32, mscorlib">
-    <value>20</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverElement.Name" xml:space="preserve">
-    <value>ucrReceiverElement</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverElement.Type" xml:space="preserve">
-    <value>instat.ucrReceiverSingle, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverElement.Parent" xml:space="preserve">
-    <value>grpElements</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverElement.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="grpElements.Location" type="System.Drawing.Point, System.Drawing">
-    <value>269, 356</value>
-  </data>
-  <data name="grpElements.Size" type="System.Drawing.Size, System.Drawing">
-    <value>144, 132</value>
-  </data>
-  <data name="grpElements.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
-  </data>
-  <data name="&gt;&gt;grpElements.Name" xml:space="preserve">
-    <value>grpElements</value>
-  </data>
-  <data name="&gt;&gt;grpElements.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;grpElements.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;grpElements.ZOrder" xml:space="preserve">
-    <value>3</value>
   </data>
   <metadata name="ttReshapeType.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>

--- a/instat/dlgTidyDailyData.resx
+++ b/instat/dlgTidyDailyData.resx
@@ -157,16 +157,16 @@
     <value>NoControl</value>
   </data>
   <data name="rdoDay.Location" type="System.Drawing.Point, System.Drawing">
-    <value>282, 30</value>
+    <value>284, 30</value>
   </data>
   <data name="rdoDay.Size" type="System.Drawing.Size, System.Drawing">
-    <value>113, 27</value>
+    <value>120, 27</value>
   </data>
   <data name="rdoDay.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
   </data>
   <data name="rdoDay.Text" xml:space="preserve">
-    <value>Day Columns (31)</value>
+    <value>Day Columns (31/62)</value>
   </data>
   <data name="rdoDay.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
     <value>MiddleCenter</value>
@@ -193,10 +193,10 @@
     <value>NoControl</value>
   </data>
   <data name="rdoMonth.Location" type="System.Drawing.Point, System.Drawing">
-    <value>171, 30</value>
+    <value>166, 30</value>
   </data>
   <data name="rdoMonth.Size" type="System.Drawing.Size, System.Drawing">
-    <value>113, 27</value>
+    <value>120, 27</value>
   </data>
   <data name="rdoMonth.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -229,10 +229,10 @@
     <value>NoControl</value>
   </data>
   <data name="rdoYear.Location" type="System.Drawing.Point, System.Drawing">
-    <value>60, 30</value>
+    <value>48, 30</value>
   </data>
   <data name="rdoYear.Size" type="System.Drawing.Size, System.Drawing">
-    <value>113, 27</value>
+    <value>120, 27</value>
   </data>
   <data name="rdoYear.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -573,6 +573,15 @@
   <data name="&gt;&gt;ucrInputNewDataFrame.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="ucrChkIgnoreInvalid.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 19</value>
+  </data>
+  <data name="ucrChkIgnoreInvalid.Size" type="System.Drawing.Size, System.Drawing">
+    <value>209, 20</value>
+  </data>
+  <data name="ucrChkIgnoreInvalid.TabIndex" type="System.Int32, mscorlib">
+    <value>22</value>
+  </data>
   <data name="&gt;&gt;ucrChkIgnoreInvalid.Name" xml:space="preserve">
     <value>ucrChkIgnoreInvalid</value>
   </data>
@@ -584,6 +593,15 @@
   </data>
   <data name="&gt;&gt;ucrChkIgnoreInvalid.ZOrder" xml:space="preserve">
     <value>0</value>
+  </data>
+  <data name="ucrChkSilent.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 53</value>
+  </data>
+  <data name="ucrChkSilent.Size" type="System.Drawing.Size, System.Drawing">
+    <value>209, 20</value>
+  </data>
+  <data name="ucrChkSilent.TabIndex" type="System.Int32, mscorlib">
+    <value>23</value>
   </data>
   <data name="&gt;&gt;ucrChkSilent.Name" xml:space="preserve">
     <value>ucrChkSilent</value>
@@ -718,10 +736,10 @@
     <value>12</value>
   </data>
   <data name="ucrPnlReshapeClimaticData.Location" type="System.Drawing.Point, System.Drawing">
-    <value>60, 26</value>
+    <value>41, 26</value>
   </data>
   <data name="ucrPnlReshapeClimaticData.Size" type="System.Drawing.Size, System.Drawing">
-    <value>335, 35</value>
+    <value>372, 35</value>
   </data>
   <data name="ucrPnlReshapeClimaticData.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -813,6 +831,12 @@
   <data name="$this.Text" xml:space="preserve">
     <value>Tidy Daily Data</value>
   </data>
+  <data name="&gt;&gt;ttReshapeType.Name" xml:space="preserve">
+    <value>ttReshapeType</value>
+  </data>
+  <data name="&gt;&gt;ttReshapeType.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>dlgTidyDailyData</value>
   </data>
@@ -864,46 +888,7 @@
   <data name="&gt;&gt;grpElements.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
-  <data name="ucrChkIgnoreInvalid.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 19</value>
-  </data>
-  <data name="ucrChkIgnoreInvalid.Size" type="System.Drawing.Size, System.Drawing">
-    <value>209, 20</value>
-  </data>
-  <data name="ucrChkIgnoreInvalid.TabIndex" type="System.Int32, mscorlib">
-    <value>22</value>
-  </data>
-  <data name="&gt;&gt;ucrChkIgnoreInvalid.Name" xml:space="preserve">
-    <value>ucrChkIgnoreInvalid</value>
-  </data>
-  <data name="&gt;&gt;ucrChkIgnoreInvalid.Type" xml:space="preserve">
-    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrChkIgnoreInvalid.Parent" xml:space="preserve">
-    <value>grpOptions</value>
-  </data>
-  <data name="&gt;&gt;ucrChkIgnoreInvalid.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="ucrChkSilent.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 53</value>
-  </data>
-  <data name="ucrChkSilent.Size" type="System.Drawing.Size, System.Drawing">
-    <value>209, 20</value>
-  </data>
-  <data name="ucrChkSilent.TabIndex" type="System.Int32, mscorlib">
-    <value>23</value>
-  </data>
-  <data name="&gt;&gt;ucrChkSilent.Name" xml:space="preserve">
-    <value>ucrChkSilent</value>
-  </data>
-  <data name="&gt;&gt;ucrChkSilent.Type" xml:space="preserve">
-    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrChkSilent.Parent" xml:space="preserve">
-    <value>grpOptions</value>
-  </data>
-  <data name="&gt;&gt;ucrChkSilent.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
+  <metadata name="ttReshapeType.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>

--- a/instat/dlgTidyDailyData.resx
+++ b/instat/dlgTidyDailyData.resx
@@ -556,13 +556,10 @@
     <value>385, 61</value>
   </data>
   <data name="lblNColumns.Size" type="System.Drawing.Size, System.Drawing">
-    <value>19, 13</value>
+    <value>0, 13</value>
   </data>
   <data name="lblNColumns.TabIndex" type="System.Int32, mscorlib">
     <value>28</value>
-  </data>
-  <data name="lblNColumns.Text" xml:space="preserve">
-    <value>(0)</value>
   </data>
   <data name="&gt;&gt;lblNColumns.Name" xml:space="preserve">
     <value>lblNColumns</value>
@@ -627,6 +624,15 @@
   <data name="&gt;&gt;ucrInputNewDataFrame.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
+  <data name="ucrChkIgnoreInvalid.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 19</value>
+  </data>
+  <data name="ucrChkIgnoreInvalid.Size" type="System.Drawing.Size, System.Drawing">
+    <value>209, 20</value>
+  </data>
+  <data name="ucrChkIgnoreInvalid.TabIndex" type="System.Int32, mscorlib">
+    <value>22</value>
+  </data>
   <data name="&gt;&gt;ucrChkIgnoreInvalid.Name" xml:space="preserve">
     <value>ucrChkIgnoreInvalid</value>
   </data>
@@ -638,6 +644,15 @@
   </data>
   <data name="&gt;&gt;ucrChkIgnoreInvalid.ZOrder" xml:space="preserve">
     <value>0</value>
+  </data>
+  <data name="ucrChkSilent.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 53</value>
+  </data>
+  <data name="ucrChkSilent.Size" type="System.Drawing.Size, System.Drawing">
+    <value>209, 20</value>
+  </data>
+  <data name="ucrChkSilent.TabIndex" type="System.Int32, mscorlib">
+    <value>23</value>
   </data>
   <data name="&gt;&gt;ucrChkSilent.Name" xml:space="preserve">
     <value>ucrChkSilent</value>
@@ -923,48 +938,6 @@
   </data>
   <data name="&gt;&gt;grpElements.ZOrder" xml:space="preserve">
     <value>4</value>
-  </data>
-  <data name="ucrChkIgnoreInvalid.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 19</value>
-  </data>
-  <data name="ucrChkIgnoreInvalid.Size" type="System.Drawing.Size, System.Drawing">
-    <value>209, 20</value>
-  </data>
-  <data name="ucrChkIgnoreInvalid.TabIndex" type="System.Int32, mscorlib">
-    <value>22</value>
-  </data>
-  <data name="&gt;&gt;ucrChkIgnoreInvalid.Name" xml:space="preserve">
-    <value>ucrChkIgnoreInvalid</value>
-  </data>
-  <data name="&gt;&gt;ucrChkIgnoreInvalid.Type" xml:space="preserve">
-    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrChkIgnoreInvalid.Parent" xml:space="preserve">
-    <value>grpOptions</value>
-  </data>
-  <data name="&gt;&gt;ucrChkIgnoreInvalid.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="ucrChkSilent.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 53</value>
-  </data>
-  <data name="ucrChkSilent.Size" type="System.Drawing.Size, System.Drawing">
-    <value>209, 20</value>
-  </data>
-  <data name="ucrChkSilent.TabIndex" type="System.Int32, mscorlib">
-    <value>23</value>
-  </data>
-  <data name="&gt;&gt;ucrChkSilent.Name" xml:space="preserve">
-    <value>ucrChkSilent</value>
-  </data>
-  <data name="&gt;&gt;ucrChkSilent.Type" xml:space="preserve">
-    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrChkSilent.Parent" xml:space="preserve">
-    <value>grpOptions</value>
-  </data>
-  <data name="&gt;&gt;ucrChkSilent.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <metadata name="ttReshapeType.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>

--- a/instat/dlgTidyDailyData.vb
+++ b/instat/dlgTidyDailyData.vb
@@ -52,9 +52,12 @@ Public Class dlgTidyDailyData
         ucrPnlReshapeClimaticData.AddRadioButton(rdoMonth)
         ucrPnlReshapeClimaticData.AddRadioButton(rdoDay)
 
+        ttReshapeType.SetToolTip(rdoYear, "One column for each year")
+        ttReshapeType.SetToolTip(rdoMonth, "One column for each month (12)")
+        ttReshapeType.SetToolTip(rdoDay, "One column for each day in month (31), or alternative value/flag columns for each day in month (62)")
+
         ucrSelectorTidyDailyData.SetParameter(New RParameter("x", 0))
         ucrSelectorTidyDailyData.SetParameterIsrfunction()
-
 
         ucrReceiverStation.Selector = ucrSelectorTidyDailyData
         ucrReceiverMultipleStack.Selector = ucrSelectorTidyDailyData
@@ -66,7 +69,6 @@ Public Class dlgTidyDailyData
 
         ucrReceiverMultipleStack.SetParameter(New RParameter("stack_cols", 2))
         ucrReceiverMultipleStack.SetParameterIsString()
-
 
         ucrReceiverStation.SetParameter(New RParameter("station", 6))
         ucrReceiverStation.SetParameterIsString()
@@ -205,10 +207,13 @@ Public Class dlgTidyDailyData
     Private Sub ColumnstoStackText()
         If rdoYear.Checked Then
             lblColumnstoStack.Text = "Year Columns:"
+            ttReshapeType.SetToolTip(lblColumnstoStack, ttReshapeType.GetToolTip(rdoYear))
         ElseIf rdoMonth.Checked Then
             lblColumnstoStack.Text = "Month Columns (12):"
+            ttReshapeType.SetToolTip(lblColumnstoStack, ttReshapeType.GetToolTip(rdoMonth))
         Else
-            lblColumnstoStack.Text = "Day Columns (31):"
+            lblColumnstoStack.Text = "Day Columns (31/62):"
+            ttReshapeType.SetToolTip(lblColumnstoStack, ttReshapeType.GetToolTip(rdoDay))
         End If
     End Sub
 

--- a/instat/dlgTidyDailyData.vb
+++ b/instat/dlgTidyDailyData.vb
@@ -60,40 +60,54 @@ Public Class dlgTidyDailyData
         ucrSelectorTidyDailyData.SetParameterIsrfunction()
 
         ucrReceiverStation.Selector = ucrSelectorTidyDailyData
-        ucrReceiverMultipleStack.Selector = ucrSelectorTidyDailyData
-        ucrReceiverElement.Selector = ucrSelectorTidyDailyData
-
-        ucrReceiverYear.Selector = ucrSelectorTidyDailyData
-        ucrReceiverMonth.Selector = ucrSelectorTidyDailyData
-        ucrReceiverDayofMonth.Selector = ucrSelectorTidyDailyData
-
-        ucrReceiverMultipleStack.SetParameter(New RParameter("stack_cols", 2))
-        ucrReceiverMultipleStack.SetParameterIsString()
-
         ucrReceiverStation.SetParameter(New RParameter("station", 6))
         ucrReceiverStation.SetParameterIsString()
+        ucrReceiverStation.bExcludeFromSelector = True
+        ucrReceiverStation.SetLinkedDisplayControl(lblStation)
 
+        ucrReceiverMultipleStack.Selector = ucrSelectorTidyDailyData
+        ucrReceiverMultipleStack.SetParameter(New RParameter("stack_cols", 2))
+        ucrReceiverMultipleStack.SetParameterIsString()
+        ucrReceiverMultipleStack.bExcludeFromSelector = True
+
+        ucrReceiverElement.Selector = ucrSelectorTidyDailyData
         ucrReceiverElement.SetParameter(New RParameter("element", 7))
         ucrReceiverElement.SetParameterIsString()
+        ucrReceiverElement.bExcludeFromSelector = True
+        ucrReceiverElement.SetLinkedDisplayControl(lblMultipleElement)
 
         ucrTextBoxElementName.SetParameter(New RParameter("element_name", 8))
         ucrTextBoxElementName.SetRDefault(Chr(34) & "value" & Chr(34))
         ucrTextBoxElementName.SetValidationTypeAsRVariable()
+        ucrTextBoxElementName.SetLinkedDisplayControl(lblElementName)
+
+        ucrChkUnstackElements.SetText("Unstack elements")
+        ucrChkUnstackElements.SetParameter(New RParameter("unstack_elements", 12), bNewChangeParameterValue:=True)
+        ucrChkUnstackElements.SetRDefault("TRUE")
 
         'rdoYear
-        'TODO; Receivers for Station, Month and Day might be added later for the "Year Columns" format.
+        'TODO Receivers for Station, Month and Day might be added later for the "Year Columns" format but not currently needed from the "Instat" format.
 
         'rdoMonth
+        ucrReceiverYear.Selector = ucrSelectorTidyDailyData
         ucrReceiverYear.SetParameter(New RParameter("year", 5))
         ucrReceiverYear.SetParameterIsString()
+        ucrReceiverYear.bExcludeFromSelector = True
+        ucrReceiverYear.SetLinkedDisplayControl(lblYear)
 
+        ucrReceiverDayofMonth.Selector = ucrSelectorTidyDailyData
         ucrReceiverDayofMonth.SetParameter(New RParameter("day", 3))
         ucrReceiverDayofMonth.SetParameterIsString()
+        ucrReceiverDayofMonth.bExcludeFromSelector = True
+        ucrReceiverDayofMonth.SetLinkedDisplayControl(lblDayofMonth)
 
         'rdoDay
 
+        ucrReceiverMonth.Selector = ucrSelectorTidyDailyData
         ucrReceiverMonth.SetParameter(New RParameter("month", 4))
         ucrReceiverMonth.SetParameterIsString()
+        ucrReceiverMonth.bExcludeFromSelector = True
+        ucrReceiverMonth.SetLinkedDisplayControl(lblMonth)
 
         'Checkboxes
         ucrChkIgnoreInvalid.SetParameter(New RParameter("ignore_invalid", 9))
@@ -115,16 +129,6 @@ Public Class dlgTidyDailyData
         ucrPnlReshapeClimaticData.AddParameterValuesCondition(rdoYear, "format", Chr(34) & "years" & Chr(34))
         ucrPnlReshapeClimaticData.AddParameterValuesCondition(rdoMonth, "format", Chr(34) & "months" & Chr(34))
         ucrPnlReshapeClimaticData.AddParameterValuesCondition(rdoDay, "format", Chr(34) & "days" & Chr(34))
-
-        ucrReceiverStation.SetLinkedDisplayControl(lblStation)
-
-        ucrReceiverYear.SetLinkedDisplayControl(lblYear)
-        ucrReceiverDayofMonth.SetLinkedDisplayControl(lblDayofMonth)
-
-        ucrReceiverMonth.SetLinkedDisplayControl(lblMonth)
-
-        ucrReceiverElement.SetLinkedDisplayControl(lblMultipleElement)
-        ucrTextBoxElementName.SetLinkedDisplayControl(lblElementName)
 
         ucrInputNewDataFrame.SetParameter(New RParameter("new_name", iNewPosition:=12))
         ucrInputNewDataFrame.SetDefaultTypeAsDataFrame()
@@ -233,9 +237,11 @@ Public Class dlgTidyDailyData
         If Not ucrReceiverElement.IsEmpty Then
             clsTidyClimaticFunction.RemoveParameterByName("element_name")
             ucrTextBoxElementName.Enabled = False
+            ucrChkUnstackElements.Visible = True
         Else
             clsTidyClimaticFunction.AddParameter("element_name", Chr(34) & ucrTextBoxElementName.GetText & Chr(34), iPosition:=8)
             ucrTextBoxElementName.Enabled = True
+            ucrChkUnstackElements.Visible = False
         End If
     End Sub
 
@@ -259,4 +265,7 @@ Public Class dlgTidyDailyData
         ElementAddRemoveParam()
     End Sub
 
+    Private Sub ucrReceiverMultipleStack_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverMultipleStack.ControlValueChanged
+        lblNColumns.Text = "(" & ucrReceiverMultipleStack.lstSelectedVariables.Items.Count & ")"
+    End Sub
 End Class

--- a/instat/static/InstatObject/R/instat_object_R6.R
+++ b/instat/static/InstatObject/R/instat_object_R6.R
@@ -2074,7 +2074,7 @@ DataBook$set("public","tidy_climatic_data", function(x, format, stack_cols, day,
   
   if(continue) {
     # Standard format of slowest varying structure variables first (station then element then date) followed by measurements
-    if(!missing(station)) z <- data.frame(station = y$station, date = y$date)
+    if(!missing(station)) z <- data.frame(station = forcats::as_factor(y$station), date = y$date)
     else z <- data.frame(date = y$date)
     if(!missing(element)) z$element <- y$element
     z[[element_name]] <- y[[element_name]]
@@ -2112,7 +2112,6 @@ DataBook$set("public","tidy_climatic_data", function(x, format, stack_cols, day,
     if(continue) {
       # Add this last to ensure date varies fastest
       id_cols <- c(id_cols, "date")
-      print(id_cols)
       # TODO Find a better way to do this. Update if there could be more the 3 id cols.
       if(length(id_cols) == 1) {
         z <- z %>% dplyr::arrange(.data[[id_cols[1]]])

--- a/instat/static/InstatObject/R/instat_object_R6.R
+++ b/instat/static/InstatObject/R/instat_object_R6.R
@@ -2050,10 +2050,10 @@ DataBook$set("public","tidy_climatic_data", function(x, format, stack_cols, day,
       cat("\n*** Invalid dates ***\n\n")
       invalid_data <- dplyr::filter(y, invalid_ind)
       if(format == "days" || format == "months") {
-        invalid_data_display <- invalid_data %>% select(year, month, day)
+        invalid_data_display <- invalid_data %>% dplyr::select(year, month, day)
       }
       else {
-        invalid_data_display <- invalid_data %>% select(year, doy)
+        invalid_data_display <- invalid_data %>% dplyr::select(year, doy)
       }
       if(!missing(station)) {
         invalid_data_display <- data.frame(station = invalid_data$station, invalid_data_display)

--- a/instat/static/InstatObject/R/instat_object_R6.R
+++ b/instat/static/InstatObject/R/instat_object_R6.R
@@ -1935,6 +1935,7 @@ DataBook$set("public","tidy_climatic_data", function(x, format, stack_cols, day,
       # We assume that value/flag columns alternate and are in correct order i.e. c(value1, flag1, value2, flag2, ..., value31, flag31)
       val_col_names <- stack_cols[seq(1, 2 * ndays - 1, 2)]
       flag_col_names <- stack_cols[seq(2, 2 * ndays, 2)]
+      # TODO This should be a more global function
       if(!all(sapply(x[, val_col_names], function(col) is.numeric(col) || (is.logical(col) && all(is.na(col)))))) stop("Every other column must be numeric to represent values (starting with the first columns). \nThe following value columns are not numeric: ", paste(stack_cols[!sapply(x[, val_col_names], is.numeric)], collapse = ","))
       # Name of flag column
       flag_name <- "flag"

--- a/instat/static/InstatObject/R/instat_object_R6.R
+++ b/instat/static/InstatObject/R/instat_object_R6.R
@@ -1822,6 +1822,8 @@ DataBook$set("public", "crops_definitions", function(data_name, year, station, r
 #' If FALSE (the default) an error will be given with details of where the values occur.
 #' Strongly recommended to first run with FALSE and then TRUE after examining or correcting any issues.
 #' @param silent If TRUE, rows with non missing element values on invalid dates will not be reported.
+#' @param unstack_elements If TRUE, when there are multiple elements there will be one column for each element (unstacked), otherwise there will be an element
+#' column and a value column. This also applies to flag columns if included.
 #' @param new_name Name for the new data frame.
 #' @export
 #' @examples
@@ -1831,11 +1833,10 @@ DataBook$set("public", "crops_definitions", function(data_name, year, station, r
 #' yearcols[60,4:6] <- NA
 #' tidy_climatic_data(x = yearcols, format = "years", stack_cols = c("X2000", "X2001", "X2002", "X2003"), element_name = "tmin")
 
-DataBook$set("public","tidy_climatic_data", function(x, format, stack_cols, day, month, year, stack_years, station, element, element_name = "value", ignore_invalid = FALSE, silent = FALSE, new_name) {
+DataBook$set("public","tidy_climatic_data", function(x, format, stack_cols, day, month, year, stack_years, station, element, element_name = "value", ignore_invalid = FALSE, silent = FALSE, unstack_elements = TRUE, new_name) {
   
   if(!format %in% c("days", "months", "years")) stop("format must be either 'days', 'months' or 'years'")
   if(!all(stack_cols %in% names(x))) stop("Some of the stack_cols were not found in x.")
-  if(!all(sapply(x[, stack_cols], function(col) is.numeric(col) || (is.logical(col) && all(is.na(col)))))) stop("All stack_cols must be numeric\nThe following stack_cols are not numeric: ", paste(stack_cols[!sapply(x[, stack_cols], is.numeric)], collapse = ","))
   if(!missing(day) && !day %in% names(x)) stop("day column not found in x.")
   if(!missing(month) && !month %in% names(x)) stop("month column not found in x.")
   if(!missing(year) && !year %in% names(x)) stop("year column not found in x.")
@@ -1869,6 +1870,14 @@ DataBook$set("public","tidy_climatic_data", function(x, format, stack_cols, day,
       # Month format will be used in as.Date()
       month_format <- "%m"
     }
+    # This case is for numeric months but stored as character e.g. c("1", "2")
+    else if(all(!is.na(as.numeric(month_data)))) {
+      if(all(as.numeric(month_data) %in% 1:12)) {
+        month_format <- "%m"
+        # This ensures format is correct and removes any spaces etc. e.g. "1 " -> 1
+        x[[month]] <- as.numeric(month_data)
+      }
+    }
     else {
       # Convert to title case to match month.name and month.abb
       month_data_title <- stringr::str_to_title(month_data)
@@ -1894,19 +1903,20 @@ DataBook$set("public","tidy_climatic_data", function(x, format, stack_cols, day,
   if(!missing(year)) {
     year_data <- x[[year]]
     if(anyNA(year_data)) stop("year column contains: ", sum(is.na(year_data)), " missing values")
-    if(!is.numeric(year_data)) stop("year column must be numeric")
-    
     year_format <- ""
+    if(!is.numeric(year_data)) {
+      if(all(!is.na(as.numeric(year_data)))) {
+        x[[year]] <- as.numeric(year_data)
+        year_data <- x[[year]]
+      }
+      else stop("Cannot recognise years from year column. Try using a numeric year column.")
+    }
     if(all(stringr::str_length(year_data) == 4)) year_format <- "%Y"
     else if(all(stringr::str_length(year_data) == 2)) year_format <- "%y"
-    else {
-      stop("Inconsistent values found in year column. Year column must be column of four digit years or column of two digit years")
-    }
+    else stop("Inconsistent values found in year column. Year column must be column of four digit years or column of two digit years")
   }
   
-  
   if(format == "days") {
-    
     # month column required in this case
     if(missing(month)) stop("month column is required when format == 'days'")
     
@@ -1914,7 +1924,21 @@ DataBook$set("public","tidy_climatic_data", function(x, format, stack_cols, day,
     if(missing(year)) stop("year column is required when format == 'days'")
     
     # stack column checks
-    if(length(stack_cols) != 31) stop("You have specified: ", length(stack_cols), " stack columns\nThere must be exactly 31 stack columns when format == 'days'")
+    if(length(stack_cols) != 31 && length(stack_cols) != 62) stop("You have specified: ", length(stack_cols), " stack columns\nThere must be exactly 31 or 62 stack columns when format == 'days'")
+    
+    # TRUE if flag columns are included
+    flags <- length(stack_cols) == 62
+    if(flags) {
+      # We assume that value/flag columns alternate and are in correct order i.e. c(value1, flag1, value2, flag2, ..., value31, flag31)
+      val_col_names <- stack_cols[seq(1, 61, 2)]
+      flag_col_names <- stack_cols[seq(2, 62, 2)]
+      if(!all(sapply(x[, val_col_names], function(col) is.numeric(col) || (is.logical(col) && all(is.na(col)))))) stop("Every other column must be numeric to represent values (starting with the first columns). \nThe following value columns are not numeric: ", paste(stack_cols[!sapply(x[, val_col_names], is.numeric)], collapse = ","))
+      # Name of flag column
+      flag_name <- "flag"
+    }
+    else {
+      if(!all(sapply(x[, stack_cols], function(col) is.numeric(col) || (is.logical(col) && all(is.na(col)))))) stop("All stack_cols must be numeric\nThe following stack_cols are not numeric: ", paste(stack_cols[!sapply(x[, stack_cols], is.numeric)], collapse = ","))
+    }
     
     # This ensures all other columns are dropped
     y <- data.frame(year = x[[year]], month = x[[month]], x[ , stack_cols])
@@ -1922,14 +1946,27 @@ DataBook$set("public","tidy_climatic_data", function(x, format, stack_cols, day,
     if(!missing(element)) y$element <- x[[element]]
     # In case element_name is the name of an existing column in y
     if(element_name %in% names(y)) element_name <- next_default_item(prefix = element_name, existing_names = names(y))
-    y <- reshape2::melt(y, measure.vars = stack_cols, value.name = element_name, variable.name = "day")
-    
-    # This assumes stack_cols are in the correct order i.e. 1 - 31
-    y$day <- as.numeric(y$day)
+    if(flags) {
+      # renaming the stack_cols with a consistent pattern makes it possible for pivot_longer to stack both sets of columns together and construct the day column correctly
+      # This assumes stack_cols are in the correct order i.e. c(value1, flag1, value2, flag2, ..., value31, flag31)
+      new_stack_cols <- paste(c("value", "flag"), rep(1:31, each = 2), sep = "_")
+      names(y)[names(y) %in% stack_cols] <- new_stack_cols
+      # ".value" is a special sentinel used in names_to ensure names of value columns come from the names of cols. See ?pivot_longer values_to section for details.
+      y <- tidyr::pivot_longer(y, cols = tidyselect::all_of(new_stack_cols), names_to = c(".value", "day"), names_sep = "_")
+    }
+    else {
+      # renaming the stack_cols so that the day column can be constructed correctly
+      # This assumes stack_cols are in the correct order i.e. 1 - 31
+      new_stack_cols <- paste0("day", 1:31)
+      names(y)[names(y) %in% stack_cols] <- new_stack_cols
+      y <- tidyr::pivot_longer(y, cols = tidyselect::all_of(new_stack_cols), names_to = "day", values_to = element_name)
+      y$day <- substr(y$day, 4, 5)
+    }
     
     y$date <- as.Date(paste(y$year, y$month, y$day), format = paste(year_format, month_format, "%d"))
   }
   else if(format == "months") {
+    if(!all(sapply(x[, stack_cols], function(col) is.numeric(col) || (is.logical(col) && all(is.na(col)))))) stop("All stack_cols must be numeric\nThe following stack_cols are not numeric: ", paste(stack_cols[!sapply(x[, stack_cols], is.numeric)], collapse = ","))
     
     # month column required in this case
     if(missing(day)) stop("day column is required when format == 'months'")
@@ -1946,14 +1983,17 @@ DataBook$set("public","tidy_climatic_data", function(x, format, stack_cols, day,
     if(!missing(element)) y$element <- x[[element]]
     # In case element_name is the name of an existing column in y
     if(element_name %in% names(y)) element_name <- next_default_item(prefix = element_name, existing_names = names(y))
-    y <- reshape2::melt(y, measure.vars = stack_cols, value.name = element_name, variable.name = "month")
-    
+    # renaming the stack_cols so that the day column can be constructed correctly
     # This assumes stack_cols are in the correct order i.e. 1 - 12
-    y$month <- as.numeric(y$month)
+    new_stack_cols <- paste0("month", 1:12)
+    names(y)[names(y) %in% stack_cols] <- new_stack_cols
+    y <- tidyr::pivot_longer(y, cols = tidyselect::all_of(new_stack_cols), names_to = "month", values_to = element_name)
+    y$month <- substr(y$month, 6, 8)
     
     y$date <- as.Date(paste(y$year, y$month, y$day), format = paste(year_format, "%m", "%d"))
   }
   else if(format == "years") {
+    if(!all(sapply(x[, stack_cols], function(col) is.numeric(col) || (is.logical(col) && all(is.na(col)))))) stop("All stack_cols must be numeric\nThe following stack_cols are not numeric: ", paste(stack_cols[!sapply(x[, stack_cols], is.numeric)], collapse = ","))
     
     by_cols <- c()
     if(!missing(station)) by_cols <- c(by_cols, station)
@@ -1967,6 +2007,8 @@ DataBook$set("public","tidy_climatic_data", function(x, format, stack_cols, day,
     
     if(!missing(stack_years) && length(year_list) != length(stack_cols)) stop("stack_years must be the same length as stack_cols")
     
+    # stack_years allows to specify the years represented by stack_cols.
+    # If this is blank, attempt to infer stack_years by assuming stack_cols are in the format c("X1990", "X1991", ...)
     if(missing(stack_years)) {
       # Remove first character and convert to numeric
       stack_years <- as.numeric(stringr::str_sub(stack_cols, 2))
@@ -1983,12 +2025,11 @@ DataBook$set("public","tidy_climatic_data", function(x, format, stack_cols, day,
     if(!missing(element)) y$element <- x[[element]]
     # In case element_name is the name of an existing column in y
     if(element_name %in% names(y)) element_name <- next_default_item(prefix = element_name, existing_names = names(y))
-    y <- reshape2::melt(y, measure.vars = stack_cols, value.name = element_name, variable.name = "year")
+    y <- tidyr::pivot_longer(y, cols = tidyselect::all_of(stack_cols), names_to = "year", values_to = element_name)
     
     # This assumes stack_cols and stack_years are in the same order
     y$year <- plyr::mapvalues(y$year, stack_cols, stack_years)
-    y$year <- as.numeric(levels(y$year))[y$year]
-    
+
     # Replacing day 60 with 0 for non-leap years. This will result in NA dates.
     y$doy[(!lubridate::leap_year(y$year)) & y$doy == 60] <- 0
     y$doy[(!lubridate::leap_year(y$year)) & y$doy > 60] <- y$doy[(!lubridate::leap_year(y$year)) & y$doy > 60] - 1
@@ -2029,22 +2070,34 @@ DataBook$set("public","tidy_climatic_data", function(x, format, stack_cols, day,
   }
   
   if(continue) {
-    # Standard format of slowest varying structure variables first (station then date) followed by measurements
+    # Standard format of slowest varying structure variables first (station then element then date) followed by measurements
     if(!missing(station)) z <- data.frame(station = y$station, date = y$date)
     else z <- data.frame(date = y$date)
-    z[[element_name]] <- y[[element_name]]
-    
     if(!missing(element)) z$element <- y$element
+    z[[element_name]] <- y[[element_name]]
+    if(flags) z[[flag_name]] <- y[[flag_name]]
+    
+    # Initialise id columns used for sorting data
+    id_cols <- c()
+    if(!missing(station)) id_cols <- c(id_cols, "station")
     
     z <- dplyr::filter(z, !is.na(date))
     
-    # If data contains multiple elements, unstack the element column
+    # If data contains multiple elements, optionally unstack the element column
     if(!missing(element)) {
-      z <- reshape2::dcast(z, ... ~ element, value.var = element_name)
+      if(unstack_elements) {
+        # pivot_wider allows unstacking multiple column sets, used when flags included.
+        values_from <- c(element_name)
+        if(flags) values_from <- c(values_from, flag_name)
+        z <- tidyr::pivot_wider(z, names_from = element, values_from = tidyselect::all_of(values_from))
+      }
+      # If not unstacking then need to sort by element column
+      else id_cols <- c(id_cols, "element")
     }
-    if(!missing(station)) z <- z %>% dplyr::group_by(station) %>% dplyr::arrange(date, .by_group = TRUE) %>% ungroup()
-    else z <- z %>% dplyr::arrange(date)
-    
+    # Add this last to ensure date varies fastest
+    id_cols <- c(id_cols, "date")
+    #z <- z %>% dplyr::arrange(tidyselect::all_of(id_cols))
+
     if(missing(new_name) || new_name == "") new_name <- next_default_item("data", existing_names = self$get_data_names())
     data_list <- list(z)
     names(data_list) <- new_name

--- a/instat/ucrReceiverMultiple.vb
+++ b/instat/ucrReceiverMultiple.vb
@@ -92,6 +92,7 @@ Public Class ucrReceiverMultiple
                 Selector.RemoveFromVariablesList(strTempItem)
             Next
             OnSelectionChanged()
+            MyBase.RemoveSelected()
         End If
     End Sub
 
@@ -103,7 +104,6 @@ Public Class ucrReceiverMultiple
             strItems.Add(lviVar.Text)
         Next
         Remove(strItems.ToArray())
-        'RemoveSelected()
     End Sub
 
     Public Overrides Function IsEmpty() As Boolean


### PR DESCRIPTION
fixes #5383 

@africanmathsinitiative/developers this is ready for review. Please test all 3 cases as the R code has changed substantially.

- allow 62 columns to be given for day option for flags
- added tooltips on radio buttons and receiver label to explain cases
- added label to show number of columns in multiple receiver
- set selector to remove columns added in a receiver to make selection clearer
- allowed month and year columns to be non-numeric
- added an "unstack elements" option for multiple elements
- stop and give output if unstacking and values are not unique

Also included here is a bug fix in `ucrReceiverMultiple`. The additional line added ensures that the selector refreshes when using the "Clear" option in the receiver. This is only important if the columns are removed from the selector when added which is why this has gone unnoticed for a long time.