### PR TITLE
Simplify Joining Columns options on Merge dialog

### DIFF
--- a/instat/dlgMerge.vb
+++ b/instat/dlgMerge.vb
@@ -26,6 +26,7 @@ Public Class dlgMerge
     Private ttJoinType As New ToolTip
     Private dctJoinTexts As New Dictionary(Of String, String)
     Private bMergeColumnsExist As Boolean
+    Private clsSuffixC As RFunction
 
     ' This dialog has a bug when using numeric and integer columns as the joining columns.
     ' Issue reported here: https://github.com/hadley/dplyr/issues/2164
@@ -98,6 +99,7 @@ Public Class dlgMerge
     Private Sub SetDefaults()
         clsMerge = New RFunction
         clsByList = New RFunction
+        clsSuffixC = New RFunction
 
         ucrFirstDataFrame.Reset()
         ucrSecondDataFrame.Reset()
@@ -108,6 +110,8 @@ Public Class dlgMerge
         clsMerge.SetRCommand("full_join")
 
         clsByList.SetRCommand("c")
+
+        clsSuffixC.SetRCommand("c")
 
         ucrBase.clsRsyntax.SetBaseRFunction(clsMerge)
         bResetSubdialog = True
@@ -172,14 +176,16 @@ Public Class dlgMerge
 
     Private Sub DataFrames_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrFirstDataFrame.ControlValueChanged, ucrSecondDataFrame.ControlValueChanged
         If ucrFirstDataFrame.cboAvailableDataFrames.Text <> "" AndAlso ucrSecondDataFrame.cboAvailableDataFrames.Text <> "" Then
-            clsMerge.AddParameter("suffix", "c(" & Chr(34) & ucrFirstDataFrame.cboAvailableDataFrames.Text & Chr(34) & ", " & Chr(34) & ucrSecondDataFrame.cboAvailableDataFrames.Text & Chr(34) & ")")
+            clsSuffixC.AddParameter("0", strParameterValue:=Chr(34) & ucrFirstDataFrame.cboAvailableDataFrames.Text & Chr(34), iPosition:=0, bIncludeArgumentName:=False)
+            clsSuffixC.AddParameter("1", strParameterValue:=Chr(34) & ucrSecondDataFrame.cboAvailableDataFrames.Text & Chr(34), iPosition:=1, bIncludeArgumentName:=False)
         Else
             clsMerge.RemoveParameterByName("suffix")
         End If
         ' Ensures options set on the subdialog are "reset" since they depend on data frame choice
         clsMerge.RemoveParameterByName("by")
-        clsMerge.AddParameter("x", clsRFunctionParameter:=ucrFirstDataFrame.clsCurrDataFrame)
-        clsMerge.AddParameter("y", clsRFunctionParameter:=ucrSecondDataFrame.clsCurrDataFrame)
+        clsByList.ClearParameters()
+        clsMerge.AddParameter("x", clsRFunctionParameter:=ucrFirstDataFrame.clsCurrDataFrame, iPosition:=0)
+        clsMerge.AddParameter("y", clsRFunctionParameter:=ucrSecondDataFrame.clsCurrDataFrame, iPosition:=1)
         SetMergingBy()
     End Sub
 
@@ -192,6 +198,7 @@ Public Class dlgMerge
         Dim lstJoinPairs As New List(Of String)
         Dim lstFirstColumns As List(Of String)
         Dim lstSecondColumns As List(Of String)
+        Dim i As Integer = 0
 
         If ucrFirstDataFrame.cboAvailableDataFrames.Text <> "" AndAlso ucrSecondDataFrame.cboAvailableDataFrames.Text <> "" Then
             If clsMerge.ContainsParameter("by") Then
@@ -201,11 +208,17 @@ Public Class dlgMerge
             Else
                 lstFirstColumns = frmMain.clsRLink.GetColumnNames(ucrFirstDataFrame.cboAvailableDataFrames.Text)
                 lstSecondColumns = frmMain.clsRLink.GetColumnNames(ucrSecondDataFrame.cboAvailableDataFrames.Text)
+                i = 0
                 For Each strFirst As String In lstFirstColumns
                     If lstSecondColumns.Contains(strFirst) Then
                         dctJoinColumns.Add(strFirst, strFirst)
