### PR TITLE
Correcting typo in One Way Frequency Table Dialog

### DIFF
--- a/instat/sdgOneWayFrequencies.vb
+++ b/instat/sdgOneWayFrequencies.vb
@@ -36,7 +36,7 @@ Public Class sdgOneWayFrequencies
 
         'Table Only
         ucrChkShowStrings.SetParameter(New RParameter("show.strings", 7), bNewChangeParameterValue:=True, bNewAddRemoveParameter:=True, strNewValueIfChecked:="TRUE", strNewValueIfUnchecked:="FALSE")
-        ucrChkShowStrings.SetText("Omit Character Variabless")
+        ucrChkShowStrings.SetText("Omit Character Variables")
 
         ucrPnlShowMissingFreq.SetParameter(New RParameter("show.na", 8))
         ucrPnlShowMissingFreq.AddRadioButton(rdoShowMissingTrue, "TRUE")


### PR DESCRIPTION
Changes as of PR #6730 requested after merging 

@shadrackkibet , I have corrected the typo error `Variabless` to `Variables`.  It is ready for review now. 
@lloyddewit , Kindly review it too. 

