### PR TITLE
Improved presentation of French & Portuguese text in Convert Columns dialog

### DIFF
--- a/instat/dlgConvertColumns.Designer.vb
+++ b/instat/dlgConvertColumns.Designer.vb
@@ -47,20 +47,20 @@ Partial Class dlgConvertColumns
         Me.rdoNumeric = New System.Windows.Forms.RadioButton()
         Me.rdoOrderedFactor = New System.Windows.Forms.RadioButton()
         Me.rdoFactor = New System.Windows.Forms.RadioButton()
-        Me.ucrPnlConvertTo = New instat.UcrPanel()
         Me.rdoConvertOrdinals = New System.Windows.Forms.RadioButton()
         Me.grpFactorToNumericOptions = New System.Windows.Forms.GroupBox()
         Me.rdoDefault = New System.Windows.Forms.RadioButton()
         Me.rdoConvertLevels = New System.Windows.Forms.RadioButton()
+        Me.ucrChkIgnoreLabels = New instat.ucrCheck()
+        Me.ucrChkCreateLabels = New instat.ucrCheck()
         Me.ucrPnlFactorToNumericOptions = New instat.UcrPanel()
         Me.ucrChkKeepAttributes = New instat.ucrCheck()
         Me.ucrNudDisplayDecimals = New instat.ucrNud()
         Me.ucrChkSpecifyDecimalsToDisplay = New instat.ucrCheck()
+        Me.ucrPnlConvertTo = New instat.UcrPanel()
         Me.ucrSelectorDataFrameColumns = New instat.ucrSelectorByDataFrameAddRemove()
         Me.ucrReceiverColumnsToConvert = New instat.ucrReceiverMultiple()
         Me.ucrBase = New instat.ucrButtons()
-        Me.ucrChkCreateLabels = New instat.ucrCheck()
-        Me.ucrChkIgnoreLabels = New instat.ucrCheck()
         Me.grpConvertTo.SuspendLayout()
         Me.grpFactorToNumericOptions.SuspendLayout()
         Me.SuspendLayout()
@@ -126,11 +126,6 @@ Partial Class dlgConvertColumns
         Me.rdoFactor.TabStop = True
         Me.rdoFactor.UseVisualStyleBackColor = True
         '
-        'ucrPnlConvertTo
-        '
-        resources.ApplyResources(Me.ucrPnlConvertTo, "ucrPnlConvertTo")
-        Me.ucrPnlConvertTo.Name = "ucrPnlConvertTo"
-        '
         'rdoConvertOrdinals
         '
         resources.ApplyResources(Me.rdoConvertOrdinals, "rdoConvertOrdinals")
@@ -162,6 +157,18 @@ Partial Class dlgConvertColumns
         Me.rdoConvertLevels.TabStop = True
         Me.rdoConvertLevels.UseVisualStyleBackColor = True
         '
+        'ucrChkIgnoreLabels
+        '
+        Me.ucrChkIgnoreLabels.Checked = False
+        resources.ApplyResources(Me.ucrChkIgnoreLabels, "ucrChkIgnoreLabels")
+        Me.ucrChkIgnoreLabels.Name = "ucrChkIgnoreLabels"
+        '
+        'ucrChkCreateLabels
+        '
+        Me.ucrChkCreateLabels.Checked = False
+        resources.ApplyResources(Me.ucrChkCreateLabels, "ucrChkCreateLabels")
+        Me.ucrChkCreateLabels.Name = "ucrChkCreateLabels"
+        '
         'ucrPnlFactorToNumericOptions
         '
         resources.ApplyResources(Me.ucrPnlFactorToNumericOptions, "ucrPnlFactorToNumericOptions")
@@ -189,6 +196,11 @@ Partial Class dlgConvertColumns
         resources.ApplyResources(Me.ucrChkSpecifyDecimalsToDisplay, "ucrChkSpecifyDecimalsToDisplay")
         Me.ucrChkSpecifyDecimalsToDisplay.Name = "ucrChkSpecifyDecimalsToDisplay"
         '
