### PR TITLE
Display of a filter in operation and retaining of state of apply option on load - Filter dialog

### DIFF
--- a/instat/dlgRestrict.vb
+++ b/instat/dlgRestrict.vb
@@ -52,7 +52,6 @@ Public Class dlgRestrict
             SetDefaults()
             bFirstLoad = False
         End If
-        SetFilterSubsetStatus()
         SetDefaultDataFrame()
         If bAutoOpenSubDialog Then
             OpenNewFilterSubDialog()

--- a/instat/dlgRestrict.vb
+++ b/instat/dlgRestrict.vb
@@ -127,6 +127,11 @@ Public Class dlgRestrict
         If sdgCreateFilter.bFilterDefined Then
             frmMain.clsRLink.RunScript(sdgCreateFilter.clsCurrentFilter.ToScript(), strComment:="Create Filter subdialog: Created new filter")
             ucrSelectorFilter.SetDataframe(sdgCreateFilter.ucrCreateFilter.ucrSelectorForFitler.ucrAvailableDataFrames.cboAvailableDataFrames.Text)
+            'Clear the receiver if the filter created is the same as the filter currently in the receiver. 
+            'Clearing ensures that the filter preview is updated correctly because it might have changed.
+            If ucrReceiverFilter.GetVariableNames(False) = sdgCreateFilter.ucrCreateFilter.ucrInputFilterName.GetText() Then
+                ucrReceiverFilter.Clear()
+            End If
             ucrReceiverFilter.Add(sdgCreateFilter.ucrCreateFilter.ucrInputFilterName.GetText())
         End If
         ucrSelectorFilter.LoadList()

--- a/instat/static/InstatObject/R/instat_object_R6.R
+++ b/instat/static/InstatObject/R/instat_object_R6.R
@@ -747,6 +747,11 @@ DataBook$set("public", "get_current_filter", function(data_name) {
 }
 )
 
+DataBook$set("public", "get_current_filter_name", function(data_name) {
+  self$get_data_objects(data_name)$get_current_filter()$name
+}
+)
+
 DataBook$set("public", "get_filter_names", function(data_name, as_list = FALSE, include = list(), exclude = list(), excluded_items = c()) {
   if(missing(data_name)) {
     #TODO what to do with excluded_items in this case

--- a/instat/ucrDataView.vb
+++ b/instat/ucrDataView.vb
@@ -42,6 +42,7 @@ Public Class ucrDataView
     Private clsConvertOrderedFactor As New RFunction
     Private clsFilterApplied As New RFunction
     Private clsHideDataFrame As New RFunction
+    Private clsGetCurrentFilterName As New RFunction
     Public lstColumnNames As New List(Of KeyValuePair(Of String, String()))
 
     Private Sub ucrDataView_Load(sender As Object, e As EventArgs) Handles MyBase.Load
@@ -84,6 +85,7 @@ Public Class ucrDataView
         clsFilterApplied.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$filter_applied")
         clsHideDataFrame.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$append_to_dataframe_metadata")
         clsViewDataFrame.SetRCommand("View")
+        clsGetCurrentFilterName.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_current_filter_name")
         UpdateRFunctionDataFrameParameters()
     End Sub
 
@@ -343,7 +345,8 @@ Public Class ucrDataView
             iColumnCount = frmMain.clsRLink.GetDataFrameColumnCount(grdCurrSheet.Name)
             lblRowDisplay.Text = "Showing " & grdCurrSheet.RowCount & " of " & iRowCount & " rows"
             If frmMain.clsRLink.RunInternalScriptGetValue(clsFilterApplied.ToScript()).AsLogical(0) Then
-                lblRowDisplay.Text = lblRowDisplay.Text & " (" & frmMain.clsRLink.GetDataFrameLength(grdCurrSheet.Name, False) & ")"
+                Dim strFilterName As String = frmMain.clsRLink.RunInternalScriptGetValue(clsGetCurrentFilterName.ToScript(), bSilent:=True).AsCharacter(0)
+                lblRowDisplay.Text = lblRowDisplay.Text & " (" & frmMain.clsRLink.GetDataFrameLength(grdCurrSheet.Name, False) & ")" & "|Active filter:" & strFilterName
             End If
             lblRowDisplay.Text = lblRowDisplay.Text & " | Showing " & grdCurrSheet.ColumnCount & " of " & iColumnCount & " columns"
             'hide startup menu items
@@ -608,6 +611,7 @@ Public Class ucrDataView
             clsGetDataFrame.AddParameter("data_name", Chr(34) & grdCurrSheet.Name & Chr(34), iPosition:=0)
             clsConvertOrderedFactor.AddParameter("data_name", Chr(34) & grdCurrSheet.Name & Chr(34), iPosition:=0)
             clsFilterApplied.AddParameter("data_name", Chr(34) & grdCurrSheet.Name & Chr(34), iPosition:=0)
+            clsGetCurrentFilterName.AddParameter("data_name", Chr(34) & grdCurrSheet.Name & Chr(34), iPosition:=0)
         End If
     End Sub
 


### PR DESCRIPTION
Fixes #5901, Fixes #6180 and Fixes #6181. @africanmathsinitiative/developers this is ready for review. 

Notes
- Removed resetting of state for apply options on load.
- Added a method for getting the filter name.
- Setting up the display of an active filter below the current sheet.
- Clearing the filter receiver.