### PR TITLE
Made default (column) names consistent following tidyverse style guide

### DIFF
--- a/instat/dlgAppend.vb
+++ b/instat/dlgAppend.vb
@@ -57,7 +57,7 @@ Public Class dlgAppend
         ucrSaveGraph.SetIsTextBox()
         ucrSaveGraph.SetSaveTypeAsDataFrame()
         ucrSaveGraph.SetLabelText("New Data Frame Name:")
-        ucrSaveGraph.SetPrefix("Append")
+        ucrSaveGraph.SetPrefix("append")
     End Sub
 
     Private Sub SetDefaults()

--- a/instat/dlgAugment.vb
+++ b/instat/dlgAugment.vb
@@ -58,7 +58,7 @@ Public Class dlgAugment
         ucrSaveNewDataFrame.SetSaveTypeAsDataFrame()
         ucrSaveNewDataFrame.lblSaveText.Visible = False
         ucrSaveNewDataFrame.SetLabelText("")
-        ucrSaveNewDataFrame.SetPrefix("Augment_dataframe")
+        ucrSaveNewDataFrame.SetPrefix("augment_dataframe")
         ucrSaveNewDataFrame.SetDataFrameSelector(ucrModelSelector.ucrAvailableDataFrames)
 
         ucrModelReceiver.SetParameter(New RParameter("x", 0))

--- a/instat/dlgBarAndPieChart.vb
+++ b/instat/dlgBarAndPieChart.vb
@@ -126,7 +126,7 @@ Public Class dlgBarAndPieChart
         ucrSaveBar.SetCheckBoxText("Save Graph")
         ucrSaveBar.SetDataFrameSelector(ucrBarChartSelector.ucrAvailableDataFrames)
         ucrSaveBar.SetSaveTypeAsGraph()
-        ucrSaveBar.SetPrefix("bar")
+        ucrSaveBar.SetPrefix("bar_plot")
         ucrSaveBar.SetAssignToIfUncheckedValue("last_graph")
 
         clsCoordFlipFunc.SetPackageName("ggplot2")
@@ -459,7 +459,7 @@ Public Class dlgBarAndPieChart
             clsRgeomBarFunction.RemoveParameterByName("width")
             clsBaseOperator.RemoveParameterByName("geom_col")
             If Not ucrSaveBar.bUserTyped Then
-                ucrSaveBar.SetPrefix("bar")
+                ucrSaveBar.SetPrefix("bar_plot")
             End If
             ucrVariablesAsFactorForBarChart.RemoveIncludedMetadataProperty("class")
             ucrVariablesAsFactorForBarChart.strSelectorHeading = "Variables"

--- a/instat/dlgBoxPlot.vb
+++ b/instat/dlgBoxPlot.vb
@@ -162,7 +162,7 @@ Public Class dlgBoxplot
         ucrChkTufte.AddFunctionNamesCondition(False, "geom_tufteboxplot", False)
         ucrChkTufte.AddFunctionNamesCondition(True, "geom_tufteboxplot")
 
-        ucrSaveBoxplot.SetPrefix("boxplot")
+        ucrSaveBoxplot.SetPrefix("box_plot")
         ucrSaveBoxplot.SetIsComboBox()
         ucrSaveBoxplot.SetCheckBoxText("Save Graph")
         ucrSaveBoxplot.SetSaveTypeAsGraph()
@@ -380,7 +380,7 @@ Public Class dlgBoxplot
                 ucrSecondFactorReceiver.ChangeParameterName("colour")
             Else
                 cmdBoxPlotOptions.Text = "Box Options"
-                ucrSaveBoxplot.SetPrefix("boxplot")
+                ucrSaveBoxplot.SetPrefix("box_plot")
                 ucrSecondFactorReceiver.ChangeParameterName("fill")
                 clsCurrGeomFunc = clsBoxplotFunc
             End If

--- a/instat/dlgClimaticBoxPlot.vb
+++ b/instat/dlgClimaticBoxPlot.vb
@@ -193,7 +193,7 @@ Public Class dlgClimaticBoxPlot
         ucrInputWithinYear.SetItems({strXAxis, strColour, strFacetWrap, strFacetRow, strFacetCol, strNone})
         ucrInputWithinYear.SetDropDownStyleAsNonEditable()
 
-        ucrSavePlot.SetPrefix("boxplot")
+        ucrSavePlot.SetPrefix("box_plot")
         ucrSavePlot.SetIsComboBox()
         ucrSavePlot.SetCheckBoxText("Save Graph")
         ucrSavePlot.SetSaveTypeAsGraph()
@@ -351,7 +351,7 @@ Public Class dlgClimaticBoxPlot
         If rdoBoxplot.Checked Then
             clsRgeomPlotFunction.SetRCommand("geom_boxplot")
             If Not ucrSavePlot.bUserTyped Then
-                ucrSavePlot.SetPrefix("boxplot")
+                ucrSavePlot.SetPrefix("box_plot")
             End If
         ElseIf rdoJitter.Checked Then
             clsRgeomPlotFunction.SetRCommand("geom_jitter")

--- a/instat/dlgClimaticStationMaps.vb
+++ b/instat/dlgClimaticStationMaps.vb
@@ -117,7 +117,7 @@ Public Class dlgClimaticStationMaps
         ucrReceiverStation.SetParameterIsString()
         ucrReceiverStation.bWithQuotes = False
 
