### PR TITLE
Fixed bug loading older files with filters applied

### DIFF
--- a/instat/static/InstatObject/R/Backend_Components/calculations.R
+++ b/instat/static/InstatObject/R/Backend_Components/calculations.R
@@ -53,6 +53,14 @@ calculation$set("public", "data_clone", function() {
 }
 )
 
+# This ensures cloned filter objects from older saved data_books have the expected parameters
+check_filter <- function(filter_obj) {
+  if (is.null(filter_obj$parameters[["and_or"]])) filter_obj$parameters[["and_or"]] <- "&"
+  if (is.null(filter_obj$parameters[["outer_not"]])) filter_obj$parameters[["outer_not"]] <- FALSE
+  if (is.null(filter_obj$parameters[["inner_not"]])) filter_obj$parameters[["inner_not"]] <- FALSE
+  return(filter_obj)
+}
+
 # calculation$set("public", "data_clone", function() {
 #   ret = calculation$new(function_name = private$function_name, parameters = private$parameters, calculated_from = private$calculated_from, is_recalculable = private$is_recalculable, sub_calculations = private$sub_calculations, type = private$type, filter_conditions = private$.filter_conditions)
 #   sub_calculations[[name]] <- sub_calculation

--- a/instat/static/InstatObject/R/data_object_R6.R
+++ b/instat/static/InstatObject/R/data_object_R6.R
@@ -1703,8 +1703,12 @@ DataSheet$set("public", "get_filter", function(filter_name) {
 
 DataSheet$set("public", "get_filter_as_logical", function(filter_name) {
   curr_filter <- self$get_filter(filter_name)
+  and_or <- curr_filter$parameters[["and_or"]]
+  # This should no longer be needed as default will be set in check_filter()
+  if (is.null(and_or)) and_or <- "&"
+  outer_not <- curr_filter$parameters[["outer_not"]]
   i <- 1
-  if (!curr_filter$parameters[["outer_not"]]) {
+  if (!isTRUE(outer_not)) {
     if (length(curr_filter$filter_conditions) == 0) {
       out <- rep(TRUE, nrow(self$get_data_frame(use_current_filter = FALSE)))
     } else {
@@ -1730,7 +1734,7 @@ DataSheet$set("public", "get_filter_as_logical", function(filter_name) {
           } else {
             logical_vec <- func(self$get_columns_from_data(condition[["column"]], use_current_filter = FALSE), condition[["value"]])
           }
-          if (!curr_filter$parameters[["inner_not"]]) {
+          if (! isTRUE(curr_filter$parameters[["inner_not"]])) {
             result[, i] <- logical_vec
           } else {
             result[, i] <- !logical_vec
@@ -1738,8 +1742,6 @@ DataSheet$set("public", "get_filter_as_logical", function(filter_name) {
         }
         i <- i + 1
       }
-      and_or <- curr_filter$parameters[["and_or"]]
-      if (is.null(and_or)) and_or <- "&"
       if (and_or == "&") {
         out <- apply(result, 1, all)
       } else if (and_or == "|") {

--- a/instat/static/InstatObject/R/instat_object_R6.R
+++ b/instat/static/InstatObject/R/instat_object_R6.R
@@ -219,8 +219,10 @@ DataBook$set("public", "clone_data_object", function(curr_data_object, include_o
   if("get_metadata" %in% curr_names) new_data_name <- curr_data_object$get_metadata(data_name_label)
   if(include_objects && "get_objects" %in% curr_names) new_objects <- curr_data_object$get_objects()
   else new_objects <- list()
-  if(include_filters && "get_filter" %in% curr_names) new_filters <- lapply(curr_data_object$get_filter(), function(x) x$data_clone())
-  else new_filters <- list()
+  if(include_filters && "get_filter" %in% curr_names) {
+    new_filters <- lapply(curr_data_object$get_filter(), function(x) x$data_clone())
+    new_filters <- lapply(new_filters, function(x) check_filter(x))
+  } else new_filters <- list()
   if(include_column_selections && "get_column_selection" %in% curr_names) new_column_selections <- lapply(curr_data_object$get_column_selection(), function(x) x$data_clone())
   else new_column_selections <- list()
   if(include_calculations && "get_calculations" %in% curr_names) new_calculations <- lapply(curr_data_object$get_calculations(), function(x) self$clone_instat_calculation(x))


### PR DESCRIPTION
fixes #6891

@africanmathsinitiative/developers this is ready for review

This bug wasn't due to the recent changes to the grid but to the recent additions to the filter objects. It's a very good bug to find and a good reminder of the importance of backwards compatibility so we can support users with older `data_book` files.

@shadrackkibet This was caused by recent additions to the parameters for filters i.e. `"inner_not"` and `"outer_not"`. Because these parameters don't exist in filter objects in `data_book`s saved a long time ago, it gives an error when trying to access these parameters. I hadn't thought too much about this before. I should have put these structures in place at the beginner so it would be clear what to do when making changes.

It's easy to resolve. I have created `check_filter()` which checks an incoming filter object when the data is imported and adds defaults to parameters which may not exist. We just need to maintain this function for any further changes to the filter object.

For extra security, I've added `isTRUE()` to checks on logical objects in the filter function. It shouldn't be needed now, but I think it's good practice as it will catch any `NULL`s that slip through.

We should also do the same for the `column selection` objects when these change in future.