### PR TITLE
Added empty placeholder for Copy Special dialog

### DIFF
--- a/instat/dlgCopySpecial.Designer.vb
+++ b/instat/dlgCopySpecial.Designer.vb
@@ -1,0 +1,30 @@
+﻿<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()> _
+Partial Class dlgCopySpecial
+    Inherits System.Windows.Forms.Form
+
+    'Form overrides dispose to clean up the component list.
+    <System.Diagnostics.DebuggerNonUserCode()> _
+    Protected Overrides Sub Dispose(ByVal disposing As Boolean)
+        Try
+            If disposing AndAlso components IsNot Nothing Then
+                components.Dispose()
+            End If
+        Finally
+            MyBase.Dispose(disposing)
+        End Try
+    End Sub
+
+    'Required by the Windows Form Designer
+    Private components As System.ComponentModel.IContainer
+
+    'NOTE: The following procedure is required by the Windows Form Designer
+    'It can be modified using the Windows Form Designer.  
+    'Do not modify it using the code editor.
+    <System.Diagnostics.DebuggerStepThrough()> _
+    Private Sub InitializeComponent()
+        components = New System.ComponentModel.Container
+        Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.ClientSize = New System.Drawing.Size(800, 450)
+        Me.Text = "dlgCopySpecial"
+    End Sub
+End Class

--- a/instat/dlgCopySpecial.vb
+++ b/instat/dlgCopySpecial.vb
@@ -1,0 +1,3 @@
+﻿Public Class dlgCopySpecial
+
+End Class

--- a/instat/instat.vbproj
+++ b/instat/instat.vbproj
@@ -272,6 +272,12 @@
     <Compile Include="dlgConditionalQuantilePlot.vb">
       <SubType>Form</SubType>
     </Compile>
+    <Compile Include="dlgCopySpecial.Designer.vb">
+      <DependentUpon>dlgCopySpecial.vb</DependentUpon>
+    </Compile>
+    <Compile Include="dlgCopySpecial.vb">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Include="dlgDisplayTopN.Designer.vb">
       <DependentUpon>dlgDisplayTopN.vb</DependentUpon>
     </Compile>


### PR DESCRIPTION
@africanmathsinitiative/developers this is ready for review.

@lloyddewit this adds a new empty dialog needed for Copy Special functionality. 
See issue #6579 for more information.