+                        clsByList.AddParameter(Chr(34) & strFirst & Chr(34), Chr(34) & strFirst & Chr(34), iPosition:=i)
+                        i = i + 1
                     End If
                 Next
+                If clsByList.iParameterCount > 0 Then
+                    clsMerge.AddParameter("by", clsRFunctionParameter:=clsByList, iPosition:=2)
+                End If
             End If
             If dctJoinColumns.Count > 0 Then
                 For Each kvpTemp As KeyValuePair(Of String, String) In dctJoinColumns
@@ -220,9 +233,10 @@ Public Class dlgMerge
         Else
             ucrInputMergingBy.SetName("")
             ucrInputMergingBy.txtInput.BackColor = SystemColors.Control
+            clsMerge.RemoveParameterByName("by")
+            clsByList.ClearParameters()
         End If
         bMergeColumnsExist = (dctJoinColumns.Count > 0)
         TestOKEnabled()
     End Sub
-
 End Class

--- a/instat/sdgMerge.Designer.vb
+++ b/instat/sdgMerge.Designer.vb
@@ -53,11 +53,8 @@ Partial Class sdgMerge
         Me.cmdRemoveSelectedPair = New System.Windows.Forms.Button()
         Me.tbcMergeOptions = New System.Windows.Forms.TabControl()
         Me.tpJoinByOptions = New System.Windows.Forms.TabPage()
-        Me.rdoChooseColumns = New System.Windows.Forms.RadioButton()
-        Me.rdoByAllMatching = New System.Windows.Forms.RadioButton()
         Me.ucrSelectorSecondDF = New instat.ucrSelectorByDataFrameAddRemove()
         Me.ucrSelectorFirstDF = New instat.ucrSelectorByDataFrameAddRemove()
-        Me.ucrPnlMergeByOptions = New instat.UcrPanel()
         Me.tpIncludeColumns = New System.Windows.Forms.TabPage()
         Me.ucrChkMergeWithSubsetSecond = New instat.ucrCheck()
         Me.ucrChkMergeWithSubsetFirst = New instat.ucrCheck()
@@ -138,6 +135,7 @@ Partial Class sdgMerge
         'lstKeyColumns
         '
         Me.lstKeyColumns.FullRowSelect = True
+        Me.lstKeyColumns.HideSelection = False
         resources.ApplyResources(Me.lstKeyColumns, "lstKeyColumns")
         Me.lstKeyColumns.Name = "lstKeyColumns"
         Me.lstKeyColumns.UseCompatibleStateImageBehavior = False
@@ -164,37 +162,17 @@ Partial Class sdgMerge
         '
         'tpJoinByOptions
         '
-        Me.tpJoinByOptions.Controls.Add(Me.rdoChooseColumns)
-        Me.tpJoinByOptions.Controls.Add(Me.rdoByAllMatching)
         Me.tpJoinByOptions.Controls.Add(Me.ucrSelectorSecondDF)
         Me.tpJoinByOptions.Controls.Add(Me.ucrSelectorFirstDF)
         Me.tpJoinByOptions.Controls.Add(Me.pnlKeyColumns)
         Me.tpJoinByOptions.Controls.Add(Me.grpKeys)
-        Me.tpJoinByOptions.Controls.Add(Me.ucrPnlMergeByOptions)
         resources.ApplyResources(Me.tpJoinByOptions, "tpJoinByOptions")
         Me.tpJoinByOptions.Name = "tpJoinByOptions"
         Me.tpJoinByOptions.UseVisualStyleBackColor = True
         '