+        'ucrPnlConvertTo
+        '
+        resources.ApplyResources(Me.ucrPnlConvertTo, "ucrPnlConvertTo")
+        Me.ucrPnlConvertTo.Name = "ucrPnlConvertTo"
+        '
         'ucrSelectorDataFrameColumns
         '
         Me.ucrSelectorDataFrameColumns.bDropUnusedFilterLevels = False
@@ -210,18 +222,6 @@ Partial Class dlgConvertColumns
         '
         resources.ApplyResources(Me.ucrBase, "ucrBase")
         Me.ucrBase.Name = "ucrBase"
-        '
-        'ucrChkCreateLabels
-        '
-        Me.ucrChkCreateLabels.Checked = False
-        resources.ApplyResources(Me.ucrChkCreateLabels, "ucrChkCreateLabels")
-        Me.ucrChkCreateLabels.Name = "ucrChkCreateLabels"
-        '
-        'ucrChkIgnoreLabels
-        '
-        Me.ucrChkIgnoreLabels.Checked = False
-        resources.ApplyResources(Me.ucrChkIgnoreLabels, "ucrChkIgnoreLabels")
-        Me.ucrChkIgnoreLabels.Name = "ucrChkIgnoreLabels"
         '
         'dlgConvertColumns
         '

--- a/instat/dlgConvertColumns.resx
+++ b/instat/dlgConvertColumns.resx
@@ -121,6 +121,10 @@
   <data name="lblColumnsToConvert.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="lblColumnsToConvert.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="lblColumnsToConvert.Location" type="System.Drawing.Point, System.Drawing">
     <value>247, 45</value>
@@ -146,116 +150,11 @@
   <data name="&gt;&gt;lblColumnsToConvert.ZOrder" xml:space="preserve">
     <value>8</value>
   </data>
-  <data name="&gt;&gt;rdoLogical.Name" xml:space="preserve">
-    <value>rdoLogical</value>
-  </data>
-  <data name="&gt;&gt;rdoLogical.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rdoLogical.Parent" xml:space="preserve">
-    <value>grpConvertTo</value>
-  </data>
-  <data name="&gt;&gt;rdoLogical.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;rdoCharacter.Name" xml:space="preserve">
-    <value>rdoCharacter</value>
-  </data>
-  <data name="&gt;&gt;rdoCharacter.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rdoCharacter.Parent" xml:space="preserve">
-    <value>grpConvertTo</value>
-  </data>
-  <data name="&gt;&gt;rdoCharacter.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;rdoInteger.Name" xml:space="preserve">
-    <value>rdoInteger</value>
-  </data>
-  <data name="&gt;&gt;rdoInteger.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rdoInteger.Parent" xml:space="preserve">
-    <value>grpConvertTo</value>
-  </data>
-  <data name="&gt;&gt;rdoInteger.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;rdoNumeric.Name" xml:space="preserve">
-    <value>rdoNumeric</value>
-  </data>
-  <data name="&gt;&gt;rdoNumeric.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rdoNumeric.Parent" xml:space="preserve">
-    <value>grpConvertTo</value>
-  </data>
-  <data name="&gt;&gt;rdoNumeric.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;rdoOrderedFactor.Name" xml:space="preserve">
-    <value>rdoOrderedFactor</value>
-  </data>
-  <data name="&gt;&gt;rdoOrderedFactor.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rdoOrderedFactor.Parent" xml:space="preserve">
-    <value>grpConvertTo</value>
-  </data>
-  <data name="&gt;&gt;rdoOrderedFactor.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;rdoFactor.Name" xml:space="preserve">
-    <value>rdoFactor</value>
-  </data>
-  <data name="&gt;&gt;rdoFactor.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rdoFactor.Parent" xml:space="preserve">
-    <value>grpConvertTo</value>
-  </data>
-  <data name="&gt;&gt;rdoFactor.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;ucrPnlConvertTo.Name" xml:space="preserve">
-    <value>ucrPnlConvertTo</value>
-  </data>
-  <data name="&gt;&gt;ucrPnlConvertTo.Type" xml:space="preserve">
-    <value>instat.UcrPanel, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrPnlConvertTo.Parent" xml:space="preserve">
-    <value>grpConvertTo</value>
-  </data>
-  <data name="&gt;&gt;ucrPnlConvertTo.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="grpConvertTo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 196</value>
-  </data>
-  <data name="grpConvertTo.Size" type="System.Drawing.Size, System.Drawing">
-    <value>357, 88</value>
-  </data>
-  <data name="grpConvertTo.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="grpConvertTo.Text" xml:space="preserve">
-    <value>Convert To</value>
-  </data>
-  <data name="&gt;&gt;grpConvertTo.Name" xml:space="preserve">
-    <value>grpConvertTo</value>
-  </data>
-  <data name="&gt;&gt;grpConvertTo.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;grpConvertTo.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;grpConvertTo.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
   <data name="rdoLogical.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
