### PR TITLE
Bug fixes: ensure comboxes to remember states in reopen of bar chart dialogue

### DIFF
--- a/instat/dlgBarAndPieChart.Designer.vb
+++ b/instat/dlgBarAndPieChart.Designer.vb
@@ -56,6 +56,8 @@ Partial Class dlgBarAndPieChart
         Me.ucrPnlOptions = New instat.UcrPanel()
         Me.rdoFrequency = New System.Windows.Forms.RadioButton()
         Me.ucrVariablesAsFactorForBarChart = New instat.ucrVariablesAsFactor()
+        Me.lblXvariable = New System.Windows.Forms.Label()
+        Me.ucrReceiverX = New instat.ucrReceiverSingle()
         Me.SuspendLayout()
         '
         'lblByFactor
@@ -189,10 +191,26 @@ Partial Class dlgBarAndPieChart
         Me.ucrVariablesAsFactorForBarChart.ucrSelector = Nothing
         Me.ucrVariablesAsFactorForBarChart.ucrVariableSelector = Nothing
         '
+        'lblXvariable
+        '
+        resources.ApplyResources(Me.lblXvariable, "lblXvariable")
+        Me.lblXvariable.Name = "lblXvariable"
+        '
+        'ucrReceiverX
+        '
+        Me.ucrReceiverX.frmParent = Me
+        resources.ApplyResources(Me.ucrReceiverX, "ucrReceiverX")
+        Me.ucrReceiverX.Name = "ucrReceiverX"
+        Me.ucrReceiverX.Selector = Nothing
+        Me.ucrReceiverX.strNcFilePath = ""
+        Me.ucrReceiverX.ucrSelector = Nothing
+        '
         'dlgBarAndPieChart
         '
         resources.ApplyResources(Me, "$this")
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.Controls.Add(Me.lblXvariable)
+        Me.Controls.Add(Me.ucrReceiverX)
         Me.Controls.Add(Me.ucrVariablesAsFactorForBarChart)
         Me.Controls.Add(Me.rdoFrequency)
         Me.Controls.Add(Me.ucrInputBarChartPositions)
@@ -237,4 +255,6 @@ Partial Class dlgBarAndPieChart
     Friend WithEvents ucrInputBarChartPositions As ucrInputComboBox
     Friend WithEvents rdoFrequency As RadioButton
     Friend WithEvents ucrVariablesAsFactorForBarChart As ucrVariablesAsFactor
+    Friend WithEvents lblXvariable As Label
+    Friend WithEvents ucrReceiverX As ucrReceiverSingle
 End Class

--- a/instat/dlgBarAndPieChart.Designer.vb
+++ b/instat/dlgBarAndPieChart.Designer.vb
@@ -144,6 +144,7 @@ Partial Class dlgBarAndPieChart
         'ucrInputYValue
         '
         Me.ucrInputYValue.AddQuotesIfUnrecognised = True
+        Me.ucrInputYValue.GetSetSelectedIndex = -1
         Me.ucrInputYValue.IsReadOnly = False
         resources.ApplyResources(Me.ucrInputYValue, "ucrInputYValue")
         Me.ucrInputYValue.Name = "ucrInputYValue"
@@ -160,6 +161,7 @@ Partial Class dlgBarAndPieChart
         'ucrInputBarChartPosition
         '
         Me.ucrInputBarChartPosition.AddQuotesIfUnrecognised = True
+        Me.ucrInputBarChartPosition.GetSetSelectedIndex = -1
         Me.ucrInputBarChartPosition.IsReadOnly = False
         resources.ApplyResources(Me.ucrInputBarChartPosition, "ucrInputBarChartPosition")
         Me.ucrInputBarChartPosition.Name = "ucrInputBarChartPosition"

--- a/instat/dlgBarAndPieChart.Designer.vb
+++ b/instat/dlgBarAndPieChart.Designer.vb
@@ -39,34 +39,24 @@ Partial Class dlgBarAndPieChart
     <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
         Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(dlgBarAndPieChart))
-        Me.lblVariable = New System.Windows.Forms.Label()
         Me.lblByFactor = New System.Windows.Forms.Label()
         Me.cmdOptions = New System.Windows.Forms.Button()
         Me.cmdPieChartOptions = New System.Windows.Forms.Button()
         Me.rdoPieChart = New System.Windows.Forms.RadioButton()
-        Me.rdoBarChart = New System.Windows.Forms.RadioButton()
+        Me.rdoValue = New System.Windows.Forms.RadioButton()
         Me.cmdBarChartOptions = New System.Windows.Forms.Button()
         Me.lblPosition = New System.Windows.Forms.Label()
-        Me.lblYvariable = New System.Windows.Forms.Label()
         Me.cmdColumnChartOptions = New System.Windows.Forms.Button()
-        Me.lblYValue = New System.Windows.Forms.Label()
         Me.ucrInputBarChartPositions = New instat.ucrInputComboBox()
-        Me.ucrInputYValues = New instat.ucrInputComboBox()
-        Me.ucrReceiverY = New instat.ucrReceiverSingle()
         Me.ucrSaveBar = New instat.ucrSave()
         Me.ucrChkFlipCoordinates = New instat.ucrCheck()
         Me.ucrReceiverByFactor = New instat.ucrReceiverSingle()
-        Me.ucrReceiverFirst = New instat.ucrReceiverSingle()
         Me.ucrBarChartSelector = New instat.ucrSelectorByDataFrameAddRemove()
         Me.ucrBase = New instat.ucrButtons()
         Me.ucrPnlOptions = New instat.UcrPanel()
+        Me.rdoFrequency = New System.Windows.Forms.RadioButton()
+        Me.ucrVariablesAsFactorForBarChart = New instat.ucrVariablesAsFactor()
         Me.SuspendLayout()
-        '
-        'lblVariable
-        '
-        resources.ApplyResources(Me.lblVariable, "lblVariable")
-        Me.lblVariable.Name = "lblVariable"
-        Me.lblVariable.Tag = "Variable:"
         '
         'lblByFactor
         '
@@ -100,17 +90,17 @@ Partial Class dlgBarAndPieChart
         Me.rdoPieChart.Tag = "Pie_Chart"
         Me.rdoPieChart.UseVisualStyleBackColor = False
         '
-        'rdoBarChart
+        'rdoValue
         '
-        resources.ApplyResources(Me.rdoBarChart, "rdoBarChart")
-        Me.rdoBarChart.BackColor = System.Drawing.SystemColors.Control
-        Me.rdoBarChart.FlatAppearance.BorderColor = System.Drawing.SystemColors.ActiveCaption
-        Me.rdoBarChart.FlatAppearance.BorderSize = 2
-        Me.rdoBarChart.FlatAppearance.CheckedBackColor = System.Drawing.SystemColors.ActiveCaption
-        Me.rdoBarChart.Name = "rdoBarChart"
-        Me.rdoBarChart.TabStop = True
-        Me.rdoBarChart.Tag = "Bar_Chart"
-        Me.rdoBarChart.UseVisualStyleBackColor = False
+        resources.ApplyResources(Me.rdoValue, "rdoValue")
+        Me.rdoValue.BackColor = System.Drawing.SystemColors.Control
+        Me.rdoValue.FlatAppearance.BorderColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoValue.FlatAppearance.BorderSize = 2
+        Me.rdoValue.FlatAppearance.CheckedBackColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoValue.Name = "rdoValue"
+        Me.rdoValue.TabStop = True
+        Me.rdoValue.Tag = "Value"
+        Me.rdoValue.UseVisualStyleBackColor = False
         '
         'cmdBarChartOptions
         '
@@ -124,22 +114,12 @@ Partial Class dlgBarAndPieChart
         resources.ApplyResources(Me.lblPosition, "lblPosition")
         Me.lblPosition.Name = "lblPosition"
         '
-        'lblYvariable
-        '
-        resources.ApplyResources(Me.lblYvariable, "lblYvariable")
-        Me.lblYvariable.Name = "lblYvariable"
-        '
         'cmdColumnChartOptions
         '
         resources.ApplyResources(Me.cmdColumnChartOptions, "cmdColumnChartOptions")
         Me.cmdColumnChartOptions.Name = "cmdColumnChartOptions"
         Me.cmdColumnChartOptions.Tag = "Column_Chart_Options"
         Me.cmdColumnChartOptions.UseVisualStyleBackColor = True
-        '
-        'lblYValue
-        '
-        resources.ApplyResources(Me.lblYValue, "lblYValue")
-        Me.lblYValue.Name = "lblYValue"
         '
         'ucrInputBarChartPositions
         '
@@ -148,23 +128,6 @@ Partial Class dlgBarAndPieChart
         Me.ucrInputBarChartPositions.IsReadOnly = False
         resources.ApplyResources(Me.ucrInputBarChartPositions, "ucrInputBarChartPositions")
         Me.ucrInputBarChartPositions.Name = "ucrInputBarChartPositions"
-        '
-        'ucrInputYValues
-        '
-        Me.ucrInputYValues.AddQuotesIfUnrecognised = True
-        Me.ucrInputYValues.GetSetSelectedIndex = -1
-        Me.ucrInputYValues.IsReadOnly = False
-        resources.ApplyResources(Me.ucrInputYValues, "ucrInputYValues")
-        Me.ucrInputYValues.Name = "ucrInputYValues"
-        '
-        'ucrReceiverY
-        '
-        Me.ucrReceiverY.frmParent = Me
-        resources.ApplyResources(Me.ucrReceiverY, "ucrReceiverY")
-        Me.ucrReceiverY.Name = "ucrReceiverY"
-        Me.ucrReceiverY.Selector = Nothing
-        Me.ucrReceiverY.strNcFilePath = ""
-        Me.ucrReceiverY.ucrSelector = Nothing
         '
         'ucrSaveBar
         '
@@ -186,15 +149,6 @@ Partial Class dlgBarAndPieChart
         Me.ucrReceiverByFactor.strNcFilePath = ""
         Me.ucrReceiverByFactor.ucrSelector = Nothing
         '
-        'ucrReceiverFirst
-        '
-        Me.ucrReceiverFirst.frmParent = Me
-        resources.ApplyResources(Me.ucrReceiverFirst, "ucrReceiverFirst")
-        Me.ucrReceiverFirst.Name = "ucrReceiverFirst"
-        Me.ucrReceiverFirst.Selector = Nothing
-        Me.ucrReceiverFirst.strNcFilePath = ""
-        Me.ucrReceiverFirst.ucrSelector = Nothing
-        '
         'ucrBarChartSelector
         '
         Me.ucrBarChartSelector.bDropUnusedFilterLevels = False
@@ -213,26 +167,44 @@ Partial Class dlgBarAndPieChart
         resources.ApplyResources(Me.ucrPnlOptions, "ucrPnlOptions")
         Me.ucrPnlOptions.Name = "ucrPnlOptions"
         '
+        'rdoFrequency
+        '
+        resources.ApplyResources(Me.rdoFrequency, "rdoFrequency")
+        Me.rdoFrequency.BackColor = System.Drawing.SystemColors.Control
+        Me.rdoFrequency.FlatAppearance.BorderColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoFrequency.FlatAppearance.BorderSize = 2
+        Me.rdoFrequency.FlatAppearance.CheckedBackColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoFrequency.Name = "rdoFrequency"
+        Me.rdoFrequency.TabStop = True
+        Me.rdoFrequency.Tag = "Frequency"
+        Me.rdoFrequency.UseVisualStyleBackColor = False
+        '
+        'ucrVariablesAsFactorForBarChart
+        '
+        Me.ucrVariablesAsFactorForBarChart.frmParent = Me
+        resources.ApplyResources(Me.ucrVariablesAsFactorForBarChart, "ucrVariablesAsFactorForBarChart")
+        Me.ucrVariablesAsFactorForBarChart.Name = "ucrVariablesAsFactorForBarChart"
+        Me.ucrVariablesAsFactorForBarChart.Selector = Nothing
+        Me.ucrVariablesAsFactorForBarChart.strNcFilePath = ""
+        Me.ucrVariablesAsFactorForBarChart.ucrSelector = Nothing
+        Me.ucrVariablesAsFactorForBarChart.ucrVariableSelector = Nothing
+        '
         'dlgBarAndPieChart
         '
         resources.ApplyResources(Me, "$this")
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.Controls.Add(Me.ucrVariablesAsFactorForBarChart)
+        Me.Controls.Add(Me.rdoFrequency)
         Me.Controls.Add(Me.ucrInputBarChartPositions)
