### PR TITLE
Separating the sub-dialog for Merge into two sub-dialogs

### DIFF
--- a/instat/dlgMerge.Designer.vb
+++ b/instat/dlgMerge.Designer.vb
@@ -48,6 +48,7 @@ Partial Class dlgMerge
         Me.ucrSecondDataFrame = New instat.ucrDataFrame()
         Me.ucrFirstDataFrame = New instat.ucrDataFrame()
         Me.ucrBase = New instat.ucrButtons()
+        Me.cmdColumnOptions = New System.Windows.Forms.Button()
         Me.SuspendLayout()
         '
         'cmdJoinOptions
@@ -82,6 +83,7 @@ Partial Class dlgMerge
         'ucrInputJoinType
         '
         Me.ucrInputJoinType.AddQuotesIfUnrecognised = True
+        Me.ucrInputJoinType.GetSetSelectedIndex = -1
         Me.ucrInputJoinType.IsReadOnly = False
         resources.ApplyResources(Me.ucrInputJoinType, "ucrInputJoinType")
         Me.ucrInputJoinType.Name = "ucrInputJoinType"
@@ -105,10 +107,17 @@ Partial Class dlgMerge
         resources.ApplyResources(Me.ucrBase, "ucrBase")
         Me.ucrBase.Name = "ucrBase"
         '
+        'cmdColumnOptions
+        '
+        resources.ApplyResources(Me.cmdColumnOptions, "cmdColumnOptions")
+        Me.cmdColumnOptions.Name = "cmdColumnOptions"
+        Me.cmdColumnOptions.UseVisualStyleBackColor = True
+        '
         'dlgMerge
         '
         resources.ApplyResources(Me, "$this")
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.Controls.Add(Me.cmdColumnOptions)
         Me.Controls.Add(Me.ucrInputMergingBy)
         Me.Controls.Add(Me.lblMergeBy)
         Me.Controls.Add(Me.ucrSaveMerge)
@@ -137,4 +146,5 @@ Partial Class dlgMerge
     Friend WithEvents ucrSaveMerge As ucrSave
     Friend WithEvents lblMergeBy As Label
     Friend WithEvents ucrInputMergingBy As ucrInputTextBox
+    Friend WithEvents cmdColumnOptions As Button
 End Class

--- a/instat/dlgMerge.resx
+++ b/instat/dlgMerge.resx
@@ -123,7 +123,7 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="cmdJoinOptions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 131</value>
+    <value>10, 150</value>
   </data>
   <data name="cmdJoinOptions.Size" type="System.Drawing.Size, System.Drawing">
     <value>115, 23</value>
@@ -187,13 +187,13 @@
     <value>9, 95</value>
   </data>
   <data name="lblMergeBy.Size" type="System.Drawing.Size, System.Drawing">
-    <value>63, 13</value>
+    <value>58, 13</value>
   </data>
   <data name="lblMergeBy.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
   </data>
   <data name="lblMergeBy.Text" xml:space="preserve">
-    <value>Merging By:</value>
+    <value>Joining By:</value>
   </data>
   <data name="&gt;&gt;lblMergeBy.Name" xml:space="preserve">
     <value>lblMergeBy</value>
@@ -211,7 +211,7 @@
     <value>87, 92</value>
   </data>
   <data name="ucrInputMergingBy.Size" type="System.Drawing.Size, System.Drawing">
-    <value>278, 33</value>
+    <value>278, 52</value>
   </data>
   <data name="ucrInputMergingBy.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -229,7 +229,7 @@
     <value>1</value>
   </data>
   <data name="ucrSaveMerge.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 191</value>
+    <value>10, 209</value>
   </data>
   <data name="ucrSaveMerge.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>4, 5, 4, 5</value>
@@ -322,7 +322,7 @@
     <value>7</value>
   </data>
   <data name="ucrBase.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 223</value>
+    <value>10, 236</value>
   </data>
   <data name="ucrBase.Size" type="System.Drawing.Size, System.Drawing">
     <value>410, 53</value>
@@ -346,7 +346,7 @@
     <value>NoControl</value>
   </data>
   <data name="cmdColumnOptions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 160</value>
+    <value>10, 179</value>
   </data>
   <data name="cmdColumnOptions.Size" type="System.Drawing.Size, System.Drawing">
     <value>115, 23</value>
@@ -355,7 +355,7 @@
     <value>7</value>
   </data>
   <data name="cmdColumnOptions.Text" xml:space="preserve">
-    <value>Column Options</value>
+    <value>Column Selection</value>
   </data>
   <data name="&gt;&gt;cmdColumnOptions.Name" xml:space="preserve">
     <value>cmdColumnOptions</value>
@@ -376,7 +376,7 @@
     <value>6, 13</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>417, 282</value>
+    <value>416, 292</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterScreen</value>

--- a/instat/dlgMerge.resx
+++ b/instat/dlgMerge.resx
@@ -123,10 +123,10 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="cmdJoinOptions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 150</value>
+    <value>87, 150</value>
   </data>
   <data name="cmdJoinOptions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>115, 23</value>
+    <value>137, 23</value>
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="cmdJoinOptions.TabIndex" type="System.Int32, mscorlib">
@@ -346,10 +346,10 @@
     <value>NoControl</value>
   </data>
   <data name="cmdColumnOptions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>250, 63</value>
+    <value>228, 150</value>
   </data>
   <data name="cmdColumnOptions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>115, 23</value>
+    <value>137, 23</value>
   </data>
   <data name="cmdColumnOptions.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>

--- a/instat/dlgMerge.resx
+++ b/instat/dlgMerge.resx
@@ -126,7 +126,7 @@
     <value>87, 150</value>
   </data>
   <data name="cmdJoinOptions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>137, 23</value>
+    <value>97, 23</value>
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="cmdJoinOptions.TabIndex" type="System.Int32, mscorlib">
@@ -346,10 +346,10 @@
     <value>NoControl</value>
   </data>
   <data name="cmdColumnOptions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>228, 150</value>
+    <value>268, 150</value>
   </data>
   <data name="cmdColumnOptions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>137, 23</value>
+    <value>97, 23</value>
   </data>
   <data name="cmdColumnOptions.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>

--- a/instat/dlgMerge.resx
+++ b/instat/dlgMerge.resx
@@ -123,17 +123,17 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="cmdJoinOptions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 184</value>
+    <value>10, 131</value>
   </data>
   <data name="cmdJoinOptions.Size" type="System.Drawing.Size, System.Drawing">
     <value>115, 23</value>
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="cmdJoinOptions.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
+    <value>6</value>
   </data>
   <data name="cmdJoinOptions.Text" xml:space="preserve">
-    <value>Merge Options</value>
+    <value>Join Options</value>
   </data>
   <data name="&gt;&gt;cmdJoinOptions.Name" xml:space="preserve">
     <value>cmdJoinOptions</value>
@@ -145,7 +145,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;cmdJoinOptions.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>8</value>
   </data>
   <data name="lnlJoinType.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -154,7 +154,7 @@
     <value>NoControl</value>
   </data>
   <data name="lnlJoinType.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 88</value>
+    <value>9, 68</value>
   </data>
   <data name="lnlJoinType.Size" type="System.Drawing.Size, System.Drawing">
     <value>56, 13</value>
@@ -175,7 +175,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lnlJoinType.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="lblMergeBy.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -184,13 +184,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblMergeBy.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 128</value>
+    <value>9, 95</value>
   </data>
   <data name="lblMergeBy.Size" type="System.Drawing.Size, System.Drawing">
     <value>63, 13</value>
   </data>
   <data name="lblMergeBy.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
+    <value>4</value>
   </data>
   <data name="lblMergeBy.Text" xml:space="preserve">
     <value>Merging By:</value>
@@ -205,16 +205,16 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblMergeBy.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="ucrInputMergingBy.Location" type="System.Drawing.Point, System.Drawing">
-    <value>87, 125</value>
+    <value>87, 92</value>
   </data>
   <data name="ucrInputMergingBy.Size" type="System.Drawing.Size, System.Drawing">
-    <value>289, 53</value>
+    <value>278, 33</value>
   </data>
   <data name="ucrInputMergingBy.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
+    <value>5</value>
   </data>
   <data name="&gt;&gt;ucrInputMergingBy.Name" xml:space="preserve">
     <value>ucrInputMergingBy</value>
@@ -226,16 +226,19 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrInputMergingBy.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="ucrSaveMerge.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 219</value>
+    <value>10, 191</value>
+  </data>
+  <data name="ucrSaveMerge.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="ucrSaveMerge.Size" type="System.Drawing.Size, System.Drawing">
     <value>301, 24</value>
   </data>
   <data name="ucrSaveMerge.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
+    <value>8</value>
   </data>
   <data name="&gt;&gt;ucrSaveMerge.Name" xml:space="preserve">
     <value>ucrSaveMerge</value>
@@ -247,10 +250,10 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrSaveMerge.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="ucrInputJoinType.Location" type="System.Drawing.Point, System.Drawing">
-    <value>116, 85</value>
+    <value>87, 65</value>
   </data>
   <data name="ucrInputJoinType.Size" type="System.Drawing.Size, System.Drawing">
     <value>137, 21</value>
@@ -268,10 +271,10 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrInputJoinType.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>5</value>
   </data>
   <data name="ucrSecondDataFrame.Location" type="System.Drawing.Point, System.Drawing">
-    <value>209, 22</value>
+    <value>216, 12</value>
   </data>
   <data name="ucrSecondDataFrame.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
@@ -292,10 +295,10 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrSecondDataFrame.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>6</value>
   </data>
   <data name="ucrFirstDataFrame.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 22</value>
+    <value>10, 12</value>
   </data>
   <data name="ucrFirstDataFrame.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
@@ -316,16 +319,16 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrFirstDataFrame.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>7</value>
   </data>
   <data name="ucrBase.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 251</value>
+    <value>10, 223</value>
   </data>
   <data name="ucrBase.Size" type="System.Drawing.Size, System.Drawing">
     <value>410, 53</value>
   </data>
   <data name="ucrBase.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
+    <value>9</value>
   </data>
   <data name="&gt;&gt;ucrBase.Name" xml:space="preserve">
     <value>ucrBase</value>
@@ -337,7 +340,34 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrBase.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>9</value>
+  </data>
+  <data name="cmdColumnOptions.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cmdColumnOptions.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 160</value>
+  </data>
+  <data name="cmdColumnOptions.Size" type="System.Drawing.Size, System.Drawing">
+    <value>115, 23</value>
+  </data>
+  <data name="cmdColumnOptions.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="cmdColumnOptions.Text" xml:space="preserve">
+    <value>Column Options</value>
+  </data>
+  <data name="&gt;&gt;cmdColumnOptions.Name" xml:space="preserve">
+    <value>cmdColumnOptions</value>
+  </data>
+  <data name="&gt;&gt;cmdColumnOptions.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cmdColumnOptions.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;cmdColumnOptions.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -346,7 +376,7 @@
     <value>6, 13</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>418, 306</value>
+    <value>417, 282</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterScreen</value>

--- a/instat/dlgMerge.resx
+++ b/instat/dlgMerge.resx
@@ -184,7 +184,7 @@
     <value>NoControl</value>
   </data>
   <data name="lblMergeBy.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 95</value>
+    <value>9, 96</value>
   </data>
   <data name="lblMergeBy.Size" type="System.Drawing.Size, System.Drawing">
     <value>58, 13</value>
@@ -208,7 +208,7 @@
     <value>2</value>
   </data>
   <data name="ucrInputMergingBy.Location" type="System.Drawing.Point, System.Drawing">
-    <value>87, 92</value>
+    <value>87, 93</value>
   </data>
   <data name="ucrInputMergingBy.Size" type="System.Drawing.Size, System.Drawing">
     <value>278, 52</value>
@@ -229,7 +229,7 @@
     <value>1</value>
   </data>
   <data name="ucrSaveMerge.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 209</value>
+    <value>10, 180</value>
   </data>
   <data name="ucrSaveMerge.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>4, 5, 4, 5</value>
