### PR TITLE
Ensure that dialog boxes are translated (e.g. into French) only after all text has been set

### DIFF
--- a/instat/dlgAddComment.vb
+++ b/instat/dlgAddComment.vb
@@ -33,12 +33,12 @@ Public Class dlgAddComment
             SetDefaults()
         End If
         bReset = False
-        autoTranslate(Me)
         SetRCodeForControls(bReset)
         If bUseSelectedPosition Then
             SetDefaultPosition()
         End If
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgAddKey.vb
+++ b/instat/dlgAddKey.vb
@@ -25,7 +25,6 @@ Public Class dlgAddKey
     Private bUniqueChecked As Boolean = False
 
     Private Sub dlgAddKey_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -38,6 +37,7 @@ Public Class dlgAddKey
         bReset = False
         bUniqueChecked = False
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgAddLink.vb
+++ b/instat/dlgAddLink.vb
@@ -23,7 +23,6 @@ Public Class dlgAddLink
     Private clsAddLink As RFunction
 
     Private Sub dlgAddLink_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -36,6 +35,7 @@ Public Class dlgAddLink
         SetRCodeForControls(bReset)
         bReset = False
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgAlignment.vb
+++ b/instat/dlgAlignment.vb
@@ -20,7 +20,6 @@ Public Class dlgAlignment
     Public bFirstLoad As Boolean = True
     Private bReset As Boolean = True
     Private Sub dlgAlignment_Load(sender As Object, e As EventArgs) Handles Me.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -31,6 +30,7 @@ Public Class dlgAlignment
         SetRCodeForControls(bReset)
         bReset = False
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgAugment.vb
+++ b/instat/dlgAugment.vb
@@ -23,7 +23,6 @@ Public Class dlgAugment
     Private clsAugment As New RFunction
 
     Private Sub dlgTidy_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bfirstload Then
             InitialiseDialog()
             bfirstload = False
@@ -34,6 +33,7 @@ Public Class dlgAugment
         SetRCodeForControls(bReset)
         bReset = False
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgBackupManager.vb
+++ b/instat/dlgBackupManager.vb
@@ -22,7 +22,6 @@ Public Class dlgBackupManager
     Private strSelectedDataFilePath As String 'holds the selected file path
 
     Private Sub dlgBackupManager_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         'Get the default Auto save Data Folder
         strAutoSaveDataFolderPath = frmMain.strAutoSaveDataFolderPath
         'set selected data file path to empty string
@@ -31,6 +30,7 @@ Public Class dlgBackupManager
         SetButtonStates(False)
         'add to the list of last loaded forms
         frmMain.clsRecentItems.addToMenu(Me)
+        autoTranslate(Me)
     End Sub
 
     'loads the files info's into the listview

--- a/instat/dlgBoxplotCountVariable.vb
+++ b/instat/dlgBoxplotCountVariable.vb
@@ -18,7 +18,6 @@ Imports instat.Translations
 Public Class dlgBoxplotCountVariable
     Public bFirstLoad As Boolean = True
     Private Sub dlgBoxplotCountVariable_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
 
         If bFirstLoad Then
             InitialiseDialog()
@@ -27,6 +26,7 @@ Public Class dlgBoxplotCountVariable
         End If
         TestOKEnabled()
 
+        autoTranslate(Me)
     End Sub
 
     Private Sub TestOKEnabled()

--- a/instat/dlgCPTtoTabularData.vb
+++ b/instat/dlgCPTtoTabularData.vb
@@ -18,7 +18,6 @@ Imports instat.Translations
 Public Class dlgCPTtoTabularData
     Public bFirstLoad As Boolean = True
     Private Sub dlgCPTtoTabularData_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
 
         If bFirstLoad Then
             InitialiseDialog()
@@ -29,6 +28,7 @@ Public Class dlgCPTtoTabularData
         End If
 
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
     Private Sub InitialiseDialog()
         ucrBase.clsRsyntax.SetFunction("climate_obj$SST_domain()")

--- a/instat/dlgCalculator.vb
+++ b/instat/dlgCalculator.vb
@@ -30,7 +30,6 @@ Public Class dlgCalculator
 
 
     Private Sub dlgCalculator_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             iBasicWidth = Me.Width
@@ -40,6 +39,7 @@ Public Class dlgCalculator
             ReopenDialog()
         End If
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub TestOKEnabled()

--- a/instat/dlgCliBoxplot.vb
+++ b/instat/dlgCliBoxplot.vb
@@ -18,7 +18,6 @@ Imports instat.Translations
 Public Class dlgCliBoxplot
     Public bFirstLoad As Boolean = True
     Private Sub dlgCliBoxplot_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
 
         If bFirstLoad Then
             InitialiseDialog()
@@ -27,6 +26,7 @@ Public Class dlgCliBoxplot
         End If
         TestOKEnabled()
 
+        autoTranslate(Me)
     End Sub
 
     Private Sub TestOKEnabled()

--- a/instat/dlgCliData.vb
+++ b/instat/dlgCliData.vb
@@ -18,13 +18,13 @@ Imports instat.Translations
 Public Class dlgCliData
     Public bFirstLoad As Boolean = True
     Private Sub dlgCliData_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             SetDefaults()
             bFirstLoad = False
         End If
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
     Private Sub InitialiseDialog()
         ucrBase.iHelpTopicID = 354

--- a/instat/dlgClimaticDataEntry.vb
+++ b/instat/dlgClimaticDataEntry.vb
@@ -45,9 +45,9 @@ Public Class dlgClimaticDataEntry
         End If
         SetRCodeForControls(bReset)
         bReset = False
-        autoTranslate(Me)
         ucrBase.OKEnabled(False)
         SetNumberCommentEnteredText(sdgCommentForDataEntry.GetSetNumberOfCommentsEntered)
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgClimaticLengthOfSeason.vb
+++ b/instat/dlgClimaticLengthOfSeason.vb
@@ -23,7 +23,6 @@ Public Class dlgClimaticLengthOfSeason
     Private clsLengthOfSeasonFunction, clsApplyInstatCalcFunction, clsCombinationCalcFunction, clsStartEndStatusFunction, clsIfElseFunction, clsIsNAFunction, clsCombinationListFunction As New RFunction
     Private clsMinusOpertor, clsAndOperator, clsOROperator As New ROperator
     Private Sub dlgClimaticLengthOfSeason_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -33,8 +32,8 @@ Public Class dlgClimaticLengthOfSeason
         End If
         SetRCodeForControls(bReset)
         bReset = False
-        autoTranslate(Me)
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgClimaticSummary.vb
+++ b/instat/dlgClimaticSummary.vb
@@ -39,10 +39,10 @@ Public Class dlgClimaticSummary
         SetRCodeForControls(bReset)
         bRCodeSet = True
         bReset = False
-        autoTranslate(Me)
         WithinYearLabelReceiverLocation()
         SetFactors()
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     ' if within-year is checked, add within-year receiver

--- a/instat/dlgClimdexIndices.vb
+++ b/instat/dlgClimdexIndices.vb
@@ -29,7 +29,6 @@ Public Class dlgClimdexIndices
     Private clsAddClimexIndices As New RFunction
 
     Private Sub dlgClimdex_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -40,6 +39,7 @@ Public Class dlgClimdexIndices
         SetRCodeForControls(bReset)
         bReset = False
         TestOkEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgColourbyProperty.vb
+++ b/instat/dlgColourbyProperty.vb
@@ -22,7 +22,6 @@ Public Class dlgColourbyProperty
     Private bReset As Boolean = True
 
     Private Sub dlgColourbyProperty_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -33,6 +32,7 @@ Public Class dlgColourbyProperty
         SetRCodeForControls(bReset)
         bReset = False
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgColumnMetadata.vb
+++ b/instat/dlgColumnMetadata.vb
@@ -19,7 +19,6 @@ Public Class dlgColumnMetadata
     Public bFirstLoad As Boolean = True
     Private Sub dlgColumnMetadata_Load(sender As Object, e As EventArgs) Handles MyBase.Load
 
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             SetDefaults()
@@ -29,6 +28,7 @@ Public Class dlgColumnMetadata
         End If
         'Checks if Ok can be enabled.
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgColumnStructures.vb
+++ b/instat/dlgColumnStructures.vb
@@ -22,7 +22,6 @@ Public Class dlgColumnStructure
     Private clsColourStructure As New RFunction
     Private bFirstLoad As Boolean = True
     Private Sub ucrSelectorColumnStructures_Load(sender As Object, e As EventArgs) Handles Me.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -34,6 +33,7 @@ Public Class dlgColumnStructure
         bReset = False
         SetColumnStructureInReceiver()
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgCompare.vb
+++ b/instat/dlgCompare.vb
@@ -34,7 +34,6 @@ Public Class dlgCompare
     Private clsSateliteMinusOperator, clsStationMinusOperator As New ROperator
 
     Private Sub dlgCompare_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -45,6 +44,7 @@ Public Class dlgCompare
         SetRCodeforControls(bReset)
         bReset = False
         TestOkEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgCompareModels.vb
