### PR TITLE
Added the first circular plot dialog (Rose diagram) in Structure>Circular 

### DIFF
--- a/instat/dlgCircularRosePlot.Designer.vb
+++ b/instat/dlgCircularRosePlot.Designer.vb
@@ -27,6 +27,10 @@ Partial Class dlgCircularRosePlot
         Me.ucrSaveCircularRosePlot = New instat.ucrSave()
         Me.ucrReceiverVariable = New instat.ucrReceiverSingle()
         Me.lblVariable = New System.Windows.Forms.Label()
+        Me.ucrInputBins = New instat.ucrInputTextBox()
+        Me.lblBins = New System.Windows.Forms.Label()
+        Me.ucrInputComboRadius = New instat.ucrInputComboBox()
+        Me.lblRadiusScale = New System.Windows.Forms.Label()
         Me.SuspendLayout()
         '
         'ucrBase
@@ -76,11 +80,53 @@ Partial Class dlgCircularRosePlot
         Me.lblVariable.TabIndex = 4
         Me.lblVariable.Text = "Variable:"
         '
+        'ucrInputBins
+        '
+        Me.ucrInputBins.AddQuotesIfUnrecognised = True
+        Me.ucrInputBins.IsMultiline = False
+        Me.ucrInputBins.IsReadOnly = False
+        Me.ucrInputBins.Location = New System.Drawing.Point(346, 128)
+        Me.ucrInputBins.Name = "ucrInputBins"
+        Me.ucrInputBins.Size = New System.Drawing.Size(66, 21)
+        Me.ucrInputBins.TabIndex = 5
+        '
+        'lblBins
+        '
+        Me.lblBins.AutoSize = True
+        Me.lblBins.Location = New System.Drawing.Point(310, 132)
+        Me.lblBins.Name = "lblBins"
+        Me.lblBins.Size = New System.Drawing.Size(30, 13)
+        Me.lblBins.TabIndex = 6
+        Me.lblBins.Text = "Bins:"
+        '
+        'ucrInputComboRadius
+        '
+        Me.ucrInputComboRadius.AddQuotesIfUnrecognised = True
+        Me.ucrInputComboRadius.GetSetSelectedIndex = -1
+        Me.ucrInputComboRadius.IsReadOnly = False
+        Me.ucrInputComboRadius.Location = New System.Drawing.Point(346, 168)
+        Me.ucrInputComboRadius.Name = "ucrInputComboRadius"
+        Me.ucrInputComboRadius.Size = New System.Drawing.Size(66, 21)
+        Me.ucrInputComboRadius.TabIndex = 7
+        '
+        'lblRadiusScale
+        '
+        Me.lblRadiusScale.AutoSize = True
+        Me.lblRadiusScale.Location = New System.Drawing.Point(267, 173)
+        Me.lblRadiusScale.Name = "lblRadiusScale"
+        Me.lblRadiusScale.Size = New System.Drawing.Size(73, 13)
+        Me.lblRadiusScale.TabIndex = 8
+        Me.lblRadiusScale.Text = "Radius Scale:"
+        '
         'dlgCircularRosePlot
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
         Me.ClientSize = New System.Drawing.Size(420, 330)
+        Me.Controls.Add(Me.lblRadiusScale)
+        Me.Controls.Add(Me.ucrInputComboRadius)
+        Me.Controls.Add(Me.lblBins)
+        Me.Controls.Add(Me.ucrInputBins)
         Me.Controls.Add(Me.lblVariable)
         Me.Controls.Add(Me.ucrReceiverVariable)
         Me.Controls.Add(Me.ucrSaveCircularRosePlot)
@@ -102,4 +148,8 @@ Partial Class dlgCircularRosePlot
     Friend WithEvents ucrSaveCircularRosePlot As ucrSave
     Friend WithEvents ucrReceiverVariable As ucrReceiverSingle
     Friend WithEvents lblVariable As Label