@@ -322,7 +322,7 @@
     <value>7</value>
   </data>
   <data name="ucrBase.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 236</value>
+    <value>10, 207</value>
   </data>
   <data name="ucrBase.Size" type="System.Drawing.Size, System.Drawing">
     <value>410, 53</value>
@@ -346,7 +346,7 @@
     <value>NoControl</value>
   </data>
   <data name="cmdColumnOptions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 179</value>
+    <value>250, 63</value>
   </data>
   <data name="cmdColumnOptions.Size" type="System.Drawing.Size, System.Drawing">
     <value>115, 23</value>
@@ -376,7 +376,7 @@
     <value>6, 13</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>416, 292</value>
+    <value>413, 263</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterScreen</value>

--- a/instat/dlgMerge.vb
+++ b/instat/dlgMerge.vb
@@ -50,7 +50,6 @@ Public Class dlgMerge
 
     Private Sub InitialiseDialog()
         Dim dctJoinTypes As New Dictionary(Of String, String)
-
         ucrBase.iHelpTopicID = 60
 
         'sdgMerge.SetRSyntax(ucrBase.clsRsyntax)
@@ -103,14 +102,11 @@ Public Class dlgMerge
 
         ucrFirstDataFrame.Reset()
         ucrSecondDataFrame.Reset()
-
         ucrSaveMerge.Reset()
 
         clsMerge.SetPackageName("dplyr")
         clsMerge.SetRCommand("full_join")
-
         clsByList.SetRCommand("c")
-
         clsSuffixC.SetRCommand("c")
 
         ucrBase.clsRsyntax.SetBaseRFunction(clsMerge)
@@ -141,6 +137,13 @@ Public Class dlgMerge
     Private Sub cmdJoinOptions_Click(sender As Object, e As EventArgs) Handles cmdJoinOptions.Click
         sdgMerge.Setup(ucrFirstDataFrame.cboAvailableDataFrames.Text, ucrSecondDataFrame.cboAvailableDataFrames.Text, clsMerge, clsByList, bResetSubdialog)
         sdgMerge.ShowDialog()
+        bResetSubdialog = False
+        SetMergingBy()
+    End Sub
+
+    Private Sub cmdColumnOptions_Click(sender As Object, e As EventArgs) Handles cmdColumnOptions.Click
+        sdgMergeColumnstoInclude.Setup(ucrFirstDataFrame.cboAvailableDataFrames.Text, ucrSecondDataFrame.cboAvailableDataFrames.Text, clsMerge, clsByList, bResetSubdialog)
+        sdgMergeColumnstoInclude.ShowDialog()
         bResetSubdialog = False
         SetMergingBy()
     End Sub
@@ -227,7 +230,7 @@ Public Class dlgMerge
                 ucrInputMergingBy.SetName(String.Join(", ", lstJoinPairs))
                 ucrInputMergingBy.txtInput.BackColor = SystemColors.Control
             Else
-                ucrInputMergingBy.SetName("No columns to merge by!" & Environment.NewLine & "Click Merge Options to specify merging columns.")
+                ucrInputMergingBy.SetName("No columns to merge by!" & Environment.NewLine & "Click Join Options to specify merging columns.")
                 ucrInputMergingBy.txtInput.BackColor = Color.LightCoral
             End If
         Else

--- a/instat/dlgMerge.vb
+++ b/instat/dlgMerge.vb
@@ -229,9 +229,11 @@ Public Class dlgMerge
                 Next
                 ucrInputMergingBy.SetName(String.Join(", ", lstJoinPairs))
                 ucrInputMergingBy.txtInput.BackColor = SystemColors.Control
+                cmdJoinOptions.BackColor = SystemColors.ControlLight
             Else
                 ucrInputMergingBy.SetName("No columns to merge by!" & Environment.NewLine & "Click Join Options to specify merging columns.")
                 ucrInputMergingBy.txtInput.BackColor = Color.LightCoral
+                cmdJoinOptions.BackColor = Color.LemonChiffon
             End If
         Else
             ucrInputMergingBy.SetName("")

--- a/instat/dlgMerge.vb
+++ b/instat/dlgMerge.vb
@@ -229,7 +229,8 @@ Public Class dlgMerge
                 Next
                 ucrInputMergingBy.SetName(String.Join(", ", lstJoinPairs))
                 ucrInputMergingBy.txtInput.BackColor = SystemColors.Control
-                cmdJoinOptions.BackColor = SystemColors.ControlLight
+                cmdJoinOptions.BackColor = SystemColors.ButtonFace
+                cmdJoinOptions.UseVisualStyleBackColor = True
             Else
                 ucrInputMergingBy.SetName("No columns to merge by!" & Environment.NewLine & "Click Join Options to specify merging columns.")
                 ucrInputMergingBy.txtInput.BackColor = Color.LightCoral

--- a/instat/dlgMergeAdditionalData.resx
+++ b/instat/dlgMergeAdditionalData.resx
@@ -154,16 +154,16 @@
     <value>NoControl</value>
   </data>
   <data name="cmdModify.Location" type="System.Drawing.Point, System.Drawing">
-    <value>297, 332</value>
+    <value>282, 332</value>
   </data>
   <data name="cmdModify.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
+    <value>90, 23</value>
   </data>
   <data name="cmdModify.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
   </data>
   <data name="cmdModify.Text" xml:space="preserve">
-    <value>Modify</value>
+    <value>Join Options</value>
   </data>
   <data name="&gt;&gt;cmdModify.Name" xml:space="preserve">
     <value>cmdModify</value>
@@ -238,13 +238,13 @@
     <value>12, 289</value>
   </data>
   <data name="lblMergeBy.Size" type="System.Drawing.Size, System.Drawing">
-    <value>54, 13</value>
+    <value>43, 13</value>
   </data>
   <data name="lblMergeBy.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
   </data>
   <data name="lblMergeBy.Text" xml:space="preserve">
-    <value>Merge by:</value>
+    <value>Join by:</value>
   </data>
   <data name="&gt;&gt;lblMergeBy.Name" xml:space="preserve">
     <value>lblMergeBy</value>

--- a/instat/dlgMergeAdditionalData.vb
+++ b/instat/dlgMergeAdditionalData.vb
@@ -202,7 +202,7 @@ Public Class dlgMergeAdditionalData
                     Next
                     bBySpecified = True
                 Else
-                    strMergeBy = "No columns with the same name. Click 'Modify' to specify merging columns."
+                    strMergeBy = "No columns with the same name. Click 'Join Options' to specify merging columns."
                     bBySpecified = False
                 End If
             End If

--- a/instat/dlgMergeAdditionalData.vb
+++ b/instat/dlgMergeAdditionalData.vb
@@ -134,7 +134,7 @@ Public Class dlgMergeAdditionalData
                 PopulateMergeByText()
                 bBySpecified = True
             Else
-                ucrInputMergingBy.SetName("No link between these data frames. Click 'Modify' to specify merging columns.")
+                ucrInputMergingBy.SetName("No link between these data frames. Click 'Join Options' to specify merging columns.")
                 clsLeftJoin.RemoveParameterByName("by")
                 bBySpecified = False
             End If
@@ -154,7 +154,7 @@ Public Class dlgMergeAdditionalData
     End Sub
 
     Private Sub cmdModify_Click(sender As Object, e As EventArgs) Handles cmdModify.Click
-        sdgMerge.Setup(ucrFirstDataFrame.cboAvailableDataFrames.Text, ucrSecondSelector.ucrAvailableDataFrames.cboAvailableDataFrames.Text, clsLeftJoin, clsByList, bResetSubdialog, False)
+        sdgMerge.Setup(ucrFirstDataFrame.cboAvailableDataFrames.Text, ucrSecondSelector.ucrAvailableDataFrames.cboAvailableDataFrames.Text, clsLeftJoin, clsByList, bResetSubdialog)
         sdgMerge.ShowDialog()
         PopulateMergeByText()
         bResetSubdialog = False

--- a/instat/sdgMerge.Designer.vb
+++ b/instat/sdgMerge.Designer.vb
@@ -19,7 +19,7 @@ Partial Class sdgMerge
     Inherits System.Windows.Forms.Form
 
     'Form overrides dispose to clean up the component list.
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Protected Overrides Sub Dispose(ByVal disposing As Boolean)
         Try
             If disposing AndAlso components IsNot Nothing Then
@@ -36,40 +36,26 @@ Partial Class sdgMerge
     'NOTE: The following procedure is required by the Windows Form Designer
     'It can be modified using the Windows Form Designer.  
     'Do not modify it using the code editor.
-    <System.Diagnostics.DebuggerStepThrough()> _
+    <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
         Me.components = New System.ComponentModel.Container()
         Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(sdgMerge))
         Me.ttJoinDetails = New System.Windows.Forms.ToolTip(Me.components)
-        Me.grpKeys = New System.Windows.Forms.GroupBox()
-        Me.cmdAddPair = New System.Windows.Forms.Button()
-        Me.lblFirstKeyMatch = New System.Windows.Forms.Label()
-        Me.ucrReceiverSecondDF = New instat.ucrReceiverSingle()
-        Me.ucrReceiverFirstDF = New instat.ucrReceiverSingle()
+        Me.ucrSubBase = New instat.ucrButtonsSubdialogue()
+        Me.ucrSelectorSecondDF = New instat.ucrSelectorByDataFrameAddRemove()
+        Me.ucrSelectorFirstDF = New instat.ucrSelectorByDataFrameAddRemove()
         Me.pnlKeyColumns = New System.Windows.Forms.Panel()
         Me.cmdRemoveAll = New System.Windows.Forms.Button()
         Me.lstKeyColumns = New System.Windows.Forms.ListView()
         Me.lblKeyColumns = New System.Windows.Forms.Label()
         Me.cmdRemoveSelectedPair = New System.Windows.Forms.Button()
-        Me.tbcMergeOptions = New System.Windows.Forms.TabControl()
-        Me.tpJoinByOptions = New System.Windows.Forms.TabPage()
-        Me.ucrSelectorSecondDF = New instat.ucrSelectorByDataFrameAddRemove()
-        Me.ucrSelectorFirstDF = New instat.ucrSelectorByDataFrameAddRemove()
-        Me.tpIncludeColumns = New System.Windows.Forms.TabPage()
-        Me.ucrChkMergeWithSubsetSecond = New instat.ucrCheck()
-        Me.ucrChkMergeWithSubsetFirst = New instat.ucrCheck()
-        Me.lblVariablesToIncludeSecond = New System.Windows.Forms.Label()
-        Me.lblVariablesToIncludeFirst = New System.Windows.Forms.Label()
-        Me.ucrReceiverSecondSelected = New instat.ucrReceiverMultiple()
-        Me.ucrReceiverFirstSelected = New instat.ucrReceiverMultiple()
-        Me.ucrSelectorColumnsToIncludeSecond = New instat.ucrSelectorByDataFrameAddRemove()
-        Me.ucrSelectorColumnsToIncludeFirst = New instat.ucrSelectorByDataFrameAddRemove()
-        Me.ucrSubBase = New instat.ucrButtonsSubdialogue()
-        Me.grpKeys.SuspendLayout()
+        Me.grpKeys = New System.Windows.Forms.GroupBox()
+        Me.cmdAddPair = New System.Windows.Forms.Button()
+        Me.lblFirstKeyMatch = New System.Windows.Forms.Label()
+        Me.ucrReceiverSecondDF = New instat.ucrReceiverSingle()
+        Me.ucrReceiverFirstDF = New instat.ucrReceiverSingle()
         Me.pnlKeyColumns.SuspendLayout()
-        Me.tbcMergeOptions.SuspendLayout()
-        Me.tpJoinByOptions.SuspendLayout()
-        Me.tpIncludeColumns.SuspendLayout()
+        Me.grpKeys.SuspendLayout()
         Me.SuspendLayout()
         '
         'ttJoinDetails
