### PR TITLE
Added right-click functionality to the column metadata (bottom tab right-click) and the data frame metadata (row right-click)

### DIFF
--- a/instat/ucrColumnMetadata.Designer.vb
+++ b/instat/ucrColumnMetadata.Designer.vb
@@ -65,10 +65,19 @@ Partial Class ucrColumnMetadata
         Me.mnuDeleteLabels = New System.Windows.Forms.ToolStripMenuItem()
         Me.lblHeader = New System.Windows.Forms.Label()
         Me.tlpTableContainer = New System.Windows.Forms.TableLayoutPanel()
+        Me.statusColumnMenu = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.deleteDataFrame = New System.Windows.Forms.ToolStripMenuItem()
+        Me.renameSheet = New System.Windows.Forms.ToolStripMenuItem()
+        Me.hideSheet = New System.Windows.Forms.ToolStripMenuItem()
+        Me.unhideSheet = New System.Windows.Forms.ToolStripMenuItem()
+        Me.copySheet = New System.Windows.Forms.ToolStripMenuItem()
+        Me.reorderSheet = New System.Windows.Forms.ToolStripMenuItem()
+        Me.viewSheet = New System.Windows.Forms.ToolStripMenuItem()
         Me.cellContextMenuStrip.SuspendLayout()
         Me.columnContextMenuStrip.SuspendLayout()
         Me.propertiesContextMenuStrip.SuspendLayout()
         Me.tlpTableContainer.SuspendLayout()
+        Me.statusColumnMenu.SuspendLayout()
         Me.SuspendLayout()
         '
         'grdVariables
@@ -82,7 +91,7 @@ Partial Class ucrColumnMetadata
         Me.grdVariables.Name = "grdVariables"
         Me.grdVariables.RowHeaderContextMenuStrip = Me.columnContextMenuStrip
         Me.grdVariables.Script = Nothing
-        Me.grdVariables.SheetTabContextMenuStrip = Nothing
+        Me.grdVariables.SheetTabContextMenuStrip = Me.statusColumnMenu
         Me.grdVariables.SheetTabNewButtonVisible = True
         Me.grdVariables.SheetTabVisible = True
         Me.grdVariables.SheetTabWidth = 154
@@ -107,7 +116,7 @@ Partial Class ucrColumnMetadata
         '
         Me.columnContextMenuStrip.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuColumnRename, Me.mnuDuplicateColumn, Me.mnuReorderColumns, Me.mnuInsertColsBefore, Me.mnuInsertColsAfter, Me.mnuDeleteCol, Me.toolStripMenuItem2, Me.mnuConvertToFactor, Me.mnuCovertToOrderedFactors, Me.mnuConvertText, Me.mnuConvertToLogical, Me.mnuConvertVariate, Me.ToolStripSeparator2, Me.mnuLevelsLabels, Me.ToolStripSeparator1, Me.mnuSort, Me.mnuColumnFilter, Me.mnuClearColumnFilter})
         Me.columnContextMenuStrip.Name = "columnContextMenuStrip"
-        Me.columnContextMenuStrip.Size = New System.Drawing.Size(213, 374)
+        Me.columnContextMenuStrip.Size = New System.Drawing.Size(213, 352)
         '
         'mnuColumnRename
         '
@@ -256,6 +265,56 @@ Partial Class ucrColumnMetadata
         Me.tlpTableContainer.Size = New System.Drawing.Size(344, 138)
         Me.tlpTableContainer.TabIndex = 7
         '
+        'statusColumnMenu
+        '
+        Me.statusColumnMenu.ImageScalingSize = New System.Drawing.Size(20, 20)
+        Me.statusColumnMenu.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.deleteDataFrame, Me.renameSheet, Me.hideSheet, Me.unhideSheet, Me.copySheet, Me.reorderSheet, Me.viewSheet})
+        Me.statusColumnMenu.Name = "statusColumnMenu"
+        Me.statusColumnMenu.Size = New System.Drawing.Size(163, 158)
+        '
+        'deleteDataFrame
+        '
+        Me.deleteDataFrame.Name = "deleteDataFrame"
+        Me.deleteDataFrame.Size = New System.Drawing.Size(162, 22)
+        Me.deleteDataFrame.Text = "Delete..."
+        '
+        'renameSheet
+        '
+        Me.renameSheet.Name = "renameSheet"
+        Me.renameSheet.Size = New System.Drawing.Size(162, 22)
+        Me.renameSheet.Text = "Rename..."
+        '
+        'hideSheet
+        '
+        Me.hideSheet.Name = "hideSheet"
+        Me.hideSheet.Size = New System.Drawing.Size(162, 22)
+        Me.hideSheet.Text = "Hide"
+        '
+        'unhideSheet
+        '
+        Me.unhideSheet.Name = "unhideSheet"
+        Me.unhideSheet.Size = New System.Drawing.Size(162, 22)
+        Me.unhideSheet.Text = "Unhide..."
+        '
+        'copySheet
+        '
+        Me.copySheet.Name = "copySheet"
+        Me.copySheet.Size = New System.Drawing.Size(162, 22)
+        Me.copySheet.Text = "Copy..."
+        '
+        'reorderSheet
+        '
+        Me.reorderSheet.Enabled = False
+        Me.reorderSheet.Name = "reorderSheet"
+        Me.reorderSheet.Size = New System.Drawing.Size(162, 22)
+        Me.reorderSheet.Text = "Reorder..."
+        '
+        'viewSheet
+        '
+        Me.viewSheet.Name = "viewSheet"
+        Me.viewSheet.Size = New System.Drawing.Size(162, 22)
+        Me.viewSheet.Text = "View Data Frame"
+        '
         'ucrColumnMetadata
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
@@ -267,6 +326,7 @@ Partial Class ucrColumnMetadata
         Me.columnContextMenuStrip.ResumeLayout(False)
         Me.propertiesContextMenuStrip.ResumeLayout(False)
         Me.tlpTableContainer.ResumeLayout(False)