+++ b/instat/dlgCompareModels.vb
@@ -21,7 +21,6 @@ Public Class dlgCompareModels
     Public clsPlotDist As New RFunction
     Public bFirstLoad As Boolean = True
     Private Sub dlgCompareModels_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             SetDefaults()
@@ -30,6 +29,7 @@ Public Class dlgCompareModels
             ReopenDialog()
         End If
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
     Private Sub InitialiseDialog()
         clsPlotDist.SetRCommand("plotDist")

--- a/instat/dlgCompareSummary.vb
+++ b/instat/dlgCompareSummary.vb
@@ -23,7 +23,6 @@ Public Class dlgCompareSummary
     Private clsSummaryFunction As New RFunction
     Private clsListFunction As New RFunction
     Private Sub dlgCompareSummary_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -34,6 +33,7 @@ Public Class dlgCompareSummary
         SetRcodeForControls(bReset)
         bReset = False
         TestOkEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgConditionalQuantilePlot.vb
+++ b/instat/dlgConditionalQuantilePlot.vb
@@ -23,7 +23,6 @@ Public Class dlgConditionalQuantilePlot
     Private clsConditionalQuantileFunction As New RFunction
     Private clsConditionalEvalFunction As New RFunction
     Private Sub dlgConditionalQuantilePlot_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             iDialogHeight = Me.Height
             iBaseMaxY = ucrBase.Location.Y
@@ -36,6 +35,7 @@ Public Class dlgConditionalQuantilePlot
         SetRcodeForControls(bReset)
         bReset = False
         TestOkEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgConvertColumns.vb
+++ b/instat/dlgConvertColumns.vb
@@ -26,7 +26,6 @@ Public Class dlgConvertColumns
     Private clsDefaultFunction As New RFunction
 
     Private Sub dlgConvertColumns_Load(sender As Object, e As EventArgs) Handles Me.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -41,6 +40,7 @@ Public Class dlgConvertColumns
         End If
         ReopenDialog()
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub ReopenDialog()

--- a/instat/dlgCorrelation.vb
+++ b/instat/dlgCorrelation.vb
@@ -35,9 +35,9 @@ Public Class dlgCorrelation
         End If
         SetRCodeForControls(bReset)
         bReset = False
-        autoTranslate(Me)
         SetDefaultColumn()
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgCorruptionDescribe.vb
+++ b/instat/dlgCorruptionDescribe.vb
@@ -18,13 +18,13 @@ Imports instat.Translations
 Public Class dlgCorruptionDescribe
     Public bFirstLoad As Boolean = True
     Private Sub dlgCorruptionDescribe_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             SetDefaults()
             bFirstLoad = False
         End If
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgCorruptionModel.vb
+++ b/instat/dlgCorruptionModel.vb
@@ -18,13 +18,13 @@ Imports instat.Translations
 Public Class dlgCorruptionModel
     Public bFirstLoad As Boolean = True
     Private Sub dlgCorruptionModel_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             SetDefaults()
             bFirstLoad = False
         End If
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgCorruptionOrganise.vb
+++ b/instat/dlgCorruptionOrganise.vb
@@ -18,13 +18,13 @@ Imports instat.Translations
 Public Class dlgCorruptionOrganise
     Public bFirstLoad As Boolean = True
     Private Sub dlgCorruptionOrganise_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             SetDefaults()
             bFirstLoad = False
         End If
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
     Private Sub InitialiseDialog()
         ucrBase.iHelpTopicID = 500

--- a/instat/dlgCountinFactor.vb
+++ b/instat/dlgCountinFactor.vb
@@ -21,7 +21,6 @@ Public Class dlgCountinFactor
     Private clsDefaultFunction As New RFunction
 
     Private Sub dlgCountinFactor_Load(sender As Object, e As EventArgs) Handles Me.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -32,6 +31,7 @@ Public Class dlgCountinFactor
         SetRCodeForControls(bReset)
         bReset = False
         TestOkEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgCreateClimateObject.vb
+++ b/instat/dlgCreateClimateObject.vb
@@ -18,7 +18,6 @@ Imports instat.Translations
 Public Class dlgCreateClimateObject
     Public bFirstLoad As Boolean = True
     Private Sub dlgCreateClimateObject_Load(sender As Object, e As EventArgs) Handles Me.Load
-        autoTranslate(Me)
 
         If bFirstLoad Then
             InitialiseDialog()
@@ -27,6 +26,7 @@ Public Class dlgCreateClimateObject
         End If
         TestOKEnabled()
 
+        autoTranslate(Me)
     End Sub
 
     Private Sub TestOKEnabled()

--- a/instat/dlgDayMonth.vb
+++ b/instat/dlgDayMonth.vb
@@ -19,7 +19,6 @@ Public Class dlgDayMonth
     Public bFirstLoad As Boolean = True
     Private Sub dlgDayMonth_Load(sender As Object, e As EventArgs) Handles MyBase.Load
 
-        autoTranslate(Me)
 
         If bFirstLoad Then
             InitialiseDialog()
@@ -30,6 +29,7 @@ Public Class dlgDayMonth
         End If
 
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
     Private Sub InitialiseDialog()
         ucrBase.clsRsyntax.SetFunction("climate_obj$day_month()")

--- a/instat/dlgDefineCRI.vb
+++ b/instat/dlgDefineCRI.vb
@@ -29,7 +29,6 @@ Public Class dlgCorruptionDefineCRI
     Private strWeightColumn As String = "Weight"
 
     Private Sub dlgDefineCRI_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -43,6 +42,7 @@ Public Class dlgCorruptionDefineCRI
         SetRCodeForControls(bReset)
         bReset = False
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgDefineCorruption.vb
+++ b/instat/dlgDefineCorruption.vb
@@ -35,8 +35,8 @@ Public Class dlgDefineCorruption
         End If
         SetRCodeForControls(bReset)
         bReset = False
-        autoTranslate(Me)
         AutoFillReceivers()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgDefineCorruptionOutputs.vb
+++ b/instat/dlgDefineCorruptionOutputs.vb
@@ -24,7 +24,6 @@ Public Class dlgCorruptionDefineOutputs
     Private clsCorruptionOutputs As New RFunction
 
     Private Sub dlgDefineCorruptionOutputs_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -37,6 +36,7 @@ Public Class dlgCorruptionDefineOutputs
         End If
         SetRCodeForControls(bReset)
         bReset = False
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgDefineRedFlags.vb
+++ b/instat/dlgDefineRedFlags.vb
@@ -24,7 +24,6 @@ Public Class dlgDefineRedFlags
     Private clsRedFlag As New RFunction
 
     Private Sub dlgDefineRedFlags_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -38,6 +37,7 @@ Public Class dlgDefineRedFlags
         SetRCodeForControls(bReset)
         SetRedFlagColumnsInReceiver()
         bReset = False
+        autoTranslate(Me)
     End Sub
 
     Private Sub SetDefaults()

--- a/instat/dlgDeleteDataFrames.vb
+++ b/instat/dlgDeleteDataFrames.vb
@@ -23,7 +23,6 @@ Public Class dlgDeleteDataFrames
     Private strSelectedDataFrame As String = ""
 
     Private Sub dlgDeleteDataFrames_Load(sender As Object, e As EventArgs) Handles Me.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -38,6 +37,7 @@ Public Class dlgDeleteDataFrames
         SetRCodeForControls(bReset)
         bReset = False
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgDeleteMetadata.vb
+++ b/instat/dlgDeleteMetadata.vb
@@ -18,7 +18,6 @@ Imports instat.Translations
 Public Class dlgDeleteMetadata
     Public bFirstLoad As Boolean = True
     Private Sub dlgDeleteMetadata_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             setDefaults()
             InitialiseDialog()
@@ -27,6 +26,7 @@ Public Class dlgDeleteMetadata
             ReopenDialog()
         End If
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub ReopenDialog()

--- a/instat/dlgDeleteModels.vb
+++ b/instat/dlgDeleteModels.vb
@@ -18,7 +18,6 @@ Imports instat.Translations
 Public Class dlgDeleteModels
     Public bFirstLoad As Boolean = True
     Private Sub dlgDeleteModels_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
 
         If bFirstLoad Then
             InitialiseDialog()