@@ -78,44 +64,26 @@ Partial Class sdgMerge
         Me.ttJoinDetails.InitialDelay = 500
         Me.ttJoinDetails.ReshowDelay = 100
         '
-        'grpKeys
+        'ucrSubBase
         '
-        Me.grpKeys.Controls.Add(Me.cmdAddPair)
-        Me.grpKeys.Controls.Add(Me.lblFirstKeyMatch)
-        Me.grpKeys.Controls.Add(Me.ucrReceiverSecondDF)
-        Me.grpKeys.Controls.Add(Me.ucrReceiverFirstDF)
-        resources.ApplyResources(Me.grpKeys, "grpKeys")
-        Me.grpKeys.Name = "grpKeys"
-        Me.grpKeys.TabStop = False
+        resources.ApplyResources(Me.ucrSubBase, "ucrSubBase")
+        Me.ucrSubBase.Name = "ucrSubBase"
         '
-        'cmdAddPair
+        'ucrSelectorSecondDF
         '
-        resources.ApplyResources(Me.cmdAddPair, "cmdAddPair")
-        Me.cmdAddPair.Name = "cmdAddPair"
-        Me.cmdAddPair.UseVisualStyleBackColor = True
+        Me.ucrSelectorSecondDF.bDropUnusedFilterLevels = False
+        Me.ucrSelectorSecondDF.bShowHiddenColumns = False
+        Me.ucrSelectorSecondDF.bUseCurrentFilter = True
+        resources.ApplyResources(Me.ucrSelectorSecondDF, "ucrSelectorSecondDF")
+        Me.ucrSelectorSecondDF.Name = "ucrSelectorSecondDF"
         '
-        'lblFirstKeyMatch
+        'ucrSelectorFirstDF
         '
-        resources.ApplyResources(Me.lblFirstKeyMatch, "lblFirstKeyMatch")
-        Me.lblFirstKeyMatch.Name = "lblFirstKeyMatch"
-        '
-        'ucrReceiverSecondDF
-        '
-        Me.ucrReceiverSecondDF.frmParent = Nothing
-        resources.ApplyResources(Me.ucrReceiverSecondDF, "ucrReceiverSecondDF")
-        Me.ucrReceiverSecondDF.Name = "ucrReceiverSecondDF"
-        Me.ucrReceiverSecondDF.Selector = Nothing
-        Me.ucrReceiverSecondDF.strNcFilePath = ""
-        Me.ucrReceiverSecondDF.ucrSelector = Nothing
-        '
-        'ucrReceiverFirstDF
-        '
-        Me.ucrReceiverFirstDF.frmParent = Nothing
-        resources.ApplyResources(Me.ucrReceiverFirstDF, "ucrReceiverFirstDF")
-        Me.ucrReceiverFirstDF.Name = "ucrReceiverFirstDF"
-        Me.ucrReceiverFirstDF.Selector = Nothing
-        Me.ucrReceiverFirstDF.strNcFilePath = ""
-        Me.ucrReceiverFirstDF.ucrSelector = Nothing
+        Me.ucrSelectorFirstDF.bDropUnusedFilterLevels = False
+        Me.ucrSelectorFirstDF.bShowHiddenColumns = False
+        Me.ucrSelectorFirstDF.bUseCurrentFilter = True
+        resources.ApplyResources(Me.ucrSelectorFirstDF, "ucrSelectorFirstDF")
+        Me.ucrSelectorFirstDF.Name = "ucrSelectorFirstDF"
         '
         'pnlKeyColumns
         '
@@ -152,133 +120,62 @@ Partial Class sdgMerge
         Me.cmdRemoveSelectedPair.Name = "cmdRemoveSelectedPair"
         Me.cmdRemoveSelectedPair.UseVisualStyleBackColor = True
         '
-        'tbcMergeOptions
+        'grpKeys
         '
-        Me.tbcMergeOptions.Controls.Add(Me.tpJoinByOptions)
-        Me.tbcMergeOptions.Controls.Add(Me.tpIncludeColumns)
-        resources.ApplyResources(Me.tbcMergeOptions, "tbcMergeOptions")
-        Me.tbcMergeOptions.Name = "tbcMergeOptions"
-        Me.tbcMergeOptions.SelectedIndex = 0
+        Me.grpKeys.Controls.Add(Me.cmdAddPair)
+        Me.grpKeys.Controls.Add(Me.lblFirstKeyMatch)
+        Me.grpKeys.Controls.Add(Me.ucrReceiverSecondDF)
+        Me.grpKeys.Controls.Add(Me.ucrReceiverFirstDF)
+        resources.ApplyResources(Me.grpKeys, "grpKeys")
+        Me.grpKeys.Name = "grpKeys"
+        Me.grpKeys.TabStop = False
         '
-        'tpJoinByOptions
+        'cmdAddPair
         '
-        Me.tpJoinByOptions.Controls.Add(Me.ucrSelectorSecondDF)
-        Me.tpJoinByOptions.Controls.Add(Me.ucrSelectorFirstDF)
-        Me.tpJoinByOptions.Controls.Add(Me.pnlKeyColumns)
-        Me.tpJoinByOptions.Controls.Add(Me.grpKeys)
-        resources.ApplyResources(Me.tpJoinByOptions, "tpJoinByOptions")
-        Me.tpJoinByOptions.Name = "tpJoinByOptions"
-        Me.tpJoinByOptions.UseVisualStyleBackColor = True
+        resources.ApplyResources(Me.cmdAddPair, "cmdAddPair")
+        Me.cmdAddPair.Name = "cmdAddPair"
+        Me.cmdAddPair.UseVisualStyleBackColor = True
         '
-        'ucrSelectorSecondDF
+        'lblFirstKeyMatch
         '
-        Me.ucrSelectorSecondDF.bDropUnusedFilterLevels = False
-        Me.ucrSelectorSecondDF.bShowHiddenColumns = False
-        Me.ucrSelectorSecondDF.bUseCurrentFilter = True
-        resources.ApplyResources(Me.ucrSelectorSecondDF, "ucrSelectorSecondDF")
-        Me.ucrSelectorSecondDF.Name = "ucrSelectorSecondDF"
+        resources.ApplyResources(Me.lblFirstKeyMatch, "lblFirstKeyMatch")
+        Me.lblFirstKeyMatch.Name = "lblFirstKeyMatch"
         '
-        'ucrSelectorFirstDF
+        'ucrReceiverSecondDF
         '
-        Me.ucrSelectorFirstDF.bDropUnusedFilterLevels = False
-        Me.ucrSelectorFirstDF.bShowHiddenColumns = False
-        Me.ucrSelectorFirstDF.bUseCurrentFilter = True
-        resources.ApplyResources(Me.ucrSelectorFirstDF, "ucrSelectorFirstDF")
-        Me.ucrSelectorFirstDF.Name = "ucrSelectorFirstDF"
+        Me.ucrReceiverSecondDF.frmParent = Me
+        resources.ApplyResources(Me.ucrReceiverSecondDF, "ucrReceiverSecondDF")
+        Me.ucrReceiverSecondDF.Name = "ucrReceiverSecondDF"
+        Me.ucrReceiverSecondDF.Selector = Nothing
+        Me.ucrReceiverSecondDF.strNcFilePath = ""
+        Me.ucrReceiverSecondDF.ucrSelector = Nothing
         '
-        'tpIncludeColumns
+        'ucrReceiverFirstDF
         '
-        Me.tpIncludeColumns.Controls.Add(Me.ucrChkMergeWithSubsetSecond)
-        Me.tpIncludeColumns.Controls.Add(Me.ucrChkMergeWithSubsetFirst)
-        Me.tpIncludeColumns.Controls.Add(Me.lblVariablesToIncludeSecond)
-        Me.tpIncludeColumns.Controls.Add(Me.lblVariablesToIncludeFirst)
-        Me.tpIncludeColumns.Controls.Add(Me.ucrReceiverSecondSelected)
-        Me.tpIncludeColumns.Controls.Add(Me.ucrReceiverFirstSelected)
-        Me.tpIncludeColumns.Controls.Add(Me.ucrSelectorColumnsToIncludeSecond)
-        Me.tpIncludeColumns.Controls.Add(Me.ucrSelectorColumnsToIncludeFirst)
-        resources.ApplyResources(Me.tpIncludeColumns, "tpIncludeColumns")
-        Me.tpIncludeColumns.Name = "tpIncludeColumns"
-        Me.tpIncludeColumns.UseVisualStyleBackColor = True
-        '
-        'ucrChkMergeWithSubsetSecond
-        '
-        Me.ucrChkMergeWithSubsetSecond.Checked = False
-        resources.ApplyResources(Me.ucrChkMergeWithSubsetSecond, "ucrChkMergeWithSubsetSecond")
-        Me.ucrChkMergeWithSubsetSecond.Name = "ucrChkMergeWithSubsetSecond"
-        '
-        'ucrChkMergeWithSubsetFirst
-        '
-        Me.ucrChkMergeWithSubsetFirst.Checked = False
-        resources.ApplyResources(Me.ucrChkMergeWithSubsetFirst, "ucrChkMergeWithSubsetFirst")
-        Me.ucrChkMergeWithSubsetFirst.Name = "ucrChkMergeWithSubsetFirst"
-        '
-        'lblVariablesToIncludeSecond
-        '
-        resources.ApplyResources(Me.lblVariablesToIncludeSecond, "lblVariablesToIncludeSecond")
-        Me.lblVariablesToIncludeSecond.Name = "lblVariablesToIncludeSecond"
-        '
-        'lblVariablesToIncludeFirst
-        '
-        resources.ApplyResources(Me.lblVariablesToIncludeFirst, "lblVariablesToIncludeFirst")
-        Me.lblVariablesToIncludeFirst.Name = "lblVariablesToIncludeFirst"
-        '
-        'ucrReceiverSecondSelected
-        '
-        Me.ucrReceiverSecondSelected.frmParent = Nothing
-        resources.ApplyResources(Me.ucrReceiverSecondSelected, "ucrReceiverSecondSelected")
-        Me.ucrReceiverSecondSelected.Name = "ucrReceiverSecondSelected"
-        Me.ucrReceiverSecondSelected.Selector = Nothing
-        Me.ucrReceiverSecondSelected.strNcFilePath = ""
-        Me.ucrReceiverSecondSelected.ucrSelector = Nothing
-        '
-        'ucrReceiverFirstSelected
-        '
-        Me.ucrReceiverFirstSelected.frmParent = Nothing
-        resources.ApplyResources(Me.ucrReceiverFirstSelected, "ucrReceiverFirstSelected")
-        Me.ucrReceiverFirstSelected.Name = "ucrReceiverFirstSelected"
-        Me.ucrReceiverFirstSelected.Selector = Nothing
-        Me.ucrReceiverFirstSelected.strNcFilePath = ""
-        Me.ucrReceiverFirstSelected.ucrSelector = Nothing
-        '
-        'ucrSelectorColumnsToIncludeSecond
-        '
-        Me.ucrSelectorColumnsToIncludeSecond.bDropUnusedFilterLevels = False
-        Me.ucrSelectorColumnsToIncludeSecond.bShowHiddenColumns = False
-        Me.ucrSelectorColumnsToIncludeSecond.bUseCurrentFilter = True
-        resources.ApplyResources(Me.ucrSelectorColumnsToIncludeSecond, "ucrSelectorColumnsToIncludeSecond")
-        Me.ucrSelectorColumnsToIncludeSecond.Name = "ucrSelectorColumnsToIncludeSecond"
-        '
-        'ucrSelectorColumnsToIncludeFirst
-        '
-        Me.ucrSelectorColumnsToIncludeFirst.bDropUnusedFilterLevels = False
-        Me.ucrSelectorColumnsToIncludeFirst.bShowHiddenColumns = False
-        Me.ucrSelectorColumnsToIncludeFirst.bUseCurrentFilter = True
-        resources.ApplyResources(Me.ucrSelectorColumnsToIncludeFirst, "ucrSelectorColumnsToIncludeFirst")
-        Me.ucrSelectorColumnsToIncludeFirst.Name = "ucrSelectorColumnsToIncludeFirst"
-        '
-        'ucrSubBase
-        '
-        resources.ApplyResources(Me.ucrSubBase, "ucrSubBase")
-        Me.ucrSubBase.Name = "ucrSubBase"
+        Me.ucrReceiverFirstDF.frmParent = Me
+        resources.ApplyResources(Me.ucrReceiverFirstDF, "ucrReceiverFirstDF")
+        Me.ucrReceiverFirstDF.Name = "ucrReceiverFirstDF"
+        Me.ucrReceiverFirstDF.Selector = Nothing
+        Me.ucrReceiverFirstDF.strNcFilePath = ""
+        Me.ucrReceiverFirstDF.ucrSelector = Nothing
         '
         'sdgMerge
         '
         resources.ApplyResources(Me, "$this")
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
-        Me.Controls.Add(Me.tbcMergeOptions)
+        Me.Controls.Add(Me.ucrSelectorSecondDF)
+        Me.Controls.Add(Me.ucrSelectorFirstDF)
+        Me.Controls.Add(Me.pnlKeyColumns)
+        Me.Controls.Add(Me.grpKeys)
         Me.Controls.Add(Me.ucrSubBase)
         Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow
         Me.MaximizeBox = False
         Me.MinimizeBox = False
         Me.Name = "sdgMerge"