-        Me.Controls.Add(Me.ucrInputYValues)
-        Me.Controls.Add(Me.lblYValue)
         Me.Controls.Add(Me.cmdColumnChartOptions)
-        Me.Controls.Add(Me.lblYvariable)
-        Me.Controls.Add(Me.ucrReceiverY)
         Me.Controls.Add(Me.lblPosition)
         Me.Controls.Add(Me.ucrSaveBar)
         Me.Controls.Add(Me.ucrChkFlipCoordinates)
-        Me.Controls.Add(Me.rdoBarChart)
+        Me.Controls.Add(Me.rdoValue)
         Me.Controls.Add(Me.rdoPieChart)
         Me.Controls.Add(Me.cmdOptions)
         Me.Controls.Add(Me.lblByFactor)
-        Me.Controls.Add(Me.lblVariable)
         Me.Controls.Add(Me.ucrReceiverByFactor)
-        Me.Controls.Add(Me.ucrReceiverFirst)
         Me.Controls.Add(Me.ucrBarChartSelector)
         Me.Controls.Add(Me.ucrBase)
         Me.Controls.Add(Me.cmdBarChartOptions)
@@ -250,23 +222,19 @@ Partial Class dlgBarAndPieChart
 
     Friend WithEvents ucrBase As ucrButtons
     Friend WithEvents ucrBarChartSelector As ucrSelectorByDataFrameAddRemove
-    Friend WithEvents ucrReceiverFirst As ucrReceiverSingle
     Friend WithEvents ucrReceiverByFactor As ucrReceiverSingle
-    Friend WithEvents lblVariable As Label
     Friend WithEvents lblByFactor As Label
     Friend WithEvents cmdOptions As Button
     Friend WithEvents cmdPieChartOptions As Button
     Friend WithEvents ucrSaveBar As ucrSave
     Friend WithEvents ucrChkFlipCoordinates As ucrCheck
-    Friend WithEvents rdoBarChart As RadioButton
+    Friend WithEvents rdoValue As RadioButton
     Friend WithEvents rdoPieChart As RadioButton
     Friend WithEvents ucrPnlOptions As UcrPanel
     Friend WithEvents cmdBarChartOptions As Button
     Friend WithEvents lblPosition As Label
-    Friend WithEvents lblYvariable As Label
-    Friend WithEvents ucrReceiverY As ucrReceiverSingle
     Friend WithEvents cmdColumnChartOptions As Button
-    Friend WithEvents lblYValue As Label
-    Friend WithEvents ucrInputYValues As ucrInputComboBox
     Friend WithEvents ucrInputBarChartPositions As ucrInputComboBox
+    Friend WithEvents rdoFrequency As RadioButton
+    Friend WithEvents ucrVariablesAsFactorForBarChart As ucrVariablesAsFactor
 End Class

--- a/instat/dlgBarAndPieChart.Designer.vb
+++ b/instat/dlgBarAndPieChart.Designer.vb
@@ -50,9 +50,9 @@ Partial Class dlgBarAndPieChart
         Me.lblYvariable = New System.Windows.Forms.Label()
         Me.cmdColumnChartOptions = New System.Windows.Forms.Button()
         Me.lblYValue = New System.Windows.Forms.Label()
-        Me.ucrInputYValue = New instat.ucrInputComboBox()
+        Me.ucrInputBarChartPositions = New instat.ucrInputComboBox()
+        Me.ucrInputYValues = New instat.ucrInputComboBox()
         Me.ucrReceiverY = New instat.ucrReceiverSingle()
-        Me.ucrInputBarChartPosition = New instat.ucrInputComboBox()
         Me.ucrSaveBar = New instat.ucrSave()
         Me.ucrChkFlipCoordinates = New instat.ucrCheck()
         Me.ucrReceiverByFactor = New instat.ucrReceiverSingle()
@@ -141,13 +141,21 @@ Partial Class dlgBarAndPieChart
         resources.ApplyResources(Me.lblYValue, "lblYValue")
         Me.lblYValue.Name = "lblYValue"
         '
-        'ucrInputYValue
+        'ucrInputBarChartPositions
         '
-        Me.ucrInputYValue.AddQuotesIfUnrecognised = True
-        Me.ucrInputYValue.GetSetSelectedIndex = -1
-        Me.ucrInputYValue.IsReadOnly = False
-        resources.ApplyResources(Me.ucrInputYValue, "ucrInputYValue")
-        Me.ucrInputYValue.Name = "ucrInputYValue"
+        Me.ucrInputBarChartPositions.AddQuotesIfUnrecognised = True
+        Me.ucrInputBarChartPositions.GetSetSelectedIndex = -1
+        Me.ucrInputBarChartPositions.IsReadOnly = False
+        resources.ApplyResources(Me.ucrInputBarChartPositions, "ucrInputBarChartPositions")
+        Me.ucrInputBarChartPositions.Name = "ucrInputBarChartPositions"
+        '
+        'ucrInputYValues
+        '
+        Me.ucrInputYValues.AddQuotesIfUnrecognised = True
+        Me.ucrInputYValues.GetSetSelectedIndex = -1
+        Me.ucrInputYValues.IsReadOnly = False
+        resources.ApplyResources(Me.ucrInputYValues, "ucrInputYValues")
+        Me.ucrInputYValues.Name = "ucrInputYValues"
         '
         'ucrReceiverY
         '
@@ -157,14 +165,6 @@ Partial Class dlgBarAndPieChart
         Me.ucrReceiverY.Selector = Nothing
         Me.ucrReceiverY.strNcFilePath = ""
         Me.ucrReceiverY.ucrSelector = Nothing
-        '
-        'ucrInputBarChartPosition
-        '
-        Me.ucrInputBarChartPosition.AddQuotesIfUnrecognised = True
-        Me.ucrInputBarChartPosition.GetSetSelectedIndex = -1
-        Me.ucrInputBarChartPosition.IsReadOnly = False
-        resources.ApplyResources(Me.ucrInputBarChartPosition, "ucrInputBarChartPosition")
-        Me.ucrInputBarChartPosition.Name = "ucrInputBarChartPosition"
         '
         'ucrSaveBar
         '
@@ -217,13 +217,13 @@ Partial Class dlgBarAndPieChart
         '
         resources.ApplyResources(Me, "$this")
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
-        Me.Controls.Add(Me.ucrInputYValue)
+        Me.Controls.Add(Me.ucrInputBarChartPositions)
+        Me.Controls.Add(Me.ucrInputYValues)
         Me.Controls.Add(Me.lblYValue)
         Me.Controls.Add(Me.cmdColumnChartOptions)
         Me.Controls.Add(Me.lblYvariable)
         Me.Controls.Add(Me.ucrReceiverY)
         Me.Controls.Add(Me.lblPosition)
-        Me.Controls.Add(Me.ucrInputBarChartPosition)
         Me.Controls.Add(Me.ucrSaveBar)
         Me.Controls.Add(Me.ucrChkFlipCoordinates)
         Me.Controls.Add(Me.rdoBarChart)
@@ -262,11 +262,11 @@ Partial Class dlgBarAndPieChart
     Friend WithEvents rdoPieChart As RadioButton
     Friend WithEvents ucrPnlOptions As UcrPanel
     Friend WithEvents cmdBarChartOptions As Button
-    Friend WithEvents ucrInputBarChartPosition As ucrInputComboBox
     Friend WithEvents lblPosition As Label
     Friend WithEvents lblYvariable As Label
     Friend WithEvents ucrReceiverY As ucrReceiverSingle
     Friend WithEvents cmdColumnChartOptions As Button
-    Friend WithEvents ucrInputYValue As ucrInputComboBox
     Friend WithEvents lblYValue As Label
+    Friend WithEvents ucrInputYValues As ucrInputComboBox
+    Friend WithEvents ucrInputBarChartPositions As ucrInputComboBox
 End Class

--- a/instat/dlgBarAndPieChart.resx
+++ b/instat/dlgBarAndPieChart.resx
@@ -127,7 +127,7 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="lblByFactor.Location" type="System.Drawing.Point, System.Drawing">
-    <value>252, 221</value>
+    <value>252, 255</value>
   </data>
   <data name="lblByFactor.Size" type="System.Drawing.Size, System.Drawing">
     <value>103, 13</value>
@@ -148,7 +148,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblByFactor.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>12</value>
   </data>
   <data name="cmdOptions.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -175,7 +175,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;cmdOptions.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>11</value>
   </data>
   <data name="cmdPieChartOptions.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -202,7 +202,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;cmdPieChartOptions.ZOrder" xml:space="preserve">
-    <value>15</value>
+    <value>17</value>
   </data>
   <data name="rdoPieChart.Appearance" type="System.Windows.Forms.Appearance, System.Windows.Forms">
     <value>Button</value>
@@ -241,7 +241,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;rdoPieChart.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>10</value>
   </data>
   <data name="rdoValue.Appearance" type="System.Windows.Forms.Appearance, System.Windows.Forms">
     <value>Button</value>
@@ -277,7 +277,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;rdoValue.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>9</value>
   </data>
   <data name="cmdBarChartOptions.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -304,7 +304,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;cmdBarChartOptions.ZOrder" xml:space="preserve">
-    <value>14</value>
+    <value>16</value>
   </data>
   <data name="lblPosition.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -313,7 +313,7 @@
     <value>NoControl</value>
   </data>
   <data name="lblPosition.Location" type="System.Drawing.Point, System.Drawing">
-    <value>252, 265</value>
+    <value>252, 297</value>
   </data>
   <data name="lblPosition.Size" type="System.Drawing.Size, System.Drawing">
     <value>47, 13</value>
@@ -334,7 +334,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblPosition.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>6</value>
   </data>
   <data name="cmdColumnChartOptions.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -361,7 +361,157 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;cmdColumnChartOptions.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>5</value>