+    Friend WithEvents ucrInputBins As ucrInputTextBox
+    Friend WithEvents lblBins As Label
+    Friend WithEvents lblRadiusScale As Label
+    Friend WithEvents ucrInputComboRadius As ucrInputComboBox
 End Class

--- a/instat/dlgCircularRosePlot.Designer.vb
+++ b/instat/dlgCircularRosePlot.Designer.vb
@@ -23,20 +23,68 @@ Partial Class dlgCircularRosePlot
     <System.Diagnostics.DebuggerStepThrough()> _
     Private Sub InitializeComponent()
         Me.ucrBase = New instat.ucrButtons()
+        Me.ucrSelctorCircularDataFrame = New instat.ucrSelectorByDataFrameAddRemove()
+        Me.ucrSaveCircularRosePlot = New instat.ucrSave()
+        Me.ucrReceiverVariable = New instat.ucrReceiverSingle()
+        Me.lblVariable = New System.Windows.Forms.Label()
         Me.SuspendLayout()
         '
         'ucrBase
         '
-        Me.ucrBase.Location = New System.Drawing.Point(6, 240)
+        Me.ucrBase.Location = New System.Drawing.Point(6, 273)
         Me.ucrBase.Name = "ucrBase"
         Me.ucrBase.Size = New System.Drawing.Size(406, 52)
         Me.ucrBase.TabIndex = 0
+        '
+        'ucrSelctorCircularDataFrame
+        '
+        Me.ucrSelctorCircularDataFrame.bDropUnusedFilterLevels = False
+        Me.ucrSelctorCircularDataFrame.bShowHiddenColumns = False
+        Me.ucrSelctorCircularDataFrame.bUseCurrentFilter = True
+        Me.ucrSelctorCircularDataFrame.Location = New System.Drawing.Point(6, 9)
+        Me.ucrSelctorCircularDataFrame.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrSelctorCircularDataFrame.Name = "ucrSelctorCircularDataFrame"
+        Me.ucrSelctorCircularDataFrame.Size = New System.Drawing.Size(210, 180)
+        Me.ucrSelctorCircularDataFrame.TabIndex = 1
+        '
+        'ucrSaveCircularRosePlot
+        '
+        Me.ucrSaveCircularRosePlot.Location = New System.Drawing.Point(6, 232)
+        Me.ucrSaveCircularRosePlot.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
+        Me.ucrSaveCircularRosePlot.Name = "ucrSaveCircularRosePlot"
+        Me.ucrSaveCircularRosePlot.Size = New System.Drawing.Size(279, 28)
+        Me.ucrSaveCircularRosePlot.TabIndex = 2
+        '
+        'ucrReceiverVariable
+        '
+        Me.ucrReceiverVariable.frmParent = Me
+        Me.ucrReceiverVariable.Location = New System.Drawing.Point(292, 64)
+        Me.ucrReceiverVariable.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrReceiverVariable.Name = "ucrReceiverVariable"
+        Me.ucrReceiverVariable.Selector = Nothing
+        Me.ucrReceiverVariable.Size = New System.Drawing.Size(120, 20)
+        Me.ucrReceiverVariable.strNcFilePath = ""
+        Me.ucrReceiverVariable.TabIndex = 3
+        Me.ucrReceiverVariable.ucrSelector = Nothing
+        '
+        'lblVariable
+        '
+        Me.lblVariable.AutoSize = True
+        Me.lblVariable.Location = New System.Drawing.Point(289, 42)
+        Me.lblVariable.Name = "lblVariable"
+        Me.lblVariable.Size = New System.Drawing.Size(48, 13)
+        Me.lblVariable.TabIndex = 4
+        Me.lblVariable.Text = "Variable:"
         '
         'dlgCircularRosePlot
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
-        Me.ClientSize = New System.Drawing.Size(420, 296)
+        Me.ClientSize = New System.Drawing.Size(420, 330)
+        Me.Controls.Add(Me.lblVariable)
+        Me.Controls.Add(Me.ucrReceiverVariable)
+        Me.Controls.Add(Me.ucrSaveCircularRosePlot)
+        Me.Controls.Add(Me.ucrSelctorCircularDataFrame)
         Me.Controls.Add(Me.ucrBase)
         Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow
         Me.MaximizeBox = False