-        Me.grpKeys.ResumeLayout(False)
-        Me.grpKeys.PerformLayout()
         Me.pnlKeyColumns.ResumeLayout(False)
         Me.pnlKeyColumns.PerformLayout()
-        Me.tbcMergeOptions.ResumeLayout(False)
-        Me.tpJoinByOptions.ResumeLayout(False)
-        Me.tpIncludeColumns.ResumeLayout(False)
-        Me.tpIncludeColumns.PerformLayout()
+        Me.grpKeys.ResumeLayout(False)
+        Me.grpKeys.PerformLayout()
         Me.ResumeLayout(False)
 
     End Sub
@@ -287,25 +184,14 @@ Partial Class sdgMerge
     Friend WithEvents ttJoinDetails As ToolTip
     Friend WithEvents ucrSelectorSecondDF As ucrSelectorByDataFrameAddRemove
     Friend WithEvents ucrSelectorFirstDF As ucrSelectorByDataFrameAddRemove
-    Friend WithEvents grpKeys As GroupBox
-    Friend WithEvents cmdAddPair As Button
-    Friend WithEvents lblFirstKeyMatch As Label
-    Friend WithEvents ucrReceiverSecondDF As ucrReceiverSingle
-    Friend WithEvents tbcMergeOptions As TabControl
-    Friend WithEvents tpJoinByOptions As TabPage
     Friend WithEvents pnlKeyColumns As Panel
     Friend WithEvents cmdRemoveAll As Button
     Friend WithEvents lstKeyColumns As ListView
     Friend WithEvents lblKeyColumns As Label
     Friend WithEvents cmdRemoveSelectedPair As Button
-    Friend WithEvents tpIncludeColumns As TabPage
+    Friend WithEvents grpKeys As GroupBox
+    Friend WithEvents cmdAddPair As Button
+    Friend WithEvents lblFirstKeyMatch As Label
+    Friend WithEvents ucrReceiverSecondDF As ucrReceiverSingle
     Friend WithEvents ucrReceiverFirstDF As ucrReceiverSingle
-    Friend WithEvents lblVariablesToIncludeSecond As Label
-    Friend WithEvents lblVariablesToIncludeFirst As Label
-    Friend WithEvents ucrReceiverSecondSelected As ucrReceiverMultiple
-    Friend WithEvents ucrReceiverFirstSelected As ucrReceiverMultiple
-    Friend WithEvents ucrSelectorColumnsToIncludeSecond As ucrSelectorByDataFrameAddRemove
-    Friend WithEvents ucrSelectorColumnsToIncludeFirst As ucrSelectorByDataFrameAddRemove
-    Friend WithEvents ucrChkMergeWithSubsetSecond As ucrCheck
-    Friend WithEvents ucrChkMergeWithSubsetFirst As ucrCheck
 End Class

--- a/instat/sdgMerge.resx
+++ b/instat/sdgMerge.resx
@@ -121,13 +121,212 @@
     <value>17, 17</value>
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="ucrSubBase.Location" type="System.Drawing.Point, System.Drawing">
+    <value>249, 292</value>
+  </data>
+  <data name="ucrSubBase.Size" type="System.Drawing.Size, System.Drawing">
+    <value>142, 30</value>
+  </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="ucrSubBase.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;ucrSubBase.Name" xml:space="preserve">
+    <value>ucrSubBase</value>
+  </data>
+  <data name="&gt;&gt;ucrSubBase.Type" xml:space="preserve">
+    <value>instat.ucrButtonsSubdialogue, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrSubBase.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrSubBase.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="ucrSelectorSecondDF.Location" type="System.Drawing.Point, System.Drawing">
+    <value>226, 18</value>
+  </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="ucrSelectorSecondDF.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="ucrSelectorSecondDF.Size" type="System.Drawing.Size, System.Drawing">
+    <value>210, 180</value>
+  </data>
+  <data name="ucrSelectorSecondDF.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;ucrSelectorSecondDF.Name" xml:space="preserve">
+    <value>ucrSelectorSecondDF</value>
+  </data>
+  <data name="&gt;&gt;ucrSelectorSecondDF.Type" xml:space="preserve">
+    <value>instat.ucrSelectorByDataFrameAddRemove, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrSelectorSecondDF.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrSelectorSecondDF.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="ucrSelectorFirstDF.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 18</value>
+  </data>
+  <data name="ucrSelectorFirstDF.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="ucrSelectorFirstDF.Size" type="System.Drawing.Size, System.Drawing">
+    <value>210, 180</value>
+  </data>
+  <data name="ucrSelectorFirstDF.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;ucrSelectorFirstDF.Name" xml:space="preserve">
+    <value>ucrSelectorFirstDF</value>
+  </data>
+  <data name="&gt;&gt;ucrSelectorFirstDF.Type" xml:space="preserve">
+    <value>instat.ucrSelectorByDataFrameAddRemove, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrSelectorFirstDF.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrSelectorFirstDF.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="cmdRemoveAll.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cmdRemoveAll.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 223</value>
+  </data>
+  <data name="cmdRemoveAll.Size" type="System.Drawing.Size, System.Drawing">
+    <value>130, 23</value>
+  </data>
+  <data name="cmdRemoveAll.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="cmdRemoveAll.Text" xml:space="preserve">
+    <value>Remove All Pairs</value>
+  </data>
+  <data name="&gt;&gt;cmdRemoveAll.Name" xml:space="preserve">
+    <value>cmdRemoveAll</value>
+  </data>
+  <data name="&gt;&gt;cmdRemoveAll.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cmdRemoveAll.Parent" xml:space="preserve">
+    <value>pnlKeyColumns</value>
+  </data>
+  <data name="&gt;&gt;cmdRemoveAll.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="lstKeyColumns.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 21</value>
+  </data>
+  <data name="lstKeyColumns.Size" type="System.Drawing.Size, System.Drawing">
+    <value>185, 167</value>
+  </data>
+  <data name="lstKeyColumns.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;lstKeyColumns.Name" xml:space="preserve">
+    <value>lstKeyColumns</value>
+  </data>
+  <data name="&gt;&gt;lstKeyColumns.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ListView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lstKeyColumns.Parent" xml:space="preserve">
+    <value>pnlKeyColumns</value>
+  </data>
+  <data name="&gt;&gt;lstKeyColumns.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="lblKeyColumns.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblKeyColumns.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblKeyColumns.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 5</value>
+  </data>
+  <data name="lblKeyColumns.Size" type="System.Drawing.Size, System.Drawing">
+    <value>68, 13</value>
+  </data>
+  <data name="lblKeyColumns.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="lblKeyColumns.Text" xml:space="preserve">
+    <value>Key Columns</value>
+  </data>
+  <data name="&gt;&gt;lblKeyColumns.Name" xml:space="preserve">
+    <value>lblKeyColumns</value>
+  </data>
+  <data name="&gt;&gt;lblKeyColumns.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblKeyColumns.Parent" xml:space="preserve">
+    <value>pnlKeyColumns</value>
+  </data>
+  <data name="&gt;&gt;lblKeyColumns.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="cmdRemoveSelectedPair.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cmdRemoveSelectedPair.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 194</value>
+  </data>
+  <data name="cmdRemoveSelectedPair.Size" type="System.Drawing.Size, System.Drawing">
+    <value>130, 23</value>
+  </data>
+  <data name="cmdRemoveSelectedPair.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="cmdRemoveSelectedPair.Text" xml:space="preserve">
+    <value>Remove Selected Pair</value>
+  </data>
+  <data name="&gt;&gt;cmdRemoveSelectedPair.Name" xml:space="preserve">
+    <value>cmdRemoveSelectedPair</value>
+  </data>
+  <data name="&gt;&gt;cmdRemoveSelectedPair.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cmdRemoveSelectedPair.Parent" xml:space="preserve">
+    <value>pnlKeyColumns</value>
+  </data>
+  <data name="&gt;&gt;cmdRemoveSelectedPair.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="pnlKeyColumns.Location" type="System.Drawing.Point, System.Drawing">
+    <value>443, 26</value>
+  </data>
+  <data name="pnlKeyColumns.Size" type="System.Drawing.Size, System.Drawing">
+    <value>194, 256</value>
+  </data>
+  <data name="pnlKeyColumns.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;pnlKeyColumns.Name" xml:space="preserve">
+    <value>pnlKeyColumns</value>
+  </data>
+  <data name="&gt;&gt;pnlKeyColumns.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pnlKeyColumns.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;pnlKeyColumns.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="cmdAddPair.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
   <data name="cmdAddPair.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 46</value>
   </data>
   <data name="cmdAddPair.Size" type="System.Drawing.Size, System.Drawing">
     <value>118, 23</value>
   </data>
-  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="cmdAddPair.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
   </data>
@@ -148,6 +347,9 @@
   </data>
   <data name="lblFirstKeyMatch.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
+  </data>
+  <data name="lblFirstKeyMatch.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
   <data name="lblFirstKeyMatch.Location" type="System.Drawing.Point, System.Drawing">
     <value>128, 22</value>
@@ -173,10 +375,36 @@
   <data name="&gt;&gt;lblFirstKeyMatch.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>644, 324</value>
+  </data>
+  <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
+    <value>CenterParent</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>Joining Columns</value>
+  </data>
+  <data name="&gt;&gt;ttJoinDetails.Name" xml:space="preserve">
+    <value>ttJoinDetails</value>
+  </data>
+  <data name="&gt;&gt;ttJoinDetails.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>sdgMerge</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Form, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="ucrReceiverSecondDF.Location" type="System.Drawing.Point, System.Drawing">
     <value>205, 20</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="ucrReceiverSecondDF.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
   </data>
@@ -223,13 +451,13 @@
     <value>3</value>
   </data>
   <data name="grpKeys.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 199</value>
+    <value>9, 204</value>
   </data>
   <data name="grpKeys.Size" type="System.Drawing.Size, System.Drawing">
     <value>335, 76</value>
   </data>
   <data name="grpKeys.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
+    <value>3</value>
   </data>
   <data name="grpKeys.Text" xml:space="preserve">
     <value>Key Columns</value>
@@ -241,585 +469,9 @@
     <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;grpKeys.Parent" xml:space="preserve">
-    <value>tpJoinByOptions</value>
+    <value>$this</value>
   </data>
   <data name="&gt;&gt;grpKeys.ZOrder" xml:space="preserve">
     <value>3</value>
