### PR TITLE
fixed convert to numeric form closing issue and updated install scripts

### DIFF
--- a/installer/inno_install_script_32bit.iss
+++ b/installer/inno_install_script_32bit.iss
@@ -5,9 +5,9 @@
 ; NOTE: The value of AppId uniquely identifies this application.
 ; Do not use the same AppId value in installers for other applications.
 ; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)
-AppId={{82EDE163-D0A3-46BB-81E4-20166879108F}
+AppId={{176720C6-F30C-4691-A688-CAF108E41AE2}
 AppName=R-Instat
-#define AppVerName "0.7.3"
+#define AppVerName "0.7.3.1"
 AppVersion={#AppVerName}
 AppPublisher=African Maths Initiative
 AppPublisherURL=http://r-instat.org/
@@ -31,10 +31,10 @@ Source: "..\instat\bin\Release\*"; DestDir: "{app}"; Flags: ignoreversion recurs
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
 [Icons]
-Name: "{group}\R-Instat 0.7.3"; Filename: "{app}\instat.exe"
+Name: "{group}\R-Instat 0.7.3.1"; Filename: "{app}\instat.exe"
 Name: "{group}\{cm:UninstallProgram,R-Instat}"; Filename: "{uninstallexe}"
-Name: "{commondesktop}\R-Instat 0.7.3"; Filename: "{app}\instat.exe"; Tasks: desktopicon
-Name: "{userappdata}\Microsoft\Internet Explorer\Quick Launch\R-Instat 0.7.3"; Filename: "{app}\instat.exe"; Tasks: quicklaunchicon
+Name: "{commondesktop}\R-Instat 0.7.3.1"; Filename: "{app}\instat.exe"; Tasks: desktopicon
+Name: "{userappdata}\Microsoft\Internet Explorer\Quick Launch\R-Instat 0.7.3.1"; Filename: "{app}\instat.exe"; Tasks: quicklaunchicon
 
 [Run]
 Filename: "{app}\instat.exe"; Description: "{cm:LaunchProgram,R-Instat}"; Flags: nowait postinstall skipifsilent

--- a/installer/inno_install_script_64bit.iss
+++ b/installer/inno_install_script_64bit.iss
@@ -5,9 +5,9 @@
 ; NOTE: The value of AppId uniquely identifies this application.
 ; Do not use the same AppId value in installers for other applications.
 ; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)
-AppId={{82EDE163-D0A3-46BB-81E4-20166879108F}
+AppId={{176720C6-F30C-4691-A688-CAF108E41AE2}
 AppName=R-Instat
-#define AppVerName "0.7.3"
+#define AppVerName "0.7.3.1"
 AppVersion={#AppVerName}
 AppPublisher=African Maths Initiative
 AppPublisherURL=http://r-instat.org/
@@ -32,10 +32,10 @@ Source: "..\instat\bin\x64\Release\*"; DestDir: "{app}"; Flags: ignoreversion re
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
 [Icons]
-Name: "{group}\R-Instat 0.7.3"; Filename: "{app}\instat.exe"
+Name: "{group}\R-Instat 0.7.3.1"; Filename: "{app}\instat.exe"
 Name: "{group}\{cm:UninstallProgram,R-Instat}"; Filename: "{uninstallexe}"
-Name: "{commondesktop}\R-Instat 0.7.3"; Filename: "{app}\instat.exe"; Tasks: desktopicon
-Name: "{userappdata}\Microsoft\Internet Explorer\Quick Launch\R-Instat 0.7.3"; Filename: "{app}\instat.exe"; Tasks: quicklaunchicon
+Name: "{commondesktop}\R-Instat 0.7.3.1"; Filename: "{app}\instat.exe"; Tasks: desktopicon
+Name: "{userappdata}\Microsoft\Internet Explorer\Quick Launch\R-Instat 0.7.3.1"; Filename: "{app}\instat.exe"; Tasks: quicklaunchicon
 
 [Run]
 Filename: "{app}\instat.exe"; Description: "{cm:LaunchProgram,R-Instat}"; Flags: nowait postinstall skipifsilent

--- a/instat/frmConvertToNumeric.vb
+++ b/instat/frmConvertToNumeric.vb
@@ -36,13 +36,8 @@
         End If
     End Sub
 
-    Private Sub ConvertButtons_Click(sender As Object, e As EventArgs) Handles cmdNormalConvert.Click, cmdLabelledConvert.Click
-        Me.Close()
-    End Sub
-
     Private Sub cmdCancel_Click(sender As Object, e As EventArgs) Handles cmdCancel.Click
         Me.DialogResult = DialogResult.Cancel
-        Me.Close()
     End Sub
 
     Private Sub cmdHelp_Click(sender As Object, e As EventArgs) Handles cmdHelp.Click

--- a/instat/ucrDataView.vb
+++ b/instat/ucrDataView.vb
@@ -658,6 +658,7 @@ Public Class ucrDataView
                 ElseIf frmConvertToNumeric.DialogResult = DialogResult.Cancel Then
                     Continue For
                 End If
+                frmConvertToNumeric.Close()
             End If
         Next
     End Sub


### PR DESCRIPTION
@ChrisMarsh82 I noticed an issue with the new closing on `frmConvertToNumeric`. This is because the `DialogResult` property seems to be lost when the form is closed. I've changed it so that the form is closed by `ucrDataView` instead. This seems to work ok. Can you check you're happy with this?

(I also included updates to the installation scripts here, but that's unrelated to this change)