### PR TITLE
Added mechanism to ignore specified UI controls when translating to a different language (e.g. to French)

### DIFF
--- a/instat/Translations.vb
+++ b/instat/Translations.vb
@@ -289,28 +289,18 @@ Public Class Translations
             End If
 
             'execute the SQL command
-
-            'Dim con As New SqlConnection(Connection_String)
-            'Dim cmd As New SqlCommand(strSqlUpdate, con)
-            'Using con
-            '    con.Open()
-            '    Dim iRowsUpdated As Integer = cmd.ExecuteNonQuery()
-            'End Using
-
-            'Using conn As New SqlConnection(connetionString)
-            '    Using cmd As New SqlCommand(strSqlUpdate, conn)
-            '        cmd.CommandType = CommandType.Text
-            '        conn.Open()
-            '        Dim i As Integer = cmd.ExecuteNonQuery()
-            '        conn.Close()
-            '    End Using
-            'End Using
-
             Try
-                'connect to the SQLite database that contains the translations
+                'specify the path of the SQLite database that contains the translations (2 levels up from the execution folder)
+                Dim strDbPath As String = Directory.GetParent(Application.StartupPath).FullName
+                strDbPath = Directory.GetParent(strDbPath).FullName
+                'strDbPath = String.Concat(strDbPath, "\translations")
+                strDbPath = Path.Combine(strDbPath, "translations")
+                strDbPath = Path.Combine(strDbPath, "rInstatTranslations.db")
+
+                'connect to the database and execute the SQL command
                 Dim clsBuilder As New SQLiteConnectionStringBuilder With {
                     .FailIfMissing = True,
-                    .DataSource = GetDbPath()}
+                    .DataSource = strDbPath}
                 Using clsConnection As New SQLiteConnection(clsBuilder.ConnectionString)
                     Using clsSqliteCmd As New SQLiteCommand(strSqlUpdate, clsConnection)
                         clsConnection.Open()
@@ -330,7 +320,7 @@ Public Class Translations
         'accidentally in the release version. 
         MsgBox("The " & strPath &
                " ignore file was processed. The application will now exit.", MsgBoxStyle.Exclamation)
-        System.Windows.Forms.Application.Exit()
+        Application.Exit()
     End Sub
 
 End Class

--- a/instat/Translations.vb
+++ b/instat/Translations.vb
@@ -312,7 +312,7 @@ Public Class Translations
                     .FailIfMissing = True,
                     .DataSource = GetDbPath()}
                 Using clsConnection As New SQLiteConnection(clsBuilder.ConnectionString)
-                    Using clsSqliteCmd As New SQLiteCommand(strSqlUpdate)
+                    Using clsSqliteCmd As New SQLiteCommand(strSqlUpdate, clsConnection)
                         clsConnection.Open()
                         iRowsUpdated = clsSqliteCmd.ExecuteNonQuery()
                         clsConnection.Close()

--- a/instat/Translations.vb
+++ b/instat/Translations.vb
@@ -262,7 +262,7 @@ Public Class Translations
                         'Ignore comment lines
                     Case "!"
                         'Add negation pattern to negation list
-                        lstIgnoreNegations.Add(strIgnoreFileLine)
+                        lstIgnoreNegations.Add(strIgnoreFileLine.Substring(1)) 'remove leading '!'
                     Case Else
                         'Add pattern to ignore list
                         lstIgnore.Add(strIgnoreFileLine)

--- a/instat/Translations.vb
+++ b/instat/Translations.vb
@@ -52,7 +52,7 @@ Public Class Translations
         ' The 'SetTranslateIgnore' function call below should normally be commented out.
         ' It only needs be uncommented when the 'translateIgnore.txt' file is updated, and the 
         ' changes need to be applied to the database.
-        SetTranslateIgnore()
+        'SetTranslateIgnore()
 
         If IsNothing(tsCollection) OrElse IsNothing(ctrParent) OrElse IsNothing(TryCast(ctrParent, Form)) Then
             Exit Sub
@@ -230,11 +230,19 @@ Public Class Translations
 
     '''--------------------------------------------------------------------------------------------
     ''' <summary>   