-  </data>
-  <data name="cmdRemoveAll.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 223</value>
-  </data>
-  <data name="cmdRemoveAll.Size" type="System.Drawing.Size, System.Drawing">
-    <value>130, 23</value>
-  </data>
-  <data name="cmdRemoveAll.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="cmdRemoveAll.Text" xml:space="preserve">
-    <value>Remove All Pairs</value>
-  </data>
-  <data name="&gt;&gt;cmdRemoveAll.Name" xml:space="preserve">
-    <value>cmdRemoveAll</value>
-  </data>
-  <data name="&gt;&gt;cmdRemoveAll.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cmdRemoveAll.Parent" xml:space="preserve">
-    <value>pnlKeyColumns</value>
-  </data>
-  <data name="&gt;&gt;cmdRemoveAll.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="lstKeyColumns.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 21</value>
-  </data>
-  <data name="lstKeyColumns.Size" type="System.Drawing.Size, System.Drawing">
-    <value>185, 167</value>
-  </data>
-  <data name="lstKeyColumns.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;lstKeyColumns.Name" xml:space="preserve">
-    <value>lstKeyColumns</value>
-  </data>
-  <data name="&gt;&gt;lstKeyColumns.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ListView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lstKeyColumns.Parent" xml:space="preserve">
-    <value>pnlKeyColumns</value>
-  </data>
-  <data name="&gt;&gt;lstKeyColumns.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="lblKeyColumns.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lblKeyColumns.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 5</value>
-  </data>
-  <data name="lblKeyColumns.Size" type="System.Drawing.Size, System.Drawing">
-    <value>68, 13</value>
-  </data>
-  <data name="lblKeyColumns.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="lblKeyColumns.Text" xml:space="preserve">
-    <value>Key Columns</value>
-  </data>
-  <data name="&gt;&gt;lblKeyColumns.Name" xml:space="preserve">
-    <value>lblKeyColumns</value>
-  </data>
-  <data name="&gt;&gt;lblKeyColumns.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblKeyColumns.Parent" xml:space="preserve">
-    <value>pnlKeyColumns</value>
-  </data>
-  <data name="&gt;&gt;lblKeyColumns.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="cmdRemoveSelectedPair.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 194</value>
-  </data>
-  <data name="cmdRemoveSelectedPair.Size" type="System.Drawing.Size, System.Drawing">
-    <value>130, 23</value>
-  </data>
-  <data name="cmdRemoveSelectedPair.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="cmdRemoveSelectedPair.Text" xml:space="preserve">
-    <value>Remove Selected Pair</value>
-  </data>
-  <data name="&gt;&gt;cmdRemoveSelectedPair.Name" xml:space="preserve">
-    <value>cmdRemoveSelectedPair</value>
-  </data>
-  <data name="&gt;&gt;cmdRemoveSelectedPair.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cmdRemoveSelectedPair.Parent" xml:space="preserve">
-    <value>pnlKeyColumns</value>
-  </data>
-  <data name="&gt;&gt;cmdRemoveSelectedPair.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="pnlKeyColumns.Location" type="System.Drawing.Point, System.Drawing">
-    <value>435, 21</value>
-  </data>
-  <data name="pnlKeyColumns.Size" type="System.Drawing.Size, System.Drawing">
-    <value>194, 256</value>
-  </data>
-  <data name="pnlKeyColumns.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;pnlKeyColumns.Name" xml:space="preserve">
-    <value>pnlKeyColumns</value>
-  </data>
-  <data name="&gt;&gt;pnlKeyColumns.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pnlKeyColumns.Parent" xml:space="preserve">
-    <value>tpJoinByOptions</value>
-  </data>
-  <data name="&gt;&gt;pnlKeyColumns.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="ucrSelectorSecondDF.Location" type="System.Drawing.Point, System.Drawing">
-    <value>222, 13</value>
-  </data>
-  <data name="ucrSelectorSecondDF.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
-  </data>
-  <data name="ucrSelectorSecondDF.Size" type="System.Drawing.Size, System.Drawing">
-    <value>210, 180</value>
-  </data>
-  <data name="ucrSelectorSecondDF.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;ucrSelectorSecondDF.Name" xml:space="preserve">
-    <value>ucrSelectorSecondDF</value>
-  </data>
-  <data name="&gt;&gt;ucrSelectorSecondDF.Type" xml:space="preserve">
-    <value>instat.ucrSelectorByDataFrameAddRemove, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrSelectorSecondDF.Parent" xml:space="preserve">
-    <value>tpJoinByOptions</value>
-  </data>
-  <data name="&gt;&gt;ucrSelectorSecondDF.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="ucrSelectorFirstDF.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 13</value>
-  </data>
-  <data name="ucrSelectorFirstDF.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
-  </data>
-  <data name="ucrSelectorFirstDF.Size" type="System.Drawing.Size, System.Drawing">
-    <value>210, 180</value>
-  </data>
-  <data name="ucrSelectorFirstDF.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;ucrSelectorFirstDF.Name" xml:space="preserve">
-    <value>ucrSelectorFirstDF</value>
-  </data>
-  <data name="&gt;&gt;ucrSelectorFirstDF.Type" xml:space="preserve">
-    <value>instat.ucrSelectorByDataFrameAddRemove, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrSelectorFirstDF.Parent" xml:space="preserve">
-    <value>tpJoinByOptions</value>
-  </data>
-  <data name="&gt;&gt;ucrSelectorFirstDF.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="tpJoinByOptions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="tpJoinByOptions.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpJoinByOptions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>648, 367</value>
-  </data>
-  <data name="tpJoinByOptions.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="tpJoinByOptions.Text" xml:space="preserve">
-    <value>Joining Columns</value>
-  </data>
-  <data name="&gt;&gt;tpJoinByOptions.Name" xml:space="preserve">
-    <value>tpJoinByOptions</value>
-  </data>
-  <data name="&gt;&gt;tpJoinByOptions.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpJoinByOptions.Parent" xml:space="preserve">
-    <value>tbcMergeOptions</value>
-  </data>
-  <data name="&gt;&gt;tpJoinByOptions.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;ucrChkMergeWithSubsetSecond.Name" xml:space="preserve">
-    <value>ucrChkMergeWithSubsetSecond</value>
-  </data>
-  <data name="&gt;&gt;ucrChkMergeWithSubsetSecond.Type" xml:space="preserve">
-    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrChkMergeWithSubsetSecond.Parent" xml:space="preserve">
-    <value>tpIncludeColumns</value>
-  </data>
-  <data name="&gt;&gt;ucrChkMergeWithSubsetSecond.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;ucrChkMergeWithSubsetFirst.Name" xml:space="preserve">
-    <value>ucrChkMergeWithSubsetFirst</value>
-  </data>
-  <data name="&gt;&gt;ucrChkMergeWithSubsetFirst.Type" xml:space="preserve">
-    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrChkMergeWithSubsetFirst.Parent" xml:space="preserve">
-    <value>tpIncludeColumns</value>
-  </data>
-  <data name="&gt;&gt;ucrChkMergeWithSubsetFirst.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;lblVariablesToIncludeSecond.Name" xml:space="preserve">
-    <value>lblVariablesToIncludeSecond</value>
-  </data>
-  <data name="&gt;&gt;lblVariablesToIncludeSecond.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblVariablesToIncludeSecond.Parent" xml:space="preserve">
-    <value>tpIncludeColumns</value>
-  </data>
-  <data name="&gt;&gt;lblVariablesToIncludeSecond.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;lblVariablesToIncludeFirst.Name" xml:space="preserve">
-    <value>lblVariablesToIncludeFirst</value>
-  </data>
-  <data name="&gt;&gt;lblVariablesToIncludeFirst.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblVariablesToIncludeFirst.Parent" xml:space="preserve">
-    <value>tpIncludeColumns</value>
-  </data>
-  <data name="&gt;&gt;lblVariablesToIncludeFirst.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverSecondSelected.Name" xml:space="preserve">
-    <value>ucrReceiverSecondSelected</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverSecondSelected.Type" xml:space="preserve">
-    <value>instat.ucrReceiverMultiple, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverSecondSelected.Parent" xml:space="preserve">
-    <value>tpIncludeColumns</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverSecondSelected.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverFirstSelected.Name" xml:space="preserve">
-    <value>ucrReceiverFirstSelected</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverFirstSelected.Type" xml:space="preserve">
-    <value>instat.ucrReceiverMultiple, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverFirstSelected.Parent" xml:space="preserve">
-    <value>tpIncludeColumns</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverFirstSelected.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;ucrSelectorColumnsToIncludeSecond.Name" xml:space="preserve">
-    <value>ucrSelectorColumnsToIncludeSecond</value>
-  </data>
-  <data name="&gt;&gt;ucrSelectorColumnsToIncludeSecond.Type" xml:space="preserve">
-    <value>instat.ucrSelectorByDataFrameAddRemove, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrSelectorColumnsToIncludeSecond.Parent" xml:space="preserve">
-    <value>tpIncludeColumns</value>
-  </data>
-  <data name="&gt;&gt;ucrSelectorColumnsToIncludeSecond.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;ucrSelectorColumnsToIncludeFirst.Name" xml:space="preserve">
-    <value>ucrSelectorColumnsToIncludeFirst</value>
-  </data>
-  <data name="&gt;&gt;ucrSelectorColumnsToIncludeFirst.Type" xml:space="preserve">
-    <value>instat.ucrSelectorByDataFrameAddRemove, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrSelectorColumnsToIncludeFirst.Parent" xml:space="preserve">
-    <value>tpIncludeColumns</value>
-  </data>
-  <data name="&gt;&gt;ucrSelectorColumnsToIncludeFirst.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="tpIncludeColumns.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="tpIncludeColumns.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpIncludeColumns.Size" type="System.Drawing.Size, System.Drawing">
-    <value>648, 367</value>
-  </data>
-  <data name="tpIncludeColumns.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="tpIncludeColumns.Text" xml:space="preserve">
-    <value>Columns to Include</value>
-  </data>
-  <data name="&gt;&gt;tpIncludeColumns.Name" xml:space="preserve">
-    <value>tpIncludeColumns</value>
-  </data>
-  <data name="&gt;&gt;tpIncludeColumns.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpIncludeColumns.Parent" xml:space="preserve">
-    <value>tbcMergeOptions</value>
-  </data>
-  <data name="&gt;&gt;tpIncludeColumns.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="tbcMergeOptions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 8</value>
-  </data>
-  <data name="tbcMergeOptions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>656, 393</value>
-  </data>
-  <data name="tbcMergeOptions.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;tbcMergeOptions.Name" xml:space="preserve">
-    <value>tbcMergeOptions</value>
-  </data>
-  <data name="&gt;&gt;tbcMergeOptions.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tbcMergeOptions.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;tbcMergeOptions.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="ucrChkMergeWithSubsetSecond.Location" type="System.Drawing.Point, System.Drawing">
-    <value>252, 10</value>
-  </data>
-  <data name="ucrChkMergeWithSubsetSecond.Size" type="System.Drawing.Size, System.Drawing">
-    <value>210, 20</value>
-  </data>
-  <data name="ucrChkMergeWithSubsetSecond.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;ucrChkMergeWithSubsetSecond.Name" xml:space="preserve">
-    <value>ucrChkMergeWithSubsetSecond</value>
-  </data>
-  <data name="&gt;&gt;ucrChkMergeWithSubsetSecond.Type" xml:space="preserve">
-    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrChkMergeWithSubsetSecond.Parent" xml:space="preserve">
-    <value>tpIncludeColumns</value>
-  </data>
-  <data name="&gt;&gt;ucrChkMergeWithSubsetSecond.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="ucrChkMergeWithSubsetFirst.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 10</value>
-  </data>
-  <data name="ucrChkMergeWithSubsetFirst.Size" type="System.Drawing.Size, System.Drawing">
-    <value>206, 20</value>
-  </data>
-  <data name="ucrChkMergeWithSubsetFirst.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;ucrChkMergeWithSubsetFirst.Name" xml:space="preserve">
-    <value>ucrChkMergeWithSubsetFirst</value>
-  </data>
-  <data name="&gt;&gt;ucrChkMergeWithSubsetFirst.Type" xml:space="preserve">
-    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrChkMergeWithSubsetFirst.Parent" xml:space="preserve">
-    <value>tpIncludeColumns</value>
-  </data>
-  <data name="&gt;&gt;ucrChkMergeWithSubsetFirst.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="lblVariablesToIncludeSecond.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lblVariablesToIncludeSecond.Location" type="System.Drawing.Point, System.Drawing">
-    <value>249, 223</value>
-  </data>
-  <data name="lblVariablesToIncludeSecond.Size" type="System.Drawing.Size, System.Drawing">
-    <value>107, 13</value>
-  </data>
-  <data name="lblVariablesToIncludeSecond.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="lblVariablesToIncludeSecond.Text" xml:space="preserve">
-    <value>Variables To Include:</value>
-  </data>
-  <data name="&gt;&gt;lblVariablesToIncludeSecond.Name" xml:space="preserve">
-    <value>lblVariablesToIncludeSecond</value>
-  </data>
-  <data name="&gt;&gt;lblVariablesToIncludeSecond.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblVariablesToIncludeSecond.Parent" xml:space="preserve">
-    <value>tpIncludeColumns</value>
-  </data>
-  <data name="&gt;&gt;lblVariablesToIncludeSecond.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="lblVariablesToIncludeFirst.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lblVariablesToIncludeFirst.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 223</value>
-  </data>
-  <data name="lblVariablesToIncludeFirst.Size" type="System.Drawing.Size, System.Drawing">
-    <value>102, 13</value>
-  </data>
-  <data name="lblVariablesToIncludeFirst.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="lblVariablesToIncludeFirst.Text" xml:space="preserve">
-    <value>Variable To Include:</value>
-  </data>
-  <data name="&gt;&gt;lblVariablesToIncludeFirst.Name" xml:space="preserve">
-    <value>lblVariablesToIncludeFirst</value>
-  </data>
-  <data name="&gt;&gt;lblVariablesToIncludeFirst.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblVariablesToIncludeFirst.Parent" xml:space="preserve">
-    <value>tpIncludeColumns</value>
-  </data>
-  <data name="&gt;&gt;lblVariablesToIncludeFirst.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="ucrReceiverSecondSelected.Location" type="System.Drawing.Point, System.Drawing">
-    <value>252, 238</value>
-  </data>
-  <data name="ucrReceiverSecondSelected.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
-  </data>
-  <data name="ucrReceiverSecondSelected.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 119</value>
-  </data>
-  <data name="ucrReceiverSecondSelected.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverSecondSelected.Name" xml:space="preserve">
-    <value>ucrReceiverSecondSelected</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverSecondSelected.Type" xml:space="preserve">
-    <value>instat.ucrReceiverMultiple, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverSecondSelected.Parent" xml:space="preserve">
-    <value>tpIncludeColumns</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverSecondSelected.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="ucrReceiverFirstSelected.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 238</value>
-  </data>
-  <data name="ucrReceiverFirstSelected.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
-  </data>
-  <data name="ucrReceiverFirstSelected.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 119</value>
-  </data>
-  <data name="ucrReceiverFirstSelected.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverFirstSelected.Name" xml:space="preserve">
-    <value>ucrReceiverFirstSelected</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverFirstSelected.Type" xml:space="preserve">
-    <value>instat.ucrReceiverMultiple, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverFirstSelected.Parent" xml:space="preserve">
-    <value>tpIncludeColumns</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverFirstSelected.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="ucrSelectorColumnsToIncludeSecond.Location" type="System.Drawing.Point, System.Drawing">
-    <value>252, 34</value>
-  </data>
-  <data name="ucrSelectorColumnsToIncludeSecond.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
-  </data>
-  <data name="ucrSelectorColumnsToIncludeSecond.Size" type="System.Drawing.Size, System.Drawing">
-    <value>210, 180</value>
-  </data>
-  <data name="ucrSelectorColumnsToIncludeSecond.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;ucrSelectorColumnsToIncludeSecond.Name" xml:space="preserve">
-    <value>ucrSelectorColumnsToIncludeSecond</value>
-  </data>
-  <data name="&gt;&gt;ucrSelectorColumnsToIncludeSecond.Type" xml:space="preserve">
-    <value>instat.ucrSelectorByDataFrameAddRemove, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrSelectorColumnsToIncludeSecond.Parent" xml:space="preserve">
-    <value>tpIncludeColumns</value>
-  </data>
-  <data name="&gt;&gt;ucrSelectorColumnsToIncludeSecond.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="ucrSelectorColumnsToIncludeFirst.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 34</value>
-  </data>
-  <data name="ucrSelectorColumnsToIncludeFirst.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
-  </data>
-  <data name="ucrSelectorColumnsToIncludeFirst.Size" type="System.Drawing.Size, System.Drawing">
-    <value>210, 180</value>
-  </data>
-  <data name="ucrSelectorColumnsToIncludeFirst.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;ucrSelectorColumnsToIncludeFirst.Name" xml:space="preserve">
-    <value>ucrSelectorColumnsToIncludeFirst</value>
-  </data>
-  <data name="&gt;&gt;ucrSelectorColumnsToIncludeFirst.Type" xml:space="preserve">
-    <value>instat.ucrSelectorByDataFrameAddRemove, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrSelectorColumnsToIncludeFirst.Parent" xml:space="preserve">
-    <value>tpIncludeColumns</value>
-  </data>
-  <data name="&gt;&gt;ucrSelectorColumnsToIncludeFirst.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="ucrSubBase.Location" type="System.Drawing.Point, System.Drawing">
-    <value>264, 407</value>
-  </data>
-  <data name="ucrSubBase.Size" type="System.Drawing.Size, System.Drawing">
-    <value>142, 30</value>
-  </data>
-  <data name="ucrSubBase.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;ucrSubBase.Name" xml:space="preserve">
-    <value>ucrSubBase</value>
-  </data>
-  <data name="&gt;&gt;ucrSubBase.Type" xml:space="preserve">
-    <value>instat.ucrButtonsSubdialogue, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrSubBase.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;ucrSubBase.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
-  </data>
-  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>670, 439</value>
-  </data>
-  <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
-    <value>CenterParent</value>
-  </data>
-  <data name="$this.Text" xml:space="preserve">
-    <value>Merge Options</value>
-  </data>
-  <data name="&gt;&gt;ttJoinDetails.Name" xml:space="preserve">
-    <value>ttJoinDetails</value>
-  </data>
-  <data name="&gt;&gt;ttJoinDetails.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;$this.Name" xml:space="preserve">
-    <value>sdgMerge</value>
-  </data>
-  <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Form, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
 </root>