-        ucrSaveMap.SetPrefix("Map")
+        ucrSaveMap.SetPrefix("map")
         ucrSaveMap.SetSaveTypeAsGraph()
         ucrSaveMap.SetIsComboBox()
         ucrSaveMap.SetCheckBoxText("Save Map")

--- a/instat/dlgCombine.vb
+++ b/instat/dlgCombine.vb
@@ -64,7 +64,7 @@ Public Class dlgCombine
 
         ' Input Column Name
         ucrNewColName.SetIsComboBox()
-        ucrNewColName.SetPrefix("Interact")
+        ucrNewColName.SetPrefix("interact")
         ucrNewColName.SetSaveTypeAsColumn()
         ucrNewColName.SetDataFrameSelector(ucrSelectorCombineFactors.ucrAvailableDataFrames)
         ucrNewColName.SetLabelText("New Column Name:")

--- a/instat/dlgCombineText.vb
+++ b/instat/dlgCombineText.vb
@@ -57,7 +57,7 @@ Public Class dlgCombineText
 
         ' ucrSaveColumn
         ucrSaveColumn.SetIsComboBox()
-        ucrSaveColumn.SetPrefix("Combine")
+        ucrSaveColumn.SetPrefix("combine")
         ucrSaveColumn.SetSaveTypeAsColumn()
         ucrSaveColumn.SetDataFrameSelector(ucrSelectorForCombineText.ucrAvailableDataFrames)
         ucrSaveColumn.SetLabelText("New Column:")

--- a/instat/dlgConditionalQuantilePlot.vb
+++ b/instat/dlgConditionalQuantilePlot.vb
@@ -129,7 +129,7 @@ Public Class dlgConditionalQuantilePlot
         ucrReceiverStatistics.SetLinkedDisplayControl(lblStatistics)
         ucrReceiverType.SetLinkedDisplayControl(lblType)
 
-        ucrSavePlot.SetPrefix("cond_quantile")
+        ucrSavePlot.SetPrefix("cond_quantile_plot")
         ucrSavePlot.SetCheckBoxText("Save Graph")
         ucrSavePlot.SetIsComboBox()
         ucrSavePlot.SetSaveTypeAsGraph()
@@ -216,14 +216,14 @@ Public Class dlgConditionalQuantilePlot
     Private Sub ucrPnlOptions_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrPnlOptions.ControlValueChanged
         If rdoQuantiles.Checked Then
             ucrBase.clsRsyntax.SetBaseRFunction(clsConditionalQuantileFunction)
-            ucrSavePlot.SetPrefix("cond_quantile")
+            ucrSavePlot.SetPrefix("cond_quantile_plot")
             Me.Size = New System.Drawing.Size(Me.Width, 489)
             ucrBase.Location = New Point(ucrBase.Location.X, 397)
             ucrSavePlot.Location = New Point(ucrSavePlot.Location.X, 370)
             cmdPlotOptions.Text = "Conditional Quantile Options"
         Else
             ucrBase.clsRsyntax.SetBaseRFunction(clsConditionalEvalFunction)
-            ucrSavePlot.SetPrefix("cond_eval")
+            ucrSavePlot.SetPrefix("cond_eval_plot")
             Me.Size = New System.Drawing.Size(Me.Width, iDialogHeight)
             ucrBase.Location = New Point(ucrBase.Location.X, iBaseMaxY)
             ucrSavePlot.Location = New Point(ucrSavePlot.Location.X, 401)

--- a/instat/dlgConditionalQuantilePlot.vb
+++ b/instat/dlgConditionalQuantilePlot.vb
@@ -129,7 +129,7 @@ Public Class dlgConditionalQuantilePlot
         ucrReceiverStatistics.SetLinkedDisplayControl(lblStatistics)
         ucrReceiverType.SetLinkedDisplayControl(lblType)
 
-        ucrSavePlot.SetPrefix("conditionalquantile")
+        ucrSavePlot.SetPrefix("cond_quantile")
         ucrSavePlot.SetCheckBoxText("Save Graph")
         ucrSavePlot.SetIsComboBox()
         ucrSavePlot.SetSaveTypeAsGraph()
@@ -216,14 +216,14 @@ Public Class dlgConditionalQuantilePlot
     Private Sub ucrPnlOptions_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrPnlOptions.ControlValueChanged
         If rdoQuantiles.Checked Then
             ucrBase.clsRsyntax.SetBaseRFunction(clsConditionalQuantileFunction)
-            ucrSavePlot.SetPrefix("conditionalquantile")
+            ucrSavePlot.SetPrefix("cond_quantile")
             Me.Size = New System.Drawing.Size(Me.Width, 489)
             ucrBase.Location = New Point(ucrBase.Location.X, 397)
             ucrSavePlot.Location = New Point(ucrSavePlot.Location.X, 370)
             cmdPlotOptions.Text = "Conditional Quantile Options"
         Else
             ucrBase.clsRsyntax.SetBaseRFunction(clsConditionalEvalFunction)
-            ucrSavePlot.SetPrefix("conditionalEval")
+            ucrSavePlot.SetPrefix("cond_eval")
             Me.Size = New System.Drawing.Size(Me.Width, iDialogHeight)
             ucrBase.Location = New Point(ucrBase.Location.X, iBaseMaxY)
             ucrSavePlot.Location = New Point(ucrSavePlot.Location.X, 401)

--- a/instat/dlgConversions.vb
+++ b/instat/dlgConversions.vb
@@ -169,7 +169,7 @@ Public Class dlgConversions
         ucrSaveConversions.SetSaveTypeAsColumn()
         ucrSaveConversions.SetIsTextBox()
         ucrSaveConversions.SetDataFrameSelector(ucrSelectorConversions.ucrAvailableDataFrames)
