### PR TITLE
 Made the Message text box non-editable on the Remove Unused Levels dialog

### DIFF
--- a/instat/dlgRemoveUnusedLevels.Designer.vb
+++ b/instat/dlgRemoveUnusedLevels.Designer.vb
@@ -88,7 +88,7 @@ Partial Class dlgRemoveUnusedLevels
         '
         Me.ucrInputUnusedLevels.AddQuotesIfUnrecognised = True
         Me.ucrInputUnusedLevels.IsMultiline = False
-        Me.ucrInputUnusedLevels.IsReadOnly = False
+        Me.ucrInputUnusedLevels.IsReadOnly = True
         resources.ApplyResources(Me.ucrInputUnusedLevels, "ucrInputUnusedLevels")
         Me.ucrInputUnusedLevels.Name = "ucrInputUnusedLevels"
         '


### PR DESCRIPTION
@africanmathsinitiative/developers @shadrackkibet 
this partially fixes issue #7023 
This is ready for review.