-        'rdoChooseColumns
-        '
-        resources.ApplyResources(Me.rdoChooseColumns, "rdoChooseColumns")
-        Me.rdoChooseColumns.FlatAppearance.BorderColor = System.Drawing.SystemColors.ActiveCaption
-        Me.rdoChooseColumns.FlatAppearance.BorderSize = 2
-        Me.rdoChooseColumns.FlatAppearance.CheckedBackColor = System.Drawing.SystemColors.ActiveCaption
-        Me.rdoChooseColumns.Name = "rdoChooseColumns"
-        Me.rdoChooseColumns.UseVisualStyleBackColor = True
-        '
-        'rdoByAllMatching
-        '
-        resources.ApplyResources(Me.rdoByAllMatching, "rdoByAllMatching")
-        Me.rdoByAllMatching.FlatAppearance.BorderColor = System.Drawing.SystemColors.ActiveCaption
-        Me.rdoByAllMatching.FlatAppearance.BorderSize = 2
-        Me.rdoByAllMatching.FlatAppearance.CheckedBackColor = System.Drawing.SystemColors.ActiveCaption
-        Me.rdoByAllMatching.Name = "rdoByAllMatching"
-        Me.rdoByAllMatching.UseVisualStyleBackColor = True
-        '
         'ucrSelectorSecondDF
         '
+        Me.ucrSelectorSecondDF.bDropUnusedFilterLevels = False
         Me.ucrSelectorSecondDF.bShowHiddenColumns = False
         Me.ucrSelectorSecondDF.bUseCurrentFilter = True
         resources.ApplyResources(Me.ucrSelectorSecondDF, "ucrSelectorSecondDF")
@@ -202,15 +180,11 @@ Partial Class sdgMerge
         '
         'ucrSelectorFirstDF
         '
+        Me.ucrSelectorFirstDF.bDropUnusedFilterLevels = False
         Me.ucrSelectorFirstDF.bShowHiddenColumns = False
         Me.ucrSelectorFirstDF.bUseCurrentFilter = True
         resources.ApplyResources(Me.ucrSelectorFirstDF, "ucrSelectorFirstDF")
         Me.ucrSelectorFirstDF.Name = "ucrSelectorFirstDF"
-        '
-        'ucrPnlMergeByOptions
-        '
-        resources.ApplyResources(Me.ucrPnlMergeByOptions, "ucrPnlMergeByOptions")
-        Me.ucrPnlMergeByOptions.Name = "ucrPnlMergeByOptions"
         '
         'tpIncludeColumns
         '
@@ -268,6 +242,7 @@ Partial Class sdgMerge
         '
         'ucrSelectorColumnsToIncludeSecond
         '
+        Me.ucrSelectorColumnsToIncludeSecond.bDropUnusedFilterLevels = False
         Me.ucrSelectorColumnsToIncludeSecond.bShowHiddenColumns = False
         Me.ucrSelectorColumnsToIncludeSecond.bUseCurrentFilter = True
         resources.ApplyResources(Me.ucrSelectorColumnsToIncludeSecond, "ucrSelectorColumnsToIncludeSecond")
@@ -275,6 +250,7 @@ Partial Class sdgMerge
         '
         'ucrSelectorColumnsToIncludeFirst
         '
+        Me.ucrSelectorColumnsToIncludeFirst.bDropUnusedFilterLevels = False
         Me.ucrSelectorColumnsToIncludeFirst.bShowHiddenColumns = False
         Me.ucrSelectorColumnsToIncludeFirst.bUseCurrentFilter = True
         resources.ApplyResources(Me.ucrSelectorColumnsToIncludeFirst, "ucrSelectorColumnsToIncludeFirst")
@@ -324,15 +300,12 @@ Partial Class sdgMerge
     Friend WithEvents cmdRemoveSelectedPair As Button
     Friend WithEvents tpIncludeColumns As TabPage
     Friend WithEvents ucrReceiverFirstDF As ucrReceiverSingle
-    Friend WithEvents ucrPnlMergeByOptions As UcrPanel
     Friend WithEvents lblVariablesToIncludeSecond As Label
     Friend WithEvents lblVariablesToIncludeFirst As Label
     Friend WithEvents ucrReceiverSecondSelected As ucrReceiverMultiple
     Friend WithEvents ucrReceiverFirstSelected As ucrReceiverMultiple
     Friend WithEvents ucrSelectorColumnsToIncludeSecond As ucrSelectorByDataFrameAddRemove
     Friend WithEvents ucrSelectorColumnsToIncludeFirst As ucrSelectorByDataFrameAddRemove
-    Friend WithEvents rdoChooseColumns As RadioButton
-    Friend WithEvents rdoByAllMatching As RadioButton
     Friend WithEvents ucrChkMergeWithSubsetSecond As ucrCheck
     Friend WithEvents ucrChkMergeWithSubsetFirst As ucrCheck
 End Class

