### PR TITLE
Made the Try text box non-editable on the Calculator dialog

### DIFF
--- a/instat/ucrTry.Designer.vb
+++ b/instat/ucrTry.Designer.vb
@@ -39,7 +39,7 @@ Partial Class ucrTry
         '
         Me.ucrInputTryMessage.AddQuotesIfUnrecognised = True
         Me.ucrInputTryMessage.IsMultiline = False
-        Me.ucrInputTryMessage.IsReadOnly = False
+        Me.ucrInputTryMessage.IsReadOnly = True
         Me.ucrInputTryMessage.Location = New System.Drawing.Point(89, 6)
         Me.ucrInputTryMessage.Name = "ucrInputTryMessage"
         Me.ucrInputTryMessage.Size = New System.Drawing.Size(297, 21)


### PR DESCRIPTION
@africanmathsinitiative/developers @shadrackkibet 
This partly fixes #7023 
Can you look at this change.