+  </data>
+  <data name="rdoLogical.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
   <data name="rdoLogical.Location" type="System.Drawing.Point, System.Drawing">
     <value>237, 66</value>
@@ -284,6 +183,9 @@
   <data name="rdoCharacter.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
+  <data name="rdoCharacter.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
   <data name="rdoCharacter.Location" type="System.Drawing.Point, System.Drawing">
     <value>10, 66</value>
   </data>
@@ -310,6 +212,9 @@
   </data>
   <data name="rdoInteger.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
+  </data>
+  <data name="rdoInteger.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
   <data name="rdoInteger.Location" type="System.Drawing.Point, System.Drawing">
     <value>237, 43</value>
@@ -338,6 +243,9 @@
   <data name="rdoNumeric.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
+  <data name="rdoNumeric.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
   <data name="rdoNumeric.Location" type="System.Drawing.Point, System.Drawing">
     <value>237, 21</value>
   </data>
@@ -365,6 +273,9 @@
   <data name="rdoOrderedFactor.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
+  <data name="rdoOrderedFactor.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
   <data name="rdoOrderedFactor.Location" type="System.Drawing.Point, System.Drawing">
     <value>10, 43</value>
   </data>
@@ -391,6 +302,9 @@
   </data>
   <data name="rdoFactor.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
+  </data>
+  <data name="rdoFactor.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
   <data name="rdoFactor.Location" type="System.Drawing.Point, System.Drawing">
     <value>10, 21</value>
@@ -437,14 +351,38 @@
   <data name="&gt;&gt;ucrPnlConvertTo.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
-  <data name="rdoConvertOrdinals.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
+  <data name="grpConvertTo.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 196</value>
+  </data>
+  <data name="grpConvertTo.Size" type="System.Drawing.Size, System.Drawing">
+    <value>357, 88</value>
+  </data>
+  <data name="grpConvertTo.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="grpConvertTo.Text" xml:space="preserve">
+    <value>Convert To</value>
+  </data>
+  <data name="&gt;&gt;grpConvertTo.Name" xml:space="preserve">
+    <value>grpConvertTo</value>
+  </data>
+  <data name="&gt;&gt;grpConvertTo.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;grpConvertTo.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;grpConvertTo.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="rdoConvertOrdinals.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
   <data name="rdoConvertOrdinals.Location" type="System.Drawing.Point, System.Drawing">
     <value>11, 66</value>
   </data>
   <data name="rdoConvertOrdinals.Size" type="System.Drawing.Size, System.Drawing">
-    <value>115, 17</value>
+    <value>195, 17</value>
   </data>
   <data name="rdoConvertOrdinals.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -464,68 +402,11 @@
   <data name="&gt;&gt;rdoConvertOrdinals.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="&gt;&gt;rdoDefault.Name" xml:space="preserve">