--- a/instat/sdgMerge.resx
+++ b/instat/sdgMerge.resx
@@ -223,7 +223,7 @@
     <value>3</value>
   </data>
   <data name="grpKeys.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 243</value>
+    <value>5, 199</value>
   </data>
   <data name="grpKeys.Size" type="System.Drawing.Size, System.Drawing">
     <value>335, 76</value>
@@ -244,7 +244,7 @@
     <value>tpJoinByOptions</value>
   </data>
   <data name="&gt;&gt;grpKeys.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>3</value>
   </data>
   <data name="cmdRemoveAll.Location" type="System.Drawing.Point, System.Drawing">
     <value>6, 223</value>
@@ -343,7 +343,7 @@
     <value>3</value>
   </data>
   <data name="pnlKeyColumns.Location" type="System.Drawing.Point, System.Drawing">
-    <value>435, 65</value>
+    <value>435, 21</value>
   </data>
   <data name="pnlKeyColumns.Size" type="System.Drawing.Size, System.Drawing">
     <value>194, 256</value>
@@ -361,76 +361,10 @@
     <value>tpJoinByOptions</value>
   </data>
   <data name="&gt;&gt;pnlKeyColumns.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="rdoChooseColumns.Appearance" type="System.Windows.Forms.Appearance, System.Windows.Forms">
-    <value>Button</value>
-  </data>
-  <data name="rdoChooseColumns.FlatStyle" type="System.Windows.Forms.FlatStyle, System.Windows.Forms">
-    <value>Flat</value>
-  </data>
-  <data name="rdoChooseColumns.Location" type="System.Drawing.Point, System.Drawing">
-    <value>316, 15</value>
-  </data>
-  <data name="rdoChooseColumns.Size" type="System.Drawing.Size, System.Drawing">
-    <value>224, 28</value>
-  </data>
-  <data name="rdoChooseColumns.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
-  <data name="rdoChooseColumns.Text" xml:space="preserve">
-    <value>Choose which columns to merge by</value>
-  </data>
-  <data name="rdoChooseColumns.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleCenter</value>
-  </data>
-  <data name="&gt;&gt;rdoChooseColumns.Name" xml:space="preserve">
-    <value>rdoChooseColumns</value>
-  </data>
-  <data name="&gt;&gt;rdoChooseColumns.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rdoChooseColumns.Parent" xml:space="preserve">
-    <value>tpJoinByOptions</value>
-  </data>
-  <data name="&gt;&gt;rdoChooseColumns.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="rdoByAllMatching.Appearance" type="System.Windows.Forms.Appearance, System.Windows.Forms">
-    <value>Button</value>
-  </data>
-  <data name="rdoByAllMatching.FlatStyle" type="System.Windows.Forms.FlatStyle, System.Windows.Forms">
-    <value>Flat</value>
-  </data>
-  <data name="rdoByAllMatching.Location" type="System.Drawing.Point, System.Drawing">
-    <value>94, 15</value>
-  </data>
-  <data name="rdoByAllMatching.Size" type="System.Drawing.Size, System.Drawing">
-    <value>224, 28</value>
-  </data>
-  <data name="rdoByAllMatching.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="rdoByAllMatching.Text" xml:space="preserve">
-    <value>Merge by all columns with the same name</value>
-  </data>
-  <data name="rdoByAllMatching.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleCenter</value>
-  </data>
-  <data name="&gt;&gt;rdoByAllMatching.Name" xml:space="preserve">
-    <value>rdoByAllMatching</value>
-  </data>
-  <data name="&gt;&gt;rdoByAllMatching.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rdoByAllMatching.Parent" xml:space="preserve">
-    <value>tpJoinByOptions</value>
-  </data>
-  <data name="&gt;&gt;rdoByAllMatching.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="ucrSelectorSecondDF.Location" type="System.Drawing.Point, System.Drawing">
-    <value>222, 57</value>
+    <value>222, 13</value>
   </data>
   <data name="ucrSelectorSecondDF.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