+  </data>
+  <data name="ucrInputBarChartPositions.Location" type="System.Drawing.Point, System.Drawing">
+    <value>252, 313</value>
+  </data>
+  <data name="ucrInputBarChartPositions.Size" type="System.Drawing.Size, System.Drawing">
+    <value>92, 21</value>
+  </data>
+  <data name="ucrInputBarChartPositions.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;ucrInputBarChartPositions.Name" xml:space="preserve">
+    <value>ucrInputBarChartPositions</value>
+  </data>
+  <data name="&gt;&gt;ucrInputBarChartPositions.Type" xml:space="preserve">
+    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrInputBarChartPositions.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrInputBarChartPositions.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="ucrSaveBar.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 328</value>
+  </data>
+  <data name="ucrSaveBar.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="ucrSaveBar.Size" type="System.Drawing.Size, System.Drawing">
+    <value>255, 24</value>
+  </data>
+  <data name="ucrSaveBar.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="&gt;&gt;ucrSaveBar.Name" xml:space="preserve">
+    <value>ucrSaveBar</value>
+  </data>
+  <data name="&gt;&gt;ucrSaveBar.Type" xml:space="preserve">
+    <value>instat.ucrSave, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrSaveBar.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrSaveBar.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="ucrChkFlipCoordinates.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 302</value>
+  </data>
+  <data name="ucrChkFlipCoordinates.Size" type="System.Drawing.Size, System.Drawing">
+    <value>166, 20</value>
+  </data>
+  <data name="ucrChkFlipCoordinates.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="&gt;&gt;ucrChkFlipCoordinates.Name" xml:space="preserve">
+    <value>ucrChkFlipCoordinates</value>
+  </data>
+  <data name="&gt;&gt;ucrChkFlipCoordinates.Type" xml:space="preserve">
+    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrChkFlipCoordinates.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrChkFlipCoordinates.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>415, 411</value>
+  </data>
+  <data name="lblXvariable.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblXvariable.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblXvariable.Location" type="System.Drawing.Point, System.Drawing">
+    <value>252, 212</value>
+  </data>
+  <data name="lblXvariable.Size" type="System.Drawing.Size, System.Drawing">
+    <value>58, 13</value>
+  </data>
+  <data name="lblXvariable.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="lblXvariable.Text" xml:space="preserve">
+    <value>X Variable:</value>
+  </data>
+  <data name="&gt;&gt;lblXvariable.Name" xml:space="preserve">
+    <value>lblXvariable</value>
+  </data>
+  <data name="&gt;&gt;lblXvariable.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblXvariable.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;lblXvariable.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="ucrReceiverX.Location" type="System.Drawing.Point, System.Drawing">
+    <value>255, 226</value>
+  </data>
+  <data name="ucrReceiverX.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="ucrReceiverX.Size" type="System.Drawing.Size, System.Drawing">
+    <value>120, 21</value>
+  </data>
+  <data name="ucrReceiverX.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverX.Name" xml:space="preserve">
+    <value>ucrReceiverX</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverX.Type" xml:space="preserve">
+    <value>instat.ucrReceiverSingle, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverX.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverX.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="ucrVariablesAsFactorForBarChart.Location" type="System.Drawing.Point, System.Drawing">
+    <value>252, 62</value>
+  </data>
+  <data name="ucrVariablesAsFactorForBarChart.Size" type="System.Drawing.Size, System.Drawing">
+    <value>125, 136</value>
+  </data>
+  <data name="ucrVariablesAsFactorForBarChart.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;ucrVariablesAsFactorForBarChart.Name" xml:space="preserve">
+    <value>ucrVariablesAsFactorForBarChart</value>
+  </data>
+  <data name="&gt;&gt;ucrVariablesAsFactorForBarChart.Type" xml:space="preserve">
+    <value>instat.ucrVariablesAsFactor, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrVariablesAsFactorForBarChart.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrVariablesAsFactorForBarChart.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <data name="rdoFrequency.Appearance" type="System.Windows.Forms.Appearance, System.Windows.Forms">
     <value>Button</value>
@@ -397,106 +547,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;rdoFrequency.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
-  </data>
-  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>415, 411</value>
-  </data>
-  <data name="ucrInputBarChartPositions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>252, 281</value>
-  </data>
-  <data name="ucrInputBarChartPositions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>92, 21</value>
-  </data>
-  <data name="ucrInputBarChartPositions.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;ucrInputBarChartPositions.Name" xml:space="preserve">
-    <value>ucrInputBarChartPositions</value>
-  </data>
-  <data name="&gt;&gt;ucrInputBarChartPositions.Type" xml:space="preserve">
-    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrInputBarChartPositions.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;ucrInputBarChartPositions.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="ucrSaveBar.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 328</value>
-  </data>
-  <data name="ucrSaveBar.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
-  <data name="ucrSaveBar.Size" type="System.Drawing.Size, System.Drawing">
-    <value>255, 24</value>
-  </data>
-  <data name="ucrSaveBar.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
-  </data>
-  <data name="&gt;&gt;ucrSaveBar.Name" xml:space="preserve">
-    <value>ucrSaveBar</value>
-  </data>
-  <data name="&gt;&gt;ucrSaveBar.Type" xml:space="preserve">
-    <value>instat.ucrSave, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrSaveBar.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;ucrSaveBar.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="ucrChkFlipCoordinates.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 302</value>
-  </data>
-  <data name="ucrChkFlipCoordinates.Size" type="System.Drawing.Size, System.Drawing">
-    <value>166, 20</value>
-  </data>
-  <data name="ucrChkFlipCoordinates.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
-  </data>
-  <data name="&gt;&gt;ucrChkFlipCoordinates.Name" xml:space="preserve">
-    <value>ucrChkFlipCoordinates</value>
-  </data>
-  <data name="&gt;&gt;ucrChkFlipCoordinates.Type" xml:space="preserve">
-    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrChkFlipCoordinates.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;ucrChkFlipCoordinates.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="ucrReceiverByFactor.Location" type="System.Drawing.Point, System.Drawing">
-    <value>252, 236</value>
-  </data>
-  <data name="ucrReceiverByFactor.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
-  </data>
-  <data name="ucrReceiverByFactor.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 20</value>
-  </data>
-  <data name="ucrReceiverByFactor.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverByFactor.Name" xml:space="preserve">
-    <value>ucrReceiverByFactor</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverByFactor.Type" xml:space="preserve">
-    <value>instat.ucrReceiverSingle, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverByFactor.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverByFactor.ZOrder" xml:space="preserve">
-    <value>11</value>
+    <value>3</value>
   </data>
   <data name="ucrBarChartSelector.Location" type="System.Drawing.Point, System.Drawing">
     <value>10, 41</value>
@@ -520,7 +571,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrBarChartSelector.ZOrder" xml:space="preserve">
-    <value>12</value>
+    <value>14</value>
   </data>
   <data name="ucrBase.Location" type="System.Drawing.Point, System.Drawing">
     <value>9, 358</value>
@@ -541,7 +592,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrBase.ZOrder" xml:space="preserve">
-    <value>13</value>
+    <value>15</value>
   </data>
   <data name="ucrPnlOptions.Location" type="System.Drawing.Point, System.Drawing">
     <value>47, 6</value>
@@ -562,10 +613,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrPnlOptions.ZOrder" xml:space="preserve">
-    <value>16</value>
-  </data>
-  <data name="$this.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
+    <value>18</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterScreen</value>
@@ -579,25 +627,28 @@
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
     <value>System.Windows.Forms.Form, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="ucrVariablesAsFactorForBarChart.Location" type="System.Drawing.Point, System.Drawing">
-    <value>252, 62</value>
+  <data name="ucrReceiverByFactor.Location" type="System.Drawing.Point, System.Drawing">
+    <value>252, 270</value>
   </data>
-  <data name="ucrVariablesAsFactorForBarChart.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 136</value>
+  <data name="ucrReceiverByFactor.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
   </data>
-  <data name="ucrVariablesAsFactorForBarChart.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
+  <data name="ucrReceiverByFactor.Size" type="System.Drawing.Size, System.Drawing">
+    <value>120, 20</value>
   </data>
-  <data name="&gt;&gt;ucrVariablesAsFactorForBarChart.Name" xml:space="preserve">
-    <value>ucrVariablesAsFactorForBarChart</value>
+  <data name="ucrReceiverByFactor.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
   </data>
-  <data name="&gt;&gt;ucrVariablesAsFactorForBarChart.Type" xml:space="preserve">
-    <value>instat.ucrVariablesAsFactor, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  <data name="&gt;&gt;ucrReceiverByFactor.Name" xml:space="preserve">
+    <value>ucrReceiverByFactor</value>
   </data>
-  <data name="&gt;&gt;ucrVariablesAsFactorForBarChart.Parent" xml:space="preserve">
+  <data name="&gt;&gt;ucrReceiverByFactor.Type" xml:space="preserve">
+    <value>instat.ucrReceiverSingle, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrReceiverByFactor.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;ucrVariablesAsFactorForBarChart.ZOrder" xml:space="preserve">
-    <value>0</value>
+  <data name="&gt;&gt;ucrReceiverByFactor.ZOrder" xml:space="preserve">
+    <value>13</value>
   </data>
 </root>

--- a/instat/dlgBarAndPieChart.resx
+++ b/instat/dlgBarAndPieChart.resx
@@ -367,7 +367,7 @@
     <value>252, 313</value>
   </data>
   <data name="ucrInputBarChartPositions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>92, 21</value>
+    <value>120, 21</value>
   </data>
   <data name="ucrInputBarChartPositions.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
@@ -469,7 +469,7 @@
     <value>0</value>
   </data>
   <data name="ucrReceiverX.Location" type="System.Drawing.Point, System.Drawing">
-    <value>255, 226</value>
+    <value>252, 226</value>
   </data>
   <data name="ucrReceiverX.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>

--- a/instat/dlgBarAndPieChart.resx
+++ b/instat/dlgBarAndPieChart.resx
@@ -118,52 +118,22 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="lblVariable.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="lblVariable.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="lblVariable.Location" type="System.Drawing.Point, System.Drawing">
-    <value>252, 76</value>
-  </data>
-  <data name="lblVariable.Size" type="System.Drawing.Size, System.Drawing">
-    <value>58, 13</value>
-  </data>
-  <data name="lblVariable.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="lblVariable.Text" xml:space="preserve">
-    <value>X Variable:</value>
-  </data>
-  <data name="&gt;&gt;lblVariable.Name" xml:space="preserve">
-    <value>lblVariable</value>
-  </data>
-  <data name="&gt;&gt;lblVariable.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblVariable.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;lblVariable.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
   <data name="lblByFactor.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="lblByFactor.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="lblByFactor.Location" type="System.Drawing.Point, System.Drawing">
-    <value>252, 226</value>
+    <value>252, 221</value>
   </data>
   <data name="lblByFactor.Size" type="System.Drawing.Size, System.Drawing">
     <value>103, 13</value>
   </data>
   <data name="lblByFactor.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
+    <value>6</value>
   </data>
   <data name="lblByFactor.Text" xml:space="preserve">
     <value>By Factor (Optional):</value>
@@ -178,7 +148,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblByFactor.ZOrder" xml:space="preserve">
-    <value>12</value>
+    <value>10</value>
   </data>
   <data name="cmdOptions.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -190,7 +160,7 @@
     <value>121, 25</value>
   </data>
   <data name="cmdOptions.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
+    <value>11</value>
   </data>
   <data name="cmdOptions.Text" xml:space="preserve">
     <value>Plot Options</value>
@@ -205,7 +175,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;cmdOptions.ZOrder" xml:space="preserve">
-    <value>11</value>
+    <value>9</value>
   </data>
   <data name="cmdPieChartOptions.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -232,10 +202,13 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;cmdPieChartOptions.ZOrder" xml:space="preserve">
-    <value>19</value>
+    <value>15</value>
   </data>
   <data name="rdoPieChart.Appearance" type="System.Windows.Forms.Appearance, System.Windows.Forms">
     <value>Button</value>
+  </data>
+  <data name="rdoPieChart.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
   </data>
   <data name="rdoPieChart.FlatStyle" type="System.Windows.Forms.FlatStyle, System.Windows.Forms">
     <value>Flat</value>
@@ -244,13 +217,13 @@
     <value>NoControl</value>
   </data>
   <data name="rdoPieChart.Location" type="System.Drawing.Point, System.Drawing">
-    <value>206, 12</value>
+    <value>264, 12</value>
   </data>
   <data name="rdoPieChart.Size" type="System.Drawing.Size, System.Drawing">
     <value>110, 28</value>
   </data>
   <data name="rdoPieChart.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="rdoPieChart.Text" xml:space="preserve">
     <value>Pie Chart</value>
@@ -268,43 +241,43 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;rdoPieChart.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>8</value>
   </data>
-  <data name="rdoBarChart.Appearance" type="System.Windows.Forms.Appearance, System.Windows.Forms">
+  <data name="rdoValue.Appearance" type="System.Windows.Forms.Appearance, System.Windows.Forms">
     <value>Button</value>
   </data>
-  <data name="rdoBarChart.FlatStyle" type="System.Windows.Forms.FlatStyle, System.Windows.Forms">
+  <data name="rdoValue.FlatStyle" type="System.Windows.Forms.FlatStyle, System.Windows.Forms">
     <value>Flat</value>
   </data>
-  <data name="rdoBarChart.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="rdoValue.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="rdoBarChart.Location" type="System.Drawing.Point, System.Drawing">
-    <value>98, 12</value>
+  <data name="rdoValue.Location" type="System.Drawing.Point, System.Drawing">
+    <value>156, 12</value>
   </data>
-  <data name="rdoBarChart.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="rdoValue.Size" type="System.Drawing.Size, System.Drawing">
     <value>110, 28</value>
   </data>