+        Me.statusColumnMenu.ResumeLayout(False)
         Me.ResumeLayout(False)
 
     End Sub
@@ -297,4 +357,12 @@ Partial Class ucrColumnMetadata
     Friend WithEvents mnuDeleteLabels As ToolStripMenuItem
     Friend WithEvents cellContextMenuStrip As ContextMenuStrip
     Friend WithEvents mnuHelp As ToolStripMenuItem
+    Friend WithEvents statusColumnMenu As ContextMenuStrip
+    Friend WithEvents deleteDataFrame As ToolStripMenuItem
+    Friend WithEvents renameSheet As ToolStripMenuItem
+    Friend WithEvents hideSheet As ToolStripMenuItem
+    Friend WithEvents unhideSheet As ToolStripMenuItem
+    Friend WithEvents copySheet As ToolStripMenuItem
+    Friend WithEvents reorderSheet As ToolStripMenuItem
+    Friend WithEvents viewSheet As ToolStripMenuItem
 End Class

--- a/instat/ucrColumnMetadata.Designer.vb
+++ b/instat/ucrColumnMetadata.Designer.vb
@@ -58,7 +58,6 @@ Partial Class ucrColumnMetadata
         Me.ToolStripSeparator2 = New System.Windows.Forms.ToolStripSeparator()
         Me.mnuLevelsLabels = New System.Windows.Forms.ToolStripMenuItem()
         Me.ToolStripSeparator1 = New System.Windows.Forms.ToolStripSeparator()
-        Me.ToolStripSeparator3 = New System.Windows.Forms.ToolStripSeparator()
         Me.mnuSort = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuColumnFilter = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuClearColumnFilter = New System.Windows.Forms.ToolStripMenuItem()
@@ -106,9 +105,9 @@ Partial Class ucrColumnMetadata
         '
         'columnContextMenuStrip
         '
-        Me.columnContextMenuStrip.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuColumnRename, Me.mnuDuplicateColumn, Me.mnuReorderColumns, Me.mnuInsertColsBefore, Me.mnuInsertColsAfter, Me.mnuDeleteCol, Me.toolStripMenuItem2, Me.mnuConvertToFactor, Me.mnuCovertToOrderedFactors, Me.mnuConvertText, Me.mnuConvertToLogical, Me.mnuConvertVariate, Me.ToolStripSeparator2, Me.mnuLevelsLabels, Me.ToolStripSeparator1, Me.ToolStripSeparator3, Me.mnuSort, Me.mnuColumnFilter, Me.mnuClearColumnFilter})
+        Me.columnContextMenuStrip.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuColumnRename, Me.mnuDuplicateColumn, Me.mnuReorderColumns, Me.mnuInsertColsBefore, Me.mnuInsertColsAfter, Me.mnuDeleteCol, Me.toolStripMenuItem2, Me.mnuConvertToFactor, Me.mnuCovertToOrderedFactors, Me.mnuConvertText, Me.mnuConvertToLogical, Me.mnuConvertVariate, Me.ToolStripSeparator2, Me.mnuLevelsLabels, Me.ToolStripSeparator1, Me.mnuSort, Me.mnuColumnFilter, Me.mnuClearColumnFilter})
         Me.columnContextMenuStrip.Name = "columnContextMenuStrip"
-        Me.columnContextMenuStrip.Size = New System.Drawing.Size(213, 380)
+        Me.columnContextMenuStrip.Size = New System.Drawing.Size(213, 374)
         '
         'mnuColumnRename
         '
@@ -198,11 +197,6 @@ Partial Class ucrColumnMetadata
         Me.ToolStripSeparator1.Name = "ToolStripSeparator1"
         Me.ToolStripSeparator1.Size = New System.Drawing.Size(209, 6)
         '