@@ -45,8 +93,13 @@ Partial Class dlgCircularRosePlot
         Me.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen
         Me.Text = "Rose Plot"
         Me.ResumeLayout(False)
+        Me.PerformLayout()
 
     End Sub
 
     Friend WithEvents ucrBase As ucrButtons
+    Friend WithEvents ucrSelctorCircularDataFrame As ucrSelectorByDataFrameAddRemove
+    Friend WithEvents ucrSaveCircularRosePlot As ucrSave
+    Friend WithEvents ucrReceiverVariable As ucrReceiverSingle
+    Friend WithEvents lblVariable As Label
 End Class

--- a/instat/dlgCircularRosePlot.Designer.vb
+++ b/instat/dlgCircularRosePlot.Designer.vb
@@ -31,6 +31,7 @@ Partial Class dlgCircularRosePlot
         Me.lblBins = New System.Windows.Forms.Label()
         Me.ucrInputComboRadius = New instat.ucrInputComboBox()
         Me.lblRadiusScale = New System.Windows.Forms.Label()
+        Me.cmdCircularOptions = New System.Windows.Forms.Button()
         Me.SuspendLayout()
         '
         'ucrBase
@@ -85,7 +86,7 @@ Partial Class dlgCircularRosePlot
         Me.ucrInputBins.AddQuotesIfUnrecognised = True
         Me.ucrInputBins.IsMultiline = False
         Me.ucrInputBins.IsReadOnly = False
-        Me.ucrInputBins.Location = New System.Drawing.Point(346, 128)
+        Me.ucrInputBins.Location = New System.Drawing.Point(359, 128)
         Me.ucrInputBins.Name = "ucrInputBins"
         Me.ucrInputBins.Size = New System.Drawing.Size(66, 21)
         Me.ucrInputBins.TabIndex = 5
@@ -93,7 +94,7 @@ Partial Class dlgCircularRosePlot
         'lblBins
         '
         Me.lblBins.AutoSize = True
-        Me.lblBins.Location = New System.Drawing.Point(310, 132)
+        Me.lblBins.Location = New System.Drawing.Point(324, 132)
         Me.lblBins.Name = "lblBins"
         Me.lblBins.Size = New System.Drawing.Size(30, 13)
         Me.lblBins.TabIndex = 6
@@ -104,7 +105,7 @@ Partial Class dlgCircularRosePlot
         Me.ucrInputComboRadius.AddQuotesIfUnrecognised = True
         Me.ucrInputComboRadius.GetSetSelectedIndex = -1
         Me.ucrInputComboRadius.IsReadOnly = False
-        Me.ucrInputComboRadius.Location = New System.Drawing.Point(346, 168)
+        Me.ucrInputComboRadius.Location = New System.Drawing.Point(361, 168)
         Me.ucrInputComboRadius.Name = "ucrInputComboRadius"
         Me.ucrInputComboRadius.Size = New System.Drawing.Size(66, 21)
         Me.ucrInputComboRadius.TabIndex = 7
@@ -112,17 +113,30 @@ Partial Class dlgCircularRosePlot
         'lblRadiusScale
         '
         Me.lblRadiusScale.AutoSize = True
-        Me.lblRadiusScale.Location = New System.Drawing.Point(267, 173)
+        Me.lblRadiusScale.Location = New System.Drawing.Point(283, 172)
         Me.lblRadiusScale.Name = "lblRadiusScale"
         Me.lblRadiusScale.Size = New System.Drawing.Size(73, 13)
         Me.lblRadiusScale.TabIndex = 8
         Me.lblRadiusScale.Text = "Radius Scale:"
         '
