### PR TITLE
Ensure that each of the 6 output windows has a unique header item name (needed for translations)

### DIFF
--- a/instat/ucrColumnMetadata.Designer.vb
+++ b/instat/ucrColumnMetadata.Designer.vb
@@ -61,10 +61,6 @@ Partial Class ucrColumnMetadata
         Me.mnuSort = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuColumnFilter = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuClearColumnFilter = New System.Windows.Forms.ToolStripMenuItem()
-        Me.propertiesContextMenuStrip = New System.Windows.Forms.ContextMenuStrip(Me.components)
-        Me.mnuDeleteLabels = New System.Windows.Forms.ToolStripMenuItem()
-        Me.lblHeader = New System.Windows.Forms.Label()
-        Me.tlpTableContainer = New System.Windows.Forms.TableLayoutPanel()
         Me.statusColumnMenu = New System.Windows.Forms.ContextMenuStrip(Me.components)
         Me.deleteDataFrame = New System.Windows.Forms.ToolStripMenuItem()
         Me.renameSheet = New System.Windows.Forms.ToolStripMenuItem()
@@ -73,11 +69,15 @@ Partial Class ucrColumnMetadata
         Me.copySheet = New System.Windows.Forms.ToolStripMenuItem()
         Me.reorderSheet = New System.Windows.Forms.ToolStripMenuItem()
         Me.viewSheet = New System.Windows.Forms.ToolStripMenuItem()
+        Me.propertiesContextMenuStrip = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.mnuDeleteLabels = New System.Windows.Forms.ToolStripMenuItem()
+        Me.lblHeaderColumnMetadata = New System.Windows.Forms.Label()
+        Me.tlpTableContainer = New System.Windows.Forms.TableLayoutPanel()
         Me.cellContextMenuStrip.SuspendLayout()
         Me.columnContextMenuStrip.SuspendLayout()
+        Me.statusColumnMenu.SuspendLayout()
         Me.propertiesContextMenuStrip.SuspendLayout()
         Me.tlpTableContainer.SuspendLayout()
-        Me.statusColumnMenu.SuspendLayout()
         Me.SuspendLayout()
         '
         'grdVariables
@@ -224,47 +224,6 @@ Partial Class ucrColumnMetadata
         Me.mnuClearColumnFilter.Size = New System.Drawing.Size(212, 22)
         Me.mnuClearColumnFilter.Text = "Remove Current Filter"
         '
-        'propertiesContextMenuStrip
-        '
-        Me.propertiesContextMenuStrip.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuDeleteLabels})
-        Me.propertiesContextMenuStrip.Name = "columnContextMenuStrip"
-        Me.propertiesContextMenuStrip.Size = New System.Drawing.Size(144, 26)
-        '
-        'mnuDeleteLabels
-        '
-        Me.mnuDeleteLabels.Name = "mnuDeleteLabels"
-        Me.mnuDeleteLabels.Size = New System.Drawing.Size(143, 22)
-        Me.mnuDeleteLabels.Text = "Delete Labels"
-        '
-        'lblHeader
-        '
-        Me.lblHeader.BackColor = System.Drawing.Color.FromArgb(CType(CType(35, Byte), Integer), CType(CType(105, Byte), Integer), CType(CType(190, Byte), Integer))
-        Me.lblHeader.Dock = System.Windows.Forms.DockStyle.Fill
-        Me.lblHeader.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!)
-        Me.lblHeader.ForeColor = System.Drawing.SystemColors.Control
-        Me.lblHeader.Location = New System.Drawing.Point(3, 0)
-        Me.lblHeader.Name = "lblHeader"
-        Me.lblHeader.Size = New System.Drawing.Size(338, 20)
-        Me.lblHeader.TabIndex = 6
-        Me.lblHeader.Text = "Column Metadata"
-        Me.lblHeader.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
-        '
-        'tlpTableContainer
-        '
-        Me.tlpTableContainer.ColumnCount = 1
-        Me.tlpTableContainer.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100.0!))
-        Me.tlpTableContainer.Controls.Add(Me.grdVariables, 0, 1)
-        Me.tlpTableContainer.Controls.Add(Me.lblHeader, 0, 0)
-        Me.tlpTableContainer.Dock = System.Windows.Forms.DockStyle.Fill
-        Me.tlpTableContainer.Location = New System.Drawing.Point(0, 0)
-        Me.tlpTableContainer.Name = "tlpTableContainer"
-        Me.tlpTableContainer.RowCount = 3
-        Me.tlpTableContainer.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20.0!))
-        Me.tlpTableContainer.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100.0!))
-        Me.tlpTableContainer.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20.0!))
-        Me.tlpTableContainer.Size = New System.Drawing.Size(344, 138)
-        Me.tlpTableContainer.TabIndex = 7
-        '
         'statusColumnMenu
         '
         Me.statusColumnMenu.ImageScalingSize = New System.Drawing.Size(20, 20)
@@ -315,6 +274,47 @@ Partial Class ucrColumnMetadata
         Me.viewSheet.Size = New System.Drawing.Size(162, 22)
         Me.viewSheet.Text = "View Data Frame"
         '