-        'ToolStripSeparator3
-        '
-        Me.ToolStripSeparator3.Name = "ToolStripSeparator3"
-        Me.ToolStripSeparator3.Size = New System.Drawing.Size(209, 6)
-        '
         'mnuSort
         '
         Me.mnuSort.Name = "mnuSort"
@@ -290,7 +284,6 @@ Partial Class ucrColumnMetadata
     Friend WithEvents mnuCovertToOrderedFactors As ToolStripMenuItem
     Friend WithEvents mnuConvertText As ToolStripMenuItem
     Friend WithEvents mnuConvertVariate As ToolStripMenuItem
-    Friend WithEvents ToolStripSeparator3 As ToolStripSeparator
     Friend WithEvents mnuSort As ToolStripMenuItem
     Private WithEvents mnuColumnFilter As ToolStripMenuItem
     Private WithEvents mnuClearColumnFilter As ToolStripMenuItem

--- a/instat/ucrColumnMetadata.Designer.vb
+++ b/instat/ucrColumnMetadata.Designer.vb
@@ -40,8 +40,8 @@ Partial Class ucrColumnMetadata
     Private Sub InitializeComponent()
         Me.components = New System.ComponentModel.Container()
         Me.grdVariables = New unvell.ReoGrid.ReoGridControl()
-        Me.propertiesContextMenuStrip = New System.Windows.Forms.ContextMenuStrip(Me.components)
-        Me.mnuDeleteLabels = New System.Windows.Forms.ToolStripMenuItem()
+        Me.cellContextMenuStrip = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.mnuHelp = New System.Windows.Forms.ToolStripMenuItem()
         Me.columnContextMenuStrip = New System.Windows.Forms.ContextMenuStrip(Me.components)
         Me.mnuColumnRename = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuDuplicateColumn = New System.Windows.Forms.ToolStripMenuItem()
@@ -58,20 +58,18 @@ Partial Class ucrColumnMetadata
         Me.ToolStripSeparator2 = New System.Windows.Forms.ToolStripSeparator()
         Me.mnuLevelsLabels = New System.Windows.Forms.ToolStripMenuItem()
         Me.ToolStripSeparator1 = New System.Windows.Forms.ToolStripSeparator()
-        Me.mnuFreezeToHere = New System.Windows.Forms.ToolStripMenuItem()
-        Me.mnuUnfreeze = New System.Windows.Forms.ToolStripMenuItem()
         Me.ToolStripSeparator3 = New System.Windows.Forms.ToolStripSeparator()
         Me.mnuSort = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuColumnFilter = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuClearColumnFilter = New System.Windows.Forms.ToolStripMenuItem()
+        Me.propertiesContextMenuStrip = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.mnuDeleteLabels = New System.Windows.Forms.ToolStripMenuItem()
         Me.lblHeader = New System.Windows.Forms.Label()
         Me.tlpTableContainer = New System.Windows.Forms.TableLayoutPanel()
-        Me.cellContextMenuStrip = New System.Windows.Forms.ContextMenuStrip(Me.components)
-        Me.mnuHelp = New System.Windows.Forms.ToolStripMenuItem()
-        Me.propertiesContextMenuStrip.SuspendLayout()
-        Me.columnContextMenuStrip.SuspendLayout()
-        Me.tlpTableContainer.SuspendLayout()
         Me.cellContextMenuStrip.SuspendLayout()
+        Me.columnContextMenuStrip.SuspendLayout()
+        Me.propertiesContextMenuStrip.SuspendLayout()
+        Me.tlpTableContainer.SuspendLayout()
         Me.SuspendLayout()
         '
         'grdVariables
@@ -94,23 +92,23 @@ Partial Class ucrColumnMetadata
         Me.grdVariables.TabIndex = 2
         Me.grdVariables.Text = "Variables"
         '
-        'propertiesContextMenuStrip
+        'cellContextMenuStrip
         '
-        Me.propertiesContextMenuStrip.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuDeleteLabels})
-        Me.propertiesContextMenuStrip.Name = "columnContextMenuStrip"
-        Me.propertiesContextMenuStrip.Size = New System.Drawing.Size(144, 26)
+        Me.cellContextMenuStrip.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuHelp})
+        Me.cellContextMenuStrip.Name = "ContextMenuStrip1"
+        Me.cellContextMenuStrip.Size = New System.Drawing.Size(100, 26)
         '
-        'mnuDeleteLabels
+        'mnuHelp
         '
-        Me.mnuDeleteLabels.Name = "mnuDeleteLabels"
-        Me.mnuDeleteLabels.Size = New System.Drawing.Size(143, 22)
-        Me.mnuDeleteLabels.Text = "Delete Labels"
+        Me.mnuHelp.Name = "mnuHelp"
+        Me.mnuHelp.Size = New System.Drawing.Size(99, 22)
+        Me.mnuHelp.Text = "Help"
         '
         'columnContextMenuStrip
         '
