### PR TITLE
Ensure that One variable Compare Models subdialog opens correctly

### DIFF
--- a/instat/sdgOneVarCompareModels.vb
+++ b/instat/sdgOneVarCompareModels.vb
@@ -21,7 +21,7 @@ Public Class sdgOneVarCompareModels
     Private clsChisqtableOperator, clsChisqbreaksOperator As New ROperator
     Private clsRSyntax As RSyntax
 
-    Private Sub sdgOneVarCompareModels(sender As Object, e As EventArgs) Handles MyBase.Load
+    Private Sub sdgOneVarCompareModels_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         autoTranslate(Me)
     End Sub
 


### PR DESCRIPTION
fixes issue #6697 

@africanmathsinitiative/developers , this is ready for review
@Patowhiz , this is ready for review

The constructor was wrongly written. I have fixed it by changing it from `sdgOneVarCompareModels` to `sdgOneVarCompareModels_Load`

The sdgOneVarCompareModels Design now loads with no issue. 