### PR TITLE
Updated tab selection when updating databook

### DIFF
--- a/instat/Model/DataFrame/clsColumnMetaData.vb
+++ b/instat/Model/DataFrame/clsColumnMetaData.vb
@@ -22,6 +22,7 @@ Public Class clsColumnMetaData
     Private _strName As String
     Private _RLink As RLink
     Private _clsDataFrame As DataFrame
+    Private _hasChanged As Boolean
 
     ''' <summary>
     ''' Returns data for a given cell within the Column Meta data table
@@ -78,6 +79,20 @@ Public Class clsColumnMetaData
     End Property
 
     ''' <summary>
+    ''' holds whether the dataframe is different from visual grid component
+    ''' ToDo This is more ViewModel level not here where its stored
+    ''' </summary>
+    ''' <returns></returns>
+    Public Property HasChanged() As Boolean
+        Get
+            Return _hasChanged
+        End Get
+        Set(ByVal value As Boolean)
+            _hasChanged = value
+        End Set
+    End Property
+
+    ''' <summary>
     ''' Creates new instance of a column metadata class
     ''' </summary>
     ''' <param name="rLink"></param>
@@ -85,6 +100,7 @@ Public Class clsColumnMetaData
     Public Sub New(rLink As RLink, strName As String)
         _RLink = rLink
         _strName = strName
+        _hasChanged = True
     End Sub
 
     Private Function HasDataChanged() As Boolean
@@ -114,7 +130,7 @@ Public Class clsColumnMetaData
     Private Function GetDataFrameFromRCommand() As DataFrame
         Dim clsGetVariablesMetadata As New RFunction
         Dim expTemp As SymbolicExpression
-
+        _hasChanged = True
         clsGetVariablesMetadata.SetRCommand(_RLink.strInstatDataObject & "$get_variables_metadata")
         clsGetVariablesMetadata.AddParameter("convert_to_character", "TRUE")
         clsGetVariablesMetadata.AddParameter("data_name", Chr(34) & _strName & Chr(34))

--- a/instat/ucrColumnMetadata.vb
+++ b/instat/ucrColumnMetadata.vb
@@ -54,9 +54,14 @@ Public Class ucrColumnMetadata
     End Function
 
     Private Sub RefreshWorksheet(fillWorksheet As Worksheet, dataFrame As clsDataFrame)
+        If Not dataFrame.clsColumnMetaData.HasChanged Then
+            Exit Sub
+        End If
         AddColumns(dataFrame, fillWorksheet)
         AddRowData(dataFrame, fillWorksheet)
         UpdateWorksheetStyle(fillWorksheet)
+        dataFrame.clsColumnMetaData.HasChanged = False
+        grdVariables.CurrentWorksheet = fillWorksheet
     End Sub
 
     Private Sub AddColumns(dataFramePage As clsDataFrame, worksheet As Worksheet)
@@ -67,15 +72,22 @@ Public Class ucrColumnMetadata
     End Sub
 
     Private Sub AddAndUpdateWorksheets(grid As ReoGridControl)
+        Dim firstAddedWorksheet As Worksheet = Nothing
         For Each clsDataFrame In _clsDataBook.DataFrames
             Dim fillWorksheet As Worksheet
             fillWorksheet = grid.Worksheets.Where(Function(x) x.Name = clsDataFrame.strName).FirstOrDefault
             If fillWorksheet Is Nothing Then
                 fillWorksheet = grid.CreateWorksheet(clsDataFrame.strName)
                 grid.AddWorksheet(fillWorksheet)
+                If firstAddedWorksheet Is Nothing Then
+                    firstAddedWorksheet = fillWorksheet
+                End If
             End If
             RefreshWorksheet(fillWorksheet, clsDataFrame)
         Next
+        If firstAddedWorksheet IsNot Nothing Then
+            grid.CurrentWorksheet = firstAddedWorksheet
+        End If
     End Sub
 
     Public Sub UpdateAllWorksheetStyles()

--- a/instat/ucrDataView.vb
+++ b/instat/ucrDataView.vb
@@ -59,9 +59,8 @@ Public Class ucrDataView
         AddColumns(dataFrame.clsVisiblePage, fillWorkSheet)
         AddRowData(dataFrame, fillWorkSheet)
         UpdateWorksheetStyle(fillWorkSheet)
-
         dataFrame.clsVisiblePage.HasChanged = False
-        RefreshDisplayInformation()
+        grdData.CurrentWorksheet = fillWorkSheet
     End Sub
 
     Public Sub UpdateAllWorksheetStyles()
@@ -92,19 +91,21 @@ Public Class ucrDataView
     End Sub
 
     Private Sub AddAndUpdateWorksheets(grid As ReoGridControl)
-        'This should use existing worksheets rather than re adding
-        Dim fillWorkSheet As Worksheet
-        ' grid.Worksheets.Clear()
+        Dim firstAddedWorksheet As Worksheet = Nothing
         For Each clsDataFrame In _clsDataBook.DataFrames
-            fillWorkSheet = grid.Worksheets.Where(Function(x) x.Name = clsDataFrame.strName).FirstOrDefault
+            Dim fillWorkSheet As Worksheet = grid.Worksheets.Where(Function(x) x.Name = clsDataFrame.strName).FirstOrDefault
             If fillWorkSheet Is Nothing Then
                 fillWorkSheet = grid.CreateWorksheet(clsDataFrame.strName)
                 grid.AddWorksheet(fillWorkSheet)
-                grid.CurrentWorksheet = fillWorkSheet
+                If firstAddedWorksheet Is Nothing Then
+                    firstAddedWorksheet = fillWorkSheet
+                End If
             End If
             RefreshWorksheet(fillWorkSheet, clsDataFrame)
         Next
-
+        If firstAddedWorksheet IsNot Nothing Then
+            grid.CurrentWorksheet = firstAddedWorksheet
+        End If
     End Sub
 
     Private Sub RemoveOldWorksheets(grid As ReoGridControl)


### PR DESCRIPTION
Set up that anytime a worksheet is updated it is selected. When adding worksheets this will override any selection with the first worksheet added