### PR TITLE
Fixed bug on the use of recode factor function on Recode Factor Dialog

### DIFF
--- a/instat/dlgRecodeFactor.vb
+++ b/instat/dlgRecodeFactor.vb
@@ -226,12 +226,19 @@ Public Class dlgRecodeFactor
         Dim strNewLabels As List(Of String)
 
         strCurrentLabels = ucrFactorGrid.GetColumnAsList(ucrFactorGrid.strLabelsName, False)
-        strNewLabels = ucrFactorGrid.GetColumnAsList("New Label", True)
+        strNewLabels = ucrFactorGrid.GetColumnAsList("New Label", False)
+
+        If strCurrentLabels.Count = strNewLabels.Count Then
+            For i = 0 To strCurrentLabels.Count - 1
+                'Backtick needed for names of the vector incase the levels are not valid R names
+                clsFctRecodeFunction.RemoveParameterByPosition(i + 1)
+            Next
+        End If
 
         If ucrFactorGrid.IsColumnComplete("New Label") AndAlso strCurrentLabels.Count = strNewLabels.Count Then
             For i = 0 To strCurrentLabels.Count - 1
                 'Backtick needed for names of the vector incase the levels are not valid R names
-                clsFctRecodeFunction.AddParameter(Chr(96) & strCurrentLabels(i) & Chr(96), strNewLabels(i))
+                clsFctRecodeFunction.AddParameter(Chr(96) & strNewLabels(i) & Chr(96), Chr(34) & strCurrentLabels(i) & Chr(34), iPosition:=i + 1)
             Next
         End If
         TestOKEnabled()


### PR DESCRIPTION
Fixes #6852
I was trying to fix the bug raised recently by @cabrinenyona when trying to recode the factor with her data attached in issue #6852. We had a quick chat where she has demonstrated how she was getting the bug. Looking for a way to fix that I tried to use the new version of the Factor Recode Dialogue with forcats-package and see if I will get the sane bug @cabrinenyona was getting on version 0.7.2 then I found together with @rdstern that the change I made for recoding the factor was not working. After fixing that bug on the new version of Recode Factor Dialogue, I used the same data @cabrinenyona was using in version 0.7.2 and I found that there is no bug, and all work perfectly. So, this PR fixes the bug in the new version of the Recode Factor Dialogue and also the bug from @cabrinenyona on #6852.
@africanmathsinitiative/developers @rdstern this is ready for review. Thanks.