--- a/instat/sdgMerge.vb
+++ b/instat/sdgMerge.vb
@@ -21,7 +21,6 @@ Public Class sdgMerge
     Private bControlsInitialised As Boolean = False
     Private clsByList As New RFunction
     Private clsMerge As RFunction
-    Private bEnableColumnSelection As Boolean = True
 
     Private Sub sdgMerge_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         autoTranslate(Me)
@@ -47,7 +46,6 @@ Public Class sdgMerge
         ucrSelectorFirstDF.SetDataframe(strFirstDataName, False)
         ucrSelectorSecondDF.SetDataframe(strSecondDataName, False)
 
-        bEnableColumnSelection = bNewEnableColumnSelection
         clsMerge = clsNewMerge
         clsByList = clsNewByList
         ResetKeyList()

--- a/instat/sdgMerge.vb
+++ b/instat/sdgMerge.vb
@@ -39,7 +39,7 @@ Public Class sdgMerge
         bControlsInitialised = True
     End Sub
 
-    Public Sub Setup(strFirstDataName As String, strSecondDataName As String, clsNewMerge As RFunction, clsNewByList As RFunction, bReset As Boolean, Optional bNewEnableColumnSelection As Boolean = True)
+    Public Sub Setup(strFirstDataName As String, strSecondDataName As String, clsNewMerge As RFunction, clsNewByList As RFunction, bReset As Boolean)
         If Not bControlsInitialised Then
             InitiatiseControls()
         End If

--- a/instat/sdgMergeColumnsToInclude.Designer.vb
+++ b/instat/sdgMergeColumnsToInclude.Designer.vb
@@ -22,7 +22,7 @@ Partial Class sdgMergeColumnstoInclude
     'Do not modify it using the code editor.
     <System.Diagnostics.DebuggerStepThrough()> _
     Private Sub InitializeComponent()
-        Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(sdgMergeColumnsToInclude))
+        Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(sdgMergeColumnstoInclude))
         Me.ucrChkMergeWithSubsetSecond = New instat.ucrCheck()
         Me.ucrChkMergeWithSubsetFirst = New instat.ucrCheck()
         Me.lblVariablesToIncludeSecond = New System.Windows.Forms.Label()
@@ -95,7 +95,7 @@ Partial Class sdgMergeColumnstoInclude
         resources.ApplyResources(Me.ucrSubBase, "ucrSubBase")
         Me.ucrSubBase.Name = "ucrSubBase"
         '
-        'sdgMergeColumnsToInclude
+        'sdgMergeColumnstoInclude
         '
         resources.ApplyResources(Me, "$this")
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
@@ -111,7 +111,7 @@ Partial Class sdgMergeColumnstoInclude
         Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow
         Me.MaximizeBox = False
         Me.MinimizeBox = False
-        Me.Name = "sdgMergeColumnsToInclude"
+        Me.Name = "sdgMergeColumnstoInclude"
         Me.ResumeLayout(False)
         Me.PerformLayout()
 

--- a/instat/sdgMergeColumnsToInclude.Designer.vb
+++ b/instat/sdgMergeColumnsToInclude.Designer.vb
@@ -1,5 +1,5 @@
 ﻿<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()> _
-Partial Class sdgMergeColumnsToInclude
+Partial Class sdgMergeColumnstoInclude
     Inherits System.Windows.Forms.Form
 
     'Form overrides dispose to clean up the component list.
@@ -23,17 +23,107 @@ Partial Class sdgMergeColumnsToInclude
     <System.Diagnostics.DebuggerStepThrough()> _
     Private Sub InitializeComponent()
         Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(sdgMergeColumnsToInclude))
+        Me.ucrChkMergeWithSubsetSecond = New instat.ucrCheck()
+        Me.ucrChkMergeWithSubsetFirst = New instat.ucrCheck()
+        Me.lblVariablesToIncludeSecond = New System.Windows.Forms.Label()
+        Me.lblVariablesToIncludeFirst = New System.Windows.Forms.Label()
+        Me.ucrReceiverSecondSelected = New instat.ucrReceiverMultiple()
+        Me.ucrReceiverFirstSelected = New instat.ucrReceiverMultiple()
+        Me.ucrSelectorColumnsToIncludeSecond = New instat.ucrSelectorByDataFrameAddRemove()
+        Me.ucrSelectorColumnsToIncludeFirst = New instat.ucrSelectorByDataFrameAddRemove()
+        Me.ucrSubBase = New instat.ucrButtonsSubdialogue()
         Me.SuspendLayout()
