### PR TITLE
Fixed bug when trying to show Levels/Labels Dialogue

### DIFF
--- a/instat/dlgLabelsLevels.vb
+++ b/instat/dlgLabelsLevels.vb
@@ -119,7 +119,7 @@ Public Class dlgLabelsLevels
         Dim clsGetColumnFunction As RFunction = ucrReceiverLabels.GetVariables()
         clsGetColumnFunction.RemoveAssignTo()
 
-        If Not ucrReceiverLabels.IsEmpty Then
+        If Not ucrReceiverLabels.IsEmpty AndAlso {"factor"}.Contains(ucrReceiverLabels.strCurrDataType) Then
             clsSumCountMissingFunction.AddParameter("x", clsRFunctionParameter:=clsGetColumnFunction, iPosition:=0)
             iMissingValue = frmMain.clsRLink.RunInternalScriptGetValue(clsSumCountMissingFunction.ToScript(), bSilent:=False).AsNumeric(0)
         Else


### PR DESCRIPTION
Partially fixes #6900 
This essentially concerns the first part of issue #6900 on the way the application was throwing due to the fact that the deleted dataset from the Data View after showing the Levels/Labels dialogue was still present when trying to show the Levels/Labels of another data set.
@rdstern @africanmathsinitiative/developers this is ready for review. Thanks.