### PR TITLE
Removing space between label and input in the save control

### DIFF
--- a/instat/dlgFromLibrary.vb
+++ b/instat/dlgFromLibrary.vb
@@ -86,9 +86,9 @@ Public Class dlgFromLibrary
 
         ucrPnlOptions.AddToLinkedControls(ucrNewDataFrameName, {rdoDefaultDatasets}, bNewLinkedHideIfParameterMissing:=True, bNewLinkedUpdateFunction:=True)
 
+        ucrNewDataFrameName.SetSaveTypeAsDataFrame()
         ucrNewDataFrameName.SetLabelText("New Data Frame Name:")
         ucrNewDataFrameName.SetIsTextBox()
-        ucrNewDataFrameName.SetSaveTypeAsDataFrame()
     End Sub
 
     Private Sub SetDefaults()


### PR DESCRIPTION
@africanmathsinitiative/developers this is ready for review. It is a minor designer fix. I have removed the space between the input control and the label in the save control.

Since there is no open issue that this PR fixes see below screenshots.

**Previous**
![image](https://user-images.githubusercontent.com/26301973/109666821-9aea2a80-7b80-11eb-91bc-62ea3aa5c5c2.png)

**Current**
![image](https://user-images.githubusercontent.com/26301973/109666475-45ae1900-7b80-11eb-94f3-36fc29313c10.png)