-  <data name="rdoBarChart.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
+  <data name="rdoValue.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
   </data>
-  <data name="rdoBarChart.Text" xml:space="preserve">
-    <value>Bar Chart</value>
+  <data name="rdoValue.Text" xml:space="preserve">
+    <value>Value</value>
   </data>
-  <data name="rdoBarChart.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+  <data name="rdoValue.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
     <value>MiddleCenter</value>
   </data>
-  <data name="&gt;&gt;rdoBarChart.Name" xml:space="preserve">
-    <value>rdoBarChart</value>
+  <data name="&gt;&gt;rdoValue.Name" xml:space="preserve">
+    <value>rdoValue</value>
   </data>
-  <data name="&gt;&gt;rdoBarChart.Type" xml:space="preserve">
+  <data name="&gt;&gt;rdoValue.Type" xml:space="preserve">
     <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;rdoBarChart.Parent" xml:space="preserve">
+  <data name="&gt;&gt;rdoValue.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;rdoBarChart.ZOrder" xml:space="preserve">
-    <value>9</value>
+  <data name="&gt;&gt;rdoValue.ZOrder" xml:space="preserve">
+    <value>7</value>
   </data>
   <data name="cmdBarChartOptions.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -331,7 +304,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;cmdBarChartOptions.ZOrder" xml:space="preserve">
-    <value>18</value>
+    <value>14</value>
   </data>
   <data name="lblPosition.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -340,7 +313,7 @@
     <value>NoControl</value>
   </data>
   <data name="lblPosition.Location" type="System.Drawing.Point, System.Drawing">
-    <value>252, 176</value>
+    <value>252, 265</value>
   </data>
   <data name="lblPosition.Size" type="System.Drawing.Size, System.Drawing">
     <value>47, 13</value>
@@ -361,36 +334,6 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblPosition.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="lblYvariable.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lblYvariable.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblYvariable.Location" type="System.Drawing.Point, System.Drawing">
-    <value>252, 176</value>
-  </data>
-  <data name="lblYvariable.Size" type="System.Drawing.Size, System.Drawing">
-    <value>58, 13</value>
-  </data>
-  <data name="lblYvariable.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
-  </data>
-  <data name="lblYvariable.Text" xml:space="preserve">
-    <value>Y Variable:</value>
-  </data>
-  <data name="&gt;&gt;lblYvariable.Name" xml:space="preserve">
-    <value>lblYvariable</value>
-  </data>
-  <data name="&gt;&gt;lblYvariable.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblYvariable.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;lblYvariable.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
   <data name="cmdColumnChartOptions.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
@@ -403,7 +346,7 @@
     <value>121, 25</value>
   </data>
   <data name="cmdColumnChartOptions.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
+    <value>10</value>
   </data>
   <data name="cmdColumnChartOptions.Text" xml:space="preserve">
     <value>Column Chart Options</value>
@@ -420,76 +363,40 @@
   <data name="&gt;&gt;cmdColumnChartOptions.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
-  <data name="lblYValue.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
+  <data name="rdoFrequency.Appearance" type="System.Windows.Forms.Appearance, System.Windows.Forms">
+    <value>Button</value>
   </data>
-  <data name="lblYValue.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="rdoFrequency.FlatStyle" type="System.Windows.Forms.FlatStyle, System.Windows.Forms">
+    <value>Flat</value>
+  </data>
+  <data name="rdoFrequency.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="lblYValue.Location" type="System.Drawing.Point, System.Drawing">
-    <value>252, 126</value>
+  <data name="rdoFrequency.Location" type="System.Drawing.Point, System.Drawing">
+    <value>48, 12</value>
   </data>
-  <data name="lblYValue.Size" type="System.Drawing.Size, System.Drawing">
-    <value>47, 13</value>
+  <data name="rdoFrequency.Size" type="System.Drawing.Size, System.Drawing">
+    <value>110, 28</value>
   </data>
-  <data name="lblYValue.TabIndex" type="System.Int32, mscorlib">
-    <value>19</value>
+  <data name="rdoFrequency.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
   </data>
-  <data name="lblYValue.Text" xml:space="preserve">
-    <value>Y Value:</value>
+  <data name="rdoFrequency.Text" xml:space="preserve">
+    <value>Frequency</value>
   </data>
-  <data name="&gt;&gt;lblYValue.Name" xml:space="preserve">
-    <value>lblYValue</value>
+  <data name="rdoFrequency.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleCenter</value>
   </data>
-  <data name="&gt;&gt;lblYValue.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;rdoFrequency.Name" xml:space="preserve">
+    <value>rdoFrequency</value>
   </data>
-  <data name="&gt;&gt;lblYValue.Parent" xml:space="preserve">
+  <data name="&gt;&gt;rdoFrequency.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rdoFrequency.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;lblYValue.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="ucrInputBarChartPositions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>255, 192</value>
-  </data>
-  <data name="ucrInputBarChartPositions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>92, 21</value>
-  </data>
-  <data name="ucrInputBarChartPositions.TabIndex" type="System.Int32, mscorlib">
-    <value>35</value>
-  </data>
-  <data name="&gt;&gt;ucrInputBarChartPositions.Name" xml:space="preserve">
-    <value>ucrInputBarChartPositions</value>
-  </data>
-  <data name="&gt;&gt;ucrInputBarChartPositions.Type" xml:space="preserve">
-    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrInputBarChartPositions.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;ucrInputBarChartPositions.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="ucrInputYValues.Location" type="System.Drawing.Point, System.Drawing">
-    <value>255, 142</value>
-  </data>
-  <data name="ucrInputYValues.Size" type="System.Drawing.Size, System.Drawing">
-    <value>107, 21</value>
-  </data>
-  <data name="ucrInputYValues.TabIndex" type="System.Int32, mscorlib">
-    <value>34</value>
-  </data>
-  <data name="&gt;&gt;ucrInputYValues.Name" xml:space="preserve">
-    <value>ucrInputYValues</value>
-  </data>
-  <data name="&gt;&gt;ucrInputYValues.Type" xml:space="preserve">
-    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrInputYValues.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;ucrInputYValues.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;rdoFrequency.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
@@ -501,6 +408,27 @@
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
     <value>415, 411</value>
   </data>
+  <data name="ucrInputBarChartPositions.Location" type="System.Drawing.Point, System.Drawing">
+    <value>252, 281</value>
+  </data>
+  <data name="ucrInputBarChartPositions.Size" type="System.Drawing.Size, System.Drawing">
+    <value>92, 21</value>
+  </data>
+  <data name="ucrInputBarChartPositions.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;ucrInputBarChartPositions.Name" xml:space="preserve">
+    <value>ucrInputBarChartPositions</value>
+  </data>
+  <data name="&gt;&gt;ucrInputBarChartPositions.Type" xml:space="preserve">
+    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrInputBarChartPositions.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrInputBarChartPositions.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
   <data name="ucrSaveBar.Location" type="System.Drawing.Point, System.Drawing">
     <value>9, 328</value>
   </data>
@@ -511,7 +439,7 @@
     <value>255, 24</value>
   </data>
   <data name="ucrSaveBar.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
+    <value>13</value>
   </data>
   <data name="&gt;&gt;ucrSaveBar.Name" xml:space="preserve">
     <value>ucrSaveBar</value>
@@ -523,7 +451,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrSaveBar.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>5</value>
   </data>
   <data name="ucrChkFlipCoordinates.Location" type="System.Drawing.Point, System.Drawing">
     <value>9, 302</value>
@@ -532,7 +460,7 @@
     <value>166, 20</value>
   </data>
   <data name="ucrChkFlipCoordinates.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
+    <value>12</value>
   </data>
   <data name="&gt;&gt;ucrChkFlipCoordinates.Name" xml:space="preserve">
     <value>ucrChkFlipCoordinates</value>
@@ -544,10 +472,10 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrChkFlipCoordinates.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>6</value>
   </data>
   <data name="ucrReceiverByFactor.Location" type="System.Drawing.Point, System.Drawing">
-    <value>255, 239</value>
+    <value>252, 236</value>
   </data>
   <data name="ucrReceiverByFactor.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
@@ -556,7 +484,7 @@
     <value>120, 20</value>
   </data>
   <data name="ucrReceiverByFactor.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
+    <value>7</value>
   </data>
   <data name="&gt;&gt;ucrReceiverByFactor.Name" xml:space="preserve">
     <value>ucrReceiverByFactor</value>
@@ -568,31 +496,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrReceiverByFactor.ZOrder" xml:space="preserve">
-    <value>14</value>
-  </data>
-  <data name="ucrReceiverFirst.Location" type="System.Drawing.Point, System.Drawing">
-    <value>255, 89</value>
-  </data>
-  <data name="ucrReceiverFirst.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
-  </data>
-  <data name="ucrReceiverFirst.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 20</value>
-  </data>
-  <data name="ucrReceiverFirst.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverFirst.Name" xml:space="preserve">
-    <value>ucrReceiverFirst</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverFirst.Type" xml:space="preserve">
-    <value>instat.ucrReceiverSingle, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverFirst.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverFirst.ZOrder" xml:space="preserve">
-    <value>15</value>
+    <value>11</value>
   </data>
   <data name="ucrBarChartSelector.Location" type="System.Drawing.Point, System.Drawing">
     <value>10, 41</value>
@@ -616,7 +520,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrBarChartSelector.ZOrder" xml:space="preserve">
-    <value>16</value>
+    <value>12</value>
   </data>
   <data name="ucrBase.Location" type="System.Drawing.Point, System.Drawing">
     <value>9, 358</value>
@@ -625,7 +529,7 @@
     <value>410, 52</value>
   </data>
   <data name="ucrBase.TabIndex" type="System.Int32, mscorlib">
-    <value>16</value>
+    <value>14</value>
   </data>
   <data name="&gt;&gt;ucrBase.Name" xml:space="preserve">
     <value>ucrBase</value>
@@ -637,10 +541,10 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrBase.ZOrder" xml:space="preserve">
-    <value>17</value>
+    <value>13</value>
   </data>
   <data name="ucrPnlOptions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>66, 6</value>
+    <value>47, 6</value>
   </data>
   <data name="ucrPnlOptions.Size" type="System.Drawing.Size, System.Drawing">
     <value>330, 36</value>
@@ -658,7 +562,10 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrPnlOptions.ZOrder" xml:space="preserve">
-    <value>20</value>
+    <value>16</value>
+  </data>
+  <data name="$this.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterScreen</value>
@@ -672,28 +579,25 @@
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
     <value>System.Windows.Forms.Form, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="ucrReceiverY.Location" type="System.Drawing.Point, System.Drawing">
-    <value>255, 192</value>
+  <data name="ucrVariablesAsFactorForBarChart.Location" type="System.Drawing.Point, System.Drawing">
+    <value>252, 62</value>
   </data>
-  <data name="ucrReceiverY.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
+  <data name="ucrVariablesAsFactorForBarChart.Size" type="System.Drawing.Size, System.Drawing">
+    <value>125, 136</value>
   </data>
-  <data name="ucrReceiverY.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 21</value>
+  <data name="ucrVariablesAsFactorForBarChart.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
   </data>
-  <data name="ucrReceiverY.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
+  <data name="&gt;&gt;ucrVariablesAsFactorForBarChart.Name" xml:space="preserve">
+    <value>ucrVariablesAsFactorForBarChart</value>
   </data>
-  <data name="&gt;&gt;ucrReceiverY.Name" xml:space="preserve">
-    <value>ucrReceiverY</value>
+  <data name="&gt;&gt;ucrVariablesAsFactorForBarChart.Type" xml:space="preserve">
+    <value>instat.ucrVariablesAsFactor, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="&gt;&gt;ucrReceiverY.Type" xml:space="preserve">
-    <value>instat.ucrReceiverSingle, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrReceiverY.Parent" xml:space="preserve">
+  <data name="&gt;&gt;ucrVariablesAsFactorForBarChart.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;ucrReceiverY.ZOrder" xml:space="preserve">
-    <value>5</value>
+  <data name="&gt;&gt;ucrVariablesAsFactorForBarChart.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
 </root>

