### PR TITLE
Added Summary checkbox to the Duplicates dialog

### DIFF
--- a/instat/dlgDuplicates.Designer.vb
+++ b/instat/dlgDuplicates.Designer.vb
@@ -48,6 +48,7 @@ Partial Class dlgDuplicates
         Me.ucrPnlOptions = New instat.UcrPanel()
         Me.ucrBase = New instat.ucrButtons()
         Me.ucrSelectorDuplicateswithVariables = New instat.ucrSelectorByDataFrameAddRemove()
+        Me.ucrChkIncludeSummary = New instat.ucrCheck()
         Me.grpOptions.SuspendLayout()
         Me.SuspendLayout()
         '
@@ -144,6 +145,7 @@ Partial Class dlgDuplicates
         'ucrInputConditions
         '
         Me.ucrInputConditions.AddQuotesIfUnrecognised = True
+        Me.ucrInputConditions.GetSetSelectedIndex = -1
         Me.ucrInputConditions.IsReadOnly = False
         resources.ApplyResources(Me.ucrInputConditions, "ucrInputConditions")
         Me.ucrInputConditions.Name = "ucrInputConditions"
@@ -168,6 +170,7 @@ Partial Class dlgDuplicates
         'ucrInputComboType
         '
         Me.ucrInputComboType.AddQuotesIfUnrecognised = True
+        Me.ucrInputComboType.GetSetSelectedIndex = -1
         Me.ucrInputComboType.IsReadOnly = False
         resources.ApplyResources(Me.ucrInputComboType, "ucrInputComboType")
         Me.ucrInputComboType.Name = "ucrInputComboType"
@@ -218,10 +221,17 @@ Partial Class dlgDuplicates
         resources.ApplyResources(Me.ucrSelectorDuplicateswithVariables, "ucrSelectorDuplicateswithVariables")
         Me.ucrSelectorDuplicateswithVariables.Name = "ucrSelectorDuplicateswithVariables"
         '
+        'ucrChkIncludeSummary
+        '
+        Me.ucrChkIncludeSummary.Checked = False
+        resources.ApplyResources(Me.ucrChkIncludeSummary, "ucrChkIncludeSummary")
+        Me.ucrChkIncludeSummary.Name = "ucrChkIncludeSummary"
+        '
         'dlgDuplicates
         '
         resources.ApplyResources(Me, "$this")
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.Controls.Add(Me.ucrChkIncludeSummary)
         Me.Controls.Add(Me.grpOptions)
         Me.Controls.Add(Me.lblType)
         Me.Controls.Add(Me.lblVariablesToDuplicate)
@@ -274,4 +284,5 @@ Partial Class dlgDuplicates
     Friend WithEvents ucrInputOmitValues As ucrInputTextBox
     Friend WithEvents lblType As Label
     Friend WithEvents ucrInputComboType As ucrInputComboBox
+    Friend WithEvents ucrChkIncludeSummary As ucrCheck
 End Class

--- a/instat/dlgDuplicates.resx
+++ b/instat/dlgDuplicates.resx
@@ -132,7 +132,7 @@
     <value>39, 12</value>
   </data>
   <data name="rdoDataFrame.Size" type="System.Drawing.Size, System.Drawing">
-    <value>130, 27</value>
+    <value>115, 27</value>
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="rdoDataFrame.TabIndex" type="System.Int32, mscorlib">
@@ -154,7 +154,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;rdoDataFrame.ZOrder" xml:space="preserve">
-    <value>13</value>
+    <value>14</value>
   </data>
   <data name="rdoSelectedVariables.Appearance" type="System.Windows.Forms.Appearance, System.Windows.Forms">
     <value>Button</value>
@@ -166,10 +166,10 @@
     <value>NoControl</value>
   </data>
   <data name="rdoSelectedVariables.Location" type="System.Drawing.Point, System.Drawing">