+        'propertiesContextMenuStrip
+        '
+        Me.propertiesContextMenuStrip.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuDeleteLabels})
+        Me.propertiesContextMenuStrip.Name = "columnContextMenuStrip"
+        Me.propertiesContextMenuStrip.Size = New System.Drawing.Size(144, 26)
+        '
+        'mnuDeleteLabels
+        '
+        Me.mnuDeleteLabels.Name = "mnuDeleteLabels"
+        Me.mnuDeleteLabels.Size = New System.Drawing.Size(143, 22)
+        Me.mnuDeleteLabels.Text = "Delete Labels"
+        '
+        'lblHeaderColumnMetadata
+        '
+        Me.lblHeaderColumnMetadata.BackColor = System.Drawing.Color.FromArgb(CType(CType(35, Byte), Integer), CType(CType(105, Byte), Integer), CType(CType(190, Byte), Integer))
+        Me.lblHeaderColumnMetadata.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.lblHeaderColumnMetadata.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!)
+        Me.lblHeaderColumnMetadata.ForeColor = System.Drawing.SystemColors.Control
+        Me.lblHeaderColumnMetadata.Location = New System.Drawing.Point(3, 0)
+        Me.lblHeaderColumnMetadata.Name = "lblHeaderColumnMetadata"
+        Me.lblHeaderColumnMetadata.Size = New System.Drawing.Size(338, 20)
+        Me.lblHeaderColumnMetadata.TabIndex = 6
+        Me.lblHeaderColumnMetadata.Text = "Column Metadata"
+        Me.lblHeaderColumnMetadata.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
+        '
+        'tlpTableContainer
+        '
+        Me.tlpTableContainer.ColumnCount = 1
+        Me.tlpTableContainer.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100.0!))
+        Me.tlpTableContainer.Controls.Add(Me.grdVariables, 0, 1)
+        Me.tlpTableContainer.Controls.Add(Me.lblHeaderColumnMetadata, 0, 0)
+        Me.tlpTableContainer.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.tlpTableContainer.Location = New System.Drawing.Point(0, 0)
+        Me.tlpTableContainer.Name = "tlpTableContainer"
+        Me.tlpTableContainer.RowCount = 3
+        Me.tlpTableContainer.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20.0!))
+        Me.tlpTableContainer.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100.0!))
+        Me.tlpTableContainer.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20.0!))
+        Me.tlpTableContainer.Size = New System.Drawing.Size(344, 138)
+        Me.tlpTableContainer.TabIndex = 7
+        '
         'ucrColumnMetadata
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
@@ -324,15 +324,15 @@ Partial Class ucrColumnMetadata
         Me.Size = New System.Drawing.Size(344, 138)
         Me.cellContextMenuStrip.ResumeLayout(False)
         Me.columnContextMenuStrip.ResumeLayout(False)
+        Me.statusColumnMenu.ResumeLayout(False)
         Me.propertiesContextMenuStrip.ResumeLayout(False)
         Me.tlpTableContainer.ResumeLayout(False)
-        Me.statusColumnMenu.ResumeLayout(False)
         Me.ResumeLayout(False)
 
     End Sub
 
     Friend WithEvents grdVariables As unvell.ReoGrid.ReoGridControl
-    Friend WithEvents lblHeader As Label
+    Friend WithEvents lblHeaderColumnMetadata As Label
     Private WithEvents columnContextMenuStrip As ContextMenuStrip
     Friend WithEvents mnuColumnRename As ToolStripMenuItem
     Friend WithEvents mnuDuplicateColumn As ToolStripMenuItem

--- a/instat/ucrDataFrameMetadata.Designer.vb
+++ b/instat/ucrDataFrameMetadata.Designer.vb
@@ -42,8 +42,6 @@ Partial Class ucrDataFrameMetadata
         Me.grdMetaData = New unvell.ReoGrid.ReoGridControl()
         Me.cellContextMenuStrip = New System.Windows.Forms.ContextMenuStrip(Me.components)
         Me.mnuHelp = New System.Windows.Forms.ToolStripMenuItem()
-        Me.lblHeader = New System.Windows.Forms.Label()
-        Me.tlpTableContainer = New System.Windows.Forms.TableLayoutPanel()
         Me.rowRightClickMenu = New System.Windows.Forms.ContextMenuStrip(Me.components)
         Me.deleteDataFrame = New System.Windows.Forms.ToolStripMenuItem()
         Me.renameSheet = New System.Windows.Forms.ToolStripMenuItem()
@@ -52,9 +50,11 @@ Partial Class ucrDataFrameMetadata
         Me.copySheet = New System.Windows.Forms.ToolStripMenuItem()
         Me.reorderSheet = New System.Windows.Forms.ToolStripMenuItem()
         Me.viewSheet = New System.Windows.Forms.ToolStripMenuItem()
+        Me.lblHeaderDataFrameMetaData = New System.Windows.Forms.Label()
+        Me.tlpTableContainer = New System.Windows.Forms.TableLayoutPanel()
         Me.cellContextMenuStrip.SuspendLayout()
-        Me.tlpTableContainer.SuspendLayout()
         Me.rowRightClickMenu.SuspendLayout()
+        Me.tlpTableContainer.SuspendLayout()
         Me.SuspendLayout()
         '
         'grdMetaData
@@ -89,34 +89,6 @@ Partial Class ucrDataFrameMetadata
         Me.mnuHelp.Size = New System.Drawing.Size(99, 22)
         Me.mnuHelp.Text = "Help"
         '
