### PR TITLE
Adding survival dialog to frmmain

### DIFF
--- a/instat/frmMain.resx
+++ b/instat/frmMain.resx
@@ -3622,7 +3622,7 @@
     <value>Low_Flow</value>
   </data>
   <data name="mnuStructuredSurvivalDefine.Size" type="System.Drawing.Size, System.Drawing">
-    <value>117, 22</value>
+    <value>180, 22</value>
   </data>
   <data name="mnuStructuredSurvivalDefine.Text" xml:space="preserve">
     <value>Define...</value>

--- a/instat/frmMain.vb
+++ b/instat/frmMain.vb
@@ -2242,4 +2242,8 @@ Public Class frmMain
     Private Sub ExportToWWRToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles mnuExportToWWRToolStrip.Click
         dlgExportToWWR.ShowDialog()
     End Sub
+
+    Private Sub mnuStructuredSurvivalDefine_Click(sender As Object, e As EventArgs) Handles mnuStructuredSurvivalDefine.Click
+        dlgSurvivalObject.ShowDialog()
+    End Sub
 End Class


### PR DESCRIPTION
As requested in #6047 this PR adds the define survival object dialog to the main form.

@africanmathsinitiative/developers this is ready for review