### PR TITLE
Improved One Way Frequencies dialog, added table save and extra parameters for 'frq' function

### DIFF
--- a/instat/dlgOneWayFrequencies.Designer.vb
+++ b/instat/dlgOneWayFrequencies.Designer.vb
@@ -65,6 +65,7 @@ Partial Class dlgOneWayFrequencies
         Me.ucrPnlSort = New instat.UcrPanel()
         Me.ucrBase = New instat.ucrButtons()
         Me.ucrSelectorOneWayFreq = New instat.ucrSelectorByDataFrameAddRemove()
+        Me.ucrSaveDataFrame = New instat.ucrSave()
         Me.grpSort.SuspendLayout()
         Me.grpOutput.SuspendLayout()
         Me.SuspendLayout()
@@ -254,10 +255,16 @@ Partial Class dlgOneWayFrequencies
         resources.ApplyResources(Me.ucrSelectorOneWayFreq, "ucrSelectorOneWayFreq")
         Me.ucrSelectorOneWayFreq.Name = "ucrSelectorOneWayFreq"
         '
+        'ucrSaveDataFrame
+        '
+        resources.ApplyResources(Me.ucrSaveDataFrame, "ucrSaveDataFrame")
+        Me.ucrSaveDataFrame.Name = "ucrSaveDataFrame"
+        '
         'dlgOneWayFrequencies
         '
         resources.ApplyResources(Me, "$this")
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.Controls.Add(Me.ucrSaveDataFrame)
         Me.Controls.Add(Me.ucrNudMinFreq)
         Me.Controls.Add(Me.ucrChkMinFrq)
         Me.Controls.Add(Me.grpOutput)
@@ -315,4 +322,5 @@ Partial Class dlgOneWayFrequencies
     Friend WithEvents ucrPnlOutput As UcrPanel
     Friend WithEvents ucrNudMinFreq As ucrNud
     Friend WithEvents ucrChkMinFrq As ucrCheck
+    Friend WithEvents ucrSaveDataFrame As ucrSave
 End Class

--- a/instat/dlgOneWayFrequencies.Designer.vb
+++ b/instat/dlgOneWayFrequencies.Designer.vb
@@ -43,7 +43,6 @@ Partial Class dlgOneWayFrequencies
         Me.rdoDescending = New System.Windows.Forms.RadioButton()
         Me.rdoAscending = New System.Windows.Forms.RadioButton()
         Me.rdoNone = New System.Windows.Forms.RadioButton()
-        Me.ucrPnlSort = New instat.UcrPanel()
         Me.cmdOptions = New System.Windows.Forms.Button()
         Me.lblSelectedVariable = New System.Windows.Forms.Label()
         Me.rdoGraph = New System.Windows.Forms.RadioButton()
@@ -61,8 +60,11 @@ Partial Class dlgOneWayFrequencies
         Me.ucrReceiverWeights = New instat.ucrReceiverSingle()
         Me.ucrChkWeights = New instat.ucrCheck()
         Me.ucrChkFlip = New instat.ucrCheck()
+        Me.ucrPnlSort = New instat.UcrPanel()
         Me.ucrBase = New instat.ucrButtons()
         Me.ucrSelectorOneWayFreq = New instat.ucrSelectorByDataFrameAddRemove()
+        Me.ucrChkMinFrq = New instat.ucrCheck()
+        Me.ucrNudMinFreq = New instat.ucrNud()
         Me.grpSort.SuspendLayout()
         Me.grpOutput.SuspendLayout()
         Me.SuspendLayout()
@@ -97,11 +99,6 @@ Partial Class dlgOneWayFrequencies
         Me.rdoNone.Name = "rdoNone"
         Me.rdoNone.TabStop = True
         Me.rdoNone.UseVisualStyleBackColor = True
-        '
-        'ucrPnlSort
-        '
-        resources.ApplyResources(Me.ucrPnlSort, "ucrPnlSort")
-        Me.ucrPnlSort.Name = "ucrPnlSort"
         '
         'cmdOptions
         '
@@ -223,6 +220,11 @@ Partial Class dlgOneWayFrequencies
         resources.ApplyResources(Me.ucrChkFlip, "ucrChkFlip")
         Me.ucrChkFlip.Name = "ucrChkFlip"
         '
+        'ucrPnlSort
+        '
+        resources.ApplyResources(Me.ucrPnlSort, "ucrPnlSort")
+        Me.ucrPnlSort.Name = "ucrPnlSort"
+        '
         'ucrBase
         '
         resources.ApplyResources(Me.ucrBase, "ucrBase")
@@ -236,10 +238,28 @@ Partial Class dlgOneWayFrequencies
         resources.ApplyResources(Me.ucrSelectorOneWayFreq, "ucrSelectorOneWayFreq")
         Me.ucrSelectorOneWayFreq.Name = "ucrSelectorOneWayFreq"
         '
+        'ucrChkMinFrq
+        '
+        Me.ucrChkMinFrq.Checked = False
+        resources.ApplyResources(Me.ucrChkMinFrq, "ucrChkMinFrq")
+        Me.ucrChkMinFrq.Name = "ucrChkMinFrq"
+        '
+        'ucrNudMinFreq
+        '
+        Me.ucrNudMinFreq.DecimalPlaces = New Decimal(New Integer() {0, 0, 0, 0})
+        Me.ucrNudMinFreq.Increment = New Decimal(New Integer() {1, 0, 0, 0})
+        resources.ApplyResources(Me.ucrNudMinFreq, "ucrNudMinFreq")
+        Me.ucrNudMinFreq.Maximum = New Decimal(New Integer() {100, 0, 0, 0})
+        Me.ucrNudMinFreq.Minimum = New Decimal(New Integer() {0, 0, 0, 0})
+        Me.ucrNudMinFreq.Name = "ucrNudMinFreq"
+        Me.ucrNudMinFreq.Value = New Decimal(New Integer() {0, 0, 0, 0})
+        '
         'dlgOneWayFrequencies
         '
         resources.ApplyResources(Me, "$this")
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.Controls.Add(Me.ucrNudMinFreq)
+        Me.Controls.Add(Me.ucrChkMinFrq)
         Me.Controls.Add(Me.grpOutput)
         Me.Controls.Add(Me.ucrSaveGraph)
         Me.Controls.Add(Me.ucrReceiverOneWayFreq)
@@ -293,4 +313,6 @@ Partial Class dlgOneWayFrequencies
     Friend WithEvents rdoAsHtml As RadioButton
     Friend WithEvents rdoAsText As RadioButton
     Friend WithEvents ucrPnlOutput As UcrPanel
+    Friend WithEvents ucrNudMinFreq As ucrNud
+    Friend WithEvents ucrChkMinFrq As ucrCheck
 End Class

--- a/instat/dlgOneWayFrequencies.Designer.vb
+++ b/instat/dlgOneWayFrequencies.Designer.vb
@@ -51,6 +51,8 @@ Partial Class dlgOneWayFrequencies
         Me.grpOutput = New System.Windows.Forms.GroupBox()
         Me.rdoAsHtml = New System.Windows.Forms.RadioButton()
         Me.rdoAsText = New System.Windows.Forms.RadioButton()
+        Me.ucrNudMinFreq = New instat.ucrNud()
+        Me.ucrChkMinFrq = New instat.ucrCheck()
         Me.ucrPnlOutput = New instat.UcrPanel()
         Me.ucrSaveGraph = New instat.ucrSave()
         Me.ucrReceiverOneWayFreq = New instat.ucrReceiverMultiple()
@@ -63,8 +65,6 @@ Partial Class dlgOneWayFrequencies
         Me.ucrPnlSort = New instat.UcrPanel()
         Me.ucrBase = New instat.ucrButtons()
         Me.ucrSelectorOneWayFreq = New instat.ucrSelectorByDataFrameAddRemove()