-        'lblHeader
-        '
-        Me.lblHeader.BackColor = System.Drawing.Color.FromArgb(CType(CType(35, Byte), Integer), CType(CType(105, Byte), Integer), CType(CType(190, Byte), Integer))
-        Me.lblHeader.Dock = System.Windows.Forms.DockStyle.Fill
-        Me.lblHeader.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!)
-        Me.lblHeader.ForeColor = System.Drawing.SystemColors.Control
-        Me.lblHeader.Location = New System.Drawing.Point(3, 0)
-        Me.lblHeader.Name = "lblHeader"
-        Me.lblHeader.Size = New System.Drawing.Size(471, 20)
-        Me.lblHeader.TabIndex = 7
-        Me.lblHeader.Text = "Data Frame Metadata"
-        Me.lblHeader.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
-        '
-        'tlpTableContainer
-        '
-        Me.tlpTableContainer.ColumnCount = 1
-        Me.tlpTableContainer.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100.0!))
-        Me.tlpTableContainer.Controls.Add(Me.grdMetaData, 0, 1)
-        Me.tlpTableContainer.Controls.Add(Me.lblHeader, 0, 0)
-        Me.tlpTableContainer.Dock = System.Windows.Forms.DockStyle.Fill
-        Me.tlpTableContainer.Location = New System.Drawing.Point(0, 0)
-        Me.tlpTableContainer.Name = "tlpTableContainer"
-        Me.tlpTableContainer.RowCount = 2
-        Me.tlpTableContainer.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20.0!))
-        Me.tlpTableContainer.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100.0!))
-        Me.tlpTableContainer.Size = New System.Drawing.Size(477, 317)
-        Me.tlpTableContainer.TabIndex = 8
-        '
         'rowRightClickMenu
         '
         Me.rowRightClickMenu.ImageScalingSize = New System.Drawing.Size(20, 20)
@@ -127,45 +99,73 @@ Partial Class ucrDataFrameMetadata
         'deleteDataFrame
         '
         Me.deleteDataFrame.Name = "deleteDataFrame"
-        Me.deleteDataFrame.Size = New System.Drawing.Size(180, 22)
+        Me.deleteDataFrame.Size = New System.Drawing.Size(162, 22)
         Me.deleteDataFrame.Text = "Delete..."
         '
         'renameSheet
         '
         Me.renameSheet.Name = "renameSheet"
-        Me.renameSheet.Size = New System.Drawing.Size(180, 22)
+        Me.renameSheet.Size = New System.Drawing.Size(162, 22)
         Me.renameSheet.Text = "Rename..."
         '
         'hideSheet
         '
         Me.hideSheet.Name = "hideSheet"
-        Me.hideSheet.Size = New System.Drawing.Size(180, 22)
+        Me.hideSheet.Size = New System.Drawing.Size(162, 22)
         Me.hideSheet.Text = "Hide"
         '
         'unhideSheet
         '
         Me.unhideSheet.Name = "unhideSheet"
-        Me.unhideSheet.Size = New System.Drawing.Size(180, 22)
+        Me.unhideSheet.Size = New System.Drawing.Size(162, 22)
         Me.unhideSheet.Text = "Unhide..."
         '
         'copySheet
         '
         Me.copySheet.Name = "copySheet"
-        Me.copySheet.Size = New System.Drawing.Size(180, 22)
+        Me.copySheet.Size = New System.Drawing.Size(162, 22)
         Me.copySheet.Text = "Copy..."
         '
         'reorderSheet
         '
         Me.reorderSheet.Enabled = False
         Me.reorderSheet.Name = "reorderSheet"
-        Me.reorderSheet.Size = New System.Drawing.Size(180, 22)
+        Me.reorderSheet.Size = New System.Drawing.Size(162, 22)
         Me.reorderSheet.Text = "Reorder..."
         '
         'viewSheet
         '
         Me.viewSheet.Name = "viewSheet"
-        Me.viewSheet.Size = New System.Drawing.Size(180, 22)
+        Me.viewSheet.Size = New System.Drawing.Size(162, 22)
         Me.viewSheet.Text = "View Data Frame"
+        '
+        'lblHeaderDataFrameMetaData
+        '
+        Me.lblHeaderDataFrameMetaData.BackColor = System.Drawing.Color.FromArgb(CType(CType(35, Byte), Integer), CType(CType(105, Byte), Integer), CType(CType(190, Byte), Integer))
+        Me.lblHeaderDataFrameMetaData.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.lblHeaderDataFrameMetaData.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!)
+        Me.lblHeaderDataFrameMetaData.ForeColor = System.Drawing.SystemColors.Control
+        Me.lblHeaderDataFrameMetaData.Location = New System.Drawing.Point(3, 0)
+        Me.lblHeaderDataFrameMetaData.Name = "lblHeaderDataFrameMetaData"
+        Me.lblHeaderDataFrameMetaData.Size = New System.Drawing.Size(471, 20)
+        Me.lblHeaderDataFrameMetaData.TabIndex = 7
+        Me.lblHeaderDataFrameMetaData.Text = "Data Frame Metadata"
+        Me.lblHeaderDataFrameMetaData.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
+        '
+        'tlpTableContainer
+        '
+        Me.tlpTableContainer.ColumnCount = 1
+        Me.tlpTableContainer.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100.0!))
+        Me.tlpTableContainer.Controls.Add(Me.grdMetaData, 0, 1)
+        Me.tlpTableContainer.Controls.Add(Me.lblHeaderDataFrameMetaData, 0, 0)
+        Me.tlpTableContainer.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.tlpTableContainer.Location = New System.Drawing.Point(0, 0)
+        Me.tlpTableContainer.Name = "tlpTableContainer"
+        Me.tlpTableContainer.RowCount = 2
+        Me.tlpTableContainer.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20.0!))
+        Me.tlpTableContainer.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100.0!))
+        Me.tlpTableContainer.Size = New System.Drawing.Size(477, 317)
+        Me.tlpTableContainer.TabIndex = 8
         '
         'ucrDataFrameMetadata
         '
@@ -175,14 +175,14 @@ Partial Class ucrDataFrameMetadata
         Me.Name = "ucrDataFrameMetadata"
         Me.Size = New System.Drawing.Size(477, 317)
         Me.cellContextMenuStrip.ResumeLayout(False)
-        Me.tlpTableContainer.ResumeLayout(False)
         Me.rowRightClickMenu.ResumeLayout(False)
+        Me.tlpTableContainer.ResumeLayout(False)
         Me.ResumeLayout(False)
 
     End Sub
 
     Friend WithEvents grdMetaData As unvell.ReoGrid.ReoGridControl