-        Me.columnContextMenuStrip.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuColumnRename, Me.mnuDuplicateColumn, Me.mnuReorderColumns, Me.mnuInsertColsBefore, Me.mnuInsertColsAfter, Me.mnuDeleteCol, Me.toolStripMenuItem2, Me.mnuConvertToFactor, Me.mnuCovertToOrderedFactors, Me.mnuConvertText, Me.mnuConvertToLogical, Me.mnuConvertVariate, Me.ToolStripSeparator2, Me.mnuLevelsLabels, Me.ToolStripSeparator1, Me.mnuFreezeToHere, Me.mnuUnfreeze, Me.ToolStripSeparator3, Me.mnuSort, Me.mnuColumnFilter, Me.mnuClearColumnFilter})
+        Me.columnContextMenuStrip.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuColumnRename, Me.mnuDuplicateColumn, Me.mnuReorderColumns, Me.mnuInsertColsBefore, Me.mnuInsertColsAfter, Me.mnuDeleteCol, Me.toolStripMenuItem2, Me.mnuConvertToFactor, Me.mnuCovertToOrderedFactors, Me.mnuConvertText, Me.mnuConvertToLogical, Me.mnuConvertVariate, Me.ToolStripSeparator2, Me.mnuLevelsLabels, Me.ToolStripSeparator1, Me.ToolStripSeparator3, Me.mnuSort, Me.mnuColumnFilter, Me.mnuClearColumnFilter})
         Me.columnContextMenuStrip.Name = "columnContextMenuStrip"
-        Me.columnContextMenuStrip.Size = New System.Drawing.Size(213, 402)
+        Me.columnContextMenuStrip.Size = New System.Drawing.Size(213, 380)
         '
         'mnuColumnRename
         '
@@ -200,18 +198,6 @@ Partial Class ucrColumnMetadata
         Me.ToolStripSeparator1.Name = "ToolStripSeparator1"
         Me.ToolStripSeparator1.Size = New System.Drawing.Size(209, 6)
         '
-        'mnuFreezeToHere
-        '
-        Me.mnuFreezeToHere.Name = "mnuFreezeToHere"
-        Me.mnuFreezeToHere.Size = New System.Drawing.Size(212, 22)
-        Me.mnuFreezeToHere.Text = "Freeze to Here"
-        '
-        'mnuUnfreeze
-        '
-        Me.mnuUnfreeze.Name = "mnuUnfreeze"
-        Me.mnuUnfreeze.Size = New System.Drawing.Size(212, 22)
-        Me.mnuUnfreeze.Text = "Unfreeze"
-        '
         'ToolStripSeparator3
         '
         Me.ToolStripSeparator3.Name = "ToolStripSeparator3"
@@ -234,6 +220,18 @@ Partial Class ucrColumnMetadata
         Me.mnuClearColumnFilter.Name = "mnuClearColumnFilter"
         Me.mnuClearColumnFilter.Size = New System.Drawing.Size(212, 22)
         Me.mnuClearColumnFilter.Text = "Remove Current Filter"
+        '
+        'propertiesContextMenuStrip
+        '
+        Me.propertiesContextMenuStrip.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuDeleteLabels})
+        Me.propertiesContextMenuStrip.Name = "columnContextMenuStrip"
+        Me.propertiesContextMenuStrip.Size = New System.Drawing.Size(144, 26)
+        '
+        'mnuDeleteLabels
+        '
+        Me.mnuDeleteLabels.Name = "mnuDeleteLabels"
+        Me.mnuDeleteLabels.Size = New System.Drawing.Size(143, 22)
+        Me.mnuDeleteLabels.Text = "Delete Labels"
         '
         'lblHeader
         '
@@ -264,18 +262,6 @@ Partial Class ucrColumnMetadata
         Me.tlpTableContainer.Size = New System.Drawing.Size(344, 138)
         Me.tlpTableContainer.TabIndex = 7
         '
-        'cellContextMenuStrip
-        '
-        Me.cellContextMenuStrip.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuHelp})
-        Me.cellContextMenuStrip.Name = "ContextMenuStrip1"
-        Me.cellContextMenuStrip.Size = New System.Drawing.Size(100, 26)
-        '
-        'mnuHelp
-        '
-        Me.mnuHelp.Name = "mnuHelp"
-        Me.mnuHelp.Size = New System.Drawing.Size(152, 22)
-        Me.mnuHelp.Text = "Help"
-        '
         'ucrColumnMetadata
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
@@ -283,10 +269,10 @@ Partial Class ucrColumnMetadata
         Me.Controls.Add(Me.tlpTableContainer)
         Me.Name = "ucrColumnMetadata"
         Me.Size = New System.Drawing.Size(344, 138)
-        Me.propertiesContextMenuStrip.ResumeLayout(False)
-        Me.columnContextMenuStrip.ResumeLayout(False)
-        Me.tlpTableContainer.ResumeLayout(False)
         Me.cellContextMenuStrip.ResumeLayout(False)
