### PR TITLE
Small bug fixes in Climatic Check Data Temperature dialog

### DIFF
--- a/instat/dlgClimaticCheckDataTemperature.vb
+++ b/instat/dlgClimaticCheckDataTemperature.vb
@@ -623,7 +623,6 @@ Public Class dlgClimaticCheckDataTemperature
 
     Private Sub ucrReceiverMonth_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverMonth.ControlValueChanged, ucrReceiverElement1.ControlValueChanged, ucrReceiverElement2.ControlValueChanged
         GroupByMonth()
-        EnableOrDisableDifferenceControls()
     End Sub
 
     Private Sub ucrSelectorTemperature_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrSelectorTemperature.ControlValueChanged
@@ -638,6 +637,7 @@ Public Class dlgClimaticCheckDataTemperature
 
     Private Sub ucrReceiverElement1_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverElement1.ControlValueChanged, ucrReceiverElement2.ControlValueChanged
         FilterFunc()
+        EnableOrDisableDifferenceControls()
     End Sub
 
     Private Sub CoreControls_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrReceiverElement1.ControlContentsChanged, ucrReceiverElement2.ControlContentsChanged, ucrNudSame.ControlContentsChanged, ucrNudRangeElement1Min.ControlContentsChanged, ucrNudRangeElement1Max.ControlContentsChanged, ucrNudRangeElement2Min.ControlContentsChanged, ucrNudRangeElement2Max.ControlContentsChanged, ucrNudJump.ControlContentsChanged, ucrNudRangeElement2Min.ControlContentsChanged, ucrNudRangeElement2Max.ControlContentsChanged, ucrNudDifference.ControlContentsChanged, ucrChkRangeElement1.ControlContentsChanged, ucrChkRangeElement2.ControlContentsChanged, ucrChkJump.ControlContentsChanged, ucrChkDifference.ControlContentsChanged, ucrChkSame.ControlContentsChanged, ucrChkOutlier.ControlContentsChanged

--- a/instat/dlgClimaticCheckDataTemperature.vb
+++ b/instat/dlgClimaticCheckDataTemperature.vb
@@ -198,6 +198,8 @@ Public Class dlgClimaticCheckDataTemperature
 
         'outliers Option
         ttOutliers.SetToolTip(ucrChkOutlier, "Values that are further than this number of IQRs from the corresponding quartile.")
+
+        EnableDisableControl()
     End Sub
 
     Private Sub SetDefaults()
@@ -297,6 +299,8 @@ Public Class dlgClimaticCheckDataTemperature
         clsRunCalcFunc.AddParameter("calc", clsRFunctionParameter:=clsFilterFunc, iPosition:=0)
         clsRunCalcFunc.AddParameter("display", "FALSE")
         ucrBase.clsRsyntax.SetBaseRFunction(clsRunCalcFunc)
+
+        EnableDisableControl()
     End Sub
 
     Private Sub SetRCodeForControls(bReset)
@@ -608,8 +612,20 @@ Public Class dlgClimaticCheckDataTemperature
         End If
     End Sub
 
+    Private Sub EnableDisableControl()
+        If ucrReceiverElement1.IsEmpty OrElse ucrReceiverElement2.IsEmpty Then
+            ucrChkDifference.Enabled = False
+            ucrChkDifference.Checked = False
+            ucrNudDifference.Enabled = False
+        Else
+            ucrChkDifference.Enabled = True
+            ucrNudDifference.Enabled = True
+        End If
+    End Sub
+
     Private Sub ucrReceiverMonth_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverMonth.ControlValueChanged, ucrReceiverElement1.ControlValueChanged, ucrReceiverElement2.ControlValueChanged
         GroupByMonth()
+        EnableDisableControl()
     End Sub
 
     Private Sub ucrSelectorTemperature_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrSelectorTemperature.ControlValueChanged

--- a/instat/dlgClimaticCheckDataTemperature.vb
+++ b/instat/dlgClimaticCheckDataTemperature.vb
@@ -613,9 +613,7 @@ Public Class dlgClimaticCheckDataTemperature
         If ucrReceiverElement1.IsEmpty OrElse ucrReceiverElement2.IsEmpty Then
             ucrChkDifference.Enabled = False
             ucrNudDifference.Enabled = False
-            If ucrChkDifference.Checked Then
-                ucrChkDifference.Checked = False
-            End If
+            ucrChkDifference.Checked = False
         Else
             ucrChkDifference.Enabled = True
             ucrNudDifference.Enabled = True