-    Friend WithEvents lblHeader As Label
+    Friend WithEvents lblHeaderDataFrameMetaData As Label
     Friend WithEvents tlpTableContainer As TableLayoutPanel
     Friend WithEvents cellContextMenuStrip As ContextMenuStrip
     Friend WithEvents mnuHelp As ToolStripMenuItem

--- a/instat/ucrDataView.Designer.vb
+++ b/instat/ucrDataView.Designer.vb
@@ -65,6 +65,8 @@ Partial Class ucrDataView
         Me.mnuCellCopyRange = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuCellPasteRange = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuCellHelp = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ToolStripSeparator8 = New System.Windows.Forms.ToolStripSeparator()
+        Me.mnuCellAddComment = New System.Windows.Forms.ToolStripMenuItem()
         Me.ToolStripSeparator3 = New System.Windows.Forms.ToolStripSeparator()
         Me.mnuRenameColumn = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuDuplColumn = New System.Windows.Forms.ToolStripMenuItem()
@@ -99,7 +101,7 @@ Partial Class ucrDataView
         Me.reorderSheet = New System.Windows.Forms.ToolStripMenuItem()
         Me.ViewSheet = New System.Windows.Forms.ToolStripMenuItem()
         Me.lblRowDisplay = New System.Windows.Forms.Label()
-        Me.lblHeader = New System.Windows.Forms.Label()
+        Me.lblHeaderDataView = New System.Windows.Forms.Label()
         Me.tlpTableContainer = New System.Windows.Forms.TableLayoutPanel()
         Me.pnlDataContainer = New System.Windows.Forms.Panel()
         Me.panelSectionsAll = New System.Windows.Forms.Panel()
@@ -117,8 +119,6 @@ Partial Class ucrDataView
         Me.linkStartNewDataFrame = New System.Windows.Forms.LinkLabel()
         Me.linkStartOpenFile = New System.Windows.Forms.LinkLabel()
         Me.linkStartOpenLibrary = New System.Windows.Forms.LinkLabel()
-        Me.mnuCellAddComment = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ToolStripSeparator8 = New System.Windows.Forms.ToolStripSeparator()
         Me.columnContextMenuStrip.SuspendLayout()
         Me.cellContextMenuStrip.SuspendLayout()
         Me.rowContextMenuStrip.SuspendLayout()
@@ -267,7 +267,7 @@ Partial Class ucrDataView
         Me.cellContextMenuStrip.ImageScalingSize = New System.Drawing.Size(20, 20)
         Me.cellContextMenuStrip.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuCell, Me.ToolStripSeparator3, Me.mnuRenameColumn, Me.mnuDuplColumn, Me.mnuReorderColumn, Me.ToolStripSeparator5, Me.mnuConvertToFact, Me.mnuConvertToOrderedFactor, Me.mnuConvertToCharacter, Me.mnuConvertToLogic, Me.mnuConvertToNumeric, Me.ToolStripSeparator6, Me.mnuLebelsLevel, Me.ToolStripSeparator7, Me.mnuSorts, Me.mnuFilters, Me.mnuRemoveCurrentFilters})
         Me.cellContextMenuStrip.Name = "cellContextMenuStrip"
-        Me.cellContextMenuStrip.Size = New System.Drawing.Size(213, 336)
+        Me.cellContextMenuStrip.Size = New System.Drawing.Size(213, 314)
         '
         'mnuCell
         '
@@ -280,29 +280,40 @@ Partial Class ucrDataView
         '
         Me.mnuCellCutRange.Enabled = False
         Me.mnuCellCutRange.Name = "mnuCellCutRange"
-        Me.mnuCellCutRange.Size = New System.Drawing.Size(180, 22)
+        Me.mnuCellCutRange.Size = New System.Drawing.Size(162, 22)
         Me.mnuCellCutRange.Text = "Cut"
         Me.mnuCellCutRange.Visible = False
         '
         'mnuCellCopyRange
         '
         Me.mnuCellCopyRange.Name = "mnuCellCopyRange"
-        Me.mnuCellCopyRange.Size = New System.Drawing.Size(180, 22)
+        Me.mnuCellCopyRange.Size = New System.Drawing.Size(162, 22)
         Me.mnuCellCopyRange.Text = "Copy"
         '
         'mnuCellPasteRange
         '
         Me.mnuCellPasteRange.Enabled = False
         Me.mnuCellPasteRange.Name = "mnuCellPasteRange"
-        Me.mnuCellPasteRange.Size = New System.Drawing.Size(180, 22)
+        Me.mnuCellPasteRange.Size = New System.Drawing.Size(162, 22)
         Me.mnuCellPasteRange.Text = "Paste"
         Me.mnuCellPasteRange.Visible = False
         '
         'mnuCellHelp
         '
         Me.mnuCellHelp.Name = "mnuCellHelp"
-        Me.mnuCellHelp.Size = New System.Drawing.Size(180, 22)
+        Me.mnuCellHelp.Size = New System.Drawing.Size(162, 22)
         Me.mnuCellHelp.Text = "Help"
+        '
+        'ToolStripSeparator8
+        '
+        Me.ToolStripSeparator8.Name = "ToolStripSeparator8"
+        Me.ToolStripSeparator8.Size = New System.Drawing.Size(159, 6)
+        '
+        'mnuCellAddComment
+        '
+        Me.mnuCellAddComment.Name = "mnuCellAddComment"
+        Me.mnuCellAddComment.Size = New System.Drawing.Size(162, 22)
+        Me.mnuCellAddComment.Text = "Add Comment..."
         '
         'ToolStripSeparator3
         '