@@ -26,6 +25,7 @@ Public Class dlgDeleteModels
             bFirstLoad = False
         End If
 
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgDeleteRowsOrColums.vb
+++ b/instat/dlgDeleteRowsOrColums.vb
@@ -21,7 +21,6 @@ Public Class dlgDeleteRowsOrColums
     Private clsOperatorRowNames As New ROperator
     Private clsDeleteRows, clsDeleteColumns As RFunction
     Private Sub dlgDeleteRows_Load(sender As Object, e As EventArgs) Handles Me.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -33,6 +32,7 @@ Public Class dlgDeleteRowsOrColums
         bReset = False
         ReopenDialog()
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgDisplayDailyData.vb
+++ b/instat/dlgDisplayDailyData.vb
@@ -32,7 +32,6 @@ Public Class dlgDisplayDailyData
     Private clsLabelWrapGenFunction As New RFunction
 
     Private Sub dlgDisplayDailyData_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         bRCodeSet = False
         If bFirstLoad Then
             iBasicHeight = Me.Height
@@ -49,6 +48,7 @@ Public Class dlgDisplayDailyData
         DialogSize()
         bReset = False
         TestOkEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgDummyVariables.vb
+++ b/instat/dlgDummyVariables.vb
@@ -20,7 +20,6 @@ Public Class dlgDummyVariables
     Private bReset As Boolean = True
     Private clsDummyFunction As New RFunction
     Private Sub dlgIndicatorVariable_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -31,6 +30,7 @@ Public Class dlgDummyVariables
         SetRCodeForControls(bReset)
         bReset = False
         TestOkEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgEndOfRainsSeason.vb
+++ b/instat/dlgEndOfRainsSeason.vb
@@ -148,7 +148,6 @@ Public Class dlgEndOfRainsSeason
 #End Region
 
     Private Sub dlgEndOfRainsSeason_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstload Then
             InitialiseDialog()
             bFirstload = False
@@ -159,6 +158,7 @@ Public Class dlgEndOfRainsSeason
         SetRCodeForControls(bReset)
         bReset = False
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgEnter.vb
+++ b/instat/dlgEnter.vb
@@ -26,7 +26,6 @@ Public Class dlgEnter
     Public clsCommands As New RFunction
 
     Private Sub dlgEnter_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             SetDefaults()
@@ -35,6 +34,7 @@ Public Class dlgEnter
             ReopenDialog()
         End If
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
     Private Sub SetEntryHistory()
         ucrReceiverForEnterCalculation.AddtoCombobox(ucrReceiverForEnterCalculation.GetText)

--- a/instat/dlgExamine.vb
+++ b/instat/dlgExamine.vb
@@ -18,7 +18,6 @@ Imports instat.Translations
 Public Class dlgExamine
     Public bFirstLoad As Boolean = True
     Private Sub dlgExamine_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
 
         If bFirstLoad Then
             InitialiseDialog()
@@ -27,6 +26,7 @@ Public Class dlgExamine
         End If
         TestOKEnabled()
 
+        autoTranslate(Me)
     End Sub
 
     Private Sub TestOKEnabled()

--- a/instat/dlgExportDataset.vb
+++ b/instat/dlgExportDataset.vb
@@ -125,8 +125,8 @@ Public Class dlgExportDataset
             ucrBase.clsRsyntax.SetCommandString(strCommand)
             lblConfirm.Text = "Files with the same names will be overwritten." & Environment.NewLine & "Click Ok to Confirm the Export."
         End If
-        autoTranslate(Me)
         TestOkEnabled()
+        autoTranslate(Me)
     End Sub
 
 

--- a/instat/dlgExportRObjects.vb
+++ b/instat/dlgExportRObjects.vb
@@ -21,7 +21,6 @@ Public Class dlgExportRObjects
     Private clsExport As RFunction
 
     Private Sub dlgExportRObjects_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -32,6 +31,7 @@ Public Class dlgExportRObjects
         SetRCodeForControls(bReset)
         bReset = False
         'TestOkEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgExportRWorkspace.vb
+++ b/instat/dlgExportRWorkspace.vb
@@ -20,7 +20,6 @@ Public Class dlgExportRWorkspace
     Private bReset As Boolean = True
     Private clsDefaultFunction As New RFunction
     Private Sub dlgExportRWorkspace_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -31,6 +30,7 @@ Public Class dlgExportRWorkspace
         SetRCodeForControls(bReset)
         bReset = False
         TestOkEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgExportToCMSAF.vb
+++ b/instat/dlgExportToCMSAF.vb
@@ -23,7 +23,6 @@ Public Class dlgExportToCMSAF
     Private clsAssignOperator As New ROperator
 
     Private Sub dlgExportToCMSAF_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -34,6 +33,7 @@ Public Class dlgExportToCMSAF
         SetRCodeForControls(bReset)
         bReset = False
         TestOkEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgExportToCPT.vb
+++ b/instat/dlgExportToCPT.vb
@@ -22,7 +22,6 @@ Public Class dlgExportToCPT
     Private clsExportCPT, clsOutputCPT As New RFunction
 
     Private Sub dlgExportToCPT_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -33,6 +32,7 @@ Public Class dlgExportToCPT
         SetRCodeForControls(bReset)
         bReset = False
         TestOkEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgExportToOpenRefine.vb
+++ b/instat/dlgExportToOpenRefine.vb
@@ -24,7 +24,6 @@ Public Class dlgExportToOpenRefine
     Private clsGetDataFrame As New RFunction
 
     Private Sub dlgExportToOpenRefine_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -34,6 +33,7 @@ Public Class dlgExportToOpenRefine
         End If
         SetRCodeForControls(bReset)
         bReset = False
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgExportToWWR.vb
+++ b/instat/dlgExportToWWR.vb
@@ -24,7 +24,6 @@ Public Class dlgExportToWWR
     'R function
     Private clsWWRExport As RFunction
     Private Sub dlgExportToWWR_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitiliseDialog()
             bFirstLoad = False
@@ -36,6 +35,7 @@ Public Class dlgExportToWWR
         SetRCodeForControls(bReset)
         bReset = False
         TestOkEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitiliseDialog()

--- a/instat/dlgExportforPICSA.vb
+++ b/instat/dlgExportforPICSA.vb
@@ -19,7 +19,6 @@ Public Class dlgExportforPICSA
     Public bFirstLoad As Boolean = True
 
     Private Sub dlgExportforPICSA_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
 
         If bFirstLoad Then
             InitialiseDialog()
@@ -28,6 +27,7 @@ Public Class dlgExportforPICSA
         End If
         TestOKEnabled()
 
+        autoTranslate(Me)
     End Sub
 
     Private Sub TestOKEnabled()

--- a/instat/dlgExtremeEvents.vb
+++ b/instat/dlgExtremeEvents.vb
@@ -22,7 +22,6 @@ Public Class dlgExtremeEvents
 
 
 
-        autoTranslate(Me)
 
         If bFirstLoad Then
             InitialiseDialog()
@@ -32,6 +31,7 @@ Public Class dlgExtremeEvents
         TestOKEnabled()
 
 
+        autoTranslate(Me)
     End Sub
     Private Sub TestOKEnabled()
 

--- a/instat/dlgFindNonnumericValues.vb
+++ b/instat/dlgFindNonnumericValues.vb
@@ -38,11 +38,11 @@ Public Class dlgFindNonnumericValues
         End If
         SetRCodeForControls(bReset)
         bReset = False
-        autoTranslate(Me)
         TestOKEnabled()
         If bUseSelectedColumn Then
             SetSelectedColumn()
         End If
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgFitCorruptionModel.vb
+++ b/instat/dlgFitCorruptionModel.vb
@@ -33,7 +33,6 @@ Public Class dlgCorruptionFitModel
     Private dctPlotFunctions As New Dictionary(Of String, RFunction)
 
     Private Sub dlgFitCorruptionModel_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -46,6 +45,7 @@ Public Class dlgCorruptionFitModel
         End If
         SetRCodeForControls(bReset)
         bReset = False
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgFlatFrequencyTable.vb
+++ b/instat/dlgFlatFrequencyTable.vb
@@ -20,7 +20,6 @@ Public Class dlgFlatFrequencyTable
     Private bReset As Boolean = True
     Private clsFTable, clsTable, clsAddMargin As New RFunction
     Private Sub dlgFlatFrequencyTable_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -31,6 +30,7 @@ Public Class dlgFlatFrequencyTable
         SetRCodeForControls(bReset)
         bReset = False
         TestOkEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgFormat.vb
+++ b/instat/dlgFormat.vb
@@ -17,11 +17,11 @@
 Imports instat.Translations
 Public Class dlgFormat
     Private Sub dlgFormat_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         ucrMultiple.Selector = ucrAddRemove
         ucrMultiple.SetMeAsReceiver()
         ucrBase.OKEnabled(False)
         defaultSettings()
+        autoTranslate(Me)
     End Sub
 
     Private Sub defaultSettings()

