### PR TITLE
Resetting the save control name and checkbox in the Fit Model dialog

### DIFF
--- a/instat/dlgFitModel.vb
+++ b/instat/dlgFitModel.vb
@@ -88,7 +88,6 @@ Public Class dlgFitModel
     Private Sub SetDefaults()
         clsFormulaOperator = New ROperator
 
-        ucrBase.clsRsyntax.ClearCodes()
         clsRCIFunction = New RFunction
         clsRConvert = New RFunction
         clsSummaryFunction = New RFunction
@@ -108,6 +107,7 @@ Public Class dlgFitModel
         clsFittedValuesFunction = New RFunction
 
         ucrSelectorByDataFrameAddRemoveForFitModel.Reset()
+        ucrModelName.Reset()
         ucrReceiverResponseVar.SetMeAsReceiver()
         ucrSelectorByDataFrameAddRemoveForFitModel.Focus()
 
@@ -132,6 +132,7 @@ Public Class dlgFitModel
         clsLM = clsRegressionDefaults.clsDefaultLmFunction.Clone
         clsLM.AddParameter("formula", clsROperatorParameter:=clsFormulaOperator, iPosition:=1)
         clsLM.AddParameter("na.action", "na.exclude", iPosition:=4)
+        clsLM.SetAssignTo("last_model", strTempDataframe:=ucrSelectorByDataFrameAddRemoveForFitModel.ucrAvailableDataFrames.cboAvailableDataFrames.Text, strTempModel:="last_model", bAssignToIsPrefix:=True)
 
         'Residual Plots
         dctPlotFunctions = New Dictionary(Of String, RFunction)(clsRegressionDefaults.dctModelPlotFunctions)
@@ -172,10 +173,7 @@ Public Class dlgFitModel
         clsRstandardFunction.SetRCommand("rstandard")
         clsHatvaluesFunction.SetRCommand("hatvalues")
 
-        clsLM.SetAssignTo(ucrModelName.GetText, strTempDataframe:=ucrSelectorByDataFrameAddRemoveForFitModel.ucrAvailableDataFrames.cboAvailableDataFrames.Text, strTempModel:="last_model", bAssignToIsPrefix:=True)
-
-        clsGLM.SetAssignTo(ucrModelName.GetText, strTempDataframe:=ucrSelectorByDataFrameAddRemoveForFitModel.ucrAvailableDataFrames.cboAvailableDataFrames.Text, strTempModel:="last_model", bAssignToIsPrefix:=True)
-
+        ucrBase.clsRsyntax.ClearCodes()
         ucrBase.clsRsyntax.SetBaseRFunction(clsLM)
         ucrBase.clsRsyntax.AddToAfterCodes(clsAnovaFunction, 1)
         ucrBase.clsRsyntax.AddToAfterCodes(clsSummaryFunction, 2)


### PR DESCRIPTION
fixes #6842

@africanmathsinitiative/developers this is ready for review.

- Removed some redundant code
- Moved clearing of After/Before codes line to a consistent location like in other places
- Resetting save control by default
- Proper setting of `clsLM.SetAssignTo()` arguments so as to allow unchecking of save control checkbox by default