@@ -512,24 +523,24 @@ Partial Class ucrDataView
         Me.lblRowDisplay.Text = "Label1"
         Me.lblRowDisplay.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
         '
-        'lblHeader
+        'lblHeaderDataView
         '
-        Me.lblHeader.BackColor = System.Drawing.Color.FromArgb(CType(CType(35, Byte), Integer), CType(CType(105, Byte), Integer), CType(CType(190, Byte), Integer))
-        Me.lblHeader.Dock = System.Windows.Forms.DockStyle.Fill
-        Me.lblHeader.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!)
-        Me.lblHeader.ForeColor = System.Drawing.SystemColors.Control
-        Me.lblHeader.Location = New System.Drawing.Point(3, 0)
-        Me.lblHeader.Name = "lblHeader"
-        Me.lblHeader.Size = New System.Drawing.Size(438, 20)
-        Me.lblHeader.TabIndex = 5
-        Me.lblHeader.Text = "Data View"
-        Me.lblHeader.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
+        Me.lblHeaderDataView.BackColor = System.Drawing.Color.FromArgb(CType(CType(35, Byte), Integer), CType(CType(105, Byte), Integer), CType(CType(190, Byte), Integer))
+        Me.lblHeaderDataView.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.lblHeaderDataView.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!)
+        Me.lblHeaderDataView.ForeColor = System.Drawing.SystemColors.Control
+        Me.lblHeaderDataView.Location = New System.Drawing.Point(3, 0)
+        Me.lblHeaderDataView.Name = "lblHeaderDataView"
+        Me.lblHeaderDataView.Size = New System.Drawing.Size(438, 20)
+        Me.lblHeaderDataView.TabIndex = 5
+        Me.lblHeaderDataView.Text = "Data View"
+        Me.lblHeaderDataView.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
         '
         'tlpTableContainer
         '
         Me.tlpTableContainer.ColumnCount = 1
         Me.tlpTableContainer.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100.0!))
-        Me.tlpTableContainer.Controls.Add(Me.lblHeader, 0, 0)
+        Me.tlpTableContainer.Controls.Add(Me.lblHeaderDataView, 0, 0)
         Me.tlpTableContainer.Controls.Add(Me.lblRowDisplay, 0, 2)
         Me.tlpTableContainer.Controls.Add(Me.pnlDataContainer, 0, 1)
         Me.tlpTableContainer.Dock = System.Windows.Forms.DockStyle.Fill
@@ -733,17 +744,6 @@ Partial Class ucrDataView
         Me.linkStartOpenLibrary.TabStop = True
         Me.linkStartOpenLibrary.Text = "Open from library..."
         '
-        'mnuCellAddComment
-        '
-        Me.mnuCellAddComment.Name = "mnuCellAddComment"
-        Me.mnuCellAddComment.Size = New System.Drawing.Size(180, 22)
-        Me.mnuCellAddComment.Text = "Add Comment..."
-        '
-        'ToolStripSeparator8
-        '
-        Me.ToolStripSeparator8.Name = "ToolStripSeparator8"
-        Me.ToolStripSeparator8.Size = New System.Drawing.Size(177, 6)
-        '
         'ucrDataView
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
@@ -804,7 +804,7 @@ Partial Class ucrDataView
     Friend WithEvents lblRowDisplay As Label
     Friend WithEvents mnuAddComment As ToolStripMenuItem
     Friend WithEvents ToolStripSeparator4 As ToolStripSeparator
-    Friend WithEvents lblHeader As Label
+    Friend WithEvents lblHeaderDataView As Label
     Friend WithEvents mnuConvertToLogical As ToolStripMenuItem
     Friend WithEvents tlpTableContainer As TableLayoutPanel
     Friend WithEvents pnlDataContainer As Panel

--- a/instat/ucrDataView.vb
+++ b/instat/ucrDataView.vb
@@ -804,7 +804,8 @@ Public Class ucrDataView
         Help.ShowHelp(Me, frmMain.strStaticPath & "\" & frmMain.strHelpFilePath, HelpNavigator.TopicId, "134")
     End Sub
 
-    Private Sub lblHeader_Click(sender As Object, e As EventArgs) Handles lblHeaderDataView.Click
+    Private Sub lblHeaderDataView_Click(sender As Object, e As EventArgs) Handles lblHeaderDataView.Click
+
 
     End Sub
 

--- a/instat/ucrDataView.vb
+++ b/instat/ucrDataView.vb
@@ -804,7 +804,7 @@ Public Class ucrDataView
         Help.ShowHelp(Me, frmMain.strStaticPath & "\" & frmMain.strHelpFilePath, HelpNavigator.TopicId, "134")
     End Sub
 
-    Private Sub lblHeader_Click(sender As Object, e As EventArgs) Handles lblHeader.Click
+    Private Sub lblHeader_Click(sender As Object, e As EventArgs) Handles lblHeaderDataView.Click
 
     End Sub
 

--- a/instat/ucrLog.Designer.vb
+++ b/instat/ucrLog.Designer.vb
@@ -51,7 +51,7 @@ Partial Class ucrLog
         Me.mnuOpenLogFile = New System.Windows.Forms.ToolStripMenuItem()
         Me.ToolStripSeparator1 = New System.Windows.Forms.ToolStripSeparator()
         Me.mnuHelp = New System.Windows.Forms.ToolStripMenuItem()
-        Me.lblHeader = New System.Windows.Forms.Label()
+        Me.lblHeaderLog = New System.Windows.Forms.Label()
         Me.tlpTableContainer = New System.Windows.Forms.TableLayoutPanel()
         Me.mnuContextLogFile.SuspendLayout()
         Me.tlpTableContainer.SuspendLayout()
@@ -76,24 +76,24 @@ Partial Class ucrLog
         Me.mnuContextLogFile.ImageScalingSize = New System.Drawing.Size(24, 24)
         Me.mnuContextLogFile.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuCopy, Me.ToolStripSeparator3, Me.mnuRunCurrentLine, Me.mnuRunSelectedText, Me.mnuRunAll, Me.ToolStripSeparator2, Me.mnuSaveLogFile, Me.mnuOpenLogFile, Me.ToolStripSeparator1, Me.mnuHelp})
         Me.mnuContextLogFile.Name = "mnuContextLogFile"