+        '
+        'ucrChkMergeWithSubsetSecond
+        '
+        Me.ucrChkMergeWithSubsetSecond.Checked = False
+        resources.ApplyResources(Me.ucrChkMergeWithSubsetSecond, "ucrChkMergeWithSubsetSecond")
+        Me.ucrChkMergeWithSubsetSecond.Name = "ucrChkMergeWithSubsetSecond"
+        '
+        'ucrChkMergeWithSubsetFirst
+        '
+        Me.ucrChkMergeWithSubsetFirst.Checked = False
+        resources.ApplyResources(Me.ucrChkMergeWithSubsetFirst, "ucrChkMergeWithSubsetFirst")
+        Me.ucrChkMergeWithSubsetFirst.Name = "ucrChkMergeWithSubsetFirst"
+        '
+        'lblVariablesToIncludeSecond
+        '
+        resources.ApplyResources(Me.lblVariablesToIncludeSecond, "lblVariablesToIncludeSecond")
+        Me.lblVariablesToIncludeSecond.Name = "lblVariablesToIncludeSecond"
+        '
+        'lblVariablesToIncludeFirst
+        '
+        resources.ApplyResources(Me.lblVariablesToIncludeFirst, "lblVariablesToIncludeFirst")
+        Me.lblVariablesToIncludeFirst.Name = "lblVariablesToIncludeFirst"
+        '
+        'ucrReceiverSecondSelected
+        '
+        Me.ucrReceiverSecondSelected.frmParent = Me
+        resources.ApplyResources(Me.ucrReceiverSecondSelected, "ucrReceiverSecondSelected")
+        Me.ucrReceiverSecondSelected.Name = "ucrReceiverSecondSelected"
+        Me.ucrReceiverSecondSelected.Selector = Nothing
+        Me.ucrReceiverSecondSelected.strNcFilePath = ""
+        Me.ucrReceiverSecondSelected.ucrSelector = Nothing
+        '
+        'ucrReceiverFirstSelected
+        '
+        Me.ucrReceiverFirstSelected.frmParent = Me
+        resources.ApplyResources(Me.ucrReceiverFirstSelected, "ucrReceiverFirstSelected")
+        Me.ucrReceiverFirstSelected.Name = "ucrReceiverFirstSelected"
+        Me.ucrReceiverFirstSelected.Selector = Nothing
+        Me.ucrReceiverFirstSelected.strNcFilePath = ""
+        Me.ucrReceiverFirstSelected.ucrSelector = Nothing
+        '
+        'ucrSelectorColumnsToIncludeSecond
+        '
+        Me.ucrSelectorColumnsToIncludeSecond.bDropUnusedFilterLevels = False
+        Me.ucrSelectorColumnsToIncludeSecond.bShowHiddenColumns = False
+        Me.ucrSelectorColumnsToIncludeSecond.bUseCurrentFilter = True
+        resources.ApplyResources(Me.ucrSelectorColumnsToIncludeSecond, "ucrSelectorColumnsToIncludeSecond")
+        Me.ucrSelectorColumnsToIncludeSecond.Name = "ucrSelectorColumnsToIncludeSecond"
+        '
+        'ucrSelectorColumnsToIncludeFirst
+        '
+        Me.ucrSelectorColumnsToIncludeFirst.bDropUnusedFilterLevels = False
+        Me.ucrSelectorColumnsToIncludeFirst.bShowHiddenColumns = False
+        Me.ucrSelectorColumnsToIncludeFirst.bUseCurrentFilter = True
+        resources.ApplyResources(Me.ucrSelectorColumnsToIncludeFirst, "ucrSelectorColumnsToIncludeFirst")
+        Me.ucrSelectorColumnsToIncludeFirst.Name = "ucrSelectorColumnsToIncludeFirst"
+        '
+        'ucrSubBase
+        '
+        resources.ApplyResources(Me.ucrSubBase, "ucrSubBase")
+        Me.ucrSubBase.Name = "ucrSubBase"
         '
         'sdgMergeColumnsToInclude
         '
         resources.ApplyResources(Me, "$this")
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.Controls.Add(Me.ucrSubBase)
+        Me.Controls.Add(Me.ucrChkMergeWithSubsetSecond)
+        Me.Controls.Add(Me.ucrChkMergeWithSubsetFirst)
+        Me.Controls.Add(Me.lblVariablesToIncludeSecond)
+        Me.Controls.Add(Me.lblVariablesToIncludeFirst)
+        Me.Controls.Add(Me.ucrReceiverSecondSelected)
+        Me.Controls.Add(Me.ucrReceiverFirstSelected)
+        Me.Controls.Add(Me.ucrSelectorColumnsToIncludeSecond)
+        Me.Controls.Add(Me.ucrSelectorColumnsToIncludeFirst)
         Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow
         Me.MaximizeBox = False
         Me.MinimizeBox = False
         Me.Name = "sdgMergeColumnsToInclude"
         Me.ResumeLayout(False)
+        Me.PerformLayout()
 
     End Sub
+
+    Friend WithEvents ucrChkMergeWithSubsetSecond As ucrCheck
+    Friend WithEvents ucrChkMergeWithSubsetFirst As ucrCheck
+    Friend WithEvents lblVariablesToIncludeSecond As Label
+    Friend WithEvents lblVariablesToIncludeFirst As Label
+    Friend WithEvents ucrReceiverSecondSelected As ucrReceiverMultiple
+    Friend WithEvents ucrReceiverFirstSelected As ucrReceiverMultiple
+    Friend WithEvents ucrSelectorColumnsToIncludeSecond As ucrSelectorByDataFrameAddRemove
+    Friend WithEvents ucrSelectorColumnsToIncludeFirst As ucrSelectorByDataFrameAddRemove
+    Friend WithEvents ucrSubBase As ucrButtonsSubdialogue
 End Class

--- a/instat/sdgMergeColumnsToInclude.resx
+++ b/instat/sdgMergeColumnsToInclude.resx
@@ -172,13 +172,13 @@
     <value>252, 228</value>
   </data>
   <data name="lblVariablesToIncludeSecond.Size" type="System.Drawing.Size, System.Drawing">
-    <value>107, 13</value>
+    <value>103, 13</value>
   </data>
   <data name="lblVariablesToIncludeSecond.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
   </data>
   <data name="lblVariablesToIncludeSecond.Text" xml:space="preserve">
-    <value>Variables To Include:</value>
+    <value>Variables to Include:</value>
   </data>
   <data name="&gt;&gt;lblVariablesToIncludeSecond.Name" xml:space="preserve">
     <value>lblVariablesToIncludeSecond</value>
@@ -202,13 +202,13 @@
     <value>13, 228</value>
   </data>
   <data name="lblVariablesToIncludeFirst.Size" type="System.Drawing.Size, System.Drawing">
-    <value>102, 13</value>
+    <value>103, 13</value>
   </data>
   <data name="lblVariablesToIncludeFirst.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
   </data>
   <data name="lblVariablesToIncludeFirst.Text" xml:space="preserve">
-    <value>Variable To Include:</value>
+    <value>Variables to Include:</value>
   </data>
   <data name="&gt;&gt;lblVariablesToIncludeFirst.Name" xml:space="preserve">
     <value>lblVariablesToIncludeFirst</value>
@@ -331,7 +331,7 @@
     <value>Columns to Include</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
-    <value>sdgMergeColumnsToInclude</value>
+    <value>sdgMergeColumnstoInclude</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
     <value>System.Windows.Forms.Form, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>

--- a/instat/sdgMergeColumnsToInclude.resx
+++ b/instat/sdgMergeColumnsToInclude.resx
@@ -117,17 +117,213 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="ucrChkMergeWithSubsetSecond.Location" type="System.Drawing.Point, System.Drawing">
+    <value>255, 15</value>
+  </data>
+  <data name="ucrChkMergeWithSubsetSecond.Size" type="System.Drawing.Size, System.Drawing">
+    <value>210, 20</value>
+  </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="ucrChkMergeWithSubsetSecond.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;ucrChkMergeWithSubsetSecond.Name" xml:space="preserve">
+    <value>ucrChkMergeWithSubsetSecond</value>
+  </data>
+  <data name="&gt;&gt;ucrChkMergeWithSubsetSecond.Type" xml:space="preserve">
+    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrChkMergeWithSubsetSecond.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrChkMergeWithSubsetSecond.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="ucrChkMergeWithSubsetFirst.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 15</value>
+  </data>
+  <data name="ucrChkMergeWithSubsetFirst.Size" type="System.Drawing.Size, System.Drawing">
+    <value>206, 20</value>
+  </data>
+  <data name="ucrChkMergeWithSubsetFirst.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;ucrChkMergeWithSubsetFirst.Name" xml:space="preserve">
+    <value>ucrChkMergeWithSubsetFirst</value>
+  </data>
+  <data name="&gt;&gt;ucrChkMergeWithSubsetFirst.Type" xml:space="preserve">
+    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrChkMergeWithSubsetFirst.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrChkMergeWithSubsetFirst.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="lblVariablesToIncludeSecond.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="lblVariablesToIncludeSecond.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblVariablesToIncludeSecond.Location" type="System.Drawing.Point, System.Drawing">
+    <value>252, 228</value>
+  </data>
+  <data name="lblVariablesToIncludeSecond.Size" type="System.Drawing.Size, System.Drawing">
+    <value>107, 13</value>
+  </data>
+  <data name="lblVariablesToIncludeSecond.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="lblVariablesToIncludeSecond.Text" xml:space="preserve">
+    <value>Variables To Include:</value>
+  </data>
+  <data name="&gt;&gt;lblVariablesToIncludeSecond.Name" xml:space="preserve">
+    <value>lblVariablesToIncludeSecond</value>
+  </data>
+  <data name="&gt;&gt;lblVariablesToIncludeSecond.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblVariablesToIncludeSecond.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;lblVariablesToIncludeSecond.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="lblVariablesToIncludeFirst.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblVariablesToIncludeFirst.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblVariablesToIncludeFirst.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 228</value>
+  </data>
+  <data name="lblVariablesToIncludeFirst.Size" type="System.Drawing.Size, System.Drawing">
+    <value>102, 13</value>
+  </data>
+  <data name="lblVariablesToIncludeFirst.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="lblVariablesToIncludeFirst.Text" xml:space="preserve">
+    <value>Variable To Include:</value>
+  </data>
+  <data name="&gt;&gt;lblVariablesToIncludeFirst.Name" xml:space="preserve">
+    <value>lblVariablesToIncludeFirst</value>
+  </data>
+  <data name="&gt;&gt;lblVariablesToIncludeFirst.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblVariablesToIncludeFirst.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;lblVariablesToIncludeFirst.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>6, 13</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>465, 306</value>
+    <value>478, 414</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="ucrSubBase.Location" type="System.Drawing.Point, System.Drawing">
+    <value>168, 379</value>
+  </data>
+  <data name="ucrSubBase.Size" type="System.Drawing.Size, System.Drawing">
+    <value>142, 30</value>
+  </data>
+  <data name="ucrSubBase.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;ucrSubBase.Name" xml:space="preserve">
+    <value>ucrSubBase</value>
+  </data>
+  <data name="&gt;&gt;ucrSubBase.Type" xml:space="preserve">
+    <value>instat.ucrButtonsSubdialogue, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrSubBase.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrSubBase.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="ucrReceiverFirstSelected.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 243</value>
+  </data>
+  <data name="ucrReceiverFirstSelected.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="ucrReceiverFirstSelected.Size" type="System.Drawing.Size, System.Drawing">
+    <value>120, 119</value>
+  </data>
+  <data name="ucrReceiverFirstSelected.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverFirstSelected.Name" xml:space="preserve">
+    <value>ucrReceiverFirstSelected</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverFirstSelected.Type" xml:space="preserve">
+    <value>instat.ucrReceiverMultiple, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverFirstSelected.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverFirstSelected.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="ucrSelectorColumnsToIncludeSecond.Location" type="System.Drawing.Point, System.Drawing">
+    <value>255, 39</value>
+  </data>
+  <data name="ucrSelectorColumnsToIncludeSecond.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="ucrSelectorColumnsToIncludeSecond.Size" type="System.Drawing.Size, System.Drawing">
+    <value>210, 180</value>
+  </data>
+  <data name="ucrSelectorColumnsToIncludeSecond.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;ucrSelectorColumnsToIncludeSecond.Name" xml:space="preserve">
+    <value>ucrSelectorColumnsToIncludeSecond</value>
+  </data>
+  <data name="&gt;&gt;ucrSelectorColumnsToIncludeSecond.Type" xml:space="preserve">
+    <value>instat.ucrSelectorByDataFrameAddRemove, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrSelectorColumnsToIncludeSecond.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrSelectorColumnsToIncludeSecond.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="ucrSelectorColumnsToIncludeFirst.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 39</value>
+  </data>
+  <data name="ucrSelectorColumnsToIncludeFirst.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="ucrSelectorColumnsToIncludeFirst.Size" type="System.Drawing.Size, System.Drawing">
+    <value>210, 180</value>
+  </data>
+  <data name="ucrSelectorColumnsToIncludeFirst.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;ucrSelectorColumnsToIncludeFirst.Name" xml:space="preserve">
+    <value>ucrSelectorColumnsToIncludeFirst</value>
+  </data>
+  <data name="&gt;&gt;ucrSelectorColumnsToIncludeFirst.Type" xml:space="preserve">
+    <value>instat.ucrSelectorByDataFrameAddRemove, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrSelectorColumnsToIncludeFirst.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrSelectorColumnsToIncludeFirst.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterParent</value>
   </data>