-    <value>167, 12</value>
+    <value>152, 12</value>
   </data>
   <data name="rdoSelectedVariables.Size" type="System.Drawing.Size, System.Drawing">
-    <value>130, 27</value>
+    <value>115, 27</value>
   </data>
   <data name="rdoSelectedVariables.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -190,7 +190,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;rdoSelectedVariables.ZOrder" xml:space="preserve">
-    <value>14</value>
+    <value>15</value>
   </data>
   <data name="rdoIndexNumberOfDuplicates.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -220,7 +220,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;rdoIndexNumberOfDuplicates.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>9</value>
   </data>
   <data name="rdoDuplicatesOnly.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -250,7 +250,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;rdoDuplicatesOnly.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>10</value>
   </data>
   <data name="rdoAllDuplicateCases.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -280,7 +280,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;rdoAllDuplicateCases.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>11</value>
   </data>
   <metadata name="ttDuplicates.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>31, 6</value>
@@ -295,10 +295,10 @@
     <value>NoControl</value>
   </data>
   <data name="rdoSuccessiveValues.Location" type="System.Drawing.Point, System.Drawing">
-    <value>295, 12</value>
+    <value>265, 12</value>
   </data>
   <data name="rdoSuccessiveValues.Size" type="System.Drawing.Size, System.Drawing">
-    <value>130, 27</value>
+    <value>115, 27</value>
   </data>
   <data name="rdoSuccessiveValues.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -319,7 +319,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;rdoSuccessiveValues.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>7</value>
   </data>
   <data name="ucrInputOmitValues.Location" type="System.Drawing.Point, System.Drawing">
     <value>145, 45</value>
@@ -427,7 +427,7 @@
     <value>4</value>
   </data>
   <data name="grpOptions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 242</value>
+    <value>10, 230</value>
   </data>
   <data name="grpOptions.Size" type="System.Drawing.Size, System.Drawing">
     <value>288, 124</value>
@@ -448,7 +448,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;grpOptions.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="lblSelectedVariable.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -457,16 +457,16 @@
     <value>NoControl</value>
   </data>
   <data name="lblSelectedVariable.Location" type="System.Drawing.Point, System.Drawing">
-    <value>302, 82</value>
+    <value>277, 82</value>
   </data>
   <data name="lblSelectedVariable.Size" type="System.Drawing.Size, System.Drawing">
-    <value>93, 13</value>
+    <value>94, 13</value>
   </data>
   <data name="lblSelectedVariable.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
   </data>
   <data name="lblSelectedVariable.Text" xml:space="preserve">
-    <value>Variable to check:</value>
+    <value>Variable to Check:</value>
   </data>
   <data name="&gt;&gt;lblSelectedVariable.Name" xml:space="preserve">
     <value>lblSelectedVariable</value>
@@ -478,7 +478,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblSelectedVariable.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>6</value>
   </data>
   <data name="lblVariablesToDuplicate.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -487,16 +487,16 @@
     <value>NoControl</value>
   </data>
   <data name="lblVariablesToDuplicate.Location" type="System.Drawing.Point, System.Drawing">
-    <value>302, 82</value>
+    <value>277, 82</value>
   </data>
   <data name="lblVariablesToDuplicate.Size" type="System.Drawing.Size, System.Drawing">
-    <value>98, 13</value>
+    <value>99, 13</value>
   </data>
   <data name="lblVariablesToDuplicate.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
   </data>
   <data name="lblVariablesToDuplicate.Text" xml:space="preserve">
-    <value>Variables to check:</value>
+    <value>Variables to Check:</value>
   </data>
   <data name="&gt;&gt;lblVariablesToDuplicate.Name" xml:space="preserve">
     <value>lblVariablesToDuplicate</value>
@@ -508,7 +508,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblVariablesToDuplicate.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="lblType.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -517,7 +517,7 @@
     <value>NoControl</value>
   </data>
   <data name="lblType.Location" type="System.Drawing.Point, System.Drawing">