-        Me.mnuContextLogFile.Size = New System.Drawing.Size(231, 176)
+        Me.mnuContextLogFile.Size = New System.Drawing.Size(230, 176)
         '
         'mnuCopy
         '
         Me.mnuCopy.Name = "mnuCopy"
         Me.mnuCopy.ShortcutKeys = CType((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.C), System.Windows.Forms.Keys)
-        Me.mnuCopy.Size = New System.Drawing.Size(230, 22)
+        Me.mnuCopy.Size = New System.Drawing.Size(229, 22)
         Me.mnuCopy.Text = "Copy"
         '
         'ToolStripSeparator3
         '
         Me.ToolStripSeparator3.Name = "ToolStripSeparator3"
-        Me.ToolStripSeparator3.Size = New System.Drawing.Size(227, 6)
+        Me.ToolStripSeparator3.Size = New System.Drawing.Size(226, 6)
         '
         'mnuRunCurrentLine
         '
         Me.mnuRunCurrentLine.Name = "mnuRunCurrentLine"
-        Me.mnuRunCurrentLine.Size = New System.Drawing.Size(230, 22)
+        Me.mnuRunCurrentLine.Size = New System.Drawing.Size(229, 22)
         Me.mnuRunCurrentLine.Text = "Run Current Line"
         '
         'mnuRunSelectedText
@@ -101,7 +101,7 @@ Partial Class ucrLog
         Me.mnuRunSelectedText.Name = "mnuRunSelectedText"
         Me.mnuRunSelectedText.ShortcutKeys = CType(((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.Alt) _
             Or System.Windows.Forms.Keys.T), System.Windows.Forms.Keys)
-        Me.mnuRunSelectedText.Size = New System.Drawing.Size(230, 22)
+        Me.mnuRunSelectedText.Size = New System.Drawing.Size(229, 22)
         Me.mnuRunSelectedText.Text = "Run Selected Text"
         '
         'mnuRunAll
@@ -109,55 +109,55 @@ Partial Class ucrLog
         Me.mnuRunAll.Name = "mnuRunAll"
         Me.mnuRunAll.ShortcutKeys = CType(((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.Alt) _
             Or System.Windows.Forms.Keys.R), System.Windows.Forms.Keys)
-        Me.mnuRunAll.Size = New System.Drawing.Size(230, 22)
+        Me.mnuRunAll.Size = New System.Drawing.Size(229, 22)
         Me.mnuRunAll.Text = "Run All"
         '
         'ToolStripSeparator2
         '
         Me.ToolStripSeparator2.Name = "ToolStripSeparator2"
-        Me.ToolStripSeparator2.Size = New System.Drawing.Size(227, 6)
+        Me.ToolStripSeparator2.Size = New System.Drawing.Size(226, 6)
         '
         'mnuSaveLogFile
         '
         Me.mnuSaveLogFile.Name = "mnuSaveLogFile"
-        Me.mnuSaveLogFile.Size = New System.Drawing.Size(230, 22)
+        Me.mnuSaveLogFile.Size = New System.Drawing.Size(229, 22)
         Me.mnuSaveLogFile.Text = "Save Log File..."
         '
         'mnuOpenLogFile
         '
         Me.mnuOpenLogFile.Name = "mnuOpenLogFile"
-        Me.mnuOpenLogFile.Size = New System.Drawing.Size(230, 22)
+        Me.mnuOpenLogFile.Size = New System.Drawing.Size(229, 22)
         Me.mnuOpenLogFile.Text = "Open Log File"
         '
         'ToolStripSeparator1
         '
         Me.ToolStripSeparator1.Name = "ToolStripSeparator1"
-        Me.ToolStripSeparator1.Size = New System.Drawing.Size(227, 6)
+        Me.ToolStripSeparator1.Size = New System.Drawing.Size(226, 6)
         '
         'mnuHelp
         '
         Me.mnuHelp.Name = "mnuHelp"
-        Me.mnuHelp.Size = New System.Drawing.Size(230, 22)
+        Me.mnuHelp.Size = New System.Drawing.Size(229, 22)
         Me.mnuHelp.Text = "Help"
         '
-        'lblHeader
+        'lblHeaderLog
         '
-        Me.lblHeader.BackColor = System.Drawing.Color.FromArgb(CType(CType(35, Byte), Integer), CType(CType(105, Byte), Integer), CType(CType(190, Byte), Integer))
-        Me.lblHeader.Dock = System.Windows.Forms.DockStyle.Fill
-        Me.lblHeader.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!)
-        Me.lblHeader.ForeColor = System.Drawing.SystemColors.Control
-        Me.lblHeader.Location = New System.Drawing.Point(3, 0)
-        Me.lblHeader.Name = "lblHeader"
-        Me.lblHeader.Size = New System.Drawing.Size(525, 20)
-        Me.lblHeader.TabIndex = 8
-        Me.lblHeader.Text = "Log Window"
-        Me.lblHeader.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
+        Me.lblHeaderLog.BackColor = System.Drawing.Color.FromArgb(CType(CType(35, Byte), Integer), CType(CType(105, Byte), Integer), CType(CType(190, Byte), Integer))
+        Me.lblHeaderLog.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.lblHeaderLog.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!)
+        Me.lblHeaderLog.ForeColor = System.Drawing.SystemColors.Control
+        Me.lblHeaderLog.Location = New System.Drawing.Point(3, 0)
+        Me.lblHeaderLog.Name = "lblHeaderLog"
+        Me.lblHeaderLog.Size = New System.Drawing.Size(525, 20)
+        Me.lblHeaderLog.TabIndex = 8
+        Me.lblHeaderLog.Text = "Log Window"
+        Me.lblHeaderLog.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
         '
         'tlpTableContainer
         '
         Me.tlpTableContainer.ColumnCount = 1
         Me.tlpTableContainer.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100.0!))