@@ -139,5 +335,29 @@
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
     <value>System.Windows.Forms.Form, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="ucrReceiverSecondSelected.Location" type="System.Drawing.Point, System.Drawing">
+    <value>255, 243</value>
+  </data>
+  <data name="ucrReceiverSecondSelected.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="ucrReceiverSecondSelected.Size" type="System.Drawing.Size, System.Drawing">
+    <value>120, 119</value>
+  </data>
+  <data name="ucrReceiverSecondSelected.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverSecondSelected.Name" xml:space="preserve">
+    <value>ucrReceiverSecondSelected</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverSecondSelected.Type" xml:space="preserve">
+    <value>instat.ucrReceiverMultiple, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverSecondSelected.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverSecondSelected.ZOrder" xml:space="preserve">
+    <value>5</value>
   </data>
 </root>

--- a/instat/sdgMergeColumnsToInclude.vb
+++ b/instat/sdgMergeColumnsToInclude.vb
@@ -123,7 +123,7 @@ Public Class sdgMergeColumnstoInclude
         End If
         If ucrChkMergeWithSubsetSecond.Checked Then
             For Each clsTmpParam As RParameter In clsByList.clsParameters
-                If Not ucrReceiverFirstSelected.GetVariableNamesAsList.Contains(clsTmpParam.strArgumentValue.Trim(Chr(34))) Then
+                If Not ucrReceiverSecondSelected.GetVariableNamesAsList.Contains(clsTmpParam.strArgumentValue.Trim(Chr(34))) Then
                     ucrReceiverSecondSelected.Add(clsTmpParam.strArgumentValue.Trim(Chr(34)), ucrSelectorColumnsToIncludeSecond.ucrAvailableDataFrames.cboAvailableDataFrames.Text)
                 End If
             Next

--- a/instat/sdgMergeColumnsToInclude.vb
+++ b/instat/sdgMergeColumnsToInclude.vb
@@ -1,3 +1,134 @@
-﻿Public Class sdgMergeColumnsToInclude
+﻿' R- Instat
+' Copyright (C) 2015-2017
+'
+' This program is free software: you can redistribute it and/or modify
+' it under the terms of the GNU General Public License as published by
+' the Free Software Foundation, either version 3 of the License, or
+' (at your option) any later version.
+'
+' This program is distributed in the hope that it will be useful,
+' but WITHOUT ANY WARRANTY; without even the implied warranty of
+' MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+' GNU General Public License for more details.
+'
+' You should have received a copy of the GNU General Public License 
+' along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+Imports System.ComponentModel
+Imports instat.Translations
+
+Public Class sdgMergeColumnstoInclude
+    Private bControlsInitialised As Boolean = False
+    Private clsByList As New RFunction
+    Private clsMerge As RFunction
+    Private bEnableColumnSelection As Boolean = True
+
+    Private Sub sdgMerge_Load(sender As Object, e As EventArgs) Handles MyBase.Load
+        autoTranslate(Me)
+    End Sub
+
+    Public Sub InitiatiseControls()
+        ucrChkMergeWithSubsetFirst.SetText("Choose Subset of Columns to Merge")
+        ucrChkMergeWithSubsetFirst.AddToLinkedControls(ucrReceiverFirstSelected, {True}, bNewLinkedHideIfParameterMissing:=True)
+        ucrChkMergeWithSubsetFirst.AddParameterValueFunctionNamesCondition(True, "x", frmMain.clsRLink.strInstatDataObject & "$get_columns_from_data")
+        ucrChkMergeWithSubsetFirst.AddParameterValueFunctionNamesCondition(False, "x", frmMain.clsRLink.strInstatDataObject & "$get_data_frame")
+
+        ucrChkMergeWithSubsetSecond.SetText("Choose Subset of Columns to Merge")
+        ucrChkMergeWithSubsetSecond.AddToLinkedControls(ucrReceiverSecondSelected, {True}, bNewLinkedHideIfParameterMissing:=True)
+        ucrChkMergeWithSubsetSecond.AddParameterValueFunctionNamesCondition(True, "y", frmMain.clsRLink.strInstatDataObject & "$get_columns_from_data")
+        ucrChkMergeWithSubsetSecond.AddParameterValueFunctionNamesCondition(False, "y", frmMain.clsRLink.strInstatDataObject & "$get_data_frame")
+
+        ucrReceiverFirstSelected.SetParameter(New RParameter("x", 0))
+        ucrReceiverFirstSelected.SetParameterIsRFunction()
+        ucrReceiverFirstSelected.SetLinkedDisplayControl(lblVariablesToIncludeFirst)
+        ucrReceiverFirstSelected.Selector = ucrSelectorColumnsToIncludeFirst
+        ucrReceiverFirstSelected.SetMeAsReceiver()
+        ucrReceiverFirstSelected.bForceAsDataFrame = True
+
+        ucrReceiverSecondSelected.SetParameter(New RParameter("y", 1))
+        ucrReceiverSecondSelected.SetParameterIsRFunction()
+        ucrReceiverSecondSelected.SetLinkedDisplayControl(lblVariablesToIncludeSecond)
+        ucrReceiverSecondSelected.Selector = ucrSelectorColumnsToIncludeSecond
+        ucrReceiverSecondSelected.SetMeAsReceiver()
+        ucrReceiverSecondSelected.bForceAsDataFrame = True
+
+        bControlsInitialised = True
+    End Sub
+
+    Public Sub Setup(strFirstDataName As String, strSecondDataName As String, clsNewMerge As RFunction, clsNewByList As RFunction, bReset As Boolean, Optional bNewEnableColumnSelection As Boolean = True)
+        If Not bControlsInitialised Then
+            InitiatiseControls()
+        End If
+
+        If bNewEnableColumnSelection Then
+            ucrSelectorColumnsToIncludeFirst.SetDataframe(strFirstDataName, False)
+            ucrSelectorColumnsToIncludeSecond.SetDataframe(strSecondDataName, False)
+        End If
+        bEnableColumnSelection = bNewEnableColumnSelection
+        clsMerge = clsNewMerge
+        clsByList = clsNewByList
+
+        If bNewEnableColumnSelection Then
+            ucrChkMergeWithSubsetFirst.SetRCode(clsMerge, bReset, bCloneIfNeeded:=True)
+            ucrChkMergeWithSubsetSecond.SetRCode(clsMerge, bReset, bCloneIfNeeded:=True)
+            If ucrChkMergeWithSubsetFirst.Checked Then
+                ucrReceiverFirstSelected.SetRCode(clsMerge, bReset, bCloneIfNeeded:=True)
+            Else
+                ucrReceiverFirstSelected.Clear()
+            End If
+            If ucrChkMergeWithSubsetSecond.Checked Then
+                ucrReceiverSecondSelected.SetRCode(clsMerge, bReset, bCloneIfNeeded:=True)
+            Else
+                ucrReceiverSecondSelected.Clear()
+            End If
+            SetXParameter()
+            SetYParameter()
+        End If
+    End Sub
+
+    Private Sub SetXParameter()
+        If ucrChkMergeWithSubsetFirst.Checked AndAlso Not ucrReceiverFirstSelected.IsEmpty Then
+            clsMerge.AddParameter("x", clsRFunctionParameter:=ucrReceiverFirstSelected.GetVariables(bForceAsDataFrame:=True))
+        Else
+            clsMerge.AddParameter("x", clsRFunctionParameter:=ucrSelectorColumnsToIncludeFirst.ucrAvailableDataFrames.clsCurrDataFrame)
+        End If
+        ucrSelectorColumnsToIncludeFirst.SetVariablesVisible(ucrChkMergeWithSubsetFirst.Checked)
+    End Sub
+
+    Private Sub SetYParameter()
+        If ucrChkMergeWithSubsetSecond.Checked AndAlso Not ucrReceiverSecondSelected.IsEmpty Then
+            clsMerge.AddParameter("y", clsRFunctionParameter:=ucrReceiverSecondSelected.GetVariables(bForceAsDataFrame:=True))
+        Else
+            clsMerge.AddParameter("y", clsRFunctionParameter:=ucrSelectorColumnsToIncludeSecond.ucrAvailableDataFrames.clsCurrDataFrame)
+        End If
+        ucrSelectorColumnsToIncludeSecond.SetVariablesVisible(ucrChkMergeWithSubsetSecond.Checked)
+    End Sub
+
+    Private Sub FirstSubsetControls_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrChkMergeWithSubsetFirst.ControlValueChanged, ucrReceiverFirstSelected.ControlValueChanged
+        SetXParameter()
+    End Sub
+
+    Private Sub SecondSubsetControls_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrChkMergeWithSubsetSecond.ControlValueChanged, ucrReceiverSecondSelected.ControlValueChanged
+        SetYParameter()
+    End Sub
+
+    Private Sub sdgMergeColumnsToInclude_Closing(sender As Object, e As CancelEventArgs) Handles Me.Closing
+        Dim lstMatchingColumns As New List(Of String)
+
+        ' If user has chosen a subset of columns we need to ensure 'by' columns are also included.
+        If ucrChkMergeWithSubsetFirst.Checked Then
+            For Each clsTmpParam As RParameter In clsByList.clsParameters
+                If Not ucrReceiverFirstSelected.GetVariableNamesAsList.Contains(clsTmpParam.strArgumentName.Trim(Chr(34))) Then
+                    ucrReceiverFirstSelected.Add(clsTmpParam.strArgumentName.Trim(Chr(34)), ucrSelectorColumnsToIncludeFirst.ucrAvailableDataFrames.cboAvailableDataFrames.Text)
+                End If
+            Next
+        End If
+        If ucrChkMergeWithSubsetSecond.Checked Then
+            For Each clsTmpParam As RParameter In clsByList.clsParameters
+                If Not ucrReceiverFirstSelected.GetVariableNamesAsList.Contains(clsTmpParam.strArgumentValue.Trim(Chr(34))) Then
+                    ucrReceiverSecondSelected.Add(clsTmpParam.strArgumentValue.Trim(Chr(34)), ucrSelectorColumnsToIncludeSecond.ucrAvailableDataFrames.cboAvailableDataFrames.Text)
+                End If
+            Next
+        End If
+    End Sub
 End Class

--- a/instat/sdgMergeColumnsToInclude.vb
+++ b/instat/sdgMergeColumnsToInclude.vb
@@ -21,7 +21,6 @@ Public Class sdgMergeColumnstoInclude
     Private bControlsInitialised As Boolean = False
     Private clsByList As New RFunction
     Private clsMerge As RFunction
-    Private bEnableColumnSelection As Boolean = True
 
     Private Sub sdgMerge_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         autoTranslate(Me)
@@ -64,7 +63,6 @@ Public Class sdgMergeColumnstoInclude
             ucrSelectorColumnsToIncludeFirst.SetDataframe(strFirstDataName, False)
             ucrSelectorColumnsToIncludeSecond.SetDataframe(strSecondDataName, False)
         End If
-        bEnableColumnSelection = bNewEnableColumnSelection
         clsMerge = clsNewMerge
         clsByList = clsNewByList
 


### PR DESCRIPTION
Replaces #6277
Fixes #6265

This PR separates the two tabs in the original sub-dialog into two separate sub dialogs (as described in #6265).

@dannyparsons this is ready for review. From what I can tell, the dialogs still automatically add in columns you merge by, even if you try to remove those columns in the "Columns to Include" tab. Is this okay?