### PR TITLE
climatic data entry pasting bug fix

### DIFF
--- a/instat/sdgClimaticDataEntry.vb
+++ b/instat/sdgClimaticDataEntry.vb
@@ -373,6 +373,7 @@ Public Class sdgClimaticDataEntry
             iStartRowIndex += 1
         Next
 
+        iStartRowIndex = grdCurrentWorkSheet.SelectionRange.Row
         'then save the values if all are valid
         For index As Integer = 0 To arrPasteValues.Length - 1
             strNewValue = arrPasteValues(index).Trim


### PR DESCRIPTION
Fixes pasting into the data entry bug.
@rdstern I noticed there is a bug when pasting into the climatic data entry sub dialog. The pasting doesn't start from the top. This PR adds 1 line of code that fixes the bug.

@africanmathsinitiative/developers this is ready for review.