--- a/instat/dlgFourVariableModelling.vb
+++ b/instat/dlgFourVariableModelling.vb
@@ -37,7 +37,6 @@ Public Class dlgFourVariableModelling
     Private clsRstandardFunction, clsHatvaluesFunction, clsResidualFunction, clsFittedValuesFunction As New RFunction
 
     Private Sub dlgFourVariableModelling_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -48,6 +47,7 @@ Public Class dlgFourVariableModelling
         SetRCodeForControls(bReset)
         bReset = False
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgFromLibrary.vb
+++ b/instat/dlgFromLibrary.vb
@@ -34,7 +34,6 @@ Public Class dlgFromLibrary
     Private clsImportFunction As New RFunction 'the base function that call on import R-Instat function
 
     Private Sub dlgFromLibrary_Load(sender As Object, e As EventArgs) Handles Me.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -54,6 +53,7 @@ Public Class dlgFromLibrary
         bReset = False
         TestOkEnabled()
         EnableHelp()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgGeneralANOVA.vb
+++ b/instat/dlgGeneralANOVA.vb
@@ -18,7 +18,6 @@ Imports instat.Translations
 Public Class dlgGeneralANOVA
     Public bFirstLoad As Boolean = True
     Private Sub dlgGeneral_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             SetDefaults()
             InitialiseDialog()
@@ -27,6 +26,7 @@ Public Class dlgGeneralANOVA
             ReopenDialog()
         End If
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub TestOKEnabled()

--- a/instat/dlgGlance.vb
+++ b/instat/dlgGlance.vb
@@ -21,7 +21,6 @@ Public Class dlgGlance
     Private clsMap_df As New RFunction
 
     Private Sub dlgGlance_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bfirstload Then
             InitialiseDialog()
             bfirstload = False
@@ -32,6 +31,7 @@ Public Class dlgGlance
         SetRCodeForControls(bReset)
         bReset = False
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgHomogenization.vb
+++ b/instat/dlgHomogenization.vb
@@ -22,7 +22,6 @@ Public Class dlgHomogenization
     Private clsCptMeanFunction, clsCptVarianceFunction, clsCptMeanVarianceFunction, clsExcludeNAFunction, clsPlotFunction, clsSummaryFunction, clsSnhtFunction, clsPettittFunction, clsBuishandFunction, clsTapplyFunction, clsCompleteCasesFunction As New RFunction
     Private clsBracketsOperator, clsLeftBracketOperator, clsRightBracketOperator As New ROperator
     Private Sub dlgHomogenization_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -34,6 +33,7 @@ Public Class dlgHomogenization
         SetRCodeForControls(bReset)
         bReset = False
         TestOkEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgHypothesisTestsCalculator.vb
+++ b/instat/dlgHypothesisTestsCalculator.vb
@@ -25,7 +25,6 @@ Public Class dlgHypothesisTestsCalculator
     Private strPackageName As String
     Private clsSummary As New RFunction
     Private Sub dlgHypothesisTestsCalculator_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             SetDefaults()
@@ -34,6 +33,7 @@ Public Class dlgHypothesisTestsCalculator
         TestOKEnabled()
         SetRcodeForControls(bReset)
         bReset = False
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgImportDataset.vb
+++ b/instat/dlgImportDataset.vb
@@ -1,4 +1,4 @@
-Imports System.IO
+﻿Imports System.IO
 Imports RDotNet
 Imports instat.Translations
 
@@ -61,7 +61,6 @@ Public Class dlgImportDataset
 
     Private Sub dlgImportDataset_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         bDialogLoaded = False
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             SetDefaults()
@@ -113,6 +112,7 @@ Public Class dlgImportDataset
         bDialogLoaded = True
         bReset = False
         TestOkEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgImportERA5Data.vb
+++ b/instat/dlgImportERA5Data.vb
@@ -23,7 +23,6 @@ Public Class dlgImportERA5Data
     Private clsConcLonFunction As New RFunction
     Private clsConcLatFunction As New RFunction
     Private Sub dlgImportERA5Data_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -35,6 +34,7 @@ Public Class dlgImportERA5Data
         SetRCodeForControls(bReset)
         bReset = False
         TestOkEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgImportFromODK.vb
+++ b/instat/dlgImportFromODK.vb
@@ -22,7 +22,6 @@ Public Class dlgImportFromODK
     Private clsGetFormsFunction, clsDefaultRFunction As New RFunction
 
     Private Sub dlgImportFromODK_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -33,6 +32,7 @@ Public Class dlgImportFromODK
         SetRCodeForControls(bReset)
         bReset = False
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgImportGriddedData.vb
+++ b/instat/dlgImportGriddedData.vb
@@ -22,7 +22,6 @@ Public Class dlgImportGriddedData
     Private clsDownloadFromIRIFunction As RFunction
     Private dctDownloadPairs, dctFiles As New Dictionary(Of String, String)
     Private Sub dlgImportGriddedData_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -33,6 +32,7 @@ Public Class dlgImportGriddedData
         SetRCodeForControls(bReset)
         bReset = False
         TestOkEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgImportOpenRefine.vb
+++ b/instat/dlgImportOpenRefine.vb
@@ -22,7 +22,6 @@ Public Class dlgImportOpenRefine
     Private clsImportFunction As New RFunction
 
     Private Sub dlgImportOpenRefine_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -32,6 +31,7 @@ Public Class dlgImportOpenRefine
         End If
         SetRCodeForControls(bReset)
         bReset = False
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgInfillMissingValues.vb
+++ b/instat/dlgInfillMissingValues.vb
@@ -23,7 +23,6 @@ Public Class dlgInfillMissingValues
     Private clsApproximateFunction, clsAggregateFunction, clsNaLocfFunction, clsSplineFunction, clsNaFillFunction, clsStructTSFunction, clsSetSeedFunction, clsAveFunction, clsPatchClimateElementFunction, clsVisualizeElementNa As New RFunction
     Private clsBracketOperator As New ROperator
     Private Sub dlgInfillMissingValues_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             iDialogHeight = Me.Height
             iBaseMaxY = ucrBase.Location.Y
@@ -36,6 +35,7 @@ Public Class dlgInfillMissingValues
         SetRCodeForControls(bReset)
         bReset = False
         TestOkEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgLabelsLevels.vb
+++ b/instat/dlgLabelsLevels.vb
@@ -32,10 +32,10 @@ Public Class dlgLabelsLevels
         End If
         SetRCodeforControls(bReset)
         bReset = False
-        autoTranslate(Me)
         If bUseSelectedColumn Then
             SetDefaultColumn()
         End If
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgLocatingPointsInShapeFile.vb
+++ b/instat/dlgLocatingPointsInShapeFile.vb
@@ -29,7 +29,6 @@ Public Class dlgLocatingPointsInShapeFile
     Private clsOpeningSubsetOperator, clsIsEqualToOperator, clsEqualOpeningSubsetOperator, clsClosingSubsetOperator As New ROperator
 
     Private Sub dlgLocatingPointsInShapeFile_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitiliseDialog()
             bFirstLoad = False
@@ -41,6 +40,7 @@ Public Class dlgLocatingPointsInShapeFile
         SetRCodeForControls(bReset)
         bReset = False
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitiliseDialog()

--- a/instat/dlgLockUnlock.vb
+++ b/instat/dlgLockUnlock.vb
@@ -20,7 +20,6 @@ Public Class dlgLockUnlock
     Private bReset As Boolean = True
 
     Private Sub dlgLockUnlock_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -31,6 +30,7 @@ Public Class dlgLockUnlock
         SetRCodeForControls(bReset)
         bReset = False
         TestOkEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgMerge.vb
+++ b/instat/dlgMerge.vb
@@ -43,9 +43,9 @@ Public Class dlgMerge
         End If
         SetRCodeForControls(bReset)
         bReset = False
-        autoTranslate(Me)
         SetMergingBy()
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgMetadata.vb
+++ b/instat/dlgMetadata.vb
@@ -23,7 +23,6 @@ Public Class dlgMetadata
     Private clsLayerParam As New LayerParameter
 
     Private Sub dlgMetadata_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
 
         If bFirstLoad Then
             InitialiseDialog()
@@ -33,6 +32,7 @@ Public Class dlgMetadata
             ReopenDialog()
         End If
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub ReopenDialog()

--- a/instat/dlgMissingData.vb
+++ b/instat/dlgMissingData.vb
@@ -19,7 +19,6 @@ Public Class dlgMissingData
     Public bFirstLoad As Boolean = True
 
     Private Sub dlgMissingData_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             SetDefaults()
@@ -27,6 +26,7 @@ Public Class dlgMissingData
         End If
         TestOKEnabled()
 
+        autoTranslate(Me)
     End Sub
 
     Private Sub TestOKEnabled()