-        Me.ucrChkMinFrq = New instat.ucrCheck()
-        Me.ucrNudMinFreq = New instat.ucrNud()
         Me.grpSort.SuspendLayout()
         Me.grpOutput.SuspendLayout()
         Me.SuspendLayout()
@@ -159,6 +159,22 @@ Partial Class dlgOneWayFrequencies
         Me.rdoAsText.Name = "rdoAsText"
         Me.rdoAsText.UseVisualStyleBackColor = True
         '
+        'ucrNudMinFreq
+        '
+        Me.ucrNudMinFreq.DecimalPlaces = New Decimal(New Integer() {0, 0, 0, 0})
+        Me.ucrNudMinFreq.Increment = New Decimal(New Integer() {1, 0, 0, 0})
+        resources.ApplyResources(Me.ucrNudMinFreq, "ucrNudMinFreq")
+        Me.ucrNudMinFreq.Maximum = New Decimal(New Integer() {100, 0, 0, 0})
+        Me.ucrNudMinFreq.Minimum = New Decimal(New Integer() {0, 0, 0, 0})
+        Me.ucrNudMinFreq.Name = "ucrNudMinFreq"
+        Me.ucrNudMinFreq.Value = New Decimal(New Integer() {0, 0, 0, 0})
+        '
+        'ucrChkMinFrq
+        '
+        Me.ucrChkMinFrq.Checked = False
+        resources.ApplyResources(Me.ucrChkMinFrq, "ucrChkMinFrq")
+        Me.ucrChkMinFrq.Name = "ucrChkMinFrq"
+        '
         'ucrPnlOutput
         '
         resources.ApplyResources(Me.ucrPnlOutput, "ucrPnlOutput")
@@ -237,22 +253,6 @@ Partial Class dlgOneWayFrequencies
         Me.ucrSelectorOneWayFreq.bUseCurrentFilter = True
         resources.ApplyResources(Me.ucrSelectorOneWayFreq, "ucrSelectorOneWayFreq")
         Me.ucrSelectorOneWayFreq.Name = "ucrSelectorOneWayFreq"
-        '
-        'ucrChkMinFrq
-        '
-        Me.ucrChkMinFrq.Checked = False
-        resources.ApplyResources(Me.ucrChkMinFrq, "ucrChkMinFrq")
-        Me.ucrChkMinFrq.Name = "ucrChkMinFrq"
-        '
-        'ucrNudMinFreq
-        '
-        Me.ucrNudMinFreq.DecimalPlaces = New Decimal(New Integer() {0, 0, 0, 0})
-        Me.ucrNudMinFreq.Increment = New Decimal(New Integer() {1, 0, 0, 0})
-        resources.ApplyResources(Me.ucrNudMinFreq, "ucrNudMinFreq")
-        Me.ucrNudMinFreq.Maximum = New Decimal(New Integer() {100, 0, 0, 0})
-        Me.ucrNudMinFreq.Minimum = New Decimal(New Integer() {0, 0, 0, 0})
-        Me.ucrNudMinFreq.Name = "ucrNudMinFreq"
-        Me.ucrNudMinFreq.Value = New Decimal(New Integer() {0, 0, 0, 0})
         '
         'dlgOneWayFrequencies
         '

--- a/instat/dlgOneWayFrequencies.resx
+++ b/instat/dlgOneWayFrequencies.resx
@@ -244,7 +244,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;grpSort.ZOrder" xml:space="preserve">
-    <value>16</value>
+    <value>17</value>
   </data>
   <data name="cmdOptions.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -271,7 +271,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;cmdOptions.ZOrder" xml:space="preserve">
-    <value>15</value>
+    <value>16</value>
   </data>
   <data name="lblSelectedVariable.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -301,7 +301,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblSelectedVariable.ZOrder" xml:space="preserve">
-    <value>14</value>
+    <value>15</value>
   </data>
   <data name="rdoGraph.Appearance" type="System.Windows.Forms.Appearance, System.Windows.Forms">
     <value>Button</value>
@@ -337,7 +337,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;rdoGraph.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>7</value>
   </data>
   <data name="rdoTable.Appearance" type="System.Windows.Forms.Appearance, System.Windows.Forms">
     <value>Button</value>
@@ -373,7 +373,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;rdoTable.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>9</value>
   </data>
   <data name="rdoBoth.Appearance" type="System.Windows.Forms.Appearance, System.Windows.Forms">
     <value>Button</value>
@@ -409,7 +409,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;rdoBoth.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>6</value>
   </data>
   <data name="rdoAsHtml.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -514,7 +514,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;grpOutput.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="ucrNudMinFreq.Location" type="System.Drawing.Point, System.Drawing">
     <value>142, 328</value>
@@ -535,7 +535,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrNudMinFreq.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="ucrChkMinFrq.Location" type="System.Drawing.Point, System.Drawing">
     <value>10, 328</value>
@@ -556,7 +556,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrChkMinFrq.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="ucrSaveGraph.Location" type="System.Drawing.Point, System.Drawing">
     <value>10, 352</value>
@@ -580,7 +580,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrSaveGraph.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -589,7 +589,31 @@
     <value>6, 13</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>435, 448</value>
+    <value>435, 470</value>
+  </data>
+  <data name="ucrSaveDataFrame.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 376</value>
+  </data>
+  <data name="ucrSaveDataFrame.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="ucrSaveDataFrame.Size" type="System.Drawing.Size, System.Drawing">
+    <value>254, 24</value>
+  </data>
+  <data name="ucrSaveDataFrame.TabIndex" type="System.Int32, mscorlib">
+    <value>19</value>
+  </data>
+  <data name="&gt;&gt;ucrSaveDataFrame.Name" xml:space="preserve">
+    <value>ucrSaveDataFrame</value>
+  </data>
+  <data name="&gt;&gt;ucrSaveDataFrame.Type" xml:space="preserve">
+    <value>instat.ucrSave, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrSaveDataFrame.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrSaveDataFrame.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="ucrNudGroups.Location" type="System.Drawing.Point, System.Drawing">
     <value>142, 277</value>
@@ -610,7 +634,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrNudGroups.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>8</value>
   </data>
   <data name="ucrPnlFrequencies.Location" type="System.Drawing.Point, System.Drawing">
     <value>64, 6</value>
@@ -631,7 +655,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrPnlFrequencies.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>10</value>
   </data>
   <data name="ucrChkGroupData.Location" type="System.Drawing.Point, System.Drawing">
     <value>10, 280</value>
@@ -652,7 +676,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrChkGroupData.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>11</value>
   </data>
   <data name="ucrReceiverWeights.Location" type="System.Drawing.Point, System.Drawing">
     <value>142, 254</value>
@@ -676,7 +700,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrReceiverWeights.ZOrder" xml:space="preserve">
-    <value>11</value>
+    <value>12</value>
   </data>
   <data name="ucrChkWeights.Location" type="System.Drawing.Point, System.Drawing">
     <value>10, 256</value>
@@ -697,7 +721,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrChkWeights.ZOrder" xml:space="preserve">
-    <value>12</value>
+    <value>13</value>
   </data>
   <data name="ucrChkFlip.Location" type="System.Drawing.Point, System.Drawing">
     <value>10, 304</value>
@@ -718,10 +742,10 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrChkFlip.ZOrder" xml:space="preserve">
-    <value>13</value>
+    <value>14</value>
   </data>
   <data name="ucrBase.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 385</value>
+    <value>10, 410</value>
   </data>
   <data name="ucrBase.Size" type="System.Drawing.Size, System.Drawing">
     <value>410, 52</value>
@@ -739,7 +763,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrBase.ZOrder" xml:space="preserve">
-    <value>17</value>
+    <value>18</value>
   </data>
   <data name="ucrSelectorOneWayFreq.Location" type="System.Drawing.Point, System.Drawing">
     <value>10, 45</value>