-        Me.tlpTableContainer.Controls.Add(Me.lblHeader, 0, 0)
+        Me.tlpTableContainer.Controls.Add(Me.lblHeaderLog, 0, 0)
         Me.tlpTableContainer.Controls.Add(Me.txtLog, 0, 1)
         Me.tlpTableContainer.Dock = System.Windows.Forms.DockStyle.Fill
         Me.tlpTableContainer.Location = New System.Drawing.Point(0, 0)
@@ -183,7 +183,7 @@ Partial Class ucrLog
     End Sub
 
     Friend WithEvents txtLog As TextBox
-    Friend WithEvents lblHeader As Label
+    Friend WithEvents lblHeaderLog As Label
     Friend WithEvents mnuContextLogFile As ContextMenuStrip
     Friend WithEvents mnuOpenLogFile As ToolStripMenuItem
     Friend WithEvents mnuCopy As ToolStripMenuItem

--- a/instat/ucrOutputWindow.Designer.vb
+++ b/instat/ucrOutputWindow.Designer.vb
@@ -46,11 +46,11 @@ Partial Class ucrOutputWindow
         Me.ToolStripSeparator1 = New System.Windows.Forms.ToolStripSeparator()
         Me.deleteRTB = New System.Windows.Forms.ToolStripMenuItem()
         Me.clearRTB = New System.Windows.Forms.ToolStripMenuItem()
-        Me.lblHeader = New System.Windows.Forms.Label()
+        Me.HelpRTB = New System.Windows.Forms.ToolStripMenuItem()
+        Me.lblHeaderOutputWindow = New System.Windows.Forms.Label()
         Me.tlpTableContainer = New System.Windows.Forms.TableLayoutPanel()
         Me.ucrWPFrtfElementHost = New System.Windows.Forms.Integration.ElementHost()
         Me.ucrRichTextBox = New instat.ucrWPFRichTextBox()
-        Me.HelpRTB = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuContextRTB.SuspendLayout()
         Me.tlpTableContainer.SuspendLayout()
         Me.SuspendLayout()
@@ -60,7 +60,7 @@ Partial Class ucrOutputWindow
         Me.mnuContextRTB.ImageScalingSize = New System.Drawing.Size(24, 24)
         Me.mnuContextRTB.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.CopyRTB, Me.CopyImageRTB, Me.mnuHideCommands, Me.ToolStripSeparator1, Me.deleteRTB, Me.clearRTB, Me.HelpRTB})
         Me.mnuContextRTB.Name = "mnuContextRTB"
-        Me.mnuContextRTB.Size = New System.Drawing.Size(206, 164)
+        Me.mnuContextRTB.Size = New System.Drawing.Size(206, 142)
         '
         'CopyRTB
         '
@@ -98,25 +98,31 @@ Partial Class ucrOutputWindow
         Me.clearRTB.Size = New System.Drawing.Size(205, 22)
         Me.clearRTB.Text = "Clear"
         '
-        'lblHeader
+        'HelpRTB
         '
-        Me.lblHeader.BackColor = System.Drawing.Color.FromArgb(CType(CType(35, Byte), Integer), CType(CType(105, Byte), Integer), CType(CType(190, Byte), Integer))
-        Me.lblHeader.Dock = System.Windows.Forms.DockStyle.Fill
-        Me.lblHeader.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!)
-        Me.lblHeader.ForeColor = System.Drawing.SystemColors.Control
-        Me.lblHeader.Location = New System.Drawing.Point(3, 0)
-        Me.lblHeader.Name = "lblHeader"
-        Me.lblHeader.Size = New System.Drawing.Size(716, 20)
-        Me.lblHeader.TabIndex = 6
-        Me.lblHeader.Text = "Output Window"
-        Me.lblHeader.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
+        Me.HelpRTB.Name = "HelpRTB"
+        Me.HelpRTB.Size = New System.Drawing.Size(205, 22)
+        Me.HelpRTB.Text = "Help"
+        '
+        'lblHeaderOutputWindow
+        '
+        Me.lblHeaderOutputWindow.BackColor = System.Drawing.Color.FromArgb(CType(CType(35, Byte), Integer), CType(CType(105, Byte), Integer), CType(CType(190, Byte), Integer))
+        Me.lblHeaderOutputWindow.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.lblHeaderOutputWindow.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!)
+        Me.lblHeaderOutputWindow.ForeColor = System.Drawing.SystemColors.Control
+        Me.lblHeaderOutputWindow.Location = New System.Drawing.Point(3, 0)
+        Me.lblHeaderOutputWindow.Name = "lblHeaderOutputWindow"
+        Me.lblHeaderOutputWindow.Size = New System.Drawing.Size(716, 20)
+        Me.lblHeaderOutputWindow.TabIndex = 6
+        Me.lblHeaderOutputWindow.Text = "Output Window"
+        Me.lblHeaderOutputWindow.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
         '
         'tlpTableContainer
         '
         Me.tlpTableContainer.ColumnCount = 1
         Me.tlpTableContainer.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100.0!))
         Me.tlpTableContainer.Controls.Add(Me.ucrWPFrtfElementHost, 0, 1)