-        ucrSaveConversions.SetPrefix("Conversion")
+        ucrSaveConversions.SetPrefix("conversion")
     End Sub
 
     Private Sub SetDefaults()

--- a/instat/dlgCorrelation.vb
+++ b/instat/dlgCorrelation.vb
@@ -102,7 +102,7 @@ Public Class dlgCorrelation
         ucrPnlColumns.AddToLinkedControls(ucrPnlCompletePairwise, {rdoMultipleColumns}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:=rdoCompleteRowsOnly)
         ucrPnlCompletePairwise.SetLinkedDisplayControl(grpMissing)
 
-        ucrSaveModel.SetPrefix("Cor")
+        ucrSaveModel.SetPrefix("cor")
         ucrSaveModel.SetSaveTypeAsModel()
         ucrSaveModel.SetDataFrameSelector(ucrSelectorCorrelation.ucrAvailableDataFrames)
         ucrSaveModel.SetCheckBoxText("Result Name")

--- a/instat/dlgDefineCRI.vb
+++ b/instat/dlgDefineCRI.vb
@@ -85,7 +85,7 @@ Public Class dlgCorruptionDefineCRI
         ucrSaveCRI.SetDataFrameSelector(ucrSelectorCRI.ucrAvailableDataFrames)
         ucrSaveCRI.SetLabelText("New Column Name:")
         ucrSaveCRI.SetIsTextBox()
-        ucrSaveCRI.SetPrefix("CRI")
+        ucrSaveCRI.SetPrefix("cri")
         ucrSaveCRI.SetSaveTypeAsColumn()
     End Sub
 

--- a/instat/dlgDisplayDailyData.vb
+++ b/instat/dlgDisplayDailyData.vb
@@ -210,7 +210,7 @@ Public Class dlgDisplayDailyData
         ucrInputFacetBy.SetLinkedDisplayControl(lblFacetby)
         ucrInputFacetBy.SetDropDownStyleAsNonEditable()
 
-        ucrSaveGraph.SetPrefix("Graph")
+        ucrSaveGraph.SetPrefix("graph")
         ucrSaveGraph.SetSaveTypeAsGraph()
         ucrSaveGraph.SetDataFrameSelector(ucrSelectorDisplayDailyClimaticData.ucrAvailableDataFrames)
         ucrSaveGraph.SetIsComboBox()
@@ -442,9 +442,9 @@ Public Class dlgDisplayDailyData
     Private Sub ucrPnlFrequencyDisplay_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrPnlFrequencyDisplay.ControlValueChanged
         DialogSize()
         If rdoGraphByYear.Checked Then
-            ucrSaveGraph.SetPrefix("Graph_by_Year")
+            ucrSaveGraph.SetPrefix("graph_by_year")
         ElseIf rdoGraph.checked Then
-            ucrSaveGraph.SetPrefix("Graph")
+            ucrSaveGraph.SetPrefix("graph")
         End If
         If rdoGraph.Checked Then
             ucrBase.clsRsyntax.iCallType = 3

--- a/instat/dlgDotPlot.vb
+++ b/instat/dlgDotPlot.vb
@@ -108,7 +108,7 @@ Public Class dlgDotPlot
         ucrVariablesAsFactorDotPlot.bWithQuotes = False
         ucrVariablesAsFactorDotPlot.SetParameterIsString()
 
-        ucrSaveDotPlot.SetPrefix("dotPlot")
+        ucrSaveDotPlot.SetPrefix("dot_plot")
         ucrSaveDotPlot.SetSaveTypeAsGraph()
         ucrSaveDotPlot.SetIsComboBox()
         ucrSaveDotPlot.SetCheckBoxText("Save Graph")

--- a/instat/dlgEvapotranspiration.vb
+++ b/instat/dlgEvapotranspiration.vb
@@ -176,7 +176,7 @@ Public Class dlgEvapotranspiration
         ucrNewColName.SetDataFrameSelector(ucrSelectorEvapotranspiration.ucrAvailableDataFrames)
         ucrNewColName.SetIsComboBox()
         ucrNewColName.SetSaveTypeAsColumn()
-        ucrNewColName.SetPrefix("Evapotranspiration")
+        ucrNewColName.SetPrefix("evapotranspiration")
     End Sub
 
     Private Sub SetDefaults()

--- a/instat/dlgExtremesClimatic.vb
+++ b/instat/dlgExtremesClimatic.vb
@@ -254,14 +254,14 @@ Public Class dlgExtremesClimatic
         ucrNudRunLength.SetMinMax(iNewMin:=1, iNewMax:=Integer.MaxValue)
 
         ucrSaveMrlPlot.SetDataFrameSelector(ucrSelectorClimaticExtremes.ucrAvailableDataFrames)
-        ucrSaveMrlPlot.SetPrefix("mrlplot")
+        ucrSaveMrlPlot.SetPrefix("mrl_plot")
         ucrSaveMrlPlot.SetSaveTypeAsGraph()
         ucrSaveMrlPlot.SetIsComboBox()
         ucrSaveMrlPlot.SetCheckBoxText("Save Graph")
         ucrSaveMrlPlot.SetAssignToIfUncheckedValue("last_graph")
 
         ucrSaveThresholdPlot.SetDataFrameSelector(ucrSelectorClimaticExtremes.ucrAvailableDataFrames)
