### PR TITLE
Obtaining a subset from filtered data - Fixed problem with colouring of rows

### DIFF
--- a/instat/static/InstatObject/R/instat_object_R6.R
+++ b/instat/static/InstatObject/R/instat_object_R6.R
@@ -132,6 +132,7 @@ DataBook$set("public", "copy_data_object", function(data_name, new_name, filter_
   if(filter_name != "") {
     subset_data <- self$get_data_objects(data_name)$get_data_frame(use_current_filter = FALSE, filter_name = filter_name, retain_attr = TRUE)
     if(reset_row_names) rownames(subset_data) <- 1:nrow(subset_data)
+    new_obj$remove_current_filter()
     new_obj$set_data(subset_data)
   }
   self$append_data_object(new_name, new_obj)


### PR DESCRIPTION
Fixes #5893 @africanmathsinitiative/developers this is ready for review. This PR fixes the problem with the colouring of rows (red) when obtaining a subset from filtered data in the filter dialog.

Note
- Removed current filter when copying a data object and the filter is not missing.