+        Me.columnContextMenuStrip.ResumeLayout(False)
+        Me.propertiesContextMenuStrip.ResumeLayout(False)
+        Me.tlpTableContainer.ResumeLayout(False)
         Me.ResumeLayout(False)
 
     End Sub
@@ -304,8 +290,6 @@ Partial Class ucrColumnMetadata
     Friend WithEvents mnuCovertToOrderedFactors As ToolStripMenuItem
     Friend WithEvents mnuConvertText As ToolStripMenuItem
     Friend WithEvents mnuConvertVariate As ToolStripMenuItem
-    Friend WithEvents mnuFreezeToHere As ToolStripMenuItem
-    Friend WithEvents mnuUnfreeze As ToolStripMenuItem
     Friend WithEvents ToolStripSeparator3 As ToolStripSeparator
     Friend WithEvents mnuSort As ToolStripMenuItem
     Private WithEvents mnuColumnFilter As ToolStripMenuItem

--- a/instat/ucrColumnMetadata.resx
+++ b/instat/ucrColumnMetadata.resx
@@ -127,6 +127,6 @@
     <value>223, 22</value>
   </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>91</value>
+    <value>35</value>
   </metadata>
 </root>

--- a/instat/ucrColumnMetadata.resx
+++ b/instat/ucrColumnMetadata.resx
@@ -123,10 +123,13 @@
   <metadata name="columnContextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <metadata name="statusColumnMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>612, 25</value>
+  </metadata>
   <metadata name="propertiesContextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>223, 22</value>
   </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>35</value>
+    <value>124</value>
   </metadata>
 </root>

--- a/instat/ucrColumnMetadata.vb
+++ b/instat/ucrColumnMetadata.vb
@@ -47,8 +47,6 @@ Public Class ucrColumnMetadata
     Private Sub frmVariables_Load(sender As Object, e As EventArgs) Handles Me.Load
         loadForm()
         SetRFunctions()
-        mnuFreezeToHere.Enabled = False
-        mnuUnfreeze.Enabled = False
         mnuInsertColsAfter.Visible = False
         mnuInsertColsBefore.Visible = False
         '  grdVariables.RowHeaderContextMenuStrip = frmMain.ucrDataViewer.grdData.ColumnHeaderContextMenuStrip

--- a/instat/ucrColumnMetadata.vb
+++ b/instat/ucrColumnMetadata.vb
@@ -33,6 +33,9 @@ Public Class ucrColumnMetadata
     Private clsConvertOrderedFactor As New RFunction
     Private clsAppendVariablesMetaData As New RFunction
     Private clsGetCurrentFilterName As New RFunction
+    Private clsViewDataFrame As New RFunction
+    Private clsGetDataFrame As New RFunction
+    Private clsHideDataFrame As New RFunction
     'Public context As New frmEditor
     Public WithEvents grdCurrSheet As unvell.ReoGrid.Worksheet
     Public strPreviousCellText As String
@@ -64,6 +67,9 @@ Public Class ucrColumnMetadata
         clsUnfreezeColumns.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$unfreeze_columns")
         clsConvertOrderedFactor.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$convert_column_to_type")
         clsGetCurrentFilterName.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_current_filter_name")
+        clsViewDataFrame.SetRCommand("View")
+        clsGetDataFrame.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_data_frame")
+        clsHideDataFrame.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$append_to_dataframe_metadata")
     End Sub
 
 
@@ -369,7 +375,7 @@ Public Class ucrColumnMetadata
             clsRemoveFilter.AddParameter("data_name", Chr(34) & grdCurrSheet.Name & Chr(34), iPosition:=0)
             clsFreezeColumns.AddParameter("data_name", Chr(34) & grdCurrSheet.Name & Chr(34), iPosition:=0)
             clsUnfreezeColumns.AddParameter("data_name", Chr(34) & grdCurrSheet.Name & Chr(34), iPosition:=0)
-            'clsGetDataFrame.AddParameter("data_name", Chr(34) & grdCurrSheet.Name & Chr(34), iPosition:=0)
+            clsGetDataFrame.AddParameter("data_name", Chr(34) & grdCurrSheet.Name & Chr(34), iPosition:=0)
             clsConvertOrderedFactor.AddParameter("data_name", Chr(34) & grdCurrSheet.Name & Chr(34), iPosition:=0)
             clsGetCurrentFilterName.AddParameter("data_name", Chr(34) & grdCurrSheet.Name & Chr(34), iPosition:=0)
         End If