-        ucrSaveThresholdPlot.SetPrefix("thresholdplot")
+        ucrSaveThresholdPlot.SetPrefix("threshold_plot")
         ucrSaveThresholdPlot.SetSaveTypeAsGraph()
         ucrSaveThresholdPlot.SetIsComboBox()
         ucrSaveThresholdPlot.SetCheckBoxText("Save Graph")
@@ -272,7 +272,7 @@ Public Class dlgExtremesClimatic
         ucrNudDeclusterColumns.SetRDefault("1")
 
         ucrSaveDeclusteredPlot.SetDataFrameSelector(ucrSelectorClimaticExtremes.ucrAvailableDataFrames)
-        ucrSaveDeclusteredPlot.SetPrefix("declustredplot")
+        ucrSaveDeclusteredPlot.SetPrefix("declustred_plot")
         ucrSaveDeclusteredPlot.SetSaveTypeAsGraph()
         ucrSaveDeclusteredPlot.SetIsComboBox()
         ucrSaveDeclusteredPlot.SetCheckBoxText("Save Graph")

--- a/instat/dlgExtremesClimatic.vb
+++ b/instat/dlgExtremesClimatic.vb
@@ -272,7 +272,7 @@ Public Class dlgExtremesClimatic
         ucrNudDeclusterColumns.SetRDefault("1")
 
         ucrSaveDeclusteredPlot.SetDataFrameSelector(ucrSelectorClimaticExtremes.ucrAvailableDataFrames)
-        ucrSaveDeclusteredPlot.SetPrefix("declustred_plot")
+        ucrSaveDeclusteredPlot.SetPrefix("declustered_plot")
         ucrSaveDeclusteredPlot.SetSaveTypeAsGraph()
         ucrSaveDeclusteredPlot.SetIsComboBox()
         ucrSaveDeclusteredPlot.SetCheckBoxText("Save Graph")

--- a/instat/dlgGeneralForGraphics.vb
+++ b/instat/dlgGeneralForGraphics.vb
@@ -94,7 +94,7 @@ Public Class dlgGeneralForGraphics
         ucrFillOrColourReceiver.bWithQuotes = False
         ucrFillOrColourReceiver.SetParameterIsString()
 
-        ucrSave.SetPrefix("Graph")
+        ucrSave.SetPrefix("graph")
         ucrSave.SetIsComboBox()
         ucrSave.SetSaveTypeAsGraph()
         ucrSave.SetCheckBoxText("Save Graph")

--- a/instat/dlgGlance.vb
+++ b/instat/dlgGlance.vb
@@ -54,7 +54,7 @@ Public Class dlgGlance
         ucrSaveNewDataFrame.SetSaveTypeAsDataFrame()
         ucrSaveNewDataFrame.lblSaveText.Visible = False
         ucrSaveNewDataFrame.SetLabelText("")
-        ucrSaveNewDataFrame.SetPrefix("Glance_dataframe")
+        ucrSaveNewDataFrame.SetPrefix("glance_dataframe")
         ucrSaveNewDataFrame.SetDataFrameSelector(ucrModelSelector.ucrAvailableDataFrames)
 
         ucrModelReceiver.SetParameter(New RParameter(".x", 0))

--- a/instat/dlgHypothesisTestsCalculator.vb
+++ b/instat/dlgHypothesisTestsCalculator.vb
@@ -45,7 +45,7 @@ Public Class dlgHypothesisTestsCalculator
         ucrChkDisplayModel.SetText("Display Model")
         ucrChkSummaryModel.SetText("Summary Model")
         ucrBase.clsRsyntax.SetCommandString("")
-        ucrSaveResult.SetPrefix("Test")
+        ucrSaveResult.SetPrefix("test")
         ucrSaveResult.SetIsComboBox()
         ucrSaveResult.SetSaveTypeAsModel()
         ucrSaveResult.SetCheckBoxText("Save test object")

--- a/instat/dlgInfillMissingValues.vb
+++ b/instat/dlgInfillMissingValues.vb
@@ -260,7 +260,7 @@ Public Class dlgInfillMissingValues
         ucrInputComboMeasure.SetItems(dctMeasures)
         ucrInputComboMeasure.SetDropDownStyleAsNonEditable()
 
-        ucrSaveGraph.SetPrefix("missingplot")
+        ucrSaveGraph.SetPrefix("missing_plot")
         ucrSaveGraph.SetSaveTypeAsGraph()
         ucrSaveGraph.SetDataFrameSelector(ucrSelectorInfillMissing.ucrAvailableDataFrames)
         ucrSaveGraph.SetCheckBoxText("Save Graph")
@@ -397,21 +397,21 @@ Public Class dlgInfillMissingValues
 
     Private Sub ucrPnlMethods_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrPnlMethods.ControlValueChanged, ucrReceiverElement.ControlValueChanged
         If rdoNaApproximate.Checked Then
-            ucrSaveNewColumn.SetPrefix("Int_" & ucrReceiverElement.GetVariableNames(False))
+            ucrSaveNewColumn.SetPrefix("tnt_" & ucrReceiverElement.GetVariableNames(False))
             clsBracketOperator.AddParameter("right", clsRFunctionParameter:=clsApproximateFunction, iPosition:=1)
         ElseIf rdoNaAggregate.Checked Then
-            ucrSaveNewColumn.SetPrefix("Typ_" & ucrReceiverElement.GetVariableNames(False))
+            ucrSaveNewColumn.SetPrefix("typ_" & ucrReceiverElement.GetVariableNames(False))
         ElseIf rdoNaFill.Checked Then