@@ -451,10 +385,10 @@
     <value>tpJoinByOptions</value>
   </data>
   <data name="&gt;&gt;ucrSelectorSecondDF.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>0</value>
   </data>
   <data name="ucrSelectorFirstDF.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 57</value>
+    <value>6, 13</value>
   </data>
   <data name="ucrSelectorFirstDF.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
@@ -475,28 +409,7 @@
     <value>tpJoinByOptions</value>
   </data>
   <data name="&gt;&gt;ucrSelectorFirstDF.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="ucrPnlMergeByOptions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>90, 13</value>
-  </data>
-  <data name="ucrPnlMergeByOptions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>460, 42</value>
-  </data>
-  <data name="ucrPnlMergeByOptions.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;ucrPnlMergeByOptions.Name" xml:space="preserve">
-    <value>ucrPnlMergeByOptions</value>
-  </data>
-  <data name="&gt;&gt;ucrPnlMergeByOptions.Type" xml:space="preserve">
-    <value>instat.UcrPanel, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrPnlMergeByOptions.Parent" xml:space="preserve">
-    <value>tpJoinByOptions</value>
-  </data>
-  <data name="&gt;&gt;ucrPnlMergeByOptions.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>1</value>
   </data>
   <data name="tpJoinByOptions.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
@@ -523,6 +436,150 @@
     <value>tbcMergeOptions</value>
   </data>
   <data name="&gt;&gt;tpJoinByOptions.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;ucrChkMergeWithSubsetSecond.Name" xml:space="preserve">
+    <value>ucrChkMergeWithSubsetSecond</value>
+  </data>
+  <data name="&gt;&gt;ucrChkMergeWithSubsetSecond.Type" xml:space="preserve">
+    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrChkMergeWithSubsetSecond.Parent" xml:space="preserve">
+    <value>tpIncludeColumns</value>
+  </data>
+  <data name="&gt;&gt;ucrChkMergeWithSubsetSecond.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;ucrChkMergeWithSubsetFirst.Name" xml:space="preserve">
+    <value>ucrChkMergeWithSubsetFirst</value>
+  </data>
+  <data name="&gt;&gt;ucrChkMergeWithSubsetFirst.Type" xml:space="preserve">
+    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrChkMergeWithSubsetFirst.Parent" xml:space="preserve">
+    <value>tpIncludeColumns</value>
+  </data>
+  <data name="&gt;&gt;ucrChkMergeWithSubsetFirst.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;lblVariablesToIncludeSecond.Name" xml:space="preserve">
+    <value>lblVariablesToIncludeSecond</value>
+  </data>
+  <data name="&gt;&gt;lblVariablesToIncludeSecond.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblVariablesToIncludeSecond.Parent" xml:space="preserve">
+    <value>tpIncludeColumns</value>
+  </data>
+  <data name="&gt;&gt;lblVariablesToIncludeSecond.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;lblVariablesToIncludeFirst.Name" xml:space="preserve">
+    <value>lblVariablesToIncludeFirst</value>
+  </data>
+  <data name="&gt;&gt;lblVariablesToIncludeFirst.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblVariablesToIncludeFirst.Parent" xml:space="preserve">
+    <value>tpIncludeColumns</value>
+  </data>
+  <data name="&gt;&gt;lblVariablesToIncludeFirst.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverSecondSelected.Name" xml:space="preserve">
+    <value>ucrReceiverSecondSelected</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverSecondSelected.Type" xml:space="preserve">
+    <value>instat.ucrReceiverMultiple, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverSecondSelected.Parent" xml:space="preserve">
+    <value>tpIncludeColumns</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverSecondSelected.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverFirstSelected.Name" xml:space="preserve">
+    <value>ucrReceiverFirstSelected</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverFirstSelected.Type" xml:space="preserve">
+    <value>instat.ucrReceiverMultiple, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverFirstSelected.Parent" xml:space="preserve">
+    <value>tpIncludeColumns</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverFirstSelected.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;ucrSelectorColumnsToIncludeSecond.Name" xml:space="preserve">
+    <value>ucrSelectorColumnsToIncludeSecond</value>
+  </data>
+  <data name="&gt;&gt;ucrSelectorColumnsToIncludeSecond.Type" xml:space="preserve">
+    <value>instat.ucrSelectorByDataFrameAddRemove, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrSelectorColumnsToIncludeSecond.Parent" xml:space="preserve">
+    <value>tpIncludeColumns</value>
+  </data>
+  <data name="&gt;&gt;ucrSelectorColumnsToIncludeSecond.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;ucrSelectorColumnsToIncludeFirst.Name" xml:space="preserve">
+    <value>ucrSelectorColumnsToIncludeFirst</value>
+  </data>
+  <data name="&gt;&gt;ucrSelectorColumnsToIncludeFirst.Type" xml:space="preserve">
+    <value>instat.ucrSelectorByDataFrameAddRemove, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrSelectorColumnsToIncludeFirst.Parent" xml:space="preserve">
+    <value>tpIncludeColumns</value>
+  </data>
+  <data name="&gt;&gt;ucrSelectorColumnsToIncludeFirst.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="tpIncludeColumns.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpIncludeColumns.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpIncludeColumns.Size" type="System.Drawing.Size, System.Drawing">
+    <value>648, 367</value>
+  </data>
+  <data name="tpIncludeColumns.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="tpIncludeColumns.Text" xml:space="preserve">
+    <value>Columns to Include</value>
+  </data>
+  <data name="&gt;&gt;tpIncludeColumns.Name" xml:space="preserve">
+    <value>tpIncludeColumns</value>
+  </data>
+  <data name="&gt;&gt;tpIncludeColumns.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpIncludeColumns.Parent" xml:space="preserve">
+    <value>tbcMergeOptions</value>
+  </data>
+  <data name="&gt;&gt;tpIncludeColumns.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="tbcMergeOptions.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 8</value>
+  </data>
+  <data name="tbcMergeOptions.Size" type="System.Drawing.Size, System.Drawing">
+    <value>656, 393</value>
+  </data>
+  <data name="tbcMergeOptions.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;tbcMergeOptions.Name" xml:space="preserve">
+    <value>tbcMergeOptions</value>
+  </data>
+  <data name="&gt;&gt;tbcMergeOptions.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tbcMergeOptions.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;tbcMergeOptions.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
   <data name="ucrChkMergeWithSubsetSecond.Location" type="System.Drawing.Point, System.Drawing">