@@ -475,5 +481,44 @@ Public Class ucrColumnMetadata
 
     Private Sub mnuHelp_Click(sender As Object, e As EventArgs) Handles mnuHelp.Click
         Help.ShowHelp(Me, frmMain.strStaticPath & "\" & frmMain.strHelpFilePath, HelpNavigator.TopicId, "543")
+    End Sub
+
+    Private Sub deleteDataFrame_Click(sender As Object, e As EventArgs) Handles deleteDataFrame.Click
+        dlgDeleteDataFrames.SetDataFrameToAdd(grdCurrSheet.Name)
+        dlgDeleteDataFrames.ShowDialog()
+    End Sub
+
+    Private Sub renameSheet_Click(sender As Object, e As EventArgs) Handles renameSheet.Click
+        dlgRenameDataFrame.SetCurrentDataframe(grdCurrSheet.Name)
+        dlgRenameDataFrame.ShowDialog()
+    End Sub
+
+    Private Sub hideSheet_Click(sender As Object, e As EventArgs) Handles hideSheet.Click
+        clsHideDataFrame.AddParameter("data_name", Chr(34) & grdCurrSheet.Name & Chr(34))
+        clsHideDataFrame.AddParameter("property", "is_hidden_label")
+        clsHideDataFrame.AddParameter("new_val", "TRUE")
+        RunScriptFromColumnMetadata(clsHideDataFrame.ToScript(), strComment:="Right click menu: Hide Data Frame")
+    End Sub
+
+    Private Sub unhideSheet_Click(sender As Object, e As EventArgs) Handles unhideSheet.Click
+        dlgHideDataframes.ShowDialog()
+    End Sub
+
+    Private Sub copySheet_Click(sender As Object, e As EventArgs) Handles copySheet.Click
+        dlgCopyDataFrame.SetCurrentDataframe(grdCurrSheet.Name)
+        dlgCopyDataFrame.ShowDialog()
+    End Sub
+
+    Private Sub viewSheet_Click(sender As Object, e As EventArgs) Handles viewSheet.Click
+        Dim strScript As String = ""
+        Dim strTemp As String
+        clsViewDataFrame.AddParameter("x", clsRFunctionParameter:=clsGetDataFrame, iPosition:=0)
+        clsGetDataFrame.SetAssignTo(grdCurrSheet.Name)
+        strTemp = clsViewDataFrame.ToScript(strScript)
+        RunScriptFromColumnMetadata(strScript & strTemp, strComment:="Right click menu: View R Data Frame", bSeparateThread:=False)
+    End Sub
+
+    Private Sub reorderSheet_Click(sender As Object, e As EventArgs) Handles reorderSheet.Click
+        dlgReorderDataFrame.ShowDialog()
     End Sub
 End Class

--- a/instat/ucrColumnMetadata.vb
+++ b/instat/ucrColumnMetadata.vb
@@ -521,4 +521,8 @@ Public Class ucrColumnMetadata
     Private Sub reorderSheet_Click(sender As Object, e As EventArgs) Handles reorderSheet.Click
         dlgReorderDataFrame.ShowDialog()
     End Sub
+
+    Private Sub statusColumnMenu_Opening(sender As Object, e As CancelEventArgs) Handles statusColumnMenu.Opening
+        hideSheet.Enabled = (grdVariables.Worksheets.Count > 1)
+    End Sub
 End Class

--- a/instat/ucrColumnMetadata.vb
+++ b/instat/ucrColumnMetadata.vb
@@ -494,9 +494,9 @@ Public Class ucrColumnMetadata
     End Sub
 
     Private Sub hideSheet_Click(sender As Object, e As EventArgs) Handles hideSheet.Click
-        clsHideDataFrame.AddParameter("data_name", Chr(34) & grdCurrSheet.Name & Chr(34))
-        clsHideDataFrame.AddParameter("property", "is_hidden_label")
-        clsHideDataFrame.AddParameter("new_val", "TRUE")
+        clsHideDataFrame.AddParameter("data_name", Chr(34) & grdCurrSheet.Name & Chr(34), iPosition:=0)
+        clsHideDataFrame.AddParameter("property", "is_hidden_label", iPosition:=1)
+        clsHideDataFrame.AddParameter("new_val", "TRUE", iPosition:=2)
         RunScriptFromColumnMetadata(clsHideDataFrame.ToScript(), strComment:="Right click menu: Hide Data Frame")
     End Sub
 

--- a/instat/ucrDataFrameMetadata.Designer.vb
+++ b/instat/ucrDataFrameMetadata.Designer.vb
@@ -40,12 +40,21 @@ Partial Class ucrDataFrameMetadata
     Private Sub InitializeComponent()
         Me.components = New System.ComponentModel.Container()
         Me.grdMetaData = New unvell.ReoGrid.ReoGridControl()
-        Me.lblHeader = New System.Windows.Forms.Label()
-        Me.tlpTableContainer = New System.Windows.Forms.TableLayoutPanel()
         Me.cellContextMenuStrip = New System.Windows.Forms.ContextMenuStrip(Me.components)
         Me.mnuHelp = New System.Windows.Forms.ToolStripMenuItem()
-        Me.tlpTableContainer.SuspendLayout()
+        Me.lblHeader = New System.Windows.Forms.Label()
+        Me.tlpTableContainer = New System.Windows.Forms.TableLayoutPanel()
+        Me.rowRightClickMenu = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.deleteDataFrame = New System.Windows.Forms.ToolStripMenuItem()
+        Me.renameSheet = New System.Windows.Forms.ToolStripMenuItem()
+        Me.hideSheet = New System.Windows.Forms.ToolStripMenuItem()
+        Me.unhideSheet = New System.Windows.Forms.ToolStripMenuItem()
+        Me.copySheet = New System.Windows.Forms.ToolStripMenuItem()
+        Me.reorderSheet = New System.Windows.Forms.ToolStripMenuItem()
+        Me.viewSheet = New System.Windows.Forms.ToolStripMenuItem()
         Me.cellContextMenuStrip.SuspendLayout()
+        Me.tlpTableContainer.SuspendLayout()
+        Me.rowRightClickMenu.SuspendLayout()
         Me.SuspendLayout()
         '
         'grdMetaData
@@ -57,7 +66,7 @@ Partial Class ucrDataFrameMetadata
         Me.grdMetaData.LeadHeaderContextMenuStrip = Nothing
         Me.grdMetaData.Location = New System.Drawing.Point(3, 23)
         Me.grdMetaData.Name = "grdMetaData"
-        Me.grdMetaData.RowHeaderContextMenuStrip = Nothing
+        Me.grdMetaData.RowHeaderContextMenuStrip = Me.rowRightClickMenu
         Me.grdMetaData.Script = Nothing
         Me.grdMetaData.SheetTabContextMenuStrip = Nothing
         Me.grdMetaData.SheetTabNewButtonVisible = False
@@ -67,6 +76,18 @@ Partial Class ucrDataFrameMetadata
         Me.grdMetaData.Size = New System.Drawing.Size(471, 291)
         Me.grdMetaData.TabIndex = 1
         Me.grdMetaData.Text = "Meta Data"
+        '
+        'cellContextMenuStrip
+        '
+        Me.cellContextMenuStrip.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuHelp})
+        Me.cellContextMenuStrip.Name = "cellContextMenuStrip"
+        Me.cellContextMenuStrip.Size = New System.Drawing.Size(100, 26)
+        '
+        'mnuHelp
+        '
+        Me.mnuHelp.Name = "mnuHelp"
+        Me.mnuHelp.Size = New System.Drawing.Size(99, 22)
+        Me.mnuHelp.Text = "Help"
         '
         'lblHeader
         '