-            ucrSaveNewColumn.SetPrefix("Con_" & ucrReceiverElement.GetVariableNames(False))
+            ucrSaveNewColumn.SetPrefix("con_" & ucrReceiverElement.GetVariableNames(False))
             clsBracketOperator.AddParameter("right", clsRFunctionParameter:=clsNaFillFunction, iPosition:=1)
         ElseIf rdoNaStructTS.Checked Then
-            ucrSaveNewColumn.SetPrefix("Str_" & ucrReceiverElement.GetVariableNames(False))
+            ucrSaveNewColumn.SetPrefix("str_" & ucrReceiverElement.GetVariableNames(False))
             clsBracketOperator.AddParameter("right", clsRFunctionParameter:=clsStructTSFunction, iPosition:=1)
         ElseIf rdoNaSpline.Checked Then
-            ucrSaveNewColumn.SetPrefix("Spl_" & ucrReceiverElement.GetVariableNames(False))
+            ucrSaveNewColumn.SetPrefix("spl_" & ucrReceiverElement.GetVariableNames(False))
             clsBracketOperator.AddParameter("right", clsRFunctionParameter:=clsSplineFunction, iPosition:=1)
         ElseIf rdoNaLocf.Checked Then
-            ucrSaveNewColumn.SetPrefix("Cop_" & ucrReceiverElement.GetVariableNames(False))
+            ucrSaveNewColumn.SetPrefix("cop_" & ucrReceiverElement.GetVariableNames(False))
             clsBracketOperator.AddParameter("right", clsRFunctionParameter:=clsNaLocfFunction, iPosition:=1)
         End If
         clsAveFunction.AddParameter("FUN", clsROperatorParameter:=clsBracketOperator, iPosition:=2)

--- a/instat/dlgInfillMissingValues.vb
+++ b/instat/dlgInfillMissingValues.vb
@@ -397,7 +397,7 @@ Public Class dlgInfillMissingValues
 
     Private Sub ucrPnlMethods_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrPnlMethods.ControlValueChanged, ucrReceiverElement.ControlValueChanged
         If rdoNaApproximate.Checked Then
-            ucrSaveNewColumn.SetPrefix("tnt_" & ucrReceiverElement.GetVariableNames(False))
+            ucrSaveNewColumn.SetPrefix("int_" & ucrReceiverElement.GetVariableNames(False))
             clsBracketOperator.AddParameter("right", clsRFunctionParameter:=clsApproximateFunction, iPosition:=1)
         ElseIf rdoNaAggregate.Checked Then
             ucrSaveNewColumn.SetPrefix("typ_" & ucrReceiverElement.GetVariableNames(False))

--- a/instat/dlgInventoryPlot.vb
+++ b/instat/dlgInventoryPlot.vb
@@ -153,7 +153,7 @@ Public Class dlgInventoryPlot
         ucrInputFacetBy.SetRDefault("NULL")
         ucrInputFacetBy.SetDropDownStyleAsNonEditable()
 
-        ucrSaveGraph.SetPrefix("Inventory")
+        ucrSaveGraph.SetPrefix("inventory")
         ucrSaveGraph.SetSaveTypeAsGraph()
         ucrSaveGraph.SetDataFrameSelector(ucrInventoryPlotSelector.ucrAvailableDataFrames)
         ucrSaveGraph.SetCheckBoxText("Save Graph")

--- a/instat/dlgJitter.vb
+++ b/instat/dlgJitter.vb
@@ -87,7 +87,7 @@ Public Class dlgJitter
         ucrInputNewColName.SetSaveTypeAsColumn()
         ucrInputNewColName.SetDataFrameSelector(ucrSelectorForJitter.ucrAvailableDataFrames)
         ucrInputNewColName.SetLabelText("Column Name:")
-        ucrInputNewColName.SetPrefix("Jitter_values")
+        ucrInputNewColName.SetPrefix("jitter_values")
 
     End Sub
 

--- a/instat/dlgLinePlot.vb
+++ b/instat/dlgLinePlot.vb
@@ -168,7 +168,7 @@ Public Class dlgLinePlot
         ucrChkAddSE.SetParameter(New RParameter("se", 1))
         ucrChkAddSE.SetValuesCheckedAndUnchecked("TRUE", "FALSE")
 
-        ucrSave.SetPrefix("lineplot")
+        ucrSave.SetPrefix("line_plot")
         ucrSave.SetIsComboBox()
         ucrSave.SetSaveTypeAsGraph()
         ucrSave.SetCheckBoxText("Save Graph")
@@ -416,14 +416,14 @@ Public Class dlgLinePlot
         If rdoLine.Checked Then
             If ucrChkPathOrStep.Checked Then
                 If rdoStep.Checked Then
-                    ucrSave.SetPrefix("stepplot")
+                    ucrSave.SetPrefix("step_plot")
                     clsOptionsFunction.SetRCommand("geom_step")
                 ElseIf rdoPath.Checked Then
-                    ucrSave.SetPrefix("pathplot")
+                    ucrSave.SetPrefix("path_plot")
                     clsOptionsFunction.SetRCommand("geom_path")
                 End If
             ElseIf rdoLine.Checked Then
-                ucrSave.SetPrefix("lineplot")
+                ucrSave.SetPrefix("line_plot")
                 clsOptionsFunction.SetRCommand("geom_line")
             End If
         ElseIf rdoSmoothing.Checked Then

