### PR TITLE
Fixes translation issue on Climatic > Check Data > Boxplot dialogue

### DIFF
--- a/instat/translations/translateIgnore.txt
+++ b/instat/translations/translateIgnore.txt
@@ -79,3 +79,12 @@ dlgSplitText_ucrInputPattern%
 # In the 'Filter' dialog, the 'Selected Filter Preview' should not be translated.
 # Fixes issue #6949, related to PR #6956
 dlgRestrict_ucrInputFilterPreview
+
+# In the 'Boxplot' dialog, the selected 'Facet' either for Station, Year or Within Year should not be translated
+# Fixes issue #6185, item a)
+dlgClimaticBoxPlot_ucrInputStation%
+dlgClimaticBoxPlot_ucrInputStation_cboInput%
+dlgClimaticBoxPlot_ucrInputYear%
+dlgClimaticBoxPlot_ucrInputYear_cboInput%
+dlgClimaticBoxPlot_ucrInputWithinYear%
+dlgClimaticBoxPlot_ucrInputWithinYear_cboInput%


### PR DESCRIPTION
Partially fixes #6185 
@lloyddewit I have updated the database following the suggestion in the corresponding issue as follows in this screenshot. I also updated the `translations/translateIgnore.txt` with the controls to not translate. Please take a look. Thanks.

![image](https://user-images.githubusercontent.com/68591383/145194372-ccc1f5a7-4cb8-480a-89a3-2750cf410376.png)