@@ -96,17 +117,55 @@ Partial Class ucrDataFrameMetadata
         Me.tlpTableContainer.Size = New System.Drawing.Size(477, 317)
         Me.tlpTableContainer.TabIndex = 8
         '
-        'cellContextMenuStrip
+        'rowRightClickMenu
         '
-        Me.cellContextMenuStrip.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuHelp})
-        Me.cellContextMenuStrip.Name = "cellContextMenuStrip"
-        Me.cellContextMenuStrip.Size = New System.Drawing.Size(100, 26)
+        Me.rowRightClickMenu.ImageScalingSize = New System.Drawing.Size(20, 20)
+        Me.rowRightClickMenu.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.deleteDataFrame, Me.renameSheet, Me.hideSheet, Me.unhideSheet, Me.copySheet, Me.reorderSheet, Me.viewSheet})
+        Me.rowRightClickMenu.Name = "statusColumnMenu"
+        Me.rowRightClickMenu.Size = New System.Drawing.Size(163, 158)
         '
-        'mnuHelp
+        'deleteDataFrame
         '
-        Me.mnuHelp.Name = "mnuHelp"
-        Me.mnuHelp.Size = New System.Drawing.Size(152, 22)
-        Me.mnuHelp.Text = "Help"
+        Me.deleteDataFrame.Name = "deleteDataFrame"
+        Me.deleteDataFrame.Size = New System.Drawing.Size(180, 22)
+        Me.deleteDataFrame.Text = "Delete..."
+        '
+        'renameSheet
+        '
+        Me.renameSheet.Name = "renameSheet"
+        Me.renameSheet.Size = New System.Drawing.Size(180, 22)
+        Me.renameSheet.Text = "Rename..."
+        '
+        'hideSheet
+        '
+        Me.hideSheet.Name = "hideSheet"
+        Me.hideSheet.Size = New System.Drawing.Size(180, 22)
+        Me.hideSheet.Text = "Hide"
+        '
+        'unhideSheet
+        '
+        Me.unhideSheet.Name = "unhideSheet"
+        Me.unhideSheet.Size = New System.Drawing.Size(180, 22)
+        Me.unhideSheet.Text = "Unhide..."
+        '
+        'copySheet
+        '
+        Me.copySheet.Name = "copySheet"
+        Me.copySheet.Size = New System.Drawing.Size(180, 22)
+        Me.copySheet.Text = "Copy..."
+        '
+        'reorderSheet
+        '
+        Me.reorderSheet.Enabled = False
+        Me.reorderSheet.Name = "reorderSheet"
+        Me.reorderSheet.Size = New System.Drawing.Size(180, 22)
+        Me.reorderSheet.Text = "Reorder..."
+        '
+        'viewSheet
+        '
+        Me.viewSheet.Name = "viewSheet"
+        Me.viewSheet.Size = New System.Drawing.Size(180, 22)
+        Me.viewSheet.Text = "View Data Frame"
         '
         'ucrDataFrameMetadata
         '