+        'cmdCircularOptions
+        '
+        Me.cmdCircularOptions.Enabled = False
+        Me.cmdCircularOptions.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.cmdCircularOptions.Location = New System.Drawing.Point(6, 199)
+        Me.cmdCircularOptions.Name = "cmdCircularOptions"
+        Me.cmdCircularOptions.Size = New System.Drawing.Size(120, 25)
+        Me.cmdCircularOptions.TabIndex = 9
+        Me.cmdCircularOptions.Tag = "Circular_Options"
+        Me.cmdCircularOptions.Text = "Circular Options"
+        Me.cmdCircularOptions.UseVisualStyleBackColor = True
+        '
         'dlgCircularRosePlot
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
-        Me.ClientSize = New System.Drawing.Size(420, 330)
+        Me.ClientSize = New System.Drawing.Size(433, 330)
+        Me.Controls.Add(Me.cmdCircularOptions)
         Me.Controls.Add(Me.lblRadiusScale)
         Me.Controls.Add(Me.ucrInputComboRadius)
         Me.Controls.Add(Me.lblBins)
@@ -152,4 +166,5 @@ Partial Class dlgCircularRosePlot
     Friend WithEvents lblBins As Label
     Friend WithEvents lblRadiusScale As Label
     Friend WithEvents ucrInputComboRadius As ucrInputComboBox
+    Friend WithEvents cmdCircularOptions As Button
 End Class

--- a/instat/dlgCircularRosePlot.vb
+++ b/instat/dlgCircularRosePlot.vb
@@ -38,12 +38,23 @@ Public Class dlgCircularRosePlot
 
     Private Sub InitialiseDialog()
 
+        Dim dctRadius As New Dictionary(Of String, String)
+
+        ucrBase.clsRsyntax.bExcludeAssignedFunctionOutput = False
+        ucrBase.clsRsyntax.iCallType = 3
+
         ucrSelctorCircularDataFrame.SetParameter(New RParameter("data", 0))
         ucrSelctorCircularDataFrame.SetParameterIsrfunction()
 
         ucrReceiverVariable.SetParameter(New RParameter("x", 0))
         ucrReceiverVariable.Selector = ucrSelctorCircularDataFrame
         ucrReceiverVariable.SetParameterIsRFunction()
+
+        ucrInputComboRadius.SetParameter(New RParameter("radii.scale", 3))
+        dctRadius.Add("sqrt", Chr(34) & "sqrt" & Chr(34))
+        dctRadius.Add("sqrt", Chr(34) & "sqrt" & Chr(34))
+        ucrInputComboRadius.SetItems(dctRadius)
+
 
         ucrSaveCircularRosePlot.SetPrefix("circular_rose_plot")
         ucrSaveCircularRosePlot.SetDataFrameSelector(ucrSelctorCircularDataFrame.ucrAvailableDataFrames)
@@ -63,9 +74,16 @@ Public Class dlgCircularRosePlot
         clsRosePlotFunction.SetPackageName("circular")
         clsRosePlotFunction.SetRCommand("rose.diag")
 
+        ucrInputBins.SetParameter(New RParameter("bins", 2))
+        ucrInputBins.SetValidationTypeAsNumeric()
+        ucrInputBins.SetDefaultState(12)
+        ucrInputBins.AddQuotesIfUnrecognised = False
+
+        ucrBase.clsRsyntax.SetBaseRFunction(clsRosePlotFunction)
     End Sub
 
     Public Sub SetRCodeForControls(bReset As Boolean)
+        ucrInputBins.AddAdditionalCodeParameterPair(clsRosePlotFunction, ucrInputBins.GetParameter(), iAdditionalPairNo:=1)
         ucrReceiverVariable.SetRCode(clsRosePlotFunction, bReset)
     End Sub
 

--- a/instat/dlgCircularRosePlot.vb
+++ b/instat/dlgCircularRosePlot.vb
@@ -70,15 +70,20 @@ Public Class dlgCircularRosePlot
     End Sub
 
     Private Sub TestOkEnabled()
-
+        If ucrSaveCircularRosePlot.IsComplete AndAlso Not ucrReceiverVariable.IsEmpty Then
+            ucrBase.OKEnabled(True)
+        Else
+            ucrBase.OKEnabled(False)
+        End If
     End Sub
 
     Private Sub ucrBase_ClickReset(sender As Object, e As EventArgs) Handles ucrBase.ClickReset