--- a/instat/dlgOneVarUseModel.vb
+++ b/instat/dlgOneVarUseModel.vb
@@ -62,7 +62,7 @@ Public Class dlgOneVarUseModel
 
         'This part is temporary for now
 
-        ucrNewDataFrameName.SetPrefix("UseModel")
+        ucrNewDataFrameName.SetPrefix("use_model")
         ucrNewDataFrameName.SetDataFrameSelector(ucrSelectorUseModel.ucrAvailableDataFrames)
         ucrNewDataFrameName.SetSaveTypeAsModel()
         ucrNewDataFrameName.SetIsComboBox()

--- a/instat/dlgOtherRosePlots.vb
+++ b/instat/dlgOtherRosePlots.vb
@@ -270,15 +270,15 @@ Public Class dlgOtherRosePlots
     Private Sub ucrPnlOptions_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrPnlOptions.ControlValueChanged
         ucrReceiverDate.SetMeAsReceiver()
         If rdoPolarAnnulus.Checked Then
-            ucrSaveGraph.SetPrefix("Polar_Annulus")
+            ucrSaveGraph.SetPrefix("polar_annulus")
         ElseIf rdoPolarPlot.Checked Then
-            ucrSaveGraph.SetPrefix("Polar_Plot")
+            ucrSaveGraph.SetPrefix("polar_plot")
         ElseIf rdoPolarCluster.Checked Then
-            ucrSaveGraph.SetPrefix("Polar_Cluster")
+            ucrSaveGraph.SetPrefix("polar_cluster")
         ElseIf rdoPolarFrequency.Checked Then
-            ucrSaveGraph.SetPrefix("Polar_Frequency")
+            ucrSaveGraph.SetPrefix("polar_frequency")
         ElseIf rdoPercentileRose.Checked Then
-            ucrSaveGraph.SetPrefix("Percentile_Rose")
+            ucrSaveGraph.SetPrefix("percentile_rose")
         End If
         AddRemoveStatistic()
     End Sub

--- a/instat/dlgOtherRosePlots.vb
+++ b/instat/dlgOtherRosePlots.vb
@@ -270,15 +270,15 @@ Public Class dlgOtherRosePlots
     Private Sub ucrPnlOptions_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrPnlOptions.ControlValueChanged
         ucrReceiverDate.SetMeAsReceiver()
         If rdoPolarAnnulus.Checked Then
-            ucrSaveGraph.SetPrefix("polar_annulus")
+            ucrSaveGraph.SetPrefix("polar_annulus_plot")
         ElseIf rdoPolarPlot.Checked Then
             ucrSaveGraph.SetPrefix("polar_plot")
         ElseIf rdoPolarCluster.Checked Then
-            ucrSaveGraph.SetPrefix("polar_cluster")
+            ucrSaveGraph.SetPrefix("polar_cluster_plot")
         ElseIf rdoPolarFrequency.Checked Then
-            ucrSaveGraph.SetPrefix("polar_frequency")
+            ucrSaveGraph.SetPrefix("polar_freq_plot")
         ElseIf rdoPercentileRose.Checked Then
-            ucrSaveGraph.SetPrefix("percentile_rose")
+            ucrSaveGraph.SetPrefix("percentile_rose_plot")
         End If
         AddRemoveStatistic()
     End Sub

--- a/instat/dlgPICSARainfall.vb
+++ b/instat/dlgPICSARainfall.vb
@@ -182,7 +182,7 @@ Public Class dlgPICSARainfall
         ucrInputStation.SetItems({strFacetWrap, strFacetRow, strFacetCol, strNone})
         ucrInputStation.SetDropDownStyleAsNonEditable()
 
-        ucrSave.SetPrefix("PICSA_Rainfall_Graph")
+        ucrSave.SetPrefix("picsa_rainfall_graph")
         ucrSave.SetIsComboBox()
         ucrSave.SetSaveTypeAsGraph()
         ucrSave.SetCheckBoxText("Save Graph")

--- a/instat/dlgParallelCoordinatePlot.vb
+++ b/instat/dlgParallelCoordinatePlot.vb
@@ -100,7 +100,7 @@ Public Class dlgParallelCoordinatePlot
         ucrInputScale.SetRDefault("std")
         ucrInputScale.SetDropDownStyleAsNonEditable()
 
-        ucrSaveGraph.SetPrefix("ParCoord")
+        ucrSaveGraph.SetPrefix("par_coord")
         ucrSaveGraph.SetSaveTypeAsGraph()
         ucrSaveGraph.SetDataFrameSelector(ucrSelectorParallelCoordinatePlot.ucrAvailableDataFrames)
         ucrSaveGraph.SetCheckBoxText("Save Graph")

--- a/instat/dlgParallelCoordinatePlot.vb
+++ b/instat/dlgParallelCoordinatePlot.vb
@@ -100,7 +100,7 @@ Public Class dlgParallelCoordinatePlot
         ucrInputScale.SetRDefault("std")
         ucrInputScale.SetDropDownStyleAsNonEditable()
 
-        ucrSaveGraph.SetPrefix("par_coord")
+        ucrSaveGraph.SetPrefix("par_coord_plot")
         ucrSaveGraph.SetSaveTypeAsGraph()
         ucrSaveGraph.SetDataFrameSelector(ucrSelectorParallelCoordinatePlot.ucrAvailableDataFrames)
         ucrSaveGraph.SetCheckBoxText("Save Graph")