@@ -115,8 +174,9 @@ Partial Class ucrDataFrameMetadata
         Me.Controls.Add(Me.tlpTableContainer)
         Me.Name = "ucrDataFrameMetadata"
         Me.Size = New System.Drawing.Size(477, 317)
-        Me.tlpTableContainer.ResumeLayout(False)
         Me.cellContextMenuStrip.ResumeLayout(False)
+        Me.tlpTableContainer.ResumeLayout(False)
+        Me.rowRightClickMenu.ResumeLayout(False)
         Me.ResumeLayout(False)
 
     End Sub
@@ -126,4 +186,12 @@ Partial Class ucrDataFrameMetadata
     Friend WithEvents tlpTableContainer As TableLayoutPanel
     Friend WithEvents cellContextMenuStrip As ContextMenuStrip
     Friend WithEvents mnuHelp As ToolStripMenuItem
+    Friend WithEvents rowRightClickMenu As ContextMenuStrip
+    Friend WithEvents deleteDataFrame As ToolStripMenuItem
+    Friend WithEvents renameSheet As ToolStripMenuItem
+    Friend WithEvents hideSheet As ToolStripMenuItem
+    Friend WithEvents unhideSheet As ToolStripMenuItem
+    Friend WithEvents copySheet As ToolStripMenuItem
+    Friend WithEvents reorderSheet As ToolStripMenuItem
+    Friend WithEvents viewSheet As ToolStripMenuItem
 End Class

--- a/instat/ucrDataFrameMetadata.resx
+++ b/instat/ucrDataFrameMetadata.resx
@@ -120,4 +120,7 @@
   <metadata name="cellContextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <metadata name="rowRightClickMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>205, 13</value>
+  </metadata>
 </root>

--- a/instat/ucrDataFrameMetadata.vb
+++ b/instat/ucrDataFrameMetadata.vb
@@ -163,12 +163,12 @@ Public Class ucrDataFrameMetadata
     End Sub
 
     Private Function GetSelectedVariableNamesAsArray() As String()
-        Dim lstSelectedVars As New List(Of String)
+        Dim arrSelectedVars(grdMetaData.CurrentWorksheet.SelectionRange.Rows - 1) As String
 
         For i As Integer = grdMetaData.CurrentWorksheet.SelectionRange.Row To grdMetaData.CurrentWorksheet.SelectionRange.Row + grdMetaData.CurrentWorksheet.SelectionRange.Rows - 1
-            lstSelectedVars.Add(grdMetaData.CurrentWorksheet(i, 0))
+            arrSelectedVars(i - grdMetaData.CurrentWorksheet.SelectionRange.Row) = grdMetaData.CurrentWorksheet(i, 0)
         Next
-        Return lstSelectedVars.ToArray
+        Return arrSelectedVars
     End Function
 
     Private Sub deleteDataFrame_Click(sender As Object, e As EventArgs) Handles deleteDataFrame.Click

--- a/instat/ucrDataView.vb
+++ b/instat/ucrDataView.vb
@@ -256,18 +256,6 @@ Public Class ucrDataView
         End If
     End Sub
 
-    'Private Sub resetToDefaultHeightToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles resetToDefaultHeightToolStripMenuItem.Click
-    '    grdData.DoAction(New unvell.ReoGrid.Actions.SetRowsHeightAction(grdData.CurrentWorksheet.SelectionRange.Row, grdData.CurrentWorksheet.SelectionRange.Rows, unvell.ReoGrid.Worksheet.InitDefaultRowHeight))
-    'End Sub
-
-    'Private Sub hideRowsToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles hideRowsToolStripMenuItem.Click
-    '    grdData.DoAction(New unvell.ReoGrid.Actions.HideRowsAction(grdData.CurrentWorksheet.SelectionRange.Row, grdData.CurrentWorksheet.SelectionRange.Rows))
-    'End Sub
-
-    'Private Sub unhideRowsToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles unhideRowsToolStripMenuItem.Click
-    '    grdData.DoAction(New unvell.ReoGrid.Actions.UnhideRowsAction(grdData.CurrentWorksheet.SelectionRange.Row, grdData.CurrentWorksheet.SelectionRange.Rows))
-    'End Sub
-
     'Private Sub cutRangeToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles cutRangeToolStripMenuItem.Click
     '    Try
     '        grdData.CurrentWorksheet.Cut()


### PR DESCRIPTION
Fixes #5250 and Fixes #2967 @africanmathsinitiative/developers this is ready for review.

Notes
- Deleted extra separator, disabled freeze and unfreeze menu items
- Added and implemented facilities for tab context menu strip
- Enabled hide sheet when sheets > 1
- Removed some commented out code