-
+        SetRCodeForControls(True)
+        SetDefaults()
+        TestOkEnabled()
     End Sub
 
     Private Sub CoreControls_ControlContentsChanged() Handles ucrReceiverVariable.ControlContentsChanged, ucrSaveCircularRosePlot.ControlContentsChanged
-
+        TestOkEnabled()
     End Sub
-
 End Class

--- a/instat/dlgCircularRosePlot.vb
+++ b/instat/dlgCircularRosePlot.vb
@@ -52,7 +52,7 @@ Public Class dlgCircularRosePlot
 
         ucrInputComboRadius.SetParameter(New RParameter("radii.scale", 3))
         dctRadius.Add("sqrt", Chr(34) & "sqrt" & Chr(34))
-        dctRadius.Add("sqrt", Chr(34) & "sqrt" & Chr(34))
+        dctRadius.Add("linear", Chr(34) & "linear" & Chr(34))
         ucrInputComboRadius.SetItems(dctRadius)
 
 

--- a/instat/dlgCircularRosePlot.vb
+++ b/instat/dlgCircularRosePlot.vb
@@ -46,15 +46,20 @@ Public Class dlgCircularRosePlot
         ucrSelctorCircularDataFrame.SetParameter(New RParameter("data", 0))
         ucrSelctorCircularDataFrame.SetParameterIsrfunction()
 
-        ucrReceiverVariable.SetParameter(New RParameter("x", 0))
         ucrReceiverVariable.Selector = ucrSelctorCircularDataFrame
         ucrReceiverVariable.SetParameterIsRFunction()
 
-        ucrInputComboRadius.SetParameter(New RParameter("radii.scale", 3))
+        ucrInputComboRadius.SetParameter(New RParameter("radii.scale", 2))
         dctRadius.Add("sqrt", Chr(34) & "sqrt" & Chr(34))
         dctRadius.Add("linear", Chr(34) & "linear" & Chr(34))
         ucrInputComboRadius.SetItems(dctRadius)
+        ucrInputComboRadius.SetRDefault(Chr(34) & "sqrt" & Chr(34))
+        ucrInputComboRadius.SetDropDownStyleAsNonEditable()
 
+        ucrInputBins.SetParameter(New RParameter("bins", 1))
+        ucrInputBins.SetValidationTypeAsNumeric()
+        ucrInputBins.SetRDefault(12)
+        ucrInputBins.AddQuotesIfUnrecognised = False
 
         ucrSaveCircularRosePlot.SetPrefix("circular_rose_plot")
         ucrSaveCircularRosePlot.SetDataFrameSelector(ucrSelctorCircularDataFrame.ucrAvailableDataFrames)
@@ -73,18 +78,15 @@ Public Class dlgCircularRosePlot
 
         clsRosePlotFunction.SetPackageName("circular")
         clsRosePlotFunction.SetRCommand("rose.diag")
-
-        ucrInputBins.SetParameter(New RParameter("bins", 2))
-        ucrInputBins.SetValidationTypeAsNumeric()
-        ucrInputBins.SetDefaultState(12)
-        ucrInputBins.AddQuotesIfUnrecognised = False
+        clsRosePlotFunction.AddParameter("radii.scale", Chr(34) & "sqrt" & Chr(34))
 
         ucrBase.clsRsyntax.SetBaseRFunction(clsRosePlotFunction)
     End Sub
 
     Public Sub SetRCodeForControls(bReset As Boolean)
+        ucrReceiverVariable.AddAdditionalCodeParameterPair(clsRosePlotFunction, New RParameter("x", 0), iAdditionalPairNo:=1)
         ucrInputBins.AddAdditionalCodeParameterPair(clsRosePlotFunction, ucrInputBins.GetParameter(), iAdditionalPairNo:=1)