@@ -763,10 +787,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrSelectorOneWayFreq.ZOrder" xml:space="preserve">
-    <value>18</value>
-  </data>
-  <data name="$this.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
+    <value>19</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterScreen</value>
@@ -802,6 +823,6 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrReceiverOneWayFreq.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>5</value>
   </data>
 </root>

--- a/instat/dlgOneWayFrequencies.resx
+++ b/instat/dlgOneWayFrequencies.resx
@@ -516,8 +516,50 @@
   <data name="&gt;&gt;grpOutput.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
+  <data name="ucrNudMinFreq.Location" type="System.Drawing.Point, System.Drawing">
+    <value>142, 328</value>
+  </data>
+  <data name="ucrNudMinFreq.Size" type="System.Drawing.Size, System.Drawing">
+    <value>50, 20</value>
+  </data>
+  <data name="ucrNudMinFreq.TabIndex" type="System.Int32, mscorlib">
+    <value>18</value>
+  </data>
+  <data name="&gt;&gt;ucrNudMinFreq.Name" xml:space="preserve">
+    <value>ucrNudMinFreq</value>
+  </data>
+  <data name="&gt;&gt;ucrNudMinFreq.Type" xml:space="preserve">
+    <value>instat.ucrNud, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrNudMinFreq.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrNudMinFreq.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="ucrChkMinFrq.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 328</value>
+  </data>
+  <data name="ucrChkMinFrq.Size" type="System.Drawing.Size, System.Drawing">
+    <value>210, 20</value>
+  </data>
+  <data name="ucrChkMinFrq.TabIndex" type="System.Int32, mscorlib">
+    <value>17</value>
+  </data>
+  <data name="&gt;&gt;ucrChkMinFrq.Name" xml:space="preserve">
+    <value>ucrChkMinFrq</value>
+  </data>
+  <data name="&gt;&gt;ucrChkMinFrq.Type" xml:space="preserve">
+    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrChkMinFrq.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrChkMinFrq.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
   <data name="ucrSaveGraph.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 353</value>
+    <value>10, 352</value>
   </data>
   <data name="ucrSaveGraph.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>4, 5, 4, 5</value>
@@ -548,48 +590,6 @@
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
     <value>435, 448</value>
-  </data>
-  <data name="ucrNudMinFreq.Location" type="System.Drawing.Point, System.Drawing">
-    <value>142, 325</value>
-  </data>
-  <data name="ucrNudMinFreq.Size" type="System.Drawing.Size, System.Drawing">
-    <value>50, 20</value>
-  </data>
-  <data name="ucrNudMinFreq.TabIndex" type="System.Int32, mscorlib">
-    <value>18</value>
-  </data>
-  <data name="&gt;&gt;ucrNudMinFreq.Name" xml:space="preserve">
-    <value>ucrNudMinFreq</value>
-  </data>
-  <data name="&gt;&gt;ucrNudMinFreq.Type" xml:space="preserve">
-    <value>instat.ucrNud, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrNudMinFreq.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;ucrNudMinFreq.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="ucrChkMinFrq.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 325</value>
-  </data>
-  <data name="ucrChkMinFrq.Size" type="System.Drawing.Size, System.Drawing">
-    <value>210, 20</value>
-  </data>
-  <data name="ucrChkMinFrq.TabIndex" type="System.Int32, mscorlib">
-    <value>17</value>
-  </data>
-  <data name="&gt;&gt;ucrChkMinFrq.Name" xml:space="preserve">
-    <value>ucrChkMinFrq</value>
-  </data>
-  <data name="&gt;&gt;ucrChkMinFrq.Type" xml:space="preserve">
-    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucrChkMinFrq.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;ucrChkMinFrq.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <data name="ucrNudGroups.Location" type="System.Drawing.Point, System.Drawing">
     <value>142, 277</value>

--- a/instat/dlgOneWayFrequencies.resx
+++ b/instat/dlgOneWayFrequencies.resx
@@ -244,7 +244,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;grpSort.ZOrder" xml:space="preserve">
-    <value>14</value>
+    <value>16</value>
   </data>
   <data name="cmdOptions.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -271,7 +271,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;cmdOptions.ZOrder" xml:space="preserve">
-    <value>13</value>
+    <value>15</value>
   </data>
   <data name="lblSelectedVariable.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -301,7 +301,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblSelectedVariable.ZOrder" xml:space="preserve">
-    <value>12</value>
+    <value>14</value>
   </data>
   <data name="rdoGraph.Appearance" type="System.Windows.Forms.Appearance, System.Windows.Forms">
     <value>Button</value>
@@ -337,7 +337,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;rdoGraph.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>6</value>
   </data>
   <data name="rdoTable.Appearance" type="System.Windows.Forms.Appearance, System.Windows.Forms">
     <value>Button</value>
@@ -373,7 +373,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;rdoTable.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>8</value>
   </data>
   <data name="rdoBoth.Appearance" type="System.Windows.Forms.Appearance, System.Windows.Forms">
     <value>Button</value>
@@ -409,7 +409,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;rdoBoth.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>5</value>
   </data>
   <data name="rdoAsHtml.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -514,7 +514,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;grpOutput.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>2</value>
   </data>
   <data name="ucrSaveGraph.Location" type="System.Drawing.Point, System.Drawing">
     <value>10, 353</value>
@@ -538,7 +538,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrSaveGraph.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>3</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -548,6 +548,48 @@
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
     <value>435, 448</value>
+  </data>
+  <data name="ucrNudMinFreq.Location" type="System.Drawing.Point, System.Drawing">
+    <value>142, 325</value>
+  </data>
+  <data name="ucrNudMinFreq.Size" type="System.Drawing.Size, System.Drawing">
+    <value>50, 20</value>
+  </data>
+  <data name="ucrNudMinFreq.TabIndex" type="System.Int32, mscorlib">
+    <value>18</value>
+  </data>
+  <data name="&gt;&gt;ucrNudMinFreq.Name" xml:space="preserve">
+    <value>ucrNudMinFreq</value>
+  </data>
+  <data name="&gt;&gt;ucrNudMinFreq.Type" xml:space="preserve">
+    <value>instat.ucrNud, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrNudMinFreq.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrNudMinFreq.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="ucrChkMinFrq.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 325</value>
+  </data>
+  <data name="ucrChkMinFrq.Size" type="System.Drawing.Size, System.Drawing">
+    <value>210, 20</value>
+  </data>
+  <data name="ucrChkMinFrq.TabIndex" type="System.Int32, mscorlib">
+    <value>17</value>
+  </data>
+  <data name="&gt;&gt;ucrChkMinFrq.Name" xml:space="preserve">
+    <value>ucrChkMinFrq</value>
+  </data>
+  <data name="&gt;&gt;ucrChkMinFrq.Type" xml:space="preserve">
+    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrChkMinFrq.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ucrChkMinFrq.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="ucrNudGroups.Location" type="System.Drawing.Point, System.Drawing">
     <value>142, 277</value>
@@ -568,7 +610,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrNudGroups.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>7</value>
   </data>
   <data name="ucrPnlFrequencies.Location" type="System.Drawing.Point, System.Drawing">
     <value>64, 6</value>
@@ -589,7 +631,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrPnlFrequencies.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>9</value>
   </data>
   <data name="ucrChkGroupData.Location" type="System.Drawing.Point, System.Drawing">
     <value>10, 280</value>
@@ -610,7 +652,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrChkGroupData.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>10</value>
   </data>
   <data name="ucrReceiverWeights.Location" type="System.Drawing.Point, System.Drawing">
     <value>142, 254</value>
@@ -634,7 +676,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrReceiverWeights.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>11</value>
   </data>
   <data name="ucrChkWeights.Location" type="System.Drawing.Point, System.Drawing">
     <value>10, 256</value>
@@ -655,7 +697,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrChkWeights.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>12</value>
   </data>
   <data name="ucrChkFlip.Location" type="System.Drawing.Point, System.Drawing">
     <value>10, 304</value>