--- a/instat/dlgMissingDataTable.vb
+++ b/instat/dlgMissingDataTable.vb
@@ -19,7 +19,6 @@ Public Class dlgMissingDataTable
 
     Public bFirstLoad As Boolean = True
     Private Sub dlgMissingDataTable_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             SetDefaults()
@@ -27,6 +26,7 @@ Public Class dlgMissingDataTable
         End If
         TestOKEnabled()
 
+        autoTranslate(Me)
     End Sub
 
     Private Sub TestOKEnabled()

--- a/instat/dlgName.vb
+++ b/instat/dlgName.vb
@@ -26,7 +26,6 @@ Public Class dlgName
     Private clsDefaultRFunction As New RFunction
 
     Private Sub dlgName_Load(sender As Object, e As EventArgs) Handles Me.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -39,6 +38,7 @@ Public Class dlgName
         If bUseSelectedColumn Then
             SetSelectedColumn()
         End If
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgNewMarkovChains.vb
+++ b/instat/dlgNewMarkovChains.vb
@@ -45,13 +45,13 @@ Public Class dlgNewMarkovChains
     Private clsModelOutput As New RFunction
 
     Private Sub dlgNewMarkovChains_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             SetDefaults()
             bFirstLoad = False
         End If
         TestOkEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgNon-ParametricOneWayANOVA.vb
+++ b/instat/dlgNon-ParametricOneWayANOVA.vb
@@ -22,7 +22,6 @@ Public Class dlgNon_ParametricOneWayANOVA
     Private clsKruskalWallis As New RFunction
 
     Private Sub dlgNon_ParametricOneWayANOVA_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -33,6 +32,7 @@ Public Class dlgNon_ParametricOneWayANOVA
         SetRCodeForControls(bReset)
         bReset = False
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgOneVarCompareModels.vb
+++ b/instat/dlgOneVarCompareModels.vb
@@ -1,4 +1,4 @@
-' R- Instat
+﻿' R- Instat
 ' Copyright (C) 2015-2017
 '
 ' This program is free software: you can redistribute it and/or modify
@@ -24,7 +24,6 @@ Public Class dlgOneVarCompareModels
     Private clsChisqtableOperator, clsChisqbreaksOperator As New ROperator
 
     Private Sub dlgOneVarCompareModels_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -35,6 +34,7 @@ Public Class dlgOneVarCompareModels
         SetRCodeForControls(bReset)
         bReset = False
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgOneVarFitModel.vb
+++ b/instat/dlgOneVarFitModel.vb
@@ -32,7 +32,6 @@ Public Class dlgOneVarFitModel
     Private ReadOnly strSeparator As String = "---------------------"
 
     Private Sub dlgOneVarFitModel_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         bRCodeSet = False
         If bFirstload Then
             InitialiseDialog()
@@ -45,6 +44,7 @@ Public Class dlgOneVarFitModel
         bRCodeSet = True
         bReset = False
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgOneVarUseModel.vb
+++ b/instat/dlgOneVarUseModel.vb
@@ -26,7 +26,6 @@ Public Class dlgOneVarUseModel
     Private bPlot As Boolean
 
     Private Sub dlgOneVarUseModel_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bfirstload Then
             InitialiseDialog()
             bfirstload = False
@@ -37,6 +36,7 @@ Public Class dlgOneVarUseModel
         SetRCodeForControls(bReset)
         bReset = False
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgOneVariableGraph.vb
+++ b/instat/dlgOneVariableGraph.vb
@@ -25,7 +25,6 @@ Public Class dlgOneVariableGraph
     Public strDefaultColumns() As String = Nothing
 
     Private Sub dlgOneVariableGraph_Load(sender As Object, e As EventArgs) Handles Me.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -38,6 +37,7 @@ Public Class dlgOneVariableGraph
         bReset = False
         ReopenDialog()
         TestOkEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgOneWayFrequencies.vb
+++ b/instat/dlgOneWayFrequencies.vb
@@ -28,7 +28,6 @@ Public Class dlgOneWayFrequencies
     Public strDefaultColumns() As String = Nothing
 
     Private Sub dlgOneWayFrequencies_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -40,6 +39,7 @@ Public Class dlgOneWayFrequencies
         SetDefaultColumn()
         bReset = False
         TestOkEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgOpenNetCDF.vb
+++ b/instat/dlgOpenNetCDF.vb
@@ -51,7 +51,6 @@ Public Class dlgOpenNetCDF
     End Sub
 
     Private Sub dlgOpenNetCDF_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -68,6 +67,7 @@ Public Class dlgOpenNetCDF
         End If
         bReset = False
         TestOkEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub OpenFile()

--- a/instat/dlgOpenSST.vb
+++ b/instat/dlgOpenSST.vb
@@ -48,7 +48,6 @@ Public Class dlgOpenSST
     End Sub
 
     Private Sub dlgImportDataset_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         Me.Show()
         If bFirstLoad Then
             InitialiseDialog()
@@ -60,6 +59,7 @@ Public Class dlgOpenSST
             bStartOpenDialog = False
         End If
         TestOkEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgOptions.vb
+++ b/instat/dlgOptions.vb
@@ -239,7 +239,6 @@ Public Class dlgOptions
         cmdCancel.Enabled = False
         cmdHelp.Enabled = False
         SetInstatOptions()
-        autoTranslate(Me)
         SetView() 'needed to ensure that the tree view in the left panel correctly displays translated text
 
         If frmMain.Visible AndAlso strCurrLanguageCulture <> strPrevLanguageCulture Then
@@ -253,6 +252,7 @@ Public Class dlgOptions
         cmdHelp.Enabled = True
         ApplyEnabled(False)
         Cursor = Cursors.Default
+        autoTranslate(Me)
     End Sub
 
     Private Sub ucrPnlLanguage_ControlValueChanged() Handles ucrPnlLanguage.ControlValueChanged

--- a/instat/dlgOptions.vb
+++ b/instat/dlgOptions.vb
@@ -239,6 +239,7 @@ Public Class dlgOptions
         cmdCancel.Enabled = False
         cmdHelp.Enabled = False
         SetInstatOptions()
+        autoTranslate(Me)
         SetView() 'needed to ensure that the tree view in the left panel correctly displays translated text
 
         If frmMain.Visible AndAlso strCurrLanguageCulture <> strPrevLanguageCulture Then
@@ -252,7 +253,6 @@ Public Class dlgOptions
         cmdHelp.Enabled = True
         ApplyEnabled(False)
         Cursor = Cursors.Default
-        autoTranslate(Me)
     End Sub
 
     Private Sub ucrPnlLanguage_ControlValueChanged() Handles ucrPnlLanguage.ControlValueChanged

--- a/instat/dlgOptionsByContextFItModel.vb
+++ b/instat/dlgOptionsByContextFItModel.vb
@@ -45,7 +45,6 @@ Public Class dlgOptionsByContextFitModel
     Private dctPlotFunctions As New Dictionary(Of String, RFunction)
 
     Private Sub dlgOptionsByContextFItModel_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -56,6 +55,7 @@ Public Class dlgOptionsByContextFitModel
         SetRCodeForControls(bReset)
         bReset = False
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgOtherRosePlots.vb
+++ b/instat/dlgOtherRosePlots.vb
@@ -23,7 +23,6 @@ Public Class dlgOtherRosePlots
     Private clsOtherRosePlots As New RFunction
 
     Private Sub dlgOtherRosePlots_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitiliseDialog()
             bFirstLoad = False
@@ -35,6 +34,7 @@ Public Class dlgOtherRosePlots
         SetRCodeForControls(bReset)
         bReset = False
         TestOkEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitiliseDialog()

--- a/instat/dlgPICSACrops.vb
+++ b/instat/dlgPICSACrops.vb
@@ -23,7 +23,6 @@ Public Class dlgPICSACrops
     Private strCurrDataName As String = ""
 
     Private Sub dlgPICSACrops_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -34,6 +33,7 @@ Public Class dlgPICSACrops
         SetRCodeForControls(bReset)
         bReset = False
         TestOkEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgPICSARainfall.vb
+++ b/instat/dlgPICSARainfall.vb
@@ -123,9 +123,9 @@ Public Class dlgPICSARainfall
         End If
         SetRCodeForControls(bReset)
         bReset = False
-        autoTranslate(Me)
         XAxisDataTypeCheck()
         TestOkEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgPICSATemperature.vb
+++ b/instat/dlgPICSATemperature.vb
@@ -18,13 +18,13 @@ Imports instat.Translations
 Public Class dlgPICSATemperature
     Public bFirstLoad As Boolean = True
     Private Sub dlgPICSATemperature_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             SetDefaults()
             bFirstLoad = False
         End If
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
     Private Sub InitialiseDialog()
         ucrBase.iHelpTopicID = 479