-    <value>174, 278</value>
+    <value>178, 297</value>
   </data>
   <data name="lblType.Size" type="System.Drawing.Size, System.Drawing">
     <value>34, 13</value>
@@ -538,10 +538,10 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblType.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="ucrInputComboType.Location" type="System.Drawing.Point, System.Drawing">
-    <value>172, 294</value>
+    <value>212, 295</value>
   </data>
   <data name="ucrInputComboType.Size" type="System.Drawing.Size, System.Drawing">
     <value>84, 21</value>
@@ -559,7 +559,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrInputComboType.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -571,10 +571,31 @@
     <value>6, 13</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>464, 456</value>
+    <value>422, 473</value>
+  </data>
+  <data name="ucrChkIncludeSummary.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 360</value>
+  </data>
+  <data name="ucrChkIncludeSummary.Size" type="System.Drawing.Size, System.Drawing">
+    <value>135, 20</value>
+  </data>
+  <data name="ucrChkIncludeSummary.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="&gt;&gt;ucrChkIncludeSummary.Name" xml:space="preserve">
+    <value>ucrChkIncludeSummary</value>
+  </data>
+  <data name="&gt;&gt;ucrChkIncludeSummary.Type" xml:space="preserve">
+    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrChkIncludeSummary.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrChkIncludeSummary.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="ucrReceiverForSuccessiveValues.Location" type="System.Drawing.Point, System.Drawing">
-    <value>302, 97</value>
+    <value>277, 97</value>
   </data>
   <data name="ucrReceiverForSuccessiveValues.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
@@ -595,13 +616,13 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrReceiverForSuccessiveValues.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>8</value>
   </data>
   <data name="ucrPnlDuplicates.Location" type="System.Drawing.Point, System.Drawing">
     <value>10, 245</value>
   </data>
   <data name="ucrPnlDuplicates.Size" type="System.Drawing.Size, System.Drawing">
-    <value>262, 77</value>
+    <value>298, 77</value>
   </data>
   <data name="ucrPnlDuplicates.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -616,16 +637,19 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrPnlDuplicates.ZOrder" xml:space="preserve">
-    <value>11</value>
+    <value>12</value>
   </data>
   <data name="ucrNewColumnName.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 372</value>
+    <value>10, 388</value>
+  </data>
+  <data name="ucrNewColumnName.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="ucrNewColumnName.Size" type="System.Drawing.Size, System.Drawing">
     <value>281, 24</value>
   </data>
   <data name="ucrNewColumnName.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
+    <value>15</value>
   </data>
   <data name="&gt;&gt;ucrNewColumnName.Name" xml:space="preserve">
     <value>ucrNewColumnName</value>
@@ -637,13 +661,13 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrNewColumnName.ZOrder" xml:space="preserve">
-    <value>12</value>
+    <value>13</value>
   </data>
   <data name="ucrPnlOptions.Location" type="System.Drawing.Point, System.Drawing">
     <value>14, 8</value>
   </data>
   <data name="ucrPnlOptions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>436, 36</value>
+    <value>397, 36</value>
   </data>
   <data name="ucrPnlOptions.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -658,16 +682,16 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrPnlOptions.ZOrder" xml:space="preserve">
-    <value>15</value>
+    <value>16</value>
   </data>
   <data name="ucrBase.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 398</value>
+    <value>10, 416</value>
   </data>
   <data name="ucrBase.Size" type="System.Drawing.Size, System.Drawing">
     <value>401, 52</value>
   </data>
   <data name="ucrBase.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
+    <value>16</value>
   </data>
   <data name="&gt;&gt;ucrBase.Name" xml:space="preserve">
     <value>ucrBase</value>
@@ -679,7 +703,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrBase.ZOrder" xml:space="preserve">
-    <value>16</value>
+    <value>17</value>
   </data>
   <data name="ucrSelectorDuplicateswithVariables.Location" type="System.Drawing.Point, System.Drawing">
     <value>10, 47</value>
