### PR TITLE
Bug fix: Passing the data name when copying data frames

### DIFF
--- a/instat/dlgCopyDataFrame.vb
+++ b/instat/dlgCopyDataFrame.vb
@@ -136,6 +136,7 @@ Public Class dlgCopyDataFrame
 
     Private Sub ucrPnlOptions_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrPnlOptions.ControlValueChanged
         If Not ucrChkCopyToClipboard.Checked OrElse rdoDataFrame.Checked Then
+            clsCopyDataFrameFunction.AddParameter("data_name", strParameterValue:=Chr(34) & ucrDataFrameCopySheets.strCurrDataFrame & Chr(34), iPosition:=0)
             ucrBase.clsRsyntax.SetBaseRFunction(clsCopyDataFrameFunction)
         ElseIf rdoColumnsMetadata.Checked Then
             'todo. temporarily added here because this control's parameter pair condition is not updated


### PR DESCRIPTION
@rdstern this fixes the bug reported [here](https://github.com/africanmathsinitiative/R-Instat/pull/6567#issuecomment-891066484). Please test.