-    <value>rdoDefault</value>
-  </data>
-  <data name="&gt;&gt;rdoDefault.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rdoDefault.Parent" xml:space="preserve">
-    <value>grpFactorToNumericOptions</value>
-  </data>
-  <data name="&gt;&gt;rdoDefault.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;rdoConvertLevels.Name" xml:space="preserve">
-    <value>rdoConvertLevels</value>
-  </data>
-  <data name="&gt;&gt;rdoConvertLevels.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rdoConvertLevels.Parent" xml:space="preserve">
-    <value>grpFactorToNumericOptions</value>
-  </data>
-  <data name="&gt;&gt;rdoConvertLevels.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;ucrPnlFactorToNumericOptions.Name" xml:space="preserve">
-    <value>ucrPnlFactorToNumericOptions</value>
-  </data>
-  <data name="&gt;&gt;ucrPnlFactorToNumericOptions.Type" xml:space="preserve">
-    <value>instat.UcrPanel, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrPnlFactorToNumericOptions.Parent" xml:space="preserve">
-    <value>grpFactorToNumericOptions</value>
-  </data>
-  <data name="&gt;&gt;ucrPnlFactorToNumericOptions.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="grpFactorToNumericOptions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 312</value>
-  </data>
-  <data name="grpFactorToNumericOptions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>143, 92</value>
-  </data>
-  <data name="grpFactorToNumericOptions.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="grpFactorToNumericOptions.Text" xml:space="preserve">
-    <value>Factor Options</value>
-  </data>
-  <data name="&gt;&gt;grpFactorToNumericOptions.Name" xml:space="preserve">
-    <value>grpFactorToNumericOptions</value>
-  </data>
-  <data name="&gt;&gt;grpFactorToNumericOptions.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;grpFactorToNumericOptions.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;grpFactorToNumericOptions.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="rdoDefault.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
+  </data>
+  <data name="rdoDefault.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
   <data name="rdoDefault.Location" type="System.Drawing.Point, System.Drawing">
     <value>11, 22</value>
@@ -551,14 +432,14 @@
   <data name="&gt;&gt;rdoDefault.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="rdoConvertLevels.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
+  <data name="rdoConvertLevels.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
   <data name="rdoConvertLevels.Location" type="System.Drawing.Point, System.Drawing">
     <value>11, 44</value>
   </data>
   <data name="rdoConvertLevels.Size" type="System.Drawing.Size, System.Drawing">
-    <value>114, 17</value>
+    <value>195, 17</value>
   </data>
   <data name="rdoConvertLevels.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -582,7 +463,7 @@
     <value>3, 21</value>
   </data>
   <data name="ucrPnlFactorToNumericOptions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>134, 65</value>
+    <value>203, 65</value>
   </data>
   <data name="ucrPnlFactorToNumericOptions.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -599,11 +480,77 @@
   <data name="&gt;&gt;ucrPnlFactorToNumericOptions.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
+  <data name="grpFactorToNumericOptions.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 316</value>
+  </data>
+  <data name="grpFactorToNumericOptions.Size" type="System.Drawing.Size, System.Drawing">
+    <value>213, 92</value>
+  </data>
+  <data name="grpFactorToNumericOptions.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="grpFactorToNumericOptions.Text" xml:space="preserve">
+    <value>Factor Options</value>
+  </data>
+  <data name="&gt;&gt;grpFactorToNumericOptions.Name" xml:space="preserve">
+    <value>grpFactorToNumericOptions</value>
+  </data>
+  <data name="&gt;&gt;grpFactorToNumericOptions.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;grpFactorToNumericOptions.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;grpFactorToNumericOptions.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="ucrChkIgnoreLabels.Location" type="System.Drawing.Point, System.Drawing">
+    <value>307, 290</value>
+  </data>
+  <data name="ucrChkIgnoreLabels.Size" type="System.Drawing.Size, System.Drawing">
+    <value>138, 20</value>
+  </data>
+  <data name="ucrChkIgnoreLabels.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;ucrChkIgnoreLabels.Name" xml:space="preserve">
+    <value>ucrChkIgnoreLabels</value>
+  </data>
+  <data name="&gt;&gt;ucrChkIgnoreLabels.Type" xml:space="preserve">
+    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrChkIgnoreLabels.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrChkIgnoreLabels.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="ucrChkCreateLabels.Location" type="System.Drawing.Point, System.Drawing">
+    <value>307, 317</value>
+  </data>
+  <data name="ucrChkCreateLabels.Size" type="System.Drawing.Size, System.Drawing">
+    <value>138, 20</value>
+  </data>
+  <data name="ucrChkCreateLabels.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;ucrChkCreateLabels.Name" xml:space="preserve">
+    <value>ucrChkCreateLabels</value>
+  </data>
+  <data name="&gt;&gt;ucrChkCreateLabels.Type" xml:space="preserve">
+    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrChkCreateLabels.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrChkCreateLabels.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
   <data name="ucrChkKeepAttributes.Location" type="System.Drawing.Point, System.Drawing">
     <value>10, 290</value>
   </data>
   <data name="ucrChkKeepAttributes.Size" type="System.Drawing.Size, System.Drawing">
