### PR TITLE
Updated grid so any new dataframes added become current tab

### DIFF
--- a/instat/ucrDataView.vb
+++ b/instat/ucrDataView.vb
@@ -100,6 +100,7 @@ Public Class ucrDataView
             If fillWorkSheet Is Nothing Then
                 fillWorkSheet = grid.CreateWorksheet(clsDataFrame.strName)
                 grid.AddWorksheet(fillWorkSheet)
+                grid.CurrentWorksheet = fillWorkSheet
             End If
             RefreshWorksheet(fillWorkSheet, clsDataFrame)
         Next


### PR DESCRIPTION
This works as when the original dataframes are added the main form selects the first worksheet therefore this can be added without affecting the initial load