@@ -703,7 +727,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrSelectorDuplicateswithVariables.ZOrder" xml:space="preserve">
-    <value>17</value>
+    <value>18</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterScreen</value>
@@ -724,7 +748,7 @@
     <value>System.Windows.Forms.Form, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="ucrReceiverForSelectedVariables.Location" type="System.Drawing.Point, System.Drawing">
-    <value>302, 97</value>
+    <value>277, 97</value>
   </data>
   <data name="ucrReceiverForSelectedVariables.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
@@ -745,6 +769,6 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrReceiverForSelectedVariables.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>5</value>
   </data>
 </root>

--- a/instat/dlgDuplicates.vb
+++ b/instat/dlgDuplicates.vb
@@ -19,7 +19,7 @@ Imports instat.Translations
 Public Class dlgDuplicates
     Private bReset As Boolean = True
     Private bFirstLoad As Boolean = True
-    Private clsDuplicated2, clsDuplicated, clsStreakFunction, clsSubsetCol, clsdupCountIndex As New RFunction
+    Private clsDuplicated2, clsDuplicated, clsStreakFunction, clsSubsetCol, clsDupCountIndex, clsSummaryFunction, clsGetColumnsFunction As New RFunction
 
     Private Sub dlgDuplicatesConstructed_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         If bFirstLoad Then
@@ -120,6 +120,10 @@ Public Class dlgDuplicates
         ucrInputComboType.SetDropDownStyleAsNonEditable()
         ucrInputComboType.SetItems(dctType)
 
+        ucrChkIncludeSummary.SetText("Display Summary")
+        ucrChkIncludeSummary.AddRSyntaxContainsFunctionNamesCondition(True, {"summary"})
+        ucrChkIncludeSummary.AddRSyntaxContainsFunctionNamesCondition(False, {"summary"}, False)
+
         ucrNewColumnName.SetPrefix("dup")
         ucrNewColumnName.SetDataFrameSelector(ucrSelectorDuplicateswithVariables.ucrAvailableDataFrames)
         ucrNewColumnName.SetIsComboBox()
@@ -132,7 +136,9 @@ Public Class dlgDuplicates
         clsDuplicated2 = New RFunction
         clsStreakFunction = New RFunction
         clsSubsetCol = New RFunction
-        clsdupCountIndex = New RFunction
+        clsDupCountIndex = New RFunction
+        clsGetColumnsFunction = New RFunction
+        clsSummaryFunction = New RFunction
 
         SetDataFrameOrColumns()
         ucrNewColumnName.Reset()
@@ -149,24 +155,31 @@ Public Class dlgDuplicates
         clsStreakFunction.SetRCommand("duplicated_cases")
         clsStreakFunction.AddParameter("ignore", "NULL")
 
-        clsdupCountIndex.SetRCommand("duplicated_count_index")
+        clsDupCountIndex.SetRCommand("duplicated_count_index")
+
+        clsGetColumnsFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_columns_from_data")
+
+        clsSummaryFunction.SetRCommand("summary")
+        clsSummaryFunction.AddParameter("object", clsRFunctionParameter:=clsGetColumnsFunction)
+        clsSummaryFunction.iCallType = 2
 
         clsSubsetCol.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_columns_from_data")
         ucrBase.clsRsyntax.SetAssignTo(strAssignToName:=ucrNewColumnName.GetText, strTempDataframe:=ucrSelectorDuplicateswithVariables.ucrAvailableDataFrames.cboAvailableDataFrames.Text, strTempColumn:=ucrNewColumnName.GetText)
         ucrBase.clsRsyntax.SetBaseRFunction(clsDuplicated2)
+        ucrBase.clsRsyntax.AddToAfterCodes(clsSummaryFunction, iPosition:=0)
     End Sub
 
     Private Sub SetRCodeForControls(bReset As Boolean)
         ucrReceiverForSelectedVariables.AddAdditionalCodeParameterPair(clsDuplicated2, New RParameter("x", 1), iAdditionalPairNo:=1)