-    <value>190, 20</value>
+    <value>222, 20</value>
   </data>
   <data name="ucrChkKeepAttributes.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -621,7 +568,7 @@
     <value>3</value>
   </data>
   <data name="ucrNudDisplayDecimals.Location" type="System.Drawing.Point, System.Drawing">
-    <value>205, 316</value>
+    <value>253, 316</value>
   </data>
   <data name="ucrNudDisplayDecimals.Size" type="System.Drawing.Size, System.Drawing">
     <value>50, 20</value>
@@ -645,7 +592,7 @@
     <value>10, 316</value>
   </data>
   <data name="ucrChkSpecifyDecimalsToDisplay.Size" type="System.Drawing.Size, System.Drawing">
-    <value>190, 20</value>
+    <value>242, 20</value>
   </data>
   <data name="ucrChkSpecifyDecimalsToDisplay.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -665,12 +612,11 @@
   <data name="ucrSelectorDataFrameColumns.Location" type="System.Drawing.Point, System.Drawing">
     <value>10, 10</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="ucrSelectorDataFrameColumns.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
   </data>
   <data name="ucrSelectorDataFrameColumns.Size" type="System.Drawing.Size, System.Drawing">
-    <value>210, 180</value>
+    <value>229, 180</value>
   </data>
   <data name="ucrSelectorDataFrameColumns.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -694,49 +640,7 @@
     <value>6, 13</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>415, 463</value>
-  </data>
-  <data name="ucrChkIgnoreLabels.Location" type="System.Drawing.Point, System.Drawing">
-    <value>265, 290</value>
-  </data>
-  <data name="ucrChkIgnoreLabels.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 20</value>
-  </data>
-  <data name="ucrChkIgnoreLabels.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;ucrChkIgnoreLabels.Name" xml:space="preserve">
-    <value>ucrChkIgnoreLabels</value>
-  </data>
-  <data name="&gt;&gt;ucrChkIgnoreLabels.Type" xml:space="preserve">
-    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrChkIgnoreLabels.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;ucrChkIgnoreLabels.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="ucrChkCreateLabels.Location" type="System.Drawing.Point, System.Drawing">
-    <value>265, 317</value>
-  </data>
-  <data name="ucrChkCreateLabels.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 20</value>
-  </data>
-  <data name="ucrChkCreateLabels.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;ucrChkCreateLabels.Name" xml:space="preserve">
-    <value>ucrChkCreateLabels</value>
-  </data>
-  <data name="&gt;&gt;ucrChkCreateLabels.Type" xml:space="preserve">
-    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrChkCreateLabels.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;ucrChkCreateLabels.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>449, 463</value>
   </data>
   <data name="ucrBase.Location" type="System.Drawing.Point, System.Drawing">
     <value>10, 410</value>
@@ -758,6 +662,9 @@
   </data>
   <data name="&gt;&gt;ucrBase.ZOrder" xml:space="preserve">
     <value>10</value>
+  </data>
+  <data name="$this.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterScreen</value>


### PR DESCRIPTION
Fixes #6489 
@rdstern I widened the controls so that the texts could be well visible. Please, have a look. Thanks.