--- a/instat/dlgClimaticCheckDataTemperature.vb
+++ b/instat/dlgClimaticCheckDataTemperature.vb
@@ -613,6 +613,9 @@ Public Class dlgClimaticCheckDataTemperature
         If ucrReceiverElement1.IsEmpty OrElse ucrReceiverElement2.IsEmpty Then
             ucrChkDifference.Enabled = False
             ucrNudDifference.Enabled = False
+            If ucrChkDifference.Checked Then
+                ucrChkDifference.Checked = False
+            End If
         Else
             ucrChkDifference.Enabled = True
             ucrNudDifference.Enabled = True

--- a/instat/dlgClimaticCheckDataTemperature.vb
+++ b/instat/dlgClimaticCheckDataTemperature.vb
@@ -298,7 +298,6 @@ Public Class dlgClimaticCheckDataTemperature
         clsRunCalcFunc.AddParameter("calc", clsRFunctionParameter:=clsFilterFunc, iPosition:=0)
         clsRunCalcFunc.AddParameter("display", "FALSE")
         ucrBase.clsRsyntax.SetBaseRFunction(clsRunCalcFunc)
-
     End Sub
 
     Private Sub SetRCodeForControls(bReset)
@@ -613,7 +612,6 @@ Public Class dlgClimaticCheckDataTemperature
     Private Sub EnableOrDisableDifferenceControls()
         If ucrReceiverElement1.IsEmpty OrElse ucrReceiverElement2.IsEmpty Then
             ucrChkDifference.Enabled = False
-            ucrChkDifference.Checked = False
             ucrNudDifference.Enabled = False
         Else
             ucrChkDifference.Enabled = True

--- a/instat/dlgClimaticCheckDataTemperature.vb
+++ b/instat/dlgClimaticCheckDataTemperature.vb
@@ -541,6 +541,7 @@ Public Class dlgClimaticCheckDataTemperature
             clsOutlierCombinedOperator.RemoveParameterByName("upperOutlierTest1")
             clsOutlierCombinedOperator.RemoveParameterByName("lowerOutlierTest1")
         End If
+
         If Not ucrReceiverElement2.IsEmpty Then
             clsSameOp.AddParameter("same2", strParameterValue:=clsSameCodeElement2.strTestName, bIncludeArgumentName:=False)
             clsSameListSubCalc.AddParameter("same2test", clsRFunctionParameter:=clsSameCodeElement2.clsSameTestFunction, bIncludeArgumentName:=False)

--- a/instat/dlgClimaticCheckDataTemperature.vb
+++ b/instat/dlgClimaticCheckDataTemperature.vb
@@ -199,7 +199,6 @@ Public Class dlgClimaticCheckDataTemperature
         'outliers Option
         ttOutliers.SetToolTip(ucrChkOutlier, "Values that are further than this number of IQRs from the corresponding quartile.")
 
-        EnableDisableControl()
     End Sub
 
     Private Sub SetDefaults()
@@ -300,7 +299,6 @@ Public Class dlgClimaticCheckDataTemperature
         clsRunCalcFunc.AddParameter("display", "FALSE")
         ucrBase.clsRsyntax.SetBaseRFunction(clsRunCalcFunc)
 
-        EnableDisableControl()
     End Sub
 
     Private Sub SetRCodeForControls(bReset)
@@ -612,7 +610,7 @@ Public Class dlgClimaticCheckDataTemperature
         End If
     End Sub
 
-    Private Sub EnableDisableControl()
+    Private Sub EnableOrDisableDifferenceControls()
         If ucrReceiverElement1.IsEmpty OrElse ucrReceiverElement2.IsEmpty Then
             ucrChkDifference.Enabled = False
             ucrChkDifference.Checked = False
@@ -625,7 +623,7 @@ Public Class dlgClimaticCheckDataTemperature
 
     Private Sub ucrReceiverMonth_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverMonth.ControlValueChanged, ucrReceiverElement1.ControlValueChanged, ucrReceiverElement2.ControlValueChanged
         GroupByMonth()
-        EnableDisableControl()
+        EnableOrDisableDifferenceControls()
     End Sub
 
     Private Sub ucrSelectorTemperature_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrSelectorTemperature.ControlValueChanged


### PR DESCRIPTION
Setting enable/disable difference checkbox when one element is missing. This solves issue #5013 
@shadrackkibet this is ready to review. Thanks