-        Me.tlpTableContainer.Controls.Add(Me.lblHeader, 0, 0)
+        Me.tlpTableContainer.Controls.Add(Me.lblHeaderOutputWindow, 0, 0)
         Me.tlpTableContainer.Dock = System.Windows.Forms.DockStyle.Fill
         Me.tlpTableContainer.Location = New System.Drawing.Point(0, 0)
         Me.tlpTableContainer.Name = "tlpTableContainer"
@@ -137,12 +143,6 @@ Partial Class ucrOutputWindow
         Me.ucrWPFrtfElementHost.Text = "ucrWPFrtfElementHost"
         Me.ucrWPFrtfElementHost.Child = Me.ucrRichTextBox
         '
-        'HelpRTB
-        '
-        Me.HelpRTB.Name = "HelpRTB"
-        Me.HelpRTB.Size = New System.Drawing.Size(205, 22)
-        Me.HelpRTB.Text = "Help"
-        '
         'ucrOutputWindow
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
@@ -161,7 +161,7 @@ Partial Class ucrOutputWindow
     Friend WithEvents mnuContextRTB As ContextMenuStrip
     Friend WithEvents CopyRTB As ToolStripMenuItem
     Friend WithEvents CopyImageRTB As ToolStripMenuItem
-    Friend WithEvents lblHeader As Label
+    Friend WithEvents lblHeaderOutputWindow As Label
     Friend WithEvents tlpTableContainer As TableLayoutPanel
     Friend WithEvents ToolStripSeparator1 As ToolStripSeparator
     Friend WithEvents clearRTB As ToolStripMenuItem

--- a/instat/ucrScript.Designer.vb
+++ b/instat/ucrScript.Designer.vb
@@ -57,7 +57,7 @@ Partial Class ucrScript
         Me.ToolStripSeparator1 = New System.Windows.Forms.ToolStripSeparator()
         Me.mnuHelp = New System.Windows.Forms.ToolStripMenuItem()
         Me.cmdRun = New System.Windows.Forms.Button()
-        Me.lblHeader = New System.Windows.Forms.Label()
+        Me.lblHeaderScript = New System.Windows.Forms.Label()
         Me.tlpTableContainer = New System.Windows.Forms.TableLayoutPanel()
         Me.mnuContextScript.SuspendLayout()
         Me.tlpTableContainer.SuspendLayout()
@@ -193,24 +193,24 @@ Partial Class ucrScript
         Me.cmdRun.Text = "Run All"
         Me.cmdRun.UseVisualStyleBackColor = True
         '
-        'lblHeader
+        'lblHeaderScript
         '
-        Me.lblHeader.BackColor = System.Drawing.Color.FromArgb(CType(CType(35, Byte), Integer), CType(CType(105, Byte), Integer), CType(CType(190, Byte), Integer))
-        Me.lblHeader.Dock = System.Windows.Forms.DockStyle.Fill
-        Me.lblHeader.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!)
-        Me.lblHeader.ForeColor = System.Drawing.SystemColors.Control
-        Me.lblHeader.Location = New System.Drawing.Point(3, 0)
-        Me.lblHeader.Name = "lblHeader"
-        Me.lblHeader.Size = New System.Drawing.Size(405, 20)
-        Me.lblHeader.TabIndex = 8
-        Me.lblHeader.Text = "Script Window"
-        Me.lblHeader.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
+        Me.lblHeaderScript.BackColor = System.Drawing.Color.FromArgb(CType(CType(35, Byte), Integer), CType(CType(105, Byte), Integer), CType(CType(190, Byte), Integer))
+        Me.lblHeaderScript.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.lblHeaderScript.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!)
+        Me.lblHeaderScript.ForeColor = System.Drawing.SystemColors.Control
+        Me.lblHeaderScript.Location = New System.Drawing.Point(3, 0)
+        Me.lblHeaderScript.Name = "lblHeaderScript"
+        Me.lblHeaderScript.Size = New System.Drawing.Size(405, 20)
+        Me.lblHeaderScript.TabIndex = 8
+        Me.lblHeaderScript.Text = "Script Window"
+        Me.lblHeaderScript.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
         '
         'tlpTableContainer
         '
         Me.tlpTableContainer.ColumnCount = 1
         Me.tlpTableContainer.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100.0!))
-        Me.tlpTableContainer.Controls.Add(Me.lblHeader, 0, 0)
+        Me.tlpTableContainer.Controls.Add(Me.lblHeaderScript, 0, 0)
         Me.tlpTableContainer.Controls.Add(Me.txtScript, 0, 2)
         Me.tlpTableContainer.Controls.Add(Me.cmdRun, 0, 1)
         Me.tlpTableContainer.Dock = System.Windows.Forms.DockStyle.Fill
@@ -241,7 +241,7 @@ Partial Class ucrScript
 
     Friend WithEvents txtScript As TextBox
     Friend WithEvents cmdRun As Button
-    Friend WithEvents lblHeader As Label
+    Friend WithEvents lblHeaderScript As Label
     Friend WithEvents tlpTableContainer As TableLayoutPanel
     Friend WithEvents mnuContextScript As ContextMenuStrip
     Friend WithEvents mnuRunSelectedText As ToolStripMenuItem


### PR DESCRIPTION
This PR partially fixes issue #3721 . 

The translation mechanism requires that each translated item in a form has a unique name. `frmMain` has 6 output windows:

- Column Meta Data
- Data Frame Meta Data
- Data View
- Log
- Output
- Script

These 6 windows had the same name (`lblHeader`) for their header text. This PR renames each of the 6 names to a unique name.

This PR does not affect the functionality in any way.

@shadrackkibet , @rdstern Please could you approve/merge? thanks
