### PR TITLE
Ensure that the Display Options Sub Dialog in One Variable fit Model Dialog opens correctly

### DIFF
--- a/instat/sdgOneVarFitModDisplay.vb
+++ b/instat/sdgOneVarFitModDisplay.vb
@@ -25,7 +25,7 @@ Public Class sdgOneVarFitModDisplay
     Private clsRSyntax As RSyntax
     Public bControlsInitialised As Boolean = False
 
-    Private Sub sdgOneVarFitModDisplay(sender As Object, e As EventArgs) Handles MyBase.Load
+    Private Sub sdgOneVarFitModDisplay_load(sender As Object, e As EventArgs) Handles MyBase.Load
         autoTranslate(Me)
     End Sub
 


### PR DESCRIPTION
Fixes Issue #6591 

@africanmathsinitiative/developers , This is ready for review
@lloyddewit , This is ready for review. 

I have added  handle.load base on sdgOneVarFitModDisplay. This will ensure that the subdialog design loads in vb with no issue