### PR TITLE
Fixed bug recoding factor levels

### DIFF
--- a/instat/dlgRecodeFactor.resx
+++ b/instat/dlgRecodeFactor.resx
@@ -652,7 +652,7 @@
     <value>2</value>
   </data>
   <data name="rdoAddNa.Text" xml:space="preserve">
-    <value>add_na</value>
+    <value>Add NA</value>
   </data>
   <data name="rdoAddNa.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
     <value>MiddleCenter</value>
@@ -685,7 +685,7 @@
     <value>8</value>
   </data>
   <data name="lblNameForNa.Text" xml:space="preserve">
-    <value>Name for na:</value>
+    <value>Name for NA:</value>
   </data>
   <data name="&gt;&gt;lblNameForNa.Name" xml:space="preserve">
     <value>lblNameForNa</value>


### PR DESCRIPTION
fixes #6898

@africanmathsinitiative/developers This is ready for review

I've resolved this by changing the Recode Factor dialog back to using `plyr::recode()`. This function works in a different way allowing the duplicate values.

@N-thony @rdstern Can you confirm this resolves the issue?

I also updated some text on the dialog. We should use `NA` in capitals for the missing value code. We should also not use `_` for text on dialogs, it should always be readable normal text e.g. `Add NA` instead of `add_na`.