-        ucrReceiverForSelectedVariables.AddAdditionalCodeParameterPair(clsdupCountIndex, New RParameter("x", 1), iAdditionalPairNo:=2)
+        ucrReceiverForSelectedVariables.AddAdditionalCodeParameterPair(clsDupCountIndex, New RParameter("x", 1), iAdditionalPairNo:=2)
         ucrSelectorDuplicateswithVariables.AddAdditionalCodeParameterPair(clsDuplicated2, New RParameter("x", 0), iAdditionalPairNo:=1)
-        ucrSelectorDuplicateswithVariables.AddAdditionalCodeParameterPair(clsdupCountIndex, New RParameter("x", 0), iAdditionalPairNo:=2)
+        ucrSelectorDuplicateswithVariables.AddAdditionalCodeParameterPair(clsDupCountIndex, New RParameter("x", 0), iAdditionalPairNo:=2)
         ucrNewColumnName.AddAdditionalRCode(clsDuplicated2, iAdditionalPairNo:=1)
         ucrNewColumnName.AddAdditionalRCode(clsStreakFunction, iAdditionalPairNo:=2)
-        ucrNewColumnName.AddAdditionalRCode(clsdupCountIndex, iAdditionalPairNo:=3)
+        ucrNewColumnName.AddAdditionalRCode(clsDupCountIndex, iAdditionalPairNo:=3)
+        ucrNewColumnName.AddAdditionalRCode(clsGetColumnsFunction, iAdditionalPairNo:=4)
 
-
-        ucrInputComboType.SetRCode(clsdupCountIndex, bReset)
+        ucrInputComboType.SetRCode(clsDupCountIndex, bReset)
         ucrReceiverForSuccessiveValues.SetRCode(clsStreakFunction, bReset)
         ucrChkOmitValues.SetRCode(clsStreakFunction, bReset)
         ucrInputOmitValues.SetRCode(clsStreakFunction, bReset)
@@ -176,6 +189,8 @@ Public Class dlgDuplicates
         ucrReceiverForSelectedVariables.SetRCode(clsDuplicated, bReset)
         ucrNewColumnName.SetRCode(clsDuplicated, bReset)
         ucrPnlDuplicates.SetRCode(ucrBase.clsRsyntax.clsBaseFunction, bReset)
+        ucrChkIncludeSummary.SetRSyntax(ucrBase.clsRsyntax, bReset)
+
         If bReset Then
             ucrPnlOptions.SetRCode(ucrBase.clsRsyntax.clsBaseFunction, bReset)
         End If
@@ -220,6 +235,14 @@ Public Class dlgDuplicates
         SetDataFrameOrColumns()
     End Sub
 
+    Private Sub ucrChkIncludeSummary_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrChkIncludeSummary.ControlValueChanged
+        If ucrChkIncludeSummary.Checked Then
+            ucrBase.clsRsyntax.AddToAfterCodes(clsSummaryFunction, iPosition:=0)
+        Else
+            ucrBase.clsRsyntax.RemoveFromAfterCodes(clsSummaryFunction)
+        End If
+    End Sub
+
     Private Sub SetDataFrameOrColumns()
         If rdoDataFrame.Checked Then
             ucrSelectorDuplicateswithVariables.SetVariablesVisible(False)
@@ -227,7 +250,7 @@ Public Class dlgDuplicates
             ' note that we have to run this here because the parameter x is used for both functions and all four radio buttons
             clsDuplicated.AddParameter("x", clsRFunctionParameter:=ucrSelectorDuplicateswithVariables.ucrAvailableDataFrames.clsCurrDataFrame, iPosition:=0)
             clsDuplicated2.AddParameter("x", clsRFunctionParameter:=ucrSelectorDuplicateswithVariables.ucrAvailableDataFrames.clsCurrDataFrame, iPosition:=0)