--- a/instat/dlgPrincipalComponentAnalysis.vb
+++ b/instat/dlgPrincipalComponentAnalysis.vb
@@ -64,7 +64,7 @@ Public Class dlgPrincipalComponentAnalysis
         ucrNudNumberOfComp.SetRDefault(5)
 
         'ucrSaveResult
-        ucrSaveResult.SetPrefix("PCA")
+        ucrSaveResult.SetPrefix("pca")
         ucrSaveResult.SetSaveTypeAsModel()
         ucrSaveResult.SetDataFrameSelector(ucrSelectorPCA.ucrAvailableDataFrames)
         ucrSaveResult.SetCheckBoxText("Save Result")

--- a/instat/dlgRecodeNumeric.vb
+++ b/instat/dlgRecodeNumeric.vb
@@ -43,7 +43,7 @@ Public Class dlgRecodeNumeric
         ucrBase.clsRsyntax.AddParameter("dig.lab", "10")
 
         'ucrSave
-        ucrSaveRecode.SetPrefix("Recode")
+        ucrSaveRecode.SetPrefix("recode")
         ucrSaveRecode.SetSaveTypeAsColumn()
         ucrSaveRecode.SetDataFrameSelector(ucrSelectorForRecode.ucrAvailableDataFrames)
         ucrSaveRecode.SetIsComboBox()

--- a/instat/dlgRegularSequence.vb
+++ b/instat/dlgRegularSequence.vb
@@ -100,7 +100,7 @@ Public Class dlgRegularSequence
         ucrPnlSequenceType.AddToLinkedControls(ucrDateTimePickerTo, {rdoDates}, bNewLinkedHideIfParameterMissing:=True)
         ucrPnlSequenceType.AddToLinkedControls(ucrInputComboDatesBy, {rdoDates}, bNewLinkedHideIfParameterMissing:=True)
 
-        ucrNewColumnName.SetPrefix("Regular")
+        ucrNewColumnName.SetPrefix("regular")
         ucrNewColumnName.SetDataFrameSelector(ucrSelectDataFrameRegularSequence)
         ucrNewColumnName.SetIsComboBox()
         ucrNewColumnName.SetSaveTypeAsColumn()

--- a/instat/dlgScatterPlot.vb
+++ b/instat/dlgScatterPlot.vb
@@ -130,7 +130,7 @@ Public Class dlgScatterPlot
         ucrChkAddRugPlot.SetText("Add Rug Plot")
         ucrChkAddRugPlot.SetParameter(clsGeomRugParameter, bNewChangeParameterValue:=False, bNewAddRemoveParameter:=True)
 
-        ucrSaveScatterPlot.SetPrefix("scatterplot")
+        ucrSaveScatterPlot.SetPrefix("scatter_plot")
         ucrSaveScatterPlot.SetSaveTypeAsGraph()
         ucrSaveScatterPlot.SetDataFrameSelector(ucrSelectorForScatter.ucrAvailableDataFrames)
         ucrSaveScatterPlot.SetCheckBoxText("Save Graph")

--- a/instat/dlgSeasonalPlot.vb
+++ b/instat/dlgSeasonalPlot.vb
@@ -179,7 +179,7 @@ Public Class dlgSeasonalPlot
         ucrChkMovingAverage.AddParameterPresentCondition(True, "moving_mutate")
         ucrChkMovingAverage.AddParameterPresentCondition(False, "moving_mutate", False)
 
-        ucrSaveGraph.SetPrefix("seasonalityplot")
+        ucrSaveGraph.SetPrefix("seasonality_plot")
         ucrSaveGraph.SetIsComboBox()
         ucrSaveGraph.SetSaveTypeAsGraph()
         ucrSaveGraph.SetCheckBoxText("Save Graph")

--- a/instat/dlgTaylorDiagram.vb
+++ b/instat/dlgTaylorDiagram.vb
@@ -69,7 +69,7 @@ Public Class dlgTaylorDiagram
         ucrChkNormalise.SetText("Normalise")
         ucrChkNormalise.SetRDefault("FALSE")
 
-        ucrSavePlot.SetPrefix("taylor_diagram")
+        ucrSavePlot.SetPrefix("taylor_diagram_plot")
         ucrSavePlot.SetCheckBoxText("Save Graph")
         ucrSavePlot.SetIsComboBox()
         ucrSavePlot.SetSaveTypeAsGraph()

--- a/instat/dlgTaylorDiagram.vb
+++ b/instat/dlgTaylorDiagram.vb
@@ -69,7 +69,7 @@ Public Class dlgTaylorDiagram
         ucrChkNormalise.SetText("Normalise")
         ucrChkNormalise.SetRDefault("FALSE")
 
-        ucrSavePlot.SetPrefix("taylordiagram")
+        ucrSavePlot.SetPrefix("taylor_diagram")
         ucrSavePlot.SetCheckBoxText("Save Graph")
         ucrSavePlot.SetIsComboBox()
         ucrSavePlot.SetSaveTypeAsGraph()

--- a/instat/dlgThemes.vb
+++ b/instat/dlgThemes.vb
@@ -41,7 +41,7 @@ Public Class dlgThemes
         ucrBase.iHelpTopicID = 440
 
         ucrChkDeleteTheme.SetText("Delete Theme")
-        ucrSaveTheme.SetPrefix("Theme")
+        ucrSaveTheme.SetPrefix("theme")
         ucrSaveTheme.SetIsComboBox()
         ucrSaveTheme.SetCheckBoxText("New Theme Name")
 