--- a/instat/dlgBarAndPieChart.resx
+++ b/instat/dlgBarAndPieChart.resx
@@ -361,7 +361,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblPosition.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>6</value>
   </data>
   <data name="lblYvariable.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -391,7 +391,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblYvariable.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="cmdColumnChartOptions.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -418,7 +418,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;cmdColumnChartOptions.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="lblYValue.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -448,28 +448,49 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblYValue.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
-  <data name="ucrInputYValue.Location" type="System.Drawing.Point, System.Drawing">
-    <value>255, 142</value>
+  <data name="ucrInputBarChartPositions.Location" type="System.Drawing.Point, System.Drawing">
+    <value>255, 192</value>
   </data>
-  <data name="ucrInputYValue.Size" type="System.Drawing.Size, System.Drawing">
-    <value>107, 21</value>
+  <data name="ucrInputBarChartPositions.Size" type="System.Drawing.Size, System.Drawing">
+    <value>92, 21</value>
   </data>
-  <data name="ucrInputYValue.TabIndex" type="System.Int32, mscorlib">
-    <value>20</value>
+  <data name="ucrInputBarChartPositions.TabIndex" type="System.Int32, mscorlib">
+    <value>35</value>
   </data>
-  <data name="&gt;&gt;ucrInputYValue.Name" xml:space="preserve">
-    <value>ucrInputYValue</value>
+  <data name="&gt;&gt;ucrInputBarChartPositions.Name" xml:space="preserve">
+    <value>ucrInputBarChartPositions</value>
   </data>
-  <data name="&gt;&gt;ucrInputYValue.Type" xml:space="preserve">
+  <data name="&gt;&gt;ucrInputBarChartPositions.Type" xml:space="preserve">
     <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="&gt;&gt;ucrInputYValue.Parent" xml:space="preserve">
+  <data name="&gt;&gt;ucrInputBarChartPositions.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;ucrInputYValue.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;ucrInputBarChartPositions.ZOrder" xml:space="preserve">
     <value>0</value>
+  </data>
+  <data name="ucrInputYValues.Location" type="System.Drawing.Point, System.Drawing">
+    <value>255, 142</value>
+  </data>
+  <data name="ucrInputYValues.Size" type="System.Drawing.Size, System.Drawing">
+    <value>107, 21</value>
+  </data>
+  <data name="ucrInputYValues.TabIndex" type="System.Int32, mscorlib">
+    <value>34</value>
+  </data>
+  <data name="&gt;&gt;ucrInputYValues.Name" xml:space="preserve">
+    <value>ucrInputYValues</value>
+  </data>
+  <data name="&gt;&gt;ucrInputYValues.Type" xml:space="preserve">
+    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrInputYValues.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrInputYValues.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -479,30 +500,6 @@
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
     <value>415, 411</value>
-  </data>
-  <data name="ucrInputBarChartPosition.Location" type="System.Drawing.Point, System.Drawing">
-    <value>255, 190</value>
-  </data>
-  <data name="ucrInputBarChartPosition.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>21, 17, 21, 17</value>
-  </data>
-  <data name="ucrInputBarChartPosition.Size" type="System.Drawing.Size, System.Drawing">
-    <value>92, 21</value>
-  </data>
-  <data name="ucrInputBarChartPosition.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;ucrInputBarChartPosition.Name" xml:space="preserve">
-    <value>ucrInputBarChartPosition</value>
-  </data>
-  <data name="&gt;&gt;ucrInputBarChartPosition.Type" xml:space="preserve">
-    <value>instat.ucrInputComboBox, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrInputBarChartPosition.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;ucrInputBarChartPosition.ZOrder" xml:space="preserve">
-    <value>6</value>
   </data>
   <data name="ucrSaveBar.Location" type="System.Drawing.Point, System.Drawing">
     <value>9, 328</value>
@@ -676,7 +673,7 @@
     <value>System.Windows.Forms.Form, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="ucrReceiverY.Location" type="System.Drawing.Point, System.Drawing">
-    <value>255, 190</value>
+    <value>255, 192</value>
   </data>
   <data name="ucrReceiverY.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
@@ -697,6 +694,6 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrReceiverY.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>5</value>
   </data>
 </root>

--- a/instat/dlgBarAndPieChart.resx
+++ b/instat/dlgBarAndPieChart.resx
@@ -133,7 +133,7 @@
     <value>103, 13</value>
   </data>
   <data name="lblByFactor.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
+    <value>8</value>
   </data>
   <data name="lblByFactor.Text" xml:space="preserve">
     <value>By Factor (Optional):</value>
@@ -160,7 +160,7 @@
     <value>121, 25</value>
   </data>
   <data name="cmdOptions.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
+    <value>13</value>
   </data>
   <data name="cmdOptions.Text" xml:space="preserve">
     <value>Plot Options</value>
@@ -319,7 +319,7 @@
     <value>47, 13</value>
   </data>
   <data name="lblPosition.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
+    <value>10</value>
   </data>
   <data name="lblPosition.Text" xml:space="preserve">
     <value>Position:</value>
@@ -346,7 +346,7 @@
     <value>121, 25</value>
   </data>
   <data name="cmdColumnChartOptions.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
+    <value>12</value>
   </data>
   <data name="cmdColumnChartOptions.Text" xml:space="preserve">
     <value>Column Chart Options</value>
@@ -370,7 +370,7 @@
     <value>92, 21</value>
   </data>
   <data name="ucrInputBarChartPositions.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
+    <value>11</value>
   </data>
   <data name="&gt;&gt;ucrInputBarChartPositions.Name" xml:space="preserve">
     <value>ucrInputBarChartPositions</value>
@@ -394,7 +394,7 @@
     <value>255, 24</value>
   </data>
   <data name="ucrSaveBar.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
+    <value>15</value>
   </data>
   <data name="&gt;&gt;ucrSaveBar.Name" xml:space="preserve">
     <value>ucrSaveBar</value>
@@ -415,7 +415,7 @@
     <value>166, 20</value>
   </data>
   <data name="ucrChkFlipCoordinates.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
+    <value>14</value>
   </data>
   <data name="&gt;&gt;ucrChkFlipCoordinates.Name" xml:space="preserve">
     <value>ucrChkFlipCoordinates</value>
@@ -451,7 +451,7 @@
     <value>58, 13</value>
   </data>
   <data name="lblXvariable.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
+    <value>6</value>
   </data>
   <data name="lblXvariable.Text" xml:space="preserve">
     <value>X Variable:</value>
@@ -478,7 +478,7 @@
     <value>120, 21</value>
   </data>
   <data name="ucrReceiverX.TabIndex" type="System.Int32, mscorlib">
-    <value>16</value>
+    <value>7</value>
   </data>
   <data name="&gt;&gt;ucrReceiverX.Name" xml:space="preserve">
     <value>ucrReceiverX</value>
@@ -580,7 +580,7 @@
     <value>410, 52</value>
   </data>
   <data name="ucrBase.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
+    <value>16</value>
   </data>
   <data name="&gt;&gt;ucrBase.Name" xml:space="preserve">
     <value>ucrBase</value>
@@ -637,7 +637,7 @@
     <value>120, 20</value>
   </data>
   <data name="ucrReceiverByFactor.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
+    <value>9</value>
   </data>
   <data name="&gt;&gt;ucrReceiverByFactor.Name" xml:space="preserve">
     <value>ucrReceiverByFactor</value>

--- a/instat/dlgBarAndPieChart.vb
+++ b/instat/dlgBarAndPieChart.vb
@@ -56,8 +56,8 @@ Public Class dlgBarAndPieChart
 
         bReset = False
         ChangeLabel()
-        autoTranslate(Me)
         TestOkEnabled()
+        autoTranslate(Me)
     End Sub
 
     Private Sub InitialiseDialog()
@@ -337,12 +337,11 @@ Public Class dlgBarAndPieChart
         SetDialogOptions()
         ChangeLabel()
         setColumnChartOption()
-        TestOkEnabled()
-        autoTranslate(Me)
     End Sub
 
     Private Sub setColumnChartOption()
         If ucrInputYValue.GetValue = "Variable" Then
+            lblPosition.Visible = False
             ucrReceiverY.SetVisible(True)
             ucrReceiverY.SetMeAsReceiver()
             ucrReceiverY.AddOrRemoveParameter(True)
@@ -350,6 +349,7 @@ Public Class dlgBarAndPieChart
             ucrReceiverY.SetVisible(False)
             ucrReceiverFirst.SetMeAsReceiver()
             ucrReceiverY.AddOrRemoveParameter(False)
+            lblPosition.Visible = rdoBarChart.Checked
         End If
     End Sub
 