-            clsdupCountIndex.AddParameter("x", clsRFunctionParameter:=ucrSelectorDuplicateswithVariables.ucrAvailableDataFrames.clsCurrDataFrame, iPosition:=0)
+            clsDupCountIndex.AddParameter("x", clsRFunctionParameter:=ucrSelectorDuplicateswithVariables.ucrAvailableDataFrames.clsCurrDataFrame, iPosition:=0)
         ElseIf rdoSelectedVariables.Checked Then
             ucrReceiverForSelectedVariables.SetMeAsReceiver()
             ucrReceiverForSelectedVariables.SetParameterIsRFunction()
@@ -246,7 +269,7 @@ Public Class dlgDuplicates
             ElseIf rdoDuplicatesOnly.Checked Then
                 ucrBase.clsRsyntax.SetBaseRFunction(clsDuplicated)
             ElseIf rdoIndexNumberOfDuplicates.Checked Then
-                ucrBase.clsRsyntax.SetBaseRFunction(clsdupCountIndex)
+                ucrBase.clsRsyntax.SetBaseRFunction(clsDupCountIndex)
             End If
         ElseIf rdoSuccessiveValues.Checked Then
             ucrBase.clsRsyntax.SetBaseRFunction(clsStreakFunction)
@@ -257,15 +280,26 @@ Public Class dlgDuplicates
         SetBaseFunction()
     End Sub
 
-    Private Sub ucrSelectorDuplicateswithVariables_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrSelectorDuplicateswithVariables.ControlValueChanged, ucrPnlOptions.ControlValueChanged
+
+    Private Sub ucrSelectorDuplicateswithVariables_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrSelectorDuplicateswithVariables.ControlValueChanged
         SetDataFrameOrColumns()
+        clsGetColumnsFunction.AddParameter(strParameterName:="data_name", strParameterValue:=Chr(34) & ucrSelectorDuplicateswithVariables.ucrAvailableDataFrames.cboAvailableDataFrames.SelectedItem & Chr(34), iPosition:=0)
+    End Sub
+
+    Private Sub ucrPnlOptions_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrPnlOptions.ControlValueChanged
+        SetDataFrameOrColumns()
+    End Sub
+
+    Private Sub ucrNewColumnName_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrNewColumnName.ControlValueChanged
+        'change the parameter values
+        clsGetColumnsFunction.AddParameter(strParameterName:="col_names", strParameterValue:=Chr(34) & ucrNewColumnName.GetText & Chr(34), iPosition:=1)
     End Sub
 
     Private Sub CoreControls_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrNewColumnName.ControlContentsChanged, ucrSelectorDuplicateswithVariables.ControlContentsChanged, ucrPnlOptions.ControlContentsChanged, ucrReceiverForSelectedVariables.ControlContentsChanged, ucrReceiverForSuccessiveValues.ControlContentsChanged, ucrChkOmitValues.ControlContentsChanged, ucrChkTolerance.ControlContentsChanged, ucrInputTolerance.ControlContentsChanged, ucrInputOmitValues.ControlContentsChanged
         TestOKEnabled()
     End Sub
 
-    Private Sub ucrcorecontrols_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrChkOmitValues.ControlValueChanged, ucrReceiverForSuccessiveValues.ControlValueChanged, ucrInputConditions.ControlValueChanged, ucrInputOmitValues.ControlValueChanged
+    Private Sub ucrCoreControls_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrChkOmitValues.ControlValueChanged, ucrReceiverForSuccessiveValues.ControlValueChanged, ucrInputConditions.ControlValueChanged, ucrInputOmitValues.ControlValueChanged
         SetIgnoreVals()
     End Sub
 End Class


### PR DESCRIPTION
@africanmathsinitiative/developers this is ready for review

Fixes #6239

Changes made:
* Added checkbox to run a summary of the new column (similar to as seen in Prepare > Check Data > Non-numeric Columns).
* Naming convention - changed "clsdupCountIndex" to "clsDupCountIndex"