-    '''    TODO
+    '''    Updates the `TranslateWinForm` library database based on the specifications in the 
+    '''    'translateIgnore.txt' file. This file provides a way to ignore specified WinForm 
+    '''    controls when the application or dialog is translated into a different language.
+    '''    <para>
+    '''    For example, this file can be used to ensure that text that references pre-existing data 
+    '''    or meta data (e.g. a file name, data frame name, column name, cell value etc.) stays the 
+    '''    same, even when the rest of the dialog is translated into French or Portuguese.
+    '''    </para><para>
+    '''    This sub should be executed prior to each release to ensure that the `TranslateWinForm` 
+    '''    database specifies all the controls to ignore during the translation.  </para>  
     ''' </summary>
     '''--------------------------------------------------------------------------------------------
     Private Shared Sub SetTranslateIgnore()
-        Dim iRowsUpdated As Integer = 0
         Dim lstIgnore As New List(Of String)
         Dim lstIgnoreNegations As New List(Of String)
 
@@ -293,7 +301,6 @@ Public Class Translations
                 'specify the path of the SQLite database that contains the translations (2 levels up from the execution folder)
                 Dim strDbPath As String = Directory.GetParent(Application.StartupPath).FullName
                 strDbPath = Directory.GetParent(strDbPath).FullName
-                'strDbPath = String.Concat(strDbPath, "\translations")
                 strDbPath = Path.Combine(strDbPath, "translations")
                 strDbPath = Path.Combine(strDbPath, "rInstatTranslations.db")
 
@@ -304,7 +311,7 @@ Public Class Translations
                 Using clsConnection As New SQLiteConnection(clsBuilder.ConnectionString)
                     Using clsSqliteCmd As New SQLiteCommand(strSqlUpdate, clsConnection)
                         clsConnection.Open()
-                        iRowsUpdated = clsSqliteCmd.ExecuteNonQuery()
+                        Dim iRowsUpdated As Integer = clsSqliteCmd.ExecuteNonQuery()
                         clsConnection.Close()
                     End Using
                 End Using

--- a/instat/instat.vbproj
+++ b/instat/instat.vbproj
@@ -4956,6 +4956,7 @@
     <Content Include="LICENCE">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="translations\translateIgnore.txt" />
     <None Include="instat.licenseheader" />
     <None Include="My Project\Application.myapp">
       <Generator>MyApplicationCodeGenerator</Generator>

--- a/instat/translations/translateIgnore.txt
+++ b/instat/translations/translateIgnore.txt
@@ -1,0 +1,72 @@
+﻿####################################################################################################
+#
+# This file provides a way to ignore specified WinForm controls when the application or dialog is 
+# translated into a different language.
+# 
+# For example, this file can be used to ensure that a specific label's text stays the same, even 
+# when the the rest of the dialog is translated into French or Portuguese.
+# 
+# Examples of controls that should be ignored (i.e. never translated) include:
+# 
+#     - Text that references pre-existing data or meta data (e.g. a file name, data frame name, 
+#       column name, cell value etc.)
+#     - Text that represents R code (e.g. a variable name, code snippet or a complete 
+#       script/statement)
+# 
+# Each line in this file may represent:
+# 
+#     - The name of a specific control to ignore. The name must be identical to the name in the 
+#       'form_controls.form_name' column in the 'rInstatTranslations.db' database 
+#       (e.g. 'dlgAugment_ucrModelReceiver_txtReceiverSingle')
+# 
+#     - A group of controls to ignore. The group is specified using SQLite pattern matching 
+#       (see https://www.sqlite.org/lang_expr.html). Examples:
+#         - 'dlgAugment_%' do not translate any of the controls in the 'dlgAugment' dialog
+#         - '%_txtReceiverSingle' do not translate any text in single receivers
+# 
+#     - An exclamation point ('!') at the start of the line negates the pattern. Any control in that 
+#       pattern that was previously excluded (ignored) becomes included again. 
+#       This is similar to negation in the Git ignore file (see https://git-scm.com/docs/gitignore 
+#       for a deeper expalantion of negation).
+#       Negation can be useful if you want to ignore a group of controls with a few specific exceptions. 
+#       For example, the lines below ignore all the controls in the 'dlgBarChart' dialog apart from 
+#       the 'lblTitle' label:
+#         'dlgBarChart_%'
+#         '!dlgBarChart_%_lblTitle'
+#
+#     - Blank lines are ignored, they can be used as separators for readability
+#
+#     - A hash '#' at the start of the line indicates a comment
+# 
+# 
+# Technical note:
+# 
+# The specifications in this file will be used to construct an SQL command that updates the 
+# translation database.
+#
+# For example, if this file contains:
+# 
+#     %_lblModels
+#     %_lblModelpreview
+#     !dlgGlance_%
+#     !dlgTidy_%
+# 
+# then these lines will be used to construct the following SQL command:
+# 
+#     UPDATE form_controls SET id_text = 'DoNotTranslate' WHERE 
+#         (control_name LIKE '%_lblModels' OR control_name like '%_lblModelpreview') 
+#         AND NOT 
+#         (control_name LIKE 'dlgGlance_%' OR control_name LIKE 'dlgTidy_%')
+# 
+####################################################################################################
+
+# Single receivers normally contain column names, and these should not be translated
+# Fixes issue 6519
+%_txtReceiverSingle
+
+# In the 'New data Frame' Dialog, the user may enter the 'New Data Frame Name'. 
+# This is a literal that should not be translated.
+# Fixes issue #6581
+# TODO Can we assume that the name the user specifies for sving should never be translated 
+#      in any dialog (e.g. '%_ucrInputTextSave%')?
+dlgNewDataFrame_%_ucrInputTextSave%

--- a/instat/translations/translateIgnore.txt
+++ b/instat/translations/translateIgnore.txt
@@ -67,6 +67,6 @@
 # In the 'New data Frame' Dialog, the user may enter the 'New Data Frame Name'. 
 # This is a literal that should not be translated.
 # Fixes issue #6581
-# TODO Can we assume that the name the user specifies for sving should never be translated 
+# TODO Can we assume that the name the user specifies for saving should never be translated 
 #      in any dialog (e.g. '%_ucrInputTextSave%')?
 dlgNewDataFrame_%_ucrInputTextSave%

--- a/instat/translations/translateIgnore.txt
+++ b/instat/translations/translateIgnore.txt
@@ -27,7 +27,7 @@
 #     - An exclamation point ('!') at the start of the line negates the pattern. Any control in that 
 #       pattern that was previously excluded (ignored) becomes included again. 
 #       This is similar to negation in the Git ignore file (see https://git-scm.com/docs/gitignore 
-#       for a deeper expalantion of negation).
+#       for a deeper explanation of negation).
 #       Negation can be useful if you want to ignore a group of controls with a few specific exceptions. 
 #       For example, the lines below ignore all the controls in the 'dlgBarChart' dialog apart from 
 #       the 'lblTitle' label:

--- a/instat/translations/translateIgnore.txt
+++ b/instat/translations/translateIgnore.txt
@@ -64,9 +64,14 @@
 # Fixes issue 6519
 %_txtReceiverSingle
 
-# In the 'New data Frame' Dialog, the user may enter the 'New Data Frame Name'. 
+# In the 'New data Frame' dialog, the user may enter the 'New Data Frame Name'. 
 # This is a literal that should not be translated.
 # Fixes issue #6581
 # TODO Can we assume that the name the user specifies for saving should never be translated 
 #      in any dialog (e.g. '%_ucrInputTextSave%')?
 dlgNewDataFrame_%_ucrInputTextSave%
+
+# In the 'Split Text' dialog, the user may specify how to split the column (by space, comma, 
+# period etc.). This string should not be translated.
+# Fixes issue #6532
+dlgSplitText_ucrInputPattern%

--- a/instat/translations/translateIgnore.txt
+++ b/instat/translations/translateIgnore.txt
@@ -75,3 +75,7 @@ dlgNewDataFrame_%_ucrInputTextSave%
 # period etc.). This string should not be translated.
 # Fixes issue #6532
 dlgSplitText_ucrInputPattern%
+
+# In the 'Filter' dialog, the 'Selected Filter Preview' should not be translated.
+# Fixes issue #6949, related to PR #6956
+dlgRestrict_ucrInputFilterPreview

--- a/instat/translations/translateIgnore.txt
+++ b/instat/translations/translateIgnore.txt
@@ -4,7 +4,7 @@
 # translated into a different language.
 # 
 # For example, this file can be used to ensure that a specific label's text stays the same, even 
-# when the the rest of the dialog is translated into French or Portuguese.
+# when the rest of the dialog is translated into French or Portuguese.
 # 
 # Examples of controls that should be ignored (i.e. never translated) include:
 # 


### PR DESCRIPTION
Fixes #6581 
Fixes #6532 
Partially fixes #3721 

Added mechanism to ignore specified WinForm controls when the application or dialog is translated into a different language.
This will prevent the text from being translated. For example, if a control's text represents the name of an R parameter, then this text should not be translated.

@rdstern , @N-thony ,  Please could you review 'translateIgnore.txt' to make sure that the proposed approach is OK, and adequately explained. Updating the database from this file currently requires manual steps, but I'll automate this (maybe in a separate PR).
@rdstern Please could you also test that this fixes issue #6581 , thanks

@rachelkg You are also welcome to review if you're interested (optional)

@dannyparsons We discussed this before and you suggested that I could potentially use the Winform tag feature to label controls that should not be translated. However many dialogs use the tag for other purposes and I would have to rewrite these dialogs. The approach above also has the advantage that it allows groups of controls to be specified (using pattern matching), rather than having to manually specify each control individually. I hope you're Ok with this approach, we can discuss if needed.

@Patowhiz In one of your previous PR comments, you warned me that the 'control tag' approach may not work  - you were correct!