@@ -676,7 +718,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrChkFlip.ZOrder" xml:space="preserve">
-    <value>11</value>
+    <value>13</value>
   </data>
   <data name="ucrBase.Location" type="System.Drawing.Point, System.Drawing">
     <value>10, 385</value>
@@ -697,7 +739,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrBase.ZOrder" xml:space="preserve">
-    <value>15</value>
+    <value>17</value>
   </data>
   <data name="ucrSelectorOneWayFreq.Location" type="System.Drawing.Point, System.Drawing">
     <value>10, 45</value>
@@ -721,7 +763,10 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrSelectorOneWayFreq.ZOrder" xml:space="preserve">
-    <value>16</value>
+    <value>18</value>
+  </data>
+  <data name="$this.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterScreen</value>
@@ -757,6 +802,6 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ucrReceiverOneWayFreq.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>4</value>
   </data>
 </root>

--- a/instat/dlgOneWayFrequencies.vb
+++ b/instat/dlgOneWayFrequencies.vb
@@ -99,10 +99,15 @@ Public Class dlgOneWayFrequencies
         ucrChkGroupData.AddParameterPresentCondition(False, "auto.group", False)
 
         ucrChkMinFrq.SetText("Min Frequency")
-        ucrChkMinFrq.AddToLinkedControls(ucrNudMinFreq, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, objNewDefaultState:=0)
+        ucrChkMinFrq.AddToLinkedControls(ucrNudMinFreq, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
+        ucrChkMinFrq.AddParameterPresentCondition(True, "min.frq", True)
+        ucrChkMinFrq.AddParameterPresentCondition(False, "min.frq", False)
+
+        ucrPnlFrequencies.AddToLinkedControls(ucrChkMinFrq, {rdoTable}, bNewLinkedHideIfParameterMissing:=True)
 
         ucrNudMinFreq.SetParameter(New RParameter("min.frq", 10))
         ucrNudMinFreq.SetMinMax(0, 1000)
+        ucrNudMinFreq.SetRDefault(0)
 
 
         ucrChkFlip.SetParameter(New RParameter("coord.flip", 10))
@@ -174,6 +179,9 @@ Public Class dlgOneWayFrequencies
         ucrChkGroupData.SetRCode(clsSjMiscFrq, bReset)
         ucrNudGroups.SetRCode(clsSjMiscFrq, bReset)
         ucrSaveGraph.SetRCode(clsAsGGplot, bReset)
+        ucrNudMinFreq.SetRCode(clsSjMiscFrq, bReset)
+        ucrChkMinFrq.SetRCode(clsSjMiscFrq, bReset)
+
     End Sub
 
     Private Sub SetDefaultColumn()
@@ -270,7 +278,7 @@ Public Class dlgOneWayFrequencies
         End If
     End Sub
 
-    Private Sub Controls_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrReceiverWeights.ControlContentsChanged, ucrChkWeights.ControlContentsChanged, ucrNudGroups.ControlContentsChanged, ucrChkGroupData.ControlContentsChanged, ucrReceiverOneWayFreq.ControlContentsChanged, ucrSaveGraph.ControlContentsChanged
+    Private Sub Controls_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrReceiverWeights.ControlContentsChanged, ucrChkWeights.ControlContentsChanged, ucrNudGroups.ControlContentsChanged, ucrChkGroupData.ControlContentsChanged, ucrReceiverOneWayFreq.ControlContentsChanged, ucrSaveGraph.ControlContentsChanged, ucrNudMinFreq.ControlValueChanged, ucrChkMinFrq.ControlValueChanged
         TestOkEnabled()
     End Sub
 

--- a/instat/dlgOneWayFrequencies.vb
+++ b/instat/dlgOneWayFrequencies.vb
@@ -24,6 +24,7 @@ Public Class dlgOneWayFrequencies
     Private clsPlotGrid As New RFunction
     Private clsSjPlotList As New RFunction
     Private clsAsGGplot As New RFunction
+    Private clsAsDataFrame As New RFunction
     Public strDefaultDataFrame As String = ""
     Public strDefaultColumns() As String = Nothing
 
@@ -88,6 +89,14 @@ Public Class dlgOneWayFrequencies
         ucrPnlFrequencies.AddToLinkedControls(ucrPnlOutput, {rdoTable, rdoBoth}, bNewLinkedHideIfParameterMissing:=True)
         ucrPnlOutput.SetLinkedDisplayControl(grpOutput)
 
+        ucrPnlFrequencies.AddToLinkedControls(ucrSaveDataFrame, {rdoTable, rdoBoth}, bNewLinkedHideIfParameterMissing:=True)
+        ucrSaveDataFrame.SetPrefix("one_way_freq_table")
+        ucrSaveDataFrame.SetSaveTypeAsDataFrame()
+        ucrSaveDataFrame.SetDataFrameSelector(ucrSelectorOneWayFreq.ucrAvailableDataFrames)
+        ucrSaveDataFrame.SetCheckBoxText("Save Table")
+        ucrSaveDataFrame.SetIsComboBox()
+        ucrSaveDataFrame.SetAssignToIfUncheckedValue("last_table")
+
         ucrNudGroups.SetParameter(New RParameter("auto.grp", 9))
         ucrNudGroups.SetMinMax(2, 100)
         ucrNudGroups.Increment = 5
@@ -128,10 +137,16 @@ Public Class dlgOneWayFrequencies
         clsSjPlot = New RFunction
         clsPlotGrid = New RFunction
         clsAsGGplot = New RFunction
+        clsAsDataFrame = New RFunction
 
         ucrSelectorOneWayFreq.Reset()
         ucrReceiverOneWayFreq.SetMeAsReceiver()
         ucrSaveGraph.Reset()
+        ucrSaveDataFrame.Reset()
+
+
+        clsAsDataFrame.SetRCommand("as.data.frame")
+        clsAsDataFrame.AddParameter("x", clsRFunctionParameter:=clsSjMiscFrq, iPosition:=0)
 
         clsPlotGrid.SetPackageName("sjPlot")
         clsPlotGrid.SetRCommand("plot_grid")
@@ -182,6 +197,8 @@ Public Class dlgOneWayFrequencies
         ucrNudMinFreq.SetRCode(clsSjMiscFrq, bReset)
         ucrChkMinFrq.SetRCode(clsSjMiscFrq, bReset)
 
+        ucrSaveDataFrame.SetRCode(clsAsDataFrame, bReset)
+
     End Sub
 
     Private Sub SetDefaultColumn()
@@ -198,7 +215,7 @@ Public Class dlgOneWayFrequencies
     End Sub
 
     Private Sub TestOkEnabled()
-        If Not ucrReceiverOneWayFreq.IsEmpty() AndAlso ((ucrChkGroupData.Checked AndAlso ucrNudGroups.GetText <> "") OrElse Not ucrChkGroupData.Checked) AndAlso ucrSaveGraph.IsComplete() Then
+        If Not ucrReceiverOneWayFreq.IsEmpty() AndAlso ((ucrChkGroupData.Checked AndAlso ucrNudGroups.GetText <> "") OrElse Not ucrChkGroupData.Checked) AndAlso ucrSaveGraph.IsComplete() AndAlso ucrSaveDataFrame.IsComplete() Then
             If ucrChkWeights.Checked Then
                 If Not ucrReceiverWeights.IsEmpty Then
                     ucrBase.OKEnabled(True)
@@ -261,12 +278,13 @@ Public Class dlgOneWayFrequencies
 
     Private Sub SetBaseFunction()
         If rdoTable.Checked OrElse rdoBoth.Checked Then
-            ucrBase.clsRsyntax.SetBaseRFunction(clsSjMiscFrq)
+            ucrBase.clsRsyntax.SetBaseRFunction(If(ucrSaveDataFrame.IsComplete, clsAsDataFrame, clsSjMiscFrq))
             ucrBase.clsRsyntax.iCallType = 2
         ElseIf rdoGraph.Checked Then
             ucrBase.clsRsyntax.SetBaseRFunction(clsAsGGplot)
             ucrBase.clsRsyntax.iCallType = 3
         End If
+
     End Sub
 
     Private Sub ucrReceiverOneWayFreq_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverOneWayFreq.ControlValueChanged
@@ -278,7 +296,7 @@ Public Class dlgOneWayFrequencies
         End If
     End Sub
 
-    Private Sub Controls_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrReceiverWeights.ControlContentsChanged, ucrChkWeights.ControlContentsChanged, ucrNudGroups.ControlContentsChanged, ucrChkGroupData.ControlContentsChanged, ucrReceiverOneWayFreq.ControlContentsChanged, ucrSaveGraph.ControlContentsChanged, ucrNudMinFreq.ControlValueChanged, ucrChkMinFrq.ControlValueChanged
+    Private Sub Controls_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrReceiverWeights.ControlContentsChanged, ucrChkWeights.ControlContentsChanged, ucrNudGroups.ControlContentsChanged, ucrChkGroupData.ControlContentsChanged, ucrReceiverOneWayFreq.ControlContentsChanged, ucrSaveGraph.ControlContentsChanged, ucrNudMinFreq.ControlValueChanged, ucrChkMinFrq.ControlValueChanged, ucrSaveDataFrame.ControlValueChanged
         TestOkEnabled()
     End Sub
 

--- a/instat/dlgOneWayFrequencies.vb
+++ b/instat/dlgOneWayFrequencies.vb
@@ -115,7 +115,7 @@ Public Class dlgOneWayFrequencies
         ucrPnlFrequencies.AddToLinkedControls(ucrChkMinFrq, {rdoTable, rdoBoth}, bNewLinkedHideIfParameterMissing:=True)
 
         ucrNudMinFreq.SetParameter(New RParameter("min.frq", 10))
-        ucrNudMinFreq.SetMinMax(0, 1000)
+        ucrNudMinFreq.SetMinMax(iNewMin:=0)
         ucrNudMinFreq.SetRDefault(0)
 
 

--- a/instat/dlgOneWayFrequencies.vb
+++ b/instat/dlgOneWayFrequencies.vb
@@ -78,7 +78,7 @@ Public Class dlgOneWayFrequencies
         'setting rdoGraph and rdoTable
         ucrPnlFrequencies.AddFunctionNamesCondition(rdoTable, {"frq", "as.data.frame"})
         ucrPnlFrequencies.AddFunctionNamesCondition(rdoGraph, "as.ggplot")
-        'TODO be able to have conditions across multiple functions
+        'TODO. the both options can be added here when we are able to have panels conditions across multiple functions
 
         ucrPnlOutput.SetParameter(New RParameter("out", 7))
         ucrPnlOutput.AddRadioButton(rdoAsText, Chr(34) & "txt" & Chr(34))
@@ -143,7 +143,6 @@ Public Class dlgOneWayFrequencies
         ucrReceiverOneWayFreq.SetMeAsReceiver()
         ucrSaveGraph.Reset()
         ucrSaveDataFrame.Reset()
-
 
         clsAsDataFrame.SetRCommand("as.data.frame")
         clsAsDataFrame.AddParameter("x", clsRFunctionParameter:=clsSjMiscFrq, iPosition:=0)
@@ -251,7 +250,7 @@ Public Class dlgOneWayFrequencies
         TestOkEnabled()
     End Sub
 
-    Private Sub ucrPnlFrequencies_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrPnlFrequencies.ControlValueChanged
+    Private Sub ucrPnlFrequencies_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrPnlFrequencies.ControlValueChanged, ucrSaveDataFrame.ControlValueChanged
         SetBaseFunction()
     End Sub
 

--- a/instat/dlgOneWayFrequencies.vb
+++ b/instat/dlgOneWayFrequencies.vb
@@ -76,7 +76,7 @@ Public Class dlgOneWayFrequencies
         ucrPnlFrequencies.AddRadioButton(rdoBoth)
 
         'setting rdoGraph and rdoTable
-        ucrPnlFrequencies.AddFunctionNamesCondition(rdoTable, "frq")
+        ucrPnlFrequencies.AddFunctionNamesCondition(rdoTable, {"frq", "as.data.frame"})
         ucrPnlFrequencies.AddFunctionNamesCondition(rdoGraph, "as.ggplot")
         'TODO be able to have conditions across multiple functions
 
@@ -95,7 +95,7 @@ Public Class dlgOneWayFrequencies
         ucrSaveDataFrame.SetDataFrameSelector(ucrSelectorOneWayFreq.ucrAvailableDataFrames)
         ucrSaveDataFrame.SetCheckBoxText("Save Table")
         ucrSaveDataFrame.SetIsComboBox()
-        ucrSaveDataFrame.SetAssignToIfUncheckedValue("last_table")
+        'ucrSaveDataFrame.SetAssignToIfUncheckedValue("last_table")
 
         ucrNudGroups.SetParameter(New RParameter("auto.grp", 9))
         ucrNudGroups.SetMinMax(2, 100)
@@ -230,27 +230,6 @@ Public Class dlgOneWayFrequencies
         End If
     End Sub
 
-    Private Sub ucrBase_ClickOk(sender As Object, e As EventArgs) Handles ucrBase.ClickOk
-        Dim strGraph As String
-        Dim strTempScript As String = ""
-        Dim bIsAssigned As Boolean
-        Dim bToBeAssigned As Boolean
-        Dim strAssignTo As String
-
-        If rdoBoth.Checked Then
-            bIsAssigned = clsAsGGplot.bIsAssigned
-            bToBeAssigned = clsAsGGplot.bToBeAssigned
-            strAssignTo = clsAsGGplot.strAssignTo
-
-            strGraph = clsAsGGplot.ToScript(strTempScript)
-            frmMain.clsRLink.RunScript(strTempScript & strGraph, iCallType:=3)
-
-            clsAsGGplot.bIsAssigned = bIsAssigned
-            clsAsGGplot.bToBeAssigned = bToBeAssigned
-            clsAsGGplot.strAssignTo = strAssignTo
-        End If
-    End Sub
-
     Private Sub ucrBase_ClickReset(sender As Object, e As EventArgs) Handles ucrBase.ClickReset
         SetDefaults()
         SetRCodeForControls(True)
@@ -277,12 +256,19 @@ Public Class dlgOneWayFrequencies
     End Sub
 
     Private Sub SetBaseFunction()
-        If rdoTable.Checked OrElse rdoBoth.Checked Then
-            ucrBase.clsRsyntax.SetBaseRFunction(If(ucrSaveDataFrame.IsComplete, clsAsDataFrame, clsSjMiscFrq))
-            ucrBase.clsRsyntax.iCallType = 2
-        ElseIf rdoGraph.Checked Then
+        ucrBase.clsRsyntax.GetBeforeCodes().Clear()
+        If rdoGraph.Checked Then
             ucrBase.clsRsyntax.SetBaseRFunction(clsAsGGplot)
             ucrBase.clsRsyntax.iCallType = 3
+        Else
+            If rdoBoth.Checked Then
+                ucrBase.clsRsyntax.AddToBeforeCodes(If(ucrSaveDataFrame.ucrChkSave.Checked AndAlso ucrSaveDataFrame.IsComplete, clsAsDataFrame, clsSjMiscFrq))
+                ucrBase.clsRsyntax.SetBaseRFunction(clsAsGGplot)
+                ucrBase.clsRsyntax.iCallType = 3
+            Else
+                ucrBase.clsRsyntax.SetBaseRFunction(If(ucrSaveDataFrame.ucrChkSave.Checked AndAlso ucrSaveDataFrame.IsComplete, clsAsDataFrame, clsSjMiscFrq))
+                ucrBase.clsRsyntax.iCallType = 2
+            End If
         End If
 
     End Sub

--- a/instat/dlgOneWayFrequencies.vb
+++ b/instat/dlgOneWayFrequencies.vb
@@ -98,6 +98,13 @@ Public Class dlgOneWayFrequencies
         ucrChkGroupData.AddParameterPresentCondition(True, "auto.group")
         ucrChkGroupData.AddParameterPresentCondition(False, "auto.group", False)
 
+        ucrChkMinFrq.SetText("Min Frequency")
+        ucrChkMinFrq.AddToLinkedControls(ucrNudMinFreq, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, objNewDefaultState:=0)
+
+        ucrNudMinFreq.SetParameter(New RParameter("min.frq", 10))
+        ucrNudMinFreq.SetMinMax(0, 1000)
+
+
         ucrChkFlip.SetParameter(New RParameter("coord.flip", 10))
         ucrChkFlip.SetText("Flip Coordinates")
         ucrChkFlip.SetValuesCheckedAndUnchecked("TRUE", "FALSE")

--- a/instat/dlgOneWayFrequencies.vb
+++ b/instat/dlgOneWayFrequencies.vb
@@ -103,7 +103,7 @@ Public Class dlgOneWayFrequencies
         ucrChkMinFrq.AddParameterPresentCondition(True, "min.frq", True)
         ucrChkMinFrq.AddParameterPresentCondition(False, "min.frq", False)
 
-        ucrPnlFrequencies.AddToLinkedControls(ucrChkMinFrq, {rdoTable}, bNewLinkedHideIfParameterMissing:=True)
+        ucrPnlFrequencies.AddToLinkedControls(ucrChkMinFrq, {rdoTable, rdoBoth}, bNewLinkedHideIfParameterMissing:=True)
 
         ucrNudMinFreq.SetParameter(New RParameter("min.frq", 10))
         ucrNudMinFreq.SetMinMax(0, 1000)

--- a/instat/sdgOneWayFrequencies.Designer.vb
+++ b/instat/sdgOneWayFrequencies.Designer.vb
@@ -70,6 +70,7 @@ Partial Class sdgOneWayFrequencies
         Me.rdoBar = New System.Windows.Forms.RadioButton()
         Me.ucrPnlGraphType = New instat.UcrPanel()
         Me.ucrBaseOneWayFrequencies = New instat.ucrButtonsSubdialogue()
+        Me.ucrChkShowNa = New instat.ucrCheck()
         Me.tbpOneWayFrequencies.SuspendLayout()
         Me.tbpTable.SuspendLayout()
         Me.grpTableOptions.SuspendLayout()
@@ -95,6 +96,7 @@ Partial Class sdgOneWayFrequencies
         '
         'grpTableOptions
         '
+        Me.grpTableOptions.Controls.Add(Me.ucrChkShowNa)
         Me.grpTableOptions.Controls.Add(Me.lblTableTitle)
         Me.grpTableOptions.Controls.Add(Me.ucrInputTitle)
         Me.grpTableOptions.Controls.Add(Me.ucrChkShowStrings)
@@ -306,6 +308,12 @@ Partial Class sdgOneWayFrequencies
         resources.ApplyResources(Me.ucrBaseOneWayFrequencies, "ucrBaseOneWayFrequencies")
         Me.ucrBaseOneWayFrequencies.Name = "ucrBaseOneWayFrequencies"
         '
+        'ucrChkShowNa
+        '
+        Me.ucrChkShowNa.Checked = False
+        resources.ApplyResources(Me.ucrChkShowNa, "ucrChkShowNa")
+        Me.ucrChkShowNa.Name = "ucrChkShowNa"
+        '
         'sdgOneWayFrequencies
         '
         resources.ApplyResources(Me, "$this")
@@ -360,4 +368,5 @@ Partial Class sdgOneWayFrequencies
     Friend WithEvents lblColor As Label
     Friend WithEvents lblSize As Label
     Friend WithEvents ucrNudSize As ucrNud
+    Friend WithEvents ucrChkShowNa As ucrCheck
 End Class

--- a/instat/sdgOneWayFrequencies.Designer.vb
+++ b/instat/sdgOneWayFrequencies.Designer.vb
@@ -70,13 +70,18 @@ Partial Class sdgOneWayFrequencies
         Me.rdoBar = New System.Windows.Forms.RadioButton()
         Me.ucrPnlGraphType = New instat.UcrPanel()
         Me.ucrBaseOneWayFrequencies = New instat.ucrButtonsSubdialogue()
-        Me.ucrChkShowNa = New instat.ucrCheck()
+        Me.grpShowMissingFrequencies = New System.Windows.Forms.GroupBox()
+        Me.ucrPnlShowMissingFreq = New instat.UcrPanel()
+        Me.rdoShowMissingTrue = New System.Windows.Forms.RadioButton()
+        Me.rdoShowMissingFalse = New System.Windows.Forms.RadioButton()
+        Me.rdoShowMissingAuto = New System.Windows.Forms.RadioButton()
         Me.tbpOneWayFrequencies.SuspendLayout()
         Me.tbpTable.SuspendLayout()
         Me.grpTableOptions.SuspendLayout()
         Me.tbpGraph.SuspendLayout()
         Me.grpGraphOptions.SuspendLayout()
         Me.grpGraphType.SuspendLayout()
+        Me.grpShowMissingFrequencies.SuspendLayout()
         Me.SuspendLayout()
         '
         'tbpOneWayFrequencies
@@ -89,6 +94,7 @@ Partial Class sdgOneWayFrequencies
         '
         'tbpTable
         '
+        Me.tbpTable.Controls.Add(Me.grpShowMissingFrequencies)
         Me.tbpTable.Controls.Add(Me.grpTableOptions)
         resources.ApplyResources(Me.tbpTable, "tbpTable")
         Me.tbpTable.Name = "tbpTable"
@@ -96,7 +102,6 @@ Partial Class sdgOneWayFrequencies
         '
         'grpTableOptions
         '
-        Me.grpTableOptions.Controls.Add(Me.ucrChkShowNa)
         Me.grpTableOptions.Controls.Add(Me.lblTableTitle)
         Me.grpTableOptions.Controls.Add(Me.ucrInputTitle)
         Me.grpTableOptions.Controls.Add(Me.ucrChkShowStrings)
@@ -308,11 +313,41 @@ Partial Class sdgOneWayFrequencies
         resources.ApplyResources(Me.ucrBaseOneWayFrequencies, "ucrBaseOneWayFrequencies")
         Me.ucrBaseOneWayFrequencies.Name = "ucrBaseOneWayFrequencies"
         '
-        'ucrChkShowNa
+        'grpShowMissingFrequencies
         '
-        Me.ucrChkShowNa.Checked = False
-        resources.ApplyResources(Me.ucrChkShowNa, "ucrChkShowNa")
-        Me.ucrChkShowNa.Name = "ucrChkShowNa"
+        Me.grpShowMissingFrequencies.Controls.Add(Me.rdoShowMissingAuto)
+        Me.grpShowMissingFrequencies.Controls.Add(Me.rdoShowMissingFalse)
+        Me.grpShowMissingFrequencies.Controls.Add(Me.rdoShowMissingTrue)
+        Me.grpShowMissingFrequencies.Controls.Add(Me.ucrPnlShowMissingFreq)
+        resources.ApplyResources(Me.grpShowMissingFrequencies, "grpShowMissingFrequencies")
+        Me.grpShowMissingFrequencies.Name = "grpShowMissingFrequencies"
+        Me.grpShowMissingFrequencies.TabStop = False
+        '
+        'ucrPnlShowMissingFreq
+        '
+        resources.ApplyResources(Me.ucrPnlShowMissingFreq, "ucrPnlShowMissingFreq")
+        Me.ucrPnlShowMissingFreq.Name = "ucrPnlShowMissingFreq"
+        '
+        'rdoShowMissingTrue
+        '
+        resources.ApplyResources(Me.rdoShowMissingTrue, "rdoShowMissingTrue")
+        Me.rdoShowMissingTrue.Name = "rdoShowMissingTrue"
+        Me.rdoShowMissingTrue.TabStop = True
+        Me.rdoShowMissingTrue.UseVisualStyleBackColor = True
+        '
+        'rdoShowMissingFalse
+        '
+        resources.ApplyResources(Me.rdoShowMissingFalse, "rdoShowMissingFalse")
+        Me.rdoShowMissingFalse.Name = "rdoShowMissingFalse"
+        Me.rdoShowMissingFalse.TabStop = True
+        Me.rdoShowMissingFalse.UseVisualStyleBackColor = True
+        '
+        'rdoShowMissingAuto
+        '
+        resources.ApplyResources(Me.rdoShowMissingAuto, "rdoShowMissingAuto")
+        Me.rdoShowMissingAuto.Name = "rdoShowMissingAuto"
+        Me.rdoShowMissingAuto.TabStop = True
+        Me.rdoShowMissingAuto.UseVisualStyleBackColor = True
         '
         'sdgOneWayFrequencies
         '
@@ -333,6 +368,8 @@ Partial Class sdgOneWayFrequencies
         Me.grpGraphOptions.PerformLayout()
         Me.grpGraphType.ResumeLayout(False)
         Me.grpGraphType.PerformLayout()
+        Me.grpShowMissingFrequencies.ResumeLayout(False)
+        Me.grpShowMissingFrequencies.PerformLayout()
         Me.ResumeLayout(False)
 
     End Sub
@@ -368,5 +405,9 @@ Partial Class sdgOneWayFrequencies
     Friend WithEvents lblColor As Label
     Friend WithEvents lblSize As Label
     Friend WithEvents ucrNudSize As ucrNud
-    Friend WithEvents ucrChkShowNa As ucrCheck
+    Friend WithEvents grpShowMissingFrequencies As GroupBox
+    Friend WithEvents rdoShowMissingAuto As RadioButton
+    Friend WithEvents rdoShowMissingFalse As RadioButton
+    Friend WithEvents rdoShowMissingTrue As RadioButton
+    Friend WithEvents ucrPnlShowMissingFreq As UcrPanel
 End Class

--- a/instat/sdgOneWayFrequencies.resx
+++ b/instat/sdgOneWayFrequencies.resx
@@ -117,7 +117,29 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="ucrChkShowNa.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 52</value>
+  </data>
+  <data name="ucrChkShowNa.Size" type="System.Drawing.Size, System.Drawing">
+    <value>201, 20</value>
+  </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="ucrChkShowNa.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;ucrChkShowNa.Name" xml:space="preserve">
+    <value>ucrChkShowNa</value>
+  </data>
+  <data name="&gt;&gt;ucrChkShowNa.Type" xml:space="preserve">
+    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrChkShowNa.Parent" xml:space="preserve">
+    <value>grpTableOptions</value>
+  </data>
+  <data name="&gt;&gt;ucrChkShowNa.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="lblTableTitle.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -125,9 +147,8 @@
   <data name="lblTableTitle.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="lblTableTitle.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 56</value>
+    <value>12, 86</value>
   </data>
   <data name="lblTableTitle.Size" type="System.Drawing.Size, System.Drawing">
     <value>60, 13</value>
@@ -148,10 +169,10 @@
     <value>grpTableOptions</value>
   </data>
   <data name="&gt;&gt;lblTableTitle.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="ucrInputTitle.Location" type="System.Drawing.Point, System.Drawing">
-    <value>97, 56</value>
+    <value>97, 86</value>
   </data>
   <data name="ucrInputTitle.Size" type="System.Drawing.Size, System.Drawing">
     <value>137, 21</value>
@@ -169,7 +190,7 @@
     <value>grpTableOptions</value>
   </data>
   <data name="&gt;&gt;ucrInputTitle.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="ucrChkShowStrings.Location" type="System.Drawing.Point, System.Drawing">
     <value>12, 22</value>
@@ -190,13 +211,13 @@
     <value>grpTableOptions</value>
   </data>
   <data name="&gt;&gt;ucrChkShowStrings.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="grpTableOptions.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 6</value>
   </data>
   <data name="grpTableOptions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>236, 101</value>
+    <value>236, 135</value>
   </data>
   <data name="grpTableOptions.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -916,7 +937,7 @@
     <value>Frequencies Options</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
-    <value>sdgFrequencies</value>
+    <value>sdgOneWayFrequencies</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
     <value>System.Windows.Forms.Form, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>

--- a/instat/sdgOneWayFrequencies.resx
+++ b/instat/sdgOneWayFrequencies.resx
@@ -117,38 +117,149 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="ucrChkShowNa.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 52</value>
-  </data>
-  <data name="ucrChkShowNa.Size" type="System.Drawing.Size, System.Drawing">
-    <value>201, 20</value>
-  </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="ucrChkShowNa.TabIndex" type="System.Int32, mscorlib">
+  <data name="rdoShowMissingAuto.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="rdoShowMissingAuto.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="rdoShowMissingAuto.Location" type="System.Drawing.Point, System.Drawing">
+    <value>7, 70</value>
+  </data>
+  <data name="rdoShowMissingAuto.Size" type="System.Drawing.Size, System.Drawing">
+    <value>47, 17</value>
+  </data>
+  <data name="rdoShowMissingAuto.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="rdoShowMissingAuto.Text" xml:space="preserve">
+    <value>Auto</value>
+  </data>
+  <data name="&gt;&gt;rdoShowMissingAuto.Name" xml:space="preserve">
+    <value>rdoShowMissingAuto</value>
+  </data>
+  <data name="&gt;&gt;rdoShowMissingAuto.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rdoShowMissingAuto.Parent" xml:space="preserve">
+    <value>grpShowMissingFrequencies</value>
+  </data>
+  <data name="&gt;&gt;rdoShowMissingAuto.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="rdoShowMissingFalse.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="rdoShowMissingFalse.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="rdoShowMissingFalse.Location" type="System.Drawing.Point, System.Drawing">
+    <value>7, 45</value>
+  </data>
+  <data name="rdoShowMissingFalse.Size" type="System.Drawing.Size, System.Drawing">
+    <value>50, 17</value>
+  </data>
+  <data name="rdoShowMissingFalse.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
   </data>
-  <data name="&gt;&gt;ucrChkShowNa.Name" xml:space="preserve">
-    <value>ucrChkShowNa</value>
+  <data name="rdoShowMissingFalse.Text" xml:space="preserve">
+    <value>False</value>
   </data>
-  <data name="&gt;&gt;ucrChkShowNa.Type" xml:space="preserve">
-    <value>instat.ucrCheck, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  <data name="&gt;&gt;rdoShowMissingFalse.Name" xml:space="preserve">
+    <value>rdoShowMissingFalse</value>
   </data>
-  <data name="&gt;&gt;ucrChkShowNa.Parent" xml:space="preserve">
-    <value>grpTableOptions</value>
+  <data name="&gt;&gt;rdoShowMissingFalse.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;ucrChkShowNa.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;rdoShowMissingFalse.Parent" xml:space="preserve">
+    <value>grpShowMissingFrequencies</value>
+  </data>
+  <data name="&gt;&gt;rdoShowMissingFalse.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="rdoShowMissingTrue.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="rdoShowMissingTrue.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 20</value>
+  </data>
+  <data name="rdoShowMissingTrue.Size" type="System.Drawing.Size, System.Drawing">
+    <value>47, 17</value>
+  </data>
+  <data name="rdoShowMissingTrue.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="rdoShowMissingTrue.Text" xml:space="preserve">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;rdoShowMissingTrue.Name" xml:space="preserve">
+    <value>rdoShowMissingTrue</value>
+  </data>
+  <data name="&gt;&gt;rdoShowMissingTrue.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rdoShowMissingTrue.Parent" xml:space="preserve">
+    <value>grpShowMissingFrequencies</value>
+  </data>
+  <data name="&gt;&gt;rdoShowMissingTrue.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="ucrPnlShowMissingFreq.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 19</value>
+  </data>
+  <data name="ucrPnlShowMissingFreq.Size" type="System.Drawing.Size, System.Drawing">
+    <value>187, 68</value>
+  </data>
+  <data name="ucrPnlShowMissingFreq.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlShowMissingFreq.Name" xml:space="preserve">
+    <value>ucrPnlShowMissingFreq</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlShowMissingFreq.Type" xml:space="preserve">
+    <value>instat.UcrPanel, instat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlShowMissingFreq.Parent" xml:space="preserve">
+    <value>grpShowMissingFrequencies</value>
+  </data>
+  <data name="&gt;&gt;ucrPnlShowMissingFreq.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="grpShowMissingFrequencies.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 98</value>
+  </data>
+  <data name="grpShowMissingFrequencies.Size" type="System.Drawing.Size, System.Drawing">
+    <value>234, 97</value>
+  </data>
+  <data name="grpShowMissingFrequencies.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="grpShowMissingFrequencies.Text" xml:space="preserve">
+    <value>Show Missing Frequencies</value>
+  </data>
+  <data name="&gt;&gt;grpShowMissingFrequencies.Name" xml:space="preserve">
+    <value>grpShowMissingFrequencies</value>
+  </data>
+  <data name="&gt;&gt;grpShowMissingFrequencies.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;grpShowMissingFrequencies.Parent" xml:space="preserve">
+    <value>tbpTable</value>
+  </data>
+  <data name="&gt;&gt;grpShowMissingFrequencies.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
   <data name="lblTableTitle.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="lblTableTitle.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="lblTableTitle.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 86</value>
+    <value>12, 57</value>
   </data>
   <data name="lblTableTitle.Size" type="System.Drawing.Size, System.Drawing">
     <value>60, 13</value>
@@ -169,10 +280,10 @@
     <value>grpTableOptions</value>
   </data>
   <data name="&gt;&gt;lblTableTitle.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>0</value>
   </data>
   <data name="ucrInputTitle.Location" type="System.Drawing.Point, System.Drawing">
-    <value>97, 86</value>
+    <value>97, 60</value>
   </data>
   <data name="ucrInputTitle.Size" type="System.Drawing.Size, System.Drawing">
     <value>137, 21</value>
@@ -190,7 +301,7 @@
     <value>grpTableOptions</value>
   </data>
   <data name="&gt;&gt;ucrInputTitle.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>1</value>
   </data>
   <data name="ucrChkShowStrings.Location" type="System.Drawing.Point, System.Drawing">
     <value>12, 22</value>
@@ -211,13 +322,13 @@
     <value>grpTableOptions</value>
   </data>
   <data name="&gt;&gt;ucrChkShowStrings.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>2</value>
   </data>
   <data name="grpTableOptions.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 6</value>
   </data>
   <data name="grpTableOptions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>236, 135</value>
+    <value>236, 92</value>
   </data>
   <data name="grpTableOptions.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -235,7 +346,7 @@
     <value>tbpTable</value>
   </data>
   <data name="&gt;&gt;grpTableOptions.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="tbpTable.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
@@ -929,6 +1040,9 @@
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
     <value>365, 323</value>
+  </data>
+  <data name="$this.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterScreen</value>

--- a/instat/sdgOneWayFrequencies.vb
+++ b/instat/sdgOneWayFrequencies.vb
@@ -36,10 +36,13 @@ Public Class sdgOneWayFrequencies
 
         'Table Only
         ucrChkShowStrings.SetParameter(New RParameter("show.strings", 7), bNewChangeParameterValue:=True, bNewAddRemoveParameter:=True, strNewValueIfChecked:="TRUE", strNewValueIfUnchecked:="FALSE")
-        ucrChkShowStrings.SetText("Show Strings")
+        ucrChkShowStrings.SetText("Omit Character Variabless")
 
-        ucrChkShowNa.SetText("Show NA")
-        ucrChkShowNa.SetParameter(New RParameter("show.na", 11), bNewChangeParameterValue:=True, bNewAddRemoveParameter:=True, strNewValueIfChecked:="TRUE", strNewValueIfUnchecked:="FALSE")
+        ucrPnlShowMissingFreq.SetParameter(New RParameter("show.na", 8))
+        ucrPnlShowMissingFreq.AddRadioButton(rdoShowMissingTrue, "TRUE")
+        ucrPnlShowMissingFreq.AddRadioButton(rdoShowMissingFalse, "FALSE")
+        ucrPnlShowMissingFreq.AddRadioButton(rdoShowMissingAuto, Chr(34) & "auto" & Chr(34))
+        ucrPnlShowMissingFreq.SetRDefault("TRUE")
 
         'Graph Only
         ucrPnlGraphType.SetParameter(New RParameter("type", 4))
@@ -135,7 +138,9 @@ Public Class sdgOneWayFrequencies
         ucrInputGraphTitle.SetRCode(clsOneWayGraphFreq, bReset, bCloneIfNeeded:=True)
         ucrInputColor.SetRCode(clsOneWayGraphFreq, bReset, bCloneIfNeeded:=True)
         ucrNudSize.SetRCode(clsOneWayGraphFreq, bReset, bCloneIfNeeded:=True)
-        ucrChkShowNa.SetRCode(clsOneWayTableFreq, bReset, bCloneIfNeeded:=True)
+
+        ucrPnlShowMissingFreq.AddAdditionalCodeParameterPair(clsOneWayTableFreq, clsNewRParameter:=New RParameter("show.na", 9), iAdditionalPairNo:=1)
+        ucrPnlShowMissingFreq.SetRCode(clsOneWayTableFreq, bReset, bCloneIfNeeded:=True)
         If bReset Then
             tbpOneWayFrequencies.SelectedIndex = 0
         End If

--- a/instat/sdgOneWayFrequencies.vb
+++ b/instat/sdgOneWayFrequencies.vb
@@ -38,6 +38,9 @@ Public Class sdgOneWayFrequencies
         ucrChkShowStrings.SetParameter(New RParameter("show.strings", 7), bNewChangeParameterValue:=True, bNewAddRemoveParameter:=True, strNewValueIfChecked:="TRUE", strNewValueIfUnchecked:="FALSE")
         ucrChkShowStrings.SetText("Show Strings")
 
+        ucrChkShowNa.SetText("Show NA")
+        ucrChkShowNa.SetParameter(New RParameter("show.na", 11), bNewChangeParameterValue:=True, bNewAddRemoveParameter:=True, strNewValueIfChecked:="TRUE", strNewValueIfUnchecked:="FALSE")
+
         'Graph Only
         ucrPnlGraphType.SetParameter(New RParameter("type", 4))
         ucrPnlGraphType.AddRadioButton(rdoBar, Chr(34) & "bar" & Chr(34))
@@ -132,6 +135,7 @@ Public Class sdgOneWayFrequencies
         ucrInputGraphTitle.SetRCode(clsOneWayGraphFreq, bReset, bCloneIfNeeded:=True)
         ucrInputColor.SetRCode(clsOneWayGraphFreq, bReset, bCloneIfNeeded:=True)
         ucrNudSize.SetRCode(clsOneWayGraphFreq, bReset, bCloneIfNeeded:=True)
+        ucrChkShowNa.SetRCode(clsOneWayTableFreq, bReset, bCloneIfNeeded:=True)
         If bReset Then
             tbpOneWayFrequencies.SelectedIndex = 0
         End If


### PR DESCRIPTION
Partly fixes Issue #6670 

@africanmathsinitiative/developers , this is ready for review
@rdstern , @Patowhiz This is ready for review

- I have added the `min.frq` parameter in the `frq` function for the One Way Frequency Dialog. Additionally, I have added the `show.na` parameter in the same function. 

- A function `as.data.frame` has been added converting the result into a data frame

- A save control has been added, to save the resulting data frame for the table and Both options in the dialog.