@@ -716,54 +773,6 @@
   </data>
   <data name="&gt;&gt;ucrSelectorColumnsToIncludeFirst.ZOrder" xml:space="preserve">
     <value>7</value>
-  </data>
-  <data name="tpIncludeColumns.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="tpIncludeColumns.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpIncludeColumns.Size" type="System.Drawing.Size, System.Drawing">
-    <value>648, 367</value>
-  </data>
-  <data name="tpIncludeColumns.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="tpIncludeColumns.Text" xml:space="preserve">
-    <value>Columns to Include</value>
-  </data>
-  <data name="&gt;&gt;tpIncludeColumns.Name" xml:space="preserve">
-    <value>tpIncludeColumns</value>
-  </data>
-  <data name="&gt;&gt;tpIncludeColumns.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpIncludeColumns.Parent" xml:space="preserve">
-    <value>tbcMergeOptions</value>
-  </data>
-  <data name="&gt;&gt;tpIncludeColumns.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="tbcMergeOptions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 8</value>
-  </data>
-  <data name="tbcMergeOptions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>656, 393</value>
-  </data>
-  <data name="tbcMergeOptions.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;tbcMergeOptions.Name" xml:space="preserve">
-    <value>tbcMergeOptions</value>
-  </data>
-  <data name="&gt;&gt;tbcMergeOptions.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tbcMergeOptions.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;tbcMergeOptions.ZOrder" xml:space="preserve">
-    <value>0</value>
   </data>
   <data name="ucrSubBase.Location" type="System.Drawing.Point, System.Drawing">
     <value>264, 407</value>


### PR DESCRIPTION
Fixes some of #6265

The joining options tab of the sub dialog now always shows users the choose pairs controls. By default this is filled with all columns with the same names. 

@rdstern this change could be tested but PR is not finished yet.

@lilyclements Could you take over this PR? The remaining task is to separate the two tabs into two separate sub dialogs as described in #6265. I suggest the current sub dialog stays as the Joining Options subdialog and the new sub dialog is for Columns to Include.