--- a/instat/dlgBarAndPieChart.vb
+++ b/instat/dlgBarAndPieChart.vb
@@ -77,8 +77,8 @@ Public Class dlgBarAndPieChart
         ucrPnlOptions.AddParameterPresentCondition(rdoBarChart, "coordpolar", False)
 
         ucrPnlOptions.AddToLinkedControls({ucrChkFlipCoordinates}, {rdoBarChart}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
-        ucrPnlOptions.AddToLinkedControls(ucrInputBarChartPosition, {rdoBarChart}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
-        ucrInputBarChartPosition.SetLinkedDisplayControl(lblPosition)
+        ucrPnlOptions.AddToLinkedControls(ucrInputBarChartPositions, {rdoBarChart}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
+        ucrInputBarChartPositions.SetLinkedDisplayControl(lblPosition)
         ucrPnlOptions.AddToLinkedControls({ucrReceiverByFactor}, {rdoBarChart}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
         ucrReceiverByFactor.SetLinkedDisplayControl(lblByFactor)
 
@@ -126,23 +126,24 @@ Public Class dlgBarAndPieChart
         ucrChkFlipCoordinates.SetText("Flip Coordinates")
         ucrChkFlipCoordinates.SetParameter(clsCoordFlipParam, bNewChangeParameterValue:=False, bNewAddRemoveParameter:=True)
 
-        ucrInputYValue.SetParameter(New RParameter("stat", 0))
+
+        ucrInputYValues.SetParameter(New RParameter("stat", 0))
         dctStatOptions.Add("Count", Chr(34) & "count" & Chr(34))
         dctStatOptions.Add("Variable", Chr(34) & "identity" & Chr(34))
-        ucrInputYValue.SetItems(dctStatOptions)
-        ucrInputYValue.SetDropDownStyleAsNonEditable()
-        ucrInputYValue.SetRDefault(Chr(34) & "count" & Chr(34))
+        ucrInputYValues.SetItems(dctStatOptions)
+        ucrInputYValues.SetDropDownStyleAsNonEditable()
+        ucrInputYValues.SetRDefault(Chr(34) & "count" & Chr(34))
 
-        ucrInputBarChartPosition.SetParameter(New RParameter("position", 0))
+        ucrInputBarChartPositions.SetParameter(New RParameter("position", 0))
         dctPositionPairs.Add("Stack", Chr(34) & "stack" & Chr(34))
         dctPositionPairs.Add("Dodge", Chr(34) & "dodge" & Chr(34))
         dctPositionPairs.Add("Identity", Chr(34) & "identity" & Chr(34))
         dctPositionPairs.Add("Jitter", Chr(34) & "jitter" & Chr(34))
         dctPositionPairs.Add("Fill", Chr(34) & "fill" & Chr(34))
         dctPositionPairs.Add("Stack in reverse", "position_stack(reverse = TRUE)")
-        ucrInputBarChartPosition.SetItems(dctPositionPairs)
-        ucrInputBarChartPosition.SetDropDownStyleAsNonEditable()
-        ucrInputBarChartPosition.SetRDefault(Chr(34) & "stack" & Chr(34))
+        ucrInputBarChartPositions.SetItems(dctPositionPairs)
+        ucrInputBarChartPositions.SetDropDownStyleAsNonEditable()
+        ucrInputBarChartPositions.SetRDefault(Chr(34) & "stack" & Chr(34))
 
     End Sub
 
@@ -214,8 +215,8 @@ Public Class dlgBarAndPieChart
         ucrBarChartSelector.SetRCode(clsRggplotFunction, bReset)
         ucrPnlOptions.SetRCode(clsBaseOperator, bReset)
         ucrChkFlipCoordinates.SetRCode(clsBaseOperator, bReset)
-        ucrInputBarChartPosition.SetRCode(clsRgeomBarFunction, bReset)
-        ucrInputYValue.SetRCode(clsRgeomBarFunction, bReset)
+        ucrInputBarChartPositions.SetRCode(clsRgeomBarFunction, bReset)
+        ucrInputYValues.SetRCode(clsRgeomBarFunction, bReset)
     End Sub
 
     Private Sub TestOkEnabled()
@@ -270,7 +271,7 @@ Public Class dlgBarAndPieChart
             ucrReceiverByFactor.Clear()
         End If
         'Allows for sync with the layer parameters
-        ucrInputBarChartPosition.SetRCode(clsRgeomBarFunction, bReset)
+        ucrInputBarChartPositions.SetRCode(clsRgeomBarFunction, bReset)
         TestOkEnabled()
     End Sub
 
@@ -340,8 +341,9 @@ Public Class dlgBarAndPieChart
     End Sub
 
     Private Sub setColumnChartOption()
-        If ucrInputYValue.GetValue = "Variable" Then
+        If ucrInputYValues.GetValue = "Variable" Then
             lblPosition.Visible = False
+            ucrInputBarChartPositions.Visible = False
             ucrReceiverY.SetVisible(True)
             ucrReceiverY.SetMeAsReceiver()
             ucrReceiverY.AddOrRemoveParameter(True)
@@ -350,15 +352,24 @@ Public Class dlgBarAndPieChart
             ucrReceiverFirst.SetMeAsReceiver()
             ucrReceiverY.AddOrRemoveParameter(False)
             lblPosition.Visible = rdoBarChart.Checked
+            ucrInputBarChartPositions.Visible = rdoBarChart.Checked
         End If
     End Sub
 
-    Private Sub ucrInputYValue_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrInputYValue.ControlValueChanged
+    Private Sub ucrInputYValues_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrInputYValues.ControlValueChanged
         setColumnChartOption()
         TestOkEnabled()
     End Sub
 
     Private Sub CoreControls_ContentsChanged() Handles ucrReceiverFirst.ControlContentsChanged, ucrReceiverY.ControlContentsChanged, ucrSaveBar.ControlContentsChanged
         TestOkEnabled()
+    End Sub
+
+    Private Sub CoreControls_ContentsChanged(ucrChangedControl As ucrCore) Handles ucrSaveBar.ControlContentsChanged, ucrReceiverY.ControlContentsChanged, ucrReceiverFirst.ControlContentsChanged
+
+    End Sub
+
+    Private Sub ucrPnlOptions_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrPnlOptions.ControlValueChanged
+
     End Sub
 End Class

--- a/instat/dlgBarAndPieChart.vb
+++ b/instat/dlgBarAndPieChart.vb
@@ -86,9 +86,9 @@ Public Class dlgBarAndPieChart
         ucrBarChartSelector.SetParameter(New RParameter("data", 0))
         ucrBarChartSelector.SetParameterIsrfunction()
 
-        ucrVariablesAsFactorForBarChart.SetParameter(New RParameter("x", 0))
+        'ucrVariablesAsFactorForBarChart.SetParameter(New RParameter("x", 0))
         ucrVariablesAsFactorForBarChart.SetParameterIsString()
-        ucrVariablesAsFactorForBarChart.bWithQuotes = False
+        'ucrVariablesAsFactorForBarChart.bWithQuotes = False
         ucrVariablesAsFactorForBarChart.Selector = ucrBarChartSelector
         ucrVariablesAsFactorForBarChart.SetFactorReceiver(ucrReceiverByFactor)
         ucrVariablesAsFactorForBarChart.strSelectorHeading = "Variables"
@@ -98,7 +98,7 @@ Public Class dlgBarAndPieChart
         ucrReceiverX.Selector = ucrBarChartSelector
         ucrReceiverX.strSelectorHeading = "X Variable"
         'ucrReceiverX.SetParameter(New RParameter("x", 0))
-        ucrReceiverX.bWithQuotes = False
+        'ucrReceiverX.bWithQuotes = False
         ucrReceiverX.SetParameterIsString()
 
         ucrReceiverByFactor.Selector = ucrBarChartSelector
@@ -302,23 +302,23 @@ Public Class dlgBarAndPieChart
     End Sub
 
     Private Sub ChangeParameterName()
+        clsBarAesFunction.RemoveParameterByName("x")
+        clsBarAesFunction.RemoveParameterByName("y")
         If rdoValue.Checked Then
-            ucrVariablesAsFactorForBarChart.ChangeParameterName("y")
-            ucrReceiverX.Add(clsBarAesFunction.GetParameter("x").strArgumentValue)
-            ElseIf rdoFrequency.Checked Then
-            ucrVariablesAsFactorForBarChart.ChangeParameterName("x")
+            'ucrVariablesAsFactorForBarChart.ChangeParameterName("y")
+            clsBarAesFunction.AddParameter("x", ucrReceiverX.GetVariableNames(False), iPosition:=1)
+            clsBarAesFunction.AddParameter("y", ucrVariablesAsFactorForBarChart.GetVariableNames(False), iPosition:=2)
+        ElseIf rdoFrequency.Checked Then
+            'ucrVariablesAsFactorForBarChart.ChangeParameterName("x")
+            clsBarAesFunction.AddParameter("x", ucrVariablesAsFactorForBarChart.GetVariableNames(False), iPosition:=1)
         End If
     End Sub
-    Private Sub ucrPnlOptions_ControlValueChanged() Handles ucrPnlOptions.ControlValueChanged, ucrVariablesAsFactorForBarChart.ControlValueChanged
+    Private Sub ucrPnlOptions_ControlValueChanged() Handles ucrPnlOptions.ControlValueChanged, ucrVariablesAsFactorForBarChart.ControlValueChanged, ucrReceiverX.ControlValueChanged
         SetDialogOptions()
         ChangeParameterName()
     End Sub
 
-    Private Sub CoreControls_ContentsChanged() Handles ucrVariablesAsFactorForBarChart.ControlContentsChanged, ucrSaveBar.ControlContentsChanged
+    Private Sub CoreControls_ContentsChanged() Handles ucrVariablesAsFactorForBarChart.ControlContentsChanged, ucrSaveBar.ControlContentsChanged, ucrReceiverX.ControlContentsChanged
         TestOkEnabled()
-    End Sub
-
-    Private Sub CoreControls_ContentsChanged(ucrChangedControl As ucrCore) Handles ucrVariablesAsFactorForBarChart.ControlContentsChanged, ucrSaveBar.ControlContentsChanged
-
     End Sub
 End Class

--- a/instat/dlgBarAndPieChart.vb
+++ b/instat/dlgBarAndPieChart.vb
@@ -77,16 +77,16 @@ Public Class dlgBarAndPieChart
         ucrPnlOptions.AddFunctionNamesCondition(rdoValue, "coordpolar")
         ucrPnlOptions.AddFunctionNamesCondition(rdoPieChart, "coordpolar")
 
-        ucrPnlOptions.AddToLinkedControls({ucrChkFlipCoordinates}, {rdoFrequency, rdoValue}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
-        ucrPnlOptions.AddToLinkedControls(ucrInputBarChartPositions, {rdoFrequency, rdoValue}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
-        ucrPnlOptions.AddToLinkedControls({ucrReceiverByFactor}, {rdoFrequency, rdoValue}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
+        ucrPnlOptions.AddToLinkedControls({ucrChkFlipCoordinates, ucrInputBarChartPositions, ucrReceiverByFactor}, {rdoFrequency, rdoValue}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
+        ucrPnlOptions.AddToLinkedControls(ucrReceiverX, {rdoValue}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
         ucrReceiverByFactor.SetLinkedDisplayControl(lblByFactor)
+        ucrReceiverX.SetLinkedDisplayControl(lblXvariable)
         ucrInputBarChartPositions.SetLinkedDisplayControl(lblPosition)
 
         ucrBarChartSelector.SetParameter(New RParameter("data", 0))
         ucrBarChartSelector.SetParameterIsrfunction()
 
-        ucrVariablesAsFactorForBarChart.SetParameter(New RParameter("y", 1))
+        ucrVariablesAsFactorForBarChart.SetParameter(New RParameter("x", 0))
         ucrVariablesAsFactorForBarChart.SetParameterIsString()
         ucrVariablesAsFactorForBarChart.bWithQuotes = False
         ucrVariablesAsFactorForBarChart.Selector = ucrBarChartSelector
@@ -94,6 +94,12 @@ Public Class dlgBarAndPieChart
         ucrVariablesAsFactorForBarChart.strSelectorHeading = "Variables"
         ucrVariablesAsFactorForBarChart.SetValuesToIgnore({Chr(34) & Chr(34)})
         ucrVariablesAsFactorForBarChart.bAddParameterIfEmpty = True
+
+        ucrReceiverX.Selector = ucrBarChartSelector
+        ucrReceiverX.strSelectorHeading = "X Variable"
+        'ucrReceiverX.SetParameter(New RParameter("x", 0))
+        ucrReceiverX.bWithQuotes = False
+        ucrReceiverX.SetParameterIsString()
 
         ucrReceiverByFactor.Selector = ucrBarChartSelector
         ucrReceiverByFactor.SetIncludedDataTypes({"factor"})
@@ -196,6 +202,7 @@ Public Class dlgBarAndPieChart
 
     Private Sub SetRCodeForControls(bReset As Boolean)
         ucrVariablesAsFactorForBarChart.SetRCode(clsBarAesFunction, bReset)
+        ucrReceiverX.SetRCode(clsBarAesFunction, bReset)
         ucrReceiverByFactor.SetRCode(clsBarAesFunction, bReset)
         ucrSaveBar.SetRCode(clsBaseOperator, bReset)
         ucrBarChartSelector.SetRCode(clsRggplotFunction, bReset)
@@ -204,10 +211,18 @@ Public Class dlgBarAndPieChart
     End Sub
 
     Private Sub TestOkEnabled()
-        If (Not ucrSaveBar.IsComplete) OrElse (ucrVariablesAsFactorForBarChart.IsEmpty) Then
-            ucrBase.OKEnabled(False)
-        Else
-            ucrBase.OKEnabled(True)
+        If rdoFrequency.Checked Then
+            If Not ucrSaveBar.IsComplete OrElse ucrVariablesAsFactorForBarChart.IsEmpty Then
+                ucrBase.OKEnabled(False)
+            Else
+                ucrBase.OKEnabled(True)
+            End If
+        ElseIf rdoValue.Checked Then
+            If Not ucrSaveBar.IsComplete OrElse ucrVariablesAsFactorForBarChart.IsEmpty OrElse ucrReceiverX.IsEmpty Then
+                ucrBase.OKEnabled(False)
+            Else
+                ucrBase.OKEnabled(True)
+            End If
         End If
     End Sub
 
@@ -288,9 +303,10 @@ Public Class dlgBarAndPieChart
 
     Private Sub ChangeParameterName()
         If rdoValue.Checked Then
-            ucrVariablesAsFactorForBarChart.ChangeParameterName("x")
-        ElseIf rdoFrequency.Checked Then
             ucrVariablesAsFactorForBarChart.ChangeParameterName("y")
+            ucrReceiverX.Add(clsBarAesFunction.GetParameter("x").strArgumentValue)
+            ElseIf rdoFrequency.Checked Then
+            ucrVariablesAsFactorForBarChart.ChangeParameterName("x")
         End If
     End Sub
     Private Sub ucrPnlOptions_ControlValueChanged() Handles ucrPnlOptions.ControlValueChanged, ucrVariablesAsFactorForBarChart.ControlValueChanged
@@ -302,4 +318,7 @@ Public Class dlgBarAndPieChart
         TestOkEnabled()
     End Sub
 
+    Private Sub CoreControls_ContentsChanged(ucrChangedControl As ucrCore) Handles ucrVariablesAsFactorForBarChart.ControlContentsChanged, ucrSaveBar.ControlContentsChanged
+
+    End Sub
 End Class

--- a/instat/dlgBarAndPieChart.vb
+++ b/instat/dlgBarAndPieChart.vb
@@ -247,19 +247,11 @@ Public Class dlgBarAndPieChart
         sdgLayerOptions.SetupLayer(clsNewGgPlot:=clsRggplotFunction, clsNewGeomFunc:=clsRgeomBarFunction, clsNewGlobalAesFunc:=clsBarAesFunction, clsNewLocalAes:=clsLocalRaesFunction, bFixGeom:=True, ucrNewBaseSelector:=ucrBarChartSelector, bApplyAesGlobally:=True, bReset:=bResetBarLayerSubdialog)
         sdgLayerOptions.ShowDialog()
         bResetBarLayerSubdialog = False
-        For Each clsParam In clsBarAesFunction.clsParameters
-            If clsParam.strArgumentName = "y" AndAlso (clsParam.strArgumentValue <> "value" OrElse ucrVariablesAsFactorForBarChart.bSingleVariable) Then
-                If clsParam.strArgumentValue = (Chr(34) & Chr(34)) Then
-                    ucrVariablesAsFactorForBarChart.Clear()
-                Else ucrVariablesAsFactorForBarChart.Add(clsParam.strArgumentValue)
-                End If
-            ElseIf clsParam.strArgumentName = "x" AndAlso (clsParam.strArgumentValue <> "value" OrElse ucrVariablesAsFactorForBarChart.bSingleVariable) Then
-                If clsParam.strArgumentValue = (Chr(34) & Chr(34)) Then
-                    ucrVariablesAsFactorForBarChart.Clear()
-                Else ucrVariablesAsFactorForBarChart.Add(clsParam.strArgumentValue)
-                End If
-            End If
-        Next
+        If clsBarAesFunction.ContainsParameter("x") Then
+            ucrVariablesAsFactorForBarChart.Add(clsBarAesFunction.GetParameter("x").strArgumentValue)
+        Else
+            ucrVariablesAsFactorForBarChart.Clear()
+        End If
         If clsBarAesFunction.ContainsParameter("fill") Then
             ucrReceiverByFactor.Add(clsBarAesFunction.GetParameter("fill").strArgumentValue)
         Else

--- a/instat/dlgBarAndPieChart.vb
+++ b/instat/dlgBarAndPieChart.vb
@@ -305,12 +305,12 @@ Public Class dlgBarAndPieChart
         clsBarAesFunction.RemoveParameterByName("x")
         clsBarAesFunction.RemoveParameterByName("y")
         If rdoValue.Checked Then
-            'ucrVariablesAsFactorForBarChart.ChangeParameterName("y")
             clsBarAesFunction.AddParameter("x", ucrReceiverX.GetVariableNames(False), iPosition:=1)
             clsBarAesFunction.AddParameter("y", ucrVariablesAsFactorForBarChart.GetVariableNames(False), iPosition:=2)
+            clsRgeomBarFunction.AddParameter("stat", Chr(34) & "identity" & Chr(34), iPosition:=1)
         ElseIf rdoFrequency.Checked Then
-            'ucrVariablesAsFactorForBarChart.ChangeParameterName("x")
             clsBarAesFunction.AddParameter("x", ucrVariablesAsFactorForBarChart.GetVariableNames(False), iPosition:=1)
+            clsRgeomBarFunction.AddParameter("stat", Chr(34) & "count" & Chr(34), iPosition:=1)
         End If
     End Sub
     Private Sub ucrPnlOptions_ControlValueChanged() Handles ucrPnlOptions.ControlValueChanged, ucrVariablesAsFactorForBarChart.ControlValueChanged, ucrReceiverX.ControlValueChanged

--- a/instat/dlgBarAndPieChart.vb
+++ b/instat/dlgBarAndPieChart.vb
@@ -55,7 +55,6 @@ Public Class dlgBarAndPieChart
         SetRCodeForControls(bReset)
 
         bReset = False
-        ChangeLabel()
         TestOkEnabled()
         autoTranslate(Me)
     End Sub
@@ -71,26 +70,30 @@ Public Class dlgBarAndPieChart
         ucrBase.clsRsyntax.iCallType = 3
         ucrBase.iHelpTopicID = 438
 
-        ucrPnlOptions.AddRadioButton(rdoBarChart)
+        ucrPnlOptions.AddRadioButton(rdoFrequency)
+        ucrPnlOptions.AddRadioButton(rdoValue)
         ucrPnlOptions.AddRadioButton(rdoPieChart)
-        ucrPnlOptions.AddParameterPresentCondition(rdoPieChart, "coordpolar")
-        ucrPnlOptions.AddParameterPresentCondition(rdoBarChart, "coordpolar", False)
+        ucrPnlOptions.AddFunctionNamesCondition(rdoFrequency, "coordpolar")
+        ucrPnlOptions.AddFunctionNamesCondition(rdoValue, "coordpolar")
+        ucrPnlOptions.AddFunctionNamesCondition(rdoPieChart, "coordpolar")
 
-        ucrPnlOptions.AddToLinkedControls({ucrChkFlipCoordinates}, {rdoBarChart}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
-        ucrPnlOptions.AddToLinkedControls(ucrInputBarChartPositions, {rdoBarChart}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
-        ucrInputBarChartPositions.SetLinkedDisplayControl(lblPosition)
-        ucrPnlOptions.AddToLinkedControls({ucrReceiverByFactor}, {rdoBarChart}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
+        ucrPnlOptions.AddToLinkedControls({ucrChkFlipCoordinates}, {rdoFrequency, rdoValue}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
+        ucrPnlOptions.AddToLinkedControls(ucrInputBarChartPositions, {rdoFrequency, rdoValue}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
+        ucrPnlOptions.AddToLinkedControls({ucrReceiverByFactor}, {rdoFrequency, rdoValue}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
         ucrReceiverByFactor.SetLinkedDisplayControl(lblByFactor)
+        ucrInputBarChartPositions.SetLinkedDisplayControl(lblPosition)
 
         ucrBarChartSelector.SetParameter(New RParameter("data", 0))
         ucrBarChartSelector.SetParameterIsrfunction()
 
-        ucrReceiverFirst.Selector = ucrBarChartSelector
-        ucrReceiverFirst.strSelectorHeading = "Variables"
-        ucrReceiverFirst.SetParameter(New RParameter("x", 0))
-        ucrReceiverFirst.bWithQuotes = False
-        ucrReceiverFirst.SetParameterIsString()
-        ucrReceiverFirst.SetLinkedDisplayControl(lblVariable)
+        ucrVariablesAsFactorForBarChart.SetParameter(New RParameter("y", 1))
+        ucrVariablesAsFactorForBarChart.SetParameterIsString()
+        ucrVariablesAsFactorForBarChart.bWithQuotes = False
+        ucrVariablesAsFactorForBarChart.Selector = ucrBarChartSelector
+        ucrVariablesAsFactorForBarChart.SetFactorReceiver(ucrReceiverByFactor)
+        ucrVariablesAsFactorForBarChart.strSelectorHeading = "Variables"
+        ucrVariablesAsFactorForBarChart.SetValuesToIgnore({Chr(34) & Chr(34)})
+        ucrVariablesAsFactorForBarChart.bAddParameterIfEmpty = True
 
         ucrReceiverByFactor.Selector = ucrBarChartSelector
         ucrReceiverByFactor.SetIncludedDataTypes({"factor"})
@@ -98,13 +101,6 @@ Public Class dlgBarAndPieChart
         ucrReceiverByFactor.SetParameter(New RParameter("fill", 1))
         ucrReceiverByFactor.bWithQuotes = False
         ucrReceiverByFactor.SetParameterIsString()
-
-        ucrReceiverY.Selector = ucrBarChartSelector
-        ucrReceiverY.strSelectorHeading = "Y Variable"
-        ucrReceiverY.SetParameter(New RParameter("y", 1))
-        ucrReceiverY.bWithQuotes = False
-        ucrReceiverY.SetParameterIsString()
-        ucrReceiverY.SetLinkedDisplayControl(lblYvariable)
 
         ucrSaveBar.SetIsComboBox()
         ucrSaveBar.SetCheckBoxText("Save Graph")
@@ -126,13 +122,6 @@ Public Class dlgBarAndPieChart
         ucrChkFlipCoordinates.SetText("Flip Coordinates")
         ucrChkFlipCoordinates.SetParameter(clsCoordFlipParam, bNewChangeParameterValue:=False, bNewAddRemoveParameter:=True)
 
-
-        ucrInputYValues.SetParameter(New RParameter("stat", 0))
-        dctStatOptions.Add("Count", Chr(34) & "count" & Chr(34))
-        dctStatOptions.Add("Variable", Chr(34) & "identity" & Chr(34))
-        ucrInputYValues.SetItems(dctStatOptions)
-        ucrInputYValues.SetDropDownStyleAsNonEditable()
-        ucrInputYValues.SetRDefault(Chr(34) & "count" & Chr(34))
 
         ucrInputBarChartPositions.SetParameter(New RParameter("position", 0))
         dctPositionPairs.Add("Stack", Chr(34) & "stack" & Chr(34))
@@ -156,7 +145,7 @@ Public Class dlgBarAndPieChart
 
         ucrBarChartSelector.Reset()
         ucrBarChartSelector.SetGgplotFunction(clsBaseOperator)
-        ucrReceiverFirst.SetMeAsReceiver()
+        ucrVariablesAsFactorForBarChart.SetMeAsReceiver()
         ucrSaveBar.Reset()
         bResetSubdialog = True
         bResetBarLayerSubdialog = True
@@ -206,32 +195,19 @@ Public Class dlgBarAndPieChart
     End Sub
 
     Private Sub SetRCodeForControls(bReset As Boolean)
-        ucrReceiverFirst.SetRCode(clsBarAesFunction, bReset)
-        ucrReceiverFirst.AddAdditionalCodeParameterPair(clsPieAesFunction, New RParameter("fill", 0), iAdditionalPairNo:=1)
-        ucrReceiverY.SetRCode(clsBarAesFunction, bReset)
-        ucrReceiverY.AddAdditionalCodeParameterPair(clsPieAesFunction, New RParameter("y", 1), iAdditionalPairNo:=1)
+        ucrVariablesAsFactorForBarChart.SetRCode(clsBarAesFunction, bReset)
         ucrReceiverByFactor.SetRCode(clsBarAesFunction, bReset)
         ucrSaveBar.SetRCode(clsBaseOperator, bReset)
         ucrBarChartSelector.SetRCode(clsRggplotFunction, bReset)
-        ucrPnlOptions.SetRCode(clsBaseOperator, bReset)
         ucrChkFlipCoordinates.SetRCode(clsBaseOperator, bReset)
         ucrInputBarChartPositions.SetRCode(clsRgeomBarFunction, bReset)
-        ucrInputYValues.SetRCode(clsRgeomBarFunction, bReset)
     End Sub
 
     Private Sub TestOkEnabled()
-        If rdoBarChart.Checked Then
-            If Not ucrReceiverFirst.IsEmpty AndAlso Not (ucrReceiverY.IsEmpty AndAlso ucrReceiverY.Visible) AndAlso ucrSaveBar.IsComplete Then
-                ucrBase.OKEnabled(True)
-            Else
-                ucrBase.OKEnabled(False)
-            End If
-        ElseIf rdoPieChart.Checked Then
-            If ucrReceiverFirst.IsEmpty OrElse Not ucrSaveBar.IsComplete Then
-                ucrBase.OKEnabled(False)
-            Else
-                ucrBase.OKEnabled(True)
-            End If
+        If (Not ucrSaveBar.IsComplete) OrElse (ucrVariablesAsFactorForBarChart.IsEmpty) Then
+            ucrBase.OKEnabled(False)
+        Else
+            ucrBase.OKEnabled(True)
         End If
     End Sub
 
@@ -242,7 +218,7 @@ Public Class dlgBarAndPieChart
     End Sub
 
     Private Sub cmdOptions_Click(sender As Object, e As EventArgs) Handles cmdOptions.Click
-        If rdoBarChart.Checked Then
+        If rdoValue.Checked Or rdoFrequency.Checked Then
             sdgPlots.SetRCode(clsNewOperator:=clsBaseOperator, clsNewGlobalAesFunction:=clsBarAesFunction, clsNewYScalecontinuousFunction:=clsYScalecontinuousFunction, clsNewThemeFunction:=clsThemeFuction, dctNewThemeFunctions:=dctThemeFunctions, clsNewXScalecontinuousFunction:=clsXScalecontinuousFunction, clsNewXLabsTitleFunction:=clsXlabFunction, clsNewScaleFillViridisFunction:=clsScaleFillViridisFunction, clsNewScaleColourViridisFunction:=clsScaleColourViridisFunction, clsNewYLabTitleFunction:=clsYlabFunction, clsNewLabsFunction:=clsLabsFunction, clsNewFacetFunction:=clsRFacetFunction, ucrNewBaseSelector:=ucrBarChartSelector, clsNewCoordPolarFunction:=clsCoordPolarFunction, clsNewCoordPolarStartOperator:=clsCoordPolarStartOperator, clsNewXScaleDateFunction:=clsXScaleDateFunction, clsNewYScaleDateFunction:=clsYScaleDateFunction, bReset:=bResetSubdialog, bNewEnableDiscrete:=False)
         Else
             sdgPlots.SetRCode(clsNewOperator:=clsBaseOperator, clsNewGlobalAesFunction:=clsPieAesFunction, clsNewYScalecontinuousFunction:=clsYScalecontinuousFunction, clsNewThemeFunction:=clsThemeFuction, dctNewThemeFunctions:=dctThemeFunctions, clsNewXScalecontinuousFunction:=clsXScalecontinuousFunction, clsNewXLabsTitleFunction:=clsXlabFunction, clsNewYLabTitleFunction:=clsYlabFunction, clsNewLabsFunction:=clsLabsFunction, clsNewScaleFillViridisFunction:=clsScaleFillViridisFunction, clsNewScaleColourViridisFunction:=clsScaleColourViridisFunction, clsNewFacetFunction:=clsRFacetFunction, ucrNewBaseSelector:=ucrBarChartSelector, clsNewCoordPolarFunction:=clsCoordPolarFunction, clsNewCoordPolarStartOperator:=clsCoordPolarStartOperator, clsNewXScaleDateFunction:=clsXScaleDateFunction, clsNewYScaleDateFunction:=clsYScaleDateFunction, bReset:=bResetSubdialog)
@@ -260,11 +236,19 @@ Public Class dlgBarAndPieChart
         sdgLayerOptions.SetupLayer(clsNewGgPlot:=clsRggplotFunction, clsNewGeomFunc:=clsRgeomBarFunction, clsNewGlobalAesFunc:=clsBarAesFunction, clsNewLocalAes:=clsLocalRaesFunction, bFixGeom:=True, ucrNewBaseSelector:=ucrBarChartSelector, bApplyAesGlobally:=True, bReset:=bResetBarLayerSubdialog)
         sdgLayerOptions.ShowDialog()
         bResetBarLayerSubdialog = False
-        If clsBarAesFunction.ContainsParameter("x") Then
-            ucrReceiverFirst.Add(clsBarAesFunction.GetParameter("x").strArgumentValue)
-        Else
-            ucrReceiverFirst.Clear()
-        End If
+        For Each clsParam In clsBarAesFunction.clsParameters
+            If clsParam.strArgumentName = "y" AndAlso (clsParam.strArgumentValue <> "value" OrElse ucrVariablesAsFactorForBarChart.bSingleVariable) Then
+                If clsParam.strArgumentValue = (Chr(34) & Chr(34)) Then
+                    ucrVariablesAsFactorForBarChart.Clear()
+                Else ucrVariablesAsFactorForBarChart.Add(clsParam.strArgumentValue)
+                End If
+            ElseIf clsParam.strArgumentName = "x" AndAlso (clsParam.strArgumentValue <> "value" OrElse ucrVariablesAsFactorForBarChart.bSingleVariable) Then
+                If clsParam.strArgumentValue = (Chr(34) & Chr(34)) Then
+                    ucrVariablesAsFactorForBarChart.Clear()
+                Else ucrVariablesAsFactorForBarChart.Add(clsParam.strArgumentValue)
+                End If
+            End If
+        Next
         If clsBarAesFunction.ContainsParameter("fill") Then
             ucrReceiverByFactor.Add(clsBarAesFunction.GetParameter("fill").strArgumentValue)
         Else
@@ -279,20 +263,11 @@ Public Class dlgBarAndPieChart
         sdgLayerOptions.SetupLayer(clsNewGgPlot:=clsRggplotFunction, clsNewGeomFunc:=clsRgeomBarFunction, clsNewGlobalAesFunc:=clsPieAesFunction, clsNewLocalAes:=clsLocalRaesFunction, bFixGeom:=True, ucrNewBaseSelector:=ucrBarChartSelector, bApplyAesGlobally:=True, bReset:=bResetBarLayerSubdialog)
         sdgLayerOptions.ShowDialog()
         bResetBarLayerSubdialog = False
-        'temp fix - should instead be setting R code of the receivers here
-        If Not clsPieAesFunction.ContainsParameter("x") Then
-            clsPieAesFunction.AddParameter("x", Chr(34) & Chr(34))
-        End If
-        If clsPieAesFunction.ContainsParameter("fill") Then
-            ucrReceiverFirst.Add(clsPieAesFunction.GetParameter("fill").strArgumentValue)
-        Else
-            ucrReceiverFirst.Clear()
-        End If
         TestOkEnabled()
     End Sub
 
     Private Sub SetDialogOptions()
-        If rdoBarChart.Checked Then
+        If rdoValue.Checked Or rdoFrequency.Checked Then
             clsRggplotFunction.AddParameter("mapping", clsRFunctionParameter:=clsBarAesFunction, iPosition:=1)
             cmdPieChartOptions.Visible = False
             cmdBarChartOptions.Visible = True
@@ -306,70 +281,25 @@ Public Class dlgBarAndPieChart
             If Not ucrSaveBar.bUserTyped Then
                 ucrSaveBar.SetPrefix("bar")
             End If
-            ucrReceiverFirst.RemoveIncludedMetadataProperty("class")
-            ucrReceiverFirst.strSelectorHeading = "Variables"
-        ElseIf rdoPieChart.Checked Then
-            clsRggplotFunction.AddParameter("mapping", clsRFunctionParameter:=clsPieAesFunction, iPosition:=1)
-            clsRgeomBarFunction.AddParameter("width", "1")
-            clsBaseOperator.AddParameter(clsRCoordPolarParam)
-            clsBaseOperator.RemoveParameterByName("geom_col")
-            ucrReceiverFirst.SetMeAsReceiver()
-            cmdPieChartOptions.Visible = True
-            cmdBarChartOptions.Visible = False
-            cmdColumnChartOptions.Visible = False
-            If Not ucrSaveBar.bUserTyped Then
-                ucrSaveBar.SetPrefix("pie")
-            End If
-            ucrReceiverFirst.SetIncludedDataTypes({"factor"})
-            ucrReceiverFirst.strSelectorHeading = "Factors"
-            If Not {"factor", "logical"}.Contains(ucrReceiverFirst.strCurrDataType) Then
-                ucrReceiverFirst.Clear()
-            End If
+            ucrVariablesAsFactorForBarChart.RemoveIncludedMetadataProperty("class")
+            ucrVariablesAsFactorForBarChart.strSelectorHeading = "Variables"
         End If
     End Sub
 
-    Private Sub ChangeLabel()
-        lblVariable.Text = If(rdoBarChart.Checked, "X Variable", "Variable")
-        lblYValue.Text = If(rdoBarChart.Checked, "Y Value", "Value")
-        lblYvariable.Text = If(rdoBarChart.Checked, "Y Variable", "Value from")
+    Private Sub ChangeParameterName()
+        If rdoValue.Checked Then
+            ucrVariablesAsFactorForBarChart.ChangeParameterName("x")
+        ElseIf rdoFrequency.Checked Then
+            ucrVariablesAsFactorForBarChart.ChangeParameterName("y")
+        End If
     End Sub
-
-    Private Sub ucrPnlOptions_ControlValueChanged() Handles ucrPnlOptions.ControlValueChanged
+    Private Sub ucrPnlOptions_ControlValueChanged() Handles ucrPnlOptions.ControlValueChanged, ucrVariablesAsFactorForBarChart.ControlValueChanged
         SetDialogOptions()
-        ChangeLabel()
-        setColumnChartOption()
+        ChangeParameterName()
     End Sub
 
-    Private Sub setColumnChartOption()
-        If ucrInputYValues.GetValue = "Variable" Then
-            lblPosition.Visible = False
-            ucrInputBarChartPositions.Visible = False
-            ucrReceiverY.SetVisible(True)
-            ucrReceiverY.SetMeAsReceiver()
-            ucrReceiverY.AddOrRemoveParameter(True)
-        Else
-            ucrReceiverY.SetVisible(False)
-            ucrReceiverFirst.SetMeAsReceiver()
-            ucrReceiverY.AddOrRemoveParameter(False)
-            lblPosition.Visible = rdoBarChart.Checked
-            ucrInputBarChartPositions.Visible = rdoBarChart.Checked
-        End If
-    End Sub
-
-    Private Sub ucrInputYValues_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrInputYValues.ControlValueChanged
-        setColumnChartOption()
+    Private Sub CoreControls_ContentsChanged() Handles ucrVariablesAsFactorForBarChart.ControlContentsChanged, ucrSaveBar.ControlContentsChanged
         TestOkEnabled()
     End Sub
 
-    Private Sub CoreControls_ContentsChanged() Handles ucrReceiverFirst.ControlContentsChanged, ucrReceiverY.ControlContentsChanged, ucrSaveBar.ControlContentsChanged
-        TestOkEnabled()
-    End Sub
-
-    Private Sub CoreControls_ContentsChanged(ucrChangedControl As ucrCore) Handles ucrSaveBar.ControlContentsChanged, ucrReceiverY.ControlContentsChanged, ucrReceiverFirst.ControlContentsChanged
-
-    End Sub
-
-    Private Sub ucrPnlOptions_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrPnlOptions.ControlValueChanged
-
-    End Sub
 End Class

--- a/instat/dlgBarAndPieChart.vb
+++ b/instat/dlgBarAndPieChart.vb
@@ -86,9 +86,7 @@ Public Class dlgBarAndPieChart
         ucrBarChartSelector.SetParameter(New RParameter("data", 0))
         ucrBarChartSelector.SetParameterIsrfunction()
 
-        'ucrVariablesAsFactorForBarChart.SetParameter(New RParameter("x", 0))
         ucrVariablesAsFactorForBarChart.SetParameterIsString()
-        'ucrVariablesAsFactorForBarChart.bWithQuotes = False
         ucrVariablesAsFactorForBarChart.Selector = ucrBarChartSelector
         ucrVariablesAsFactorForBarChart.SetFactorReceiver(ucrReceiverByFactor)
         ucrVariablesAsFactorForBarChart.strSelectorHeading = "Variables"
@@ -97,8 +95,6 @@ Public Class dlgBarAndPieChart
 
         ucrReceiverX.Selector = ucrBarChartSelector
         ucrReceiverX.strSelectorHeading = "X Variable"
-        'ucrReceiverX.SetParameter(New RParameter("x", 0))
-        'ucrReceiverX.bWithQuotes = False
         ucrReceiverX.SetParameterIsString()
 
         ucrReceiverByFactor.Selector = ucrBarChartSelector


### PR DESCRIPTION
Partially fixes #6135
This PR fixes the bug in the two comboxes to remember the states in reopen, and the presentation of the labels.
@africanmathsinitiative/developers @rdstern this is ready for review. Thanks.