--- a/instat/dlgTreemap.vb
+++ b/instat/dlgTreemap.vb
@@ -140,7 +140,7 @@ Public Class dlgTreemap
         ucrSaveTreemap.SetCheckBoxText("Save Treemap")
         ucrSaveTreemap.SetDataFrameSelector(ucrSelectorTreemap.ucrAvailableDataFrames)
         ucrSaveTreemap.SetSaveTypeAsGraph()
-        ucrSaveTreemap.SetPrefix("treemap")
+        ucrSaveTreemap.SetPrefix("tree_map")
         ucrSaveTreemap.SetAssignToIfUncheckedValue("last_graph")
     End Sub
 

--- a/instat/dlgWindrose.vb
+++ b/instat/dlgWindrose.vb
@@ -76,7 +76,7 @@ Public Class dlgWindrose
         ucrInputSubTitle.SetParameter(New RParameter("subtitle"))
         ucrInputCaption.SetParameter(New RParameter("caption"))
 
-        ucrSaveGraph.SetPrefix("windrose")
+        ucrSaveGraph.SetPrefix("wind_rose")
         ucrSaveGraph.SetDataFrameSelector(ucrWindRoseSelector.ucrAvailableDataFrames)
         ucrSaveGraph.SetSaveTypeAsGraph()
         ucrSaveGraph.SetIsComboBox()

--- a/instat/sdgCorrPlot.vb
+++ b/instat/sdgCorrPlot.vb
@@ -43,7 +43,7 @@ Public Class sdgCorrPlot
         ucrChkLabel.SetText("Label")
         ucrChkLabel.SetRDefault("FALSE")
 
-        ucrSaveGraph.SetPrefix("CorGraph")
+        ucrSaveGraph.SetPrefix("cor_graph")
         ucrSaveGraph.SetSaveTypeAsGraph()
         ucrSaveGraph.SetDataFrameSelector(dlgCorrelation.ucrSelectorCorrelation.ucrAvailableDataFrames)
         ucrSaveGraph.SetCheckBoxText("Save Graph")

--- a/instat/sdgOneVarCompareModels.vb
+++ b/instat/sdgOneVarCompareModels.vb
@@ -59,7 +59,7 @@ Public Class sdgOneVarCompareModels
         ucrSaveGOF.ucrChkSave.Checked = False
 
         'ucrSaveDisplayChi
-        ' ucrSaveDisplayChi.SetPrefix("ChiSquare")
+        ' ucrSaveDisplayChi.SetPrefix("chiSquare")
         ucrSaveDisplayChi.SetSaveTypeAsDataFrame()
         ucrSaveDisplayChi.SetCheckBoxText("DisplayChi")
         ucrSaveDisplayChi.SetIsComboBox()

--- a/instat/sdgOneVarCompareModels.vb
+++ b/instat/sdgOneVarCompareModels.vb
@@ -49,7 +49,7 @@ Public Class sdgOneVarCompareModels
         ucrChkQQ.AddRSyntaxContainsFunctionNamesCondition(False, {"qqcomp"}, False)
 
         'ucrSaveGOF
-        ucrSaveGOF.SetPrefix("GOF")
+        ucrSaveGOF.SetPrefix("gof")
         ucrSaveGOF.SetCheckBoxText("Save Fit")
         ucrSaveGOF.SetIsComboBox()
         ucrSaveGOF.SetAssignToIfUncheckedValue("last_model")

--- a/instat/sdgSimpleRegOptions.vb
+++ b/instat/sdgSimpleRegOptions.vb
@@ -149,25 +149,25 @@ Public Class sdgSimpleRegOptions
 
         'Save Plots (Save tab)
         'Save Fitted Column Names
-        ucrSaveFittedColumnName.SetPrefix("Fitted")
+        ucrSaveFittedColumnName.SetPrefix("fitted")
         ucrSaveFittedColumnName.SetSaveTypeAsColumn()
         ucrSaveFittedColumnName.SetCheckBoxText("Fitted Values")
         ucrSaveFittedColumnName.SetIsComboBox()
 
         '' save residuals column names
-        ucrSaveResidualsColumnName.SetPrefix("Resids")
+        ucrSaveResidualsColumnName.SetPrefix("resids")
         ucrSaveResidualsColumnName.SetSaveTypeAsColumn()
         ucrSaveResidualsColumnName.SetCheckBoxText("Residuals")
         ucrSaveResidualsColumnName.SetIsComboBox()
 
         '' save stdresiduals column names
-        ucrSaveStdResidualsColumnName.SetPrefix("Sresids")
+        ucrSaveStdResidualsColumnName.SetPrefix("sresids")
         ucrSaveStdResidualsColumnName.SetSaveTypeAsColumn()
         ucrSaveStdResidualsColumnName.SetIsComboBox()
         ucrSaveStdResidualsColumnName.SetCheckBoxText("Std Residuals")
 
         ''save leverage column names
-        ucrSaveLeverageColumnName.SetPrefix("Lever")
+        ucrSaveLeverageColumnName.SetPrefix("lever")
         ucrSaveLeverageColumnName.SetSaveTypeAsColumn()
         ucrSaveLeverageColumnName.SetIsComboBox()
         ucrSaveLeverageColumnName.SetCheckBoxText("Leverage")


### PR DESCRIPTION
Fixes #6291
This is to make the default name when a dialog produces a new column/graph/model/object/data frame following tidyverse style guide column name.
@lloyddewit @dannyparsons there is no coding in this PR and this is ready to be merge. Thanks.