--- a/instat/dlgParallelCoordinatePlot.vb
+++ b/instat/dlgParallelCoordinatePlot.vb
@@ -37,7 +37,6 @@ Public Class dlgParallelCoordinatePlot
     Private clsScaleColourViridisFunction As New RFunction
 
     Private Sub dlgParallelCoordinatePlot_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstload Then
             InitialiseDialog()
             bFirstload = False
@@ -47,8 +46,8 @@ Public Class dlgParallelCoordinatePlot
         End If
         SetRCodeForControls(bReset)
         bReset = False
-        autoTranslate(Me)
         TestOkEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgPermuteColumn.vb
+++ b/instat/dlgPermuteColumn.vb
@@ -21,7 +21,6 @@ Public Class dlgPermuteColumn
     Private bReset As Boolean = True
 
     Private Sub dlgPermuteRows_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -32,6 +31,7 @@ Public Class dlgPermuteColumn
         SetRCodeForControls(bReset)
         bReset = False
         TestOkEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgPolynomials.vb
+++ b/instat/dlgPolynomials.vb
@@ -21,7 +21,6 @@ Public Class dlgPolynomials
     Private clsPolynomial As New RFunction
     Public clsScale As New RFunction
     Private Sub dlgPolynomials_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -31,6 +30,7 @@ Public Class dlgPolynomials
         End If
         SetRCodeForControls(bReset)
         bReset = False
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgPrintPreviewOptions.vb
+++ b/instat/dlgPrintPreviewOptions.vb
@@ -167,8 +167,8 @@ Public Class dlgPrintPreviewOptions
 
     Private Sub dlgPrintPreviewOptions_Load(sender As Object, e As EventArgs) Handles Me.Load
         sheetPreview = frmEditor.grdData.CurrentWorksheet
-        autoTranslate(Me)
         setDefaults()
+        autoTranslate(Me)
     End Sub
 
     Private Sub setDefaults()

--- a/instat/dlgRandomSubsets.vb
+++ b/instat/dlgRandomSubsets.vb
@@ -21,7 +21,6 @@ Public Class dlgRandomSubsets
     Private clsDataFrame, clsSetSeed, clsSample, clsReplicate As New RFunction
 
     Private Sub dlgRandomSubsets_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -31,6 +30,7 @@ Public Class dlgRandomSubsets
         End If
         SetRCodeForControls(bReset)
         bReset = False
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgRank.vb
+++ b/instat/dlgRank.vb
@@ -21,7 +21,6 @@ Public Class dlgRank
     Private bReset As Boolean = True
     Private clsRankFunction As New RFunction
     Private Sub dlgRank_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -32,6 +31,7 @@ Public Class dlgRank
         SetRCodeForControls(bReset)
         bReset = False
         ' TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgRatingScales.vb
+++ b/instat/dlgRatingScales.vb
@@ -28,10 +28,10 @@ Public Class dlgRatingScales
         If bReset Then
             SetDefaults()
         End If
-        autoTranslate(Me)
         SetRCodeForControls(bReset)
         bReset = False
         TestOkEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgRecodeNumericIntoQuantiles.vb
+++ b/instat/dlgRecodeNumericIntoQuantiles.vb
@@ -21,7 +21,6 @@ Public Class dlgRecodeNumericIntoQuantiles
     Private iLength As Integer
     Private clsBincodeFunction, clsQuantileFunction, clsSeqFunction As New RFunction
     Private Sub dlgRecodeNumericIntoQuantiles_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -31,6 +30,7 @@ Public Class dlgRecodeNumericIntoQuantiles
         End If
         SetRCodeForControls(bReset)
         bReset = False
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgReferenceLevel.vb
+++ b/instat/dlgReferenceLevel.vb
@@ -21,7 +21,6 @@ Public Class dlgReferenceLevel
     Private bReset As Boolean = True
     Private clsSetRefLevel As New RFunction
     Private Sub dlgReferenceLevel_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -32,6 +31,7 @@ Public Class dlgReferenceLevel
         SetRCodeforControls(bReset)
         bReset = False
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgRegularSequence.vb
+++ b/instat/dlgRegularSequence.vb
@@ -36,10 +36,10 @@ Public Class dlgRegularSequence
         If bReset Then
             SetDefaults()
         End If
-        autoTranslate(Me)
         SetDefaultRdo()
         SetRCodeForControls(bReset)
         bReset = False
+        autoTranslate(Me)
     End Sub
     'This sub is meant to set the default radiobutton on diffrent places on the Menu.
     Private Sub SetDefaultRdo()

--- a/instat/dlgRenameMetadata.vb
+++ b/instat/dlgRenameMetadata.vb
@@ -18,7 +18,6 @@ Imports instat.Translations
 Public Class dlgRenameMetadata
     Private bFirstLoad As Boolean = True
     Private Sub dlgRenameMetadata_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             setDefaults()
             InitialiseDialog()
@@ -27,6 +26,7 @@ Public Class dlgRenameMetadata
             ReopenDialog()
         End If
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub ReopenDialog()

--- a/instat/dlgRenameObjects.vb
+++ b/instat/dlgRenameObjects.vb
@@ -35,11 +35,11 @@ Public Class dlgRenameObjects
         End If
         SetRCodeforControls(bReset)
         bReset = False
-        autoTranslate(Me)
         TestOKEnabled()
         If bUseSelectedColumn Then
             SetDefaultColumn()
         End If
+        autoTranslate(Me)
     End Sub
 
     Private Sub ReopenDialog()

--- a/instat/dlgReorderDataFrame.vb
+++ b/instat/dlgReorderDataFrame.vb
@@ -33,7 +33,6 @@ Public Class dlgReorderDataFrame
     Private bFirstLoad As Boolean = True
     Private clsReorderDataFrame As New RFunction
     Private Sub dlgReorderDataFrame_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -44,6 +43,7 @@ Public Class dlgReorderDataFrame
         SetRCodeForControls(bReset)
         bReset = False
         TestOkEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgReorderMetadata.vb
+++ b/instat/dlgReorderMetadata.vb
@@ -19,7 +19,6 @@ Public Class dlgReorderMetadata
     Public bFirstLoad As Boolean = True
     Private bReset As Boolean = True
     Private Sub dlgReorderMetadata_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -31,6 +30,7 @@ Public Class dlgReorderMetadata
         bReset = False
         ReopenDialog()
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     Public Sub SetRCodeForControls(bReset As Boolean)

--- a/instat/dlgReorderSheet.vb
+++ b/instat/dlgReorderSheet.vb
@@ -20,7 +20,6 @@ Public Class dlgReorderSheet
     Private bFirstLoad As Boolean = True
     Private clsReorderDataFrame As New RFunction
     Private Sub dlgReorderDataFrame_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -31,6 +30,7 @@ Public Class dlgReorderSheet
         SetRCodeForControls(bReset)
         bReset = False
         TestOkEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgReplaceValues.vb
+++ b/instat/dlgReplaceValues.vb
@@ -23,7 +23,6 @@ Public Class dlgReplaceValues
     Private strVarType As String = ""
 
     Private Sub dlgReplace_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -34,6 +33,7 @@ Public Class dlgReplaceValues
         SetRCodeForControls(bReset)
         bReset = False
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgRownamesOrNumbers.vb
+++ b/instat/dlgRownamesOrNumbers.vb
@@ -22,7 +22,6 @@ Public Class dlgRowNamesOrNumbers
     Private clsRowNamesFunction As New RFunction
 
     Private Sub dlgRowNamesOrNumbers_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -34,6 +33,7 @@ Public Class dlgRowNamesOrNumbers
         SetRCodeForControls(bReset)
         bReset = False
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgScatterPlot.vb
+++ b/instat/dlgScatterPlot.vb
@@ -50,7 +50,6 @@ Public Class dlgScatterPlot
     Private strGeomParameterNames() As String = {strFirstParameterName, strGeomSmoothParameterName}
 
     Private Sub dlgScatterPlot_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -62,6 +61,7 @@ Public Class dlgScatterPlot
         bReset = False
         TestOkEnabled()
         CheckIfNumeric()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgSeasonalPlot.vb
+++ b/instat/dlgSeasonalPlot.vb
@@ -83,7 +83,6 @@ Public Class dlgSeasonalPlot
     Private clsYlabFunction As RFunction
 
     Private Sub dlgSeasonalPlot_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitiliseDialog()
             bFirstLoad = False
@@ -95,6 +94,7 @@ Public Class dlgSeasonalPlot
         SetRCodeForControls(bReset)
         bReset = False
         TestOkEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitiliseDialog()

--- a/instat/dlgSeasonalSummary.vb
+++ b/instat/dlgSeasonalSummary.vb
@@ -20,7 +20,6 @@ Public Class dlgSeasonalSummary
 
 
     Private Sub dlgSeasonalSummary_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
 
         If bFirstLoad Then
             InitialiseDialog()
@@ -29,6 +28,7 @@ Public Class dlgSeasonalSummary
         End If
         TestOKEnabled()
 
+        autoTranslate(Me)
     End Sub
 
     Private Sub TestOKEnabled()

--- a/instat/dlgShiftDailyData.vb
+++ b/instat/dlgShiftDailyData.vb
@@ -18,7 +18,6 @@ Imports instat.Translations
 Public Class dlgShiftDailyData
     Public bFirstLoad As Boolean = True
     Private Sub dlgShiftDailyData_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             SetDefaults()
@@ -26,6 +25,7 @@ Public Class dlgShiftDailyData
         End If
         TestOKEnabled()
 
+        autoTranslate(Me)
     End Sub
 
     Private Sub TestOKEnabled()

--- a/instat/dlgSite.vb
+++ b/instat/dlgSite.vb
@@ -18,7 +18,6 @@ Imports instat.Translations
 Public Class dlgSite
     Public bFirstLoad As Boolean = True
     Private Sub dlgSite_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             SetDefaults()
@@ -26,6 +25,7 @@ Public Class dlgSite
         End If
         TestOKEnabled()
 
+        autoTranslate(Me)
     End Sub
 
     Private Sub TestOKEnabled()

--- a/instat/dlgSpells.vb
+++ b/instat/dlgSpells.vb
@@ -35,7 +35,6 @@ Public Class dlgSpells
     Private strExcludingBetween As String = "Excluding between"
 
     Private Sub dlgSpells_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstload Then
             InitialiseDialog()
             bFirstload = False
@@ -46,6 +45,7 @@ Public Class dlgSpells
         SetRCodeForControls(bReset)
         bReset = False
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgSplitText.vb
+++ b/instat/dlgSplitText.vb
@@ -23,7 +23,6 @@ Public Class dlgSplitText
     Private clsBinaryColumns As New RFunction
 
     Private Sub dlgSplitText_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -34,6 +33,7 @@ Public Class dlgSplitText
         SetRCodeForControls(bReset)
         bReset = False
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgStack.vb
+++ b/instat/dlgStack.vb
@@ -23,7 +23,6 @@ Public Class dlgStack
     Private bReset As Boolean = True
 
     Private Sub dlgStack_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -34,6 +33,7 @@ Public Class dlgStack
         SetRCodeForControls(bReset)
         bReset = False
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgStackDailyData.vb
+++ b/instat/dlgStackDailyData.vb
@@ -18,7 +18,6 @@ Imports instat.Translations
 Public Class dlgStackDailyData
     Public bFirstLoad As Boolean = True
     Private Sub dlgStackDailyData_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             SetDefaults()
@@ -26,6 +25,7 @@ Public Class dlgStackDailyData
         End If
         TestOKEnabled()
 
+        autoTranslate(Me)
     End Sub
 
     Private Sub TestOKEnabled()

--- a/instat/dlgStandardiseCountryNames.vb
+++ b/instat/dlgStandardiseCountryNames.vb
@@ -23,7 +23,6 @@ Public Class dlgStandardiseCountryNames
     Public strDefaultColumn As String = ""
 
     Private Sub dlgStandardiseCountryNames_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -34,6 +33,7 @@ Public Class dlgStandardiseCountryNames
         SetRCodeForControls(bReset)
         SetDefaultColumn()
         bReset = False
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgStartofRains.vb
+++ b/instat/dlgStartofRains.vb
@@ -72,7 +72,6 @@ Public Class dlgStartofRains
     Private strWetSpell As String = "wet_spell"
 
     Private Sub dlgStartofRains_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -82,8 +81,8 @@ Public Class dlgStartofRains
         End If
         SetRCodeForControls(bReset)
         bReset = False
-        autoTranslate(Me)
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgSummary.vb
+++ b/instat/dlgSummary.vb
@@ -18,7 +18,6 @@ Imports instat.Translations
 Public Class dlgSummary
     Public bFirstLoad As Boolean = True
     Private Sub dlgSummary_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
 
         If bFirstLoad Then
             InitialiseDialog()
@@ -27,6 +26,7 @@ Public Class dlgSummary
         End If
         TestOKEnabled()
 
+        autoTranslate(Me)
     End Sub
 
     Private Sub TestOKEnabled()

--- a/instat/dlgSunshine.vb
+++ b/instat/dlgSunshine.vb
@@ -18,13 +18,13 @@ Imports instat.Translations
 Public Class dlgSunshine
     Public bFirstLoad As Boolean = True
     Private Sub dlgSunshine_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             SetDefaults()
             bFirstLoad = False
         End If
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
     Private Sub InitialiseDialog()
         ucrBase.iHelpTopicID = 432

--- a/instat/dlgSurvivalObject.vb
+++ b/instat/dlgSurvivalObject.vb
@@ -28,7 +28,6 @@ Public Class dlgSurvivalObject
     Private clsCreateObjectScriptPaste As New RFunction
 
     Private Sub dlgSurvivalObject_Load(sender As Object, e As EventArgs) Handles Me.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -39,6 +38,7 @@ Public Class dlgSurvivalObject
         SetRCodeforControls(bReset)
         bReset = False
         TestOkEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgTaylorDiagram.vb
+++ b/instat/dlgTaylorDiagram.vb
@@ -20,7 +20,6 @@ Public Class dlgTaylorDiagram
     Private bReset As Boolean = True
     Private clsTaylorDiagramFunction As New RFunction
     Private Sub dlgTaylorDiagram_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -32,6 +31,7 @@ Public Class dlgTaylorDiagram
 
         bReset = False
         TestOkEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgTemperature.vb
+++ b/instat/dlgTemperature.vb
@@ -18,13 +18,13 @@ Imports instat.Translations
 Public Class dlgTemperature
     Public bFirstLoad As Boolean = True
     Private Sub dlgTemperature_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             SetDefaults()
             bFirstLoad = False
         End If
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
     Private Sub InitialiseDialog()
         ucrBase.iHelpTopicID = 424

--- a/instat/dlgThreeVariableFrequencies.vb
+++ b/instat/dlgThreeVariableFrequencies.vb
@@ -25,7 +25,6 @@ Public Class dlgThreeVariableFrequencies
     Private iMaxGraphGroupX As Integer
 
     Private Sub dlgThreeVariableFrequencies_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             iMaxGraphGroupX = grpFreqTypeGraph.Location.X
@@ -38,6 +37,7 @@ Public Class dlgThreeVariableFrequencies
         ReopenDialog()
         bReset = False
         TestOkEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub ReopenDialog()

--- a/instat/dlgThreeVariablesModelling.vb
+++ b/instat/dlgThreeVariablesModelling.vb
@@ -40,7 +40,6 @@ Public Class dlgThreeVariableModelling
 
     Private dctPlotFunctions As New Dictionary(Of String, RFunction)
     Private Sub dlgThreeVariableModelling_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -51,6 +50,7 @@ Public Class dlgThreeVariableModelling
         SetRCodeForControls(bReset)
         bReset = False
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgTidy.vb
+++ b/instat/dlgTidy.vb
@@ -1,5 +1,4 @@
-﻿
-Imports instat
+﻿Imports instat
 Imports instat.Translations
 Public Class dlgTidy
     Public bfirstload As Boolean = True
@@ -9,7 +8,6 @@ Public Class dlgTidy
     Private clsTidy, clsMap_df As New RFunction
 
     Private Sub dlgTidy_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bfirstload Then
             InitialiseDialog()
             bfirstload = False
@@ -20,6 +18,7 @@ Public Class dlgTidy
         SetRCodeForControls(bReset)
         bReset = False
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgTimeSeriesPlot.vb
+++ b/instat/dlgTimeSeriesPlot.vb
@@ -180,7 +180,6 @@ Public Class dlgTimeSeriesPlot
     'Private strGeomParameterNames() As String = {strGeomLineParameterName, strGeomPointParameterName, strGeomHLineParameterName, strGeomTextReferenceParameterName, strGeomTextEstimatesParameterName, strGeomTextComparisonParameterName}
 
     Private Sub dlgTimeSeriesPlot_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -191,6 +190,7 @@ Public Class dlgTimeSeriesPlot
         SetRCodeForControls(bReset)
         bReset = False
         TestOkEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgTransformText.vb
+++ b/instat/dlgTransformText.vb
@@ -27,7 +27,6 @@ Public Class dlgTransformText
     Private iNewColMaxY As Integer
 
     Private Sub dlgTransformText_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             iFullHeight = Me.Height
@@ -42,6 +41,7 @@ Public Class dlgTransformText
         SetRCodeForControls(bReset)
         bReset = False
         TestOkEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgTwoSampleNonparametricTest.vb
+++ b/instat/dlgTwoSampleNonparametricTest.vb
@@ -18,7 +18,6 @@ Imports instat.Translations
 Public Class dlgTwoSampleNonparametricTest
     Public bFirstLoad As Boolean = True
     Private Sub dlgTwoSampleNonparametricTest_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         ucrReceiverVariable.Selector = ucrTwoSampleSelector
         ucrReceiverFactor.Selector = ucrTwoSampleSelector
         ucrReceiverFactor.SetDataType("factor")
@@ -26,6 +25,7 @@ Public Class dlgTwoSampleNonparametricTest
         If bFirstLoad Then
             'setDeafaults
         End If
+        autoTranslate(Me)
     End Sub
     Private Sub SetDefaults()
         ucrTwoSampleSelector.Reset()

--- a/instat/dlgTwoVariableFitModel.vb
+++ b/instat/dlgTwoVariableFitModel.vb
@@ -63,7 +63,6 @@ Public Class dlgTwoVariableFitModel
     Public StrMedianValue As String = ""
 
     Private Sub dlgTwoVariableFitModel_Load(sender As Object, e As EventArgs) Handles Me.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -74,6 +73,7 @@ Public Class dlgTwoVariableFitModel
         SetRCodeForControls(bReset)
         bReset = False
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgTwoVariableUseModel.vb
+++ b/instat/dlgTwoVariableUseModel.vb
@@ -22,7 +22,6 @@ Public Class dlgTwoVariableUseModel
     Dim strModel As String
 
     Private Sub dlgTwoVariableUseModel_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             SetDefaults()
@@ -31,6 +30,7 @@ Public Class dlgTwoVariableUseModel
             ReOpenDialog()
         End If
         TestOkEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub SetDefaults()

--- a/instat/dlgTwoWayFrequencies.vb
+++ b/instat/dlgTwoWayFrequencies.vb
@@ -28,7 +28,6 @@ Public Class dlgTwoWayFrequencies
     Private iTableTypeMaxX As Integer
 
     Private Sub dlgTwoWayFrequencies_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -45,6 +44,7 @@ Public Class dlgTwoWayFrequencies
         'temp needed because of show/hiding bug
         SetLocations()
         TestOkEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgUseGraph.vb
+++ b/instat/dlgUseGraph.vb
@@ -37,7 +37,6 @@ Public Class dlgUseGraph
     Private dctThemeFunctions As New Dictionary(Of String, RFunction)
 
     Private Sub dlgUseGraph_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -48,6 +47,7 @@ Public Class dlgUseGraph
         SetRCodeForControls(bReset)
         bReset = False
         TestOkEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgView.vb
+++ b/instat/dlgView.vb
@@ -23,7 +23,6 @@ Public Class dlgView
     Private bControlsUpdated As Boolean = False
 
     Private Sub dlgView_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -34,6 +33,7 @@ Public Class dlgView
         SetRCodeForControls(bReset)
         bReset = False
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgViewAndRemoveKeys.vb
+++ b/instat/dlgViewAndRemoveKeys.vb
@@ -21,7 +21,6 @@ Public Class dlgViewAndRemoveKeys
     Private clsGetKey As New RFunction
     Private clsRemoveKey As New RFunction
     Private Sub dlgViewAndRemoveKeys_Load(sender As Object, e As EventArgs) Handles Me.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -32,6 +31,7 @@ Public Class dlgViewAndRemoveKeys
         SetRCodeForControls(bReset)
         bReset = False
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgViewAndRemoveLinks.vb
+++ b/instat/dlgViewAndRemoveLinks.vb
@@ -22,7 +22,6 @@ Public Class dlgViewAndRemoveLinks
     Private clsDeleteLinks As New RFunction
 
     Private Sub dlgViewAndRemoveLinks_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -35,6 +34,7 @@ Public Class dlgViewAndRemoveLinks
         SetRCodeForControls(bReset)
         bReset = False
         TestOKEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgViewGraph.vb
+++ b/instat/dlgViewGraph.vb
@@ -23,7 +23,6 @@ Public Class dlgViewGraph
     Private strGlobalGraphDisplayOption As String
 
     Private Sub dlgViewGraph_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         strGlobalGraphDisplayOption = frmMain.clsInstatOptions.strGraphDisplayOption
         If bFirstLoad Then
             InitialiseDialog()
@@ -36,6 +35,7 @@ Public Class dlgViewGraph
         SetGraphDisplayType()
         bReset = False
         TestOkEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgViewLabelsAndLevels.vb
+++ b/instat/dlgViewLabelsAndLevels.vb
@@ -21,7 +21,6 @@ Public Class dlgViewFactorLabels
     Private clsViewFunction, clsSelect As RFunction
 
     Private Sub dlgLabelAndLevels_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -32,6 +31,7 @@ Public Class dlgViewFactorLabels
         SetRCodeForControls(bReset)
         bReset = False
         TestOkEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/sdgDataOptions.vb
+++ b/instat/sdgDataOptions.vb
@@ -35,12 +35,12 @@ Public Class sdgDataOptions
     End Sub
 
     Private Sub sdgDataOptions_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             SetDefaults()
             bFirstLoad = False
         End If
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/sdgFiltersFromFactor.vb
+++ b/instat/sdgFiltersFromFactor.vb
@@ -31,11 +31,11 @@ Public Class sdgFiltersFromFactor
     End Sub
 
     Private Sub sdgFiltersFromFactor_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseControls()
             bFirstLoad = False
         End If
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseControls()

--- a/instat/sdgFrequency.vb
+++ b/instat/sdgFrequency.vb
@@ -19,7 +19,6 @@ Public Class sdgFrequency
     Private bFirstLoad As Boolean
     Private bReset As Boolean
     Private Sub sdgFrequency_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
@@ -28,7 +27,7 @@ Public Class sdgFrequency
             SetDefaults()
         End If
         bReset = False
-
+        autoTranslate(Me)
     End Sub
 
     Private Sub SetDefaults()

--- a/instat/sdgImportFromClimSoft.vb
+++ b/instat/sdgImportFromClimSoft.vb
@@ -25,7 +25,6 @@ Public Class sdgImportFromClimSoft
     Private bConnected As Boolean
 
     Private Sub sdgImportFromClimSoft_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bFirstLoad Then
             InitialiseDialog()
             SetDefaults()
@@ -35,6 +34,7 @@ Public Class sdgImportFromClimSoft
         'could have been connected through the wizard. So check here
         bConnected = IsConnectionIsActive()
         UpdateConnectionAndControlsState()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/sdgSaveColumnPosition.vb
+++ b/instat/sdgSaveColumnPosition.vb
@@ -35,11 +35,11 @@ Public Class sdgSaveColumnPosition
     Public bRcodeFlag As Boolean = False
 
     Private Sub sdgSaveColumnPosition_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         If bControlsNotInitialised Then
             InitialiseControl()
             bControlsNotInitialised = False
         End If
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseControl()

--- a/instat/sdgSelectMonth.vb
+++ b/instat/sdgSelectMonth.vb
@@ -22,8 +22,8 @@ Public Class sdgSelectMonth
     Private clsListCalcFunction As New RFunction
 
     Private Sub sdgSelectMonth_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        autoTranslate(Me)
         InitialiseControls()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseControls()


### PR DESCRIPTION
Partially fixes issue #6473.

When a dialog opens, then it's `_Load` sub is called (e.g. `Private Sub dlgAppend_Load(...`). This sub should contain the line `autoTranslate(Me)`. This line translates the dialog text into the required language (e.g. French). It should normally be the last line in the `_Load` sub. If the line appears too early in the sub, and dialog text is changed in a subsequent line, then the changed text is not translated.

Many of the dialogs already (correctly) have the `autoTranslate(Me)` line at the end of the sub. I wrote a script to identify all the dialogs that did not. For these dialogs, this PR moves the `autoTranslate(Me)` line to the end of the `_Load` function. 

There were a large number of dialogs that required this. Therefore to save time and reduce the risk of manual error, I wrote a script to update the code automatically. I also manualy updated subdialogs and other classes as required.

Please note that it's possible that some of the corrected dialogs did not have any user-detectable translation errors. However, best practice is to translate at the end of the `_Load` sub. I decided it was safer to update all dialogs that contained this potential bug, and have the `_Load` sub implemented in the standard way.

@rdstern There are a large number of changed files. I believe the change is low risk and it is sufficient just to test a sample of the updated dialogs. Please could you look at the list of changed files in this PR, test all the changed subdialogs (`sdg...`), plus a sample of the dialog boxes? 

@shadrackkibet Please could you review? Can you think of any side-effects from moving the `autoTranslate(Me)` to the end of the `_Load` sub?
Unfortunately GitHub diff flagged some lines as changed when they are not. The only real changes are relocations of `autoTranslate(Me)`.

Many thanks