-        ucrReceiverVariable.SetRCode(clsRosePlotFunction, bReset)
+        ucrInputComboRadius.SetRCode(clsRosePlotFunction, bReset)
     End Sub
 
     Private Sub TestOkEnabled()

--- a/instat/dlgCircularRosePlot.vb
+++ b/instat/dlgCircularRosePlot.vb
@@ -1,3 +1,84 @@
-﻿Public Class dlgCircularRosePlot
+﻿'R-Instat
+' Copyright (C) 2015-2017
+'
+' This program is free software: you can redistribute it and/or modify
+' it under the terms of the GNU General Public License as published by
+' the Free Software Foundation, either version 3 of the License, or
+' (at your option) any later version.
+'
+' This program is distributed in the hope that it will be useful,
+' but WITHOUT ANY WARRANTY; without even the implied warranty of
+' MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+' GNU General Public License for more details.
+'
+' You should have received a copy of the GNU General Public License 
+' along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Imports instat.Translations
+
+Public Class dlgCircularRosePlot
+    Public bfirstload As Boolean = True
+    Public bReset As Boolean = True
+    Private clsRosePlotFunction As RFunction
+    Private Sub dlgCircularRosePlot_Load(sender As Object, e As EventArgs) Handles MyBase.Load
+        If bFirstLoad Then
+            InitialiseDialog()
+            bFirstLoad = False
+        End If
+
+        If bReset Then
+            SetDefaults()
+        End If
+
+        SetRCodeForControls(bReset)
+        bReset = False
+        autoTranslate(Me)
+        TestOkEnabled()
+    End Sub
+
+    Private Sub InitialiseDialog()
+
+        ucrSelctorCircularDataFrame.SetParameter(New RParameter("data", 0))
+        ucrSelctorCircularDataFrame.SetParameterIsrfunction()
+
+        ucrReceiverVariable.SetParameter(New RParameter("x", 0))
+        ucrReceiverVariable.Selector = ucrSelctorCircularDataFrame
+        ucrReceiverVariable.SetParameterIsRFunction()
+
+        ucrSaveCircularRosePlot.SetPrefix("circular_rose_plot")
+        ucrSaveCircularRosePlot.SetDataFrameSelector(ucrSelctorCircularDataFrame.ucrAvailableDataFrames)
+        ucrSaveCircularRosePlot.SetIsComboBox()
+        ucrSaveCircularRosePlot.SetCheckBoxText("Save Graph")
+        ucrSaveCircularRosePlot.SetSaveTypeAsGraph()
+        ucrSaveCircularRosePlot.SetAssignToIfUncheckedValue("last_graph")
+    End Sub
+
+    Private Sub SetDefaults()
+        clsRosePlotFunction = New RFunction
+
+        ucrSelctorCircularDataFrame.Reset()
+        ucrSaveCircularRosePlot.Reset()
+        ucrReceiverVariable.SetMeAsReceiver()
+
+        clsRosePlotFunction.SetPackageName("circular")
+        clsRosePlotFunction.SetRCommand("rose.diag")
+
+    End Sub
+
+    Public Sub SetRCodeForControls(bReset As Boolean)
+        ucrReceiverVariable.SetRCode(clsRosePlotFunction, bReset)
+    End Sub
+
+    Private Sub TestOkEnabled()
+
+    End Sub
+
+    Private Sub ucrBase_ClickReset(sender As Object, e As EventArgs) Handles ucrBase.ClickReset
+
+    End Sub
+
+    Private Sub CoreControls_ControlContentsChanged() Handles ucrReceiverVariable.ControlContentsChanged, ucrSaveCircularRosePlot.ControlContentsChanged
+
+    End Sub
 
 End Class


### PR DESCRIPTION

Fixes #6060
I have added and implemented the functionality of the dialog.
Added a few options as I'm still exploring more. This is also under discussions with @rdstern  and @volloholic 
I have also added a button for the circular options. Disabled for now.

@africanmathsinitiative/developers This is at the initial stage. Testing this would require you to first get the changes from PR #6093, where the dialog is enabled from the frmmain.