### PR TITLE
In the 'Evapotranspiration' dialog, set the 'Penman-Monteith' and 'Hargreaves-Samani' buttons to DoNotTranslate

### DIFF
--- a/instat/translations/translateIgnore.txt
+++ b/instat/translations/translateIgnore.txt
@@ -79,3 +79,8 @@ dlgSplitText_ucrInputPattern%
 # In the 'Filter' dialog, the 'Selected Filter Preview' should not be translated.
 # Fixes issue #6949, related to PR #6956
 dlgRestrict_ucrInputFilterPreview
+
+# In the 'Evapotranspiration' dialog, the 'Penman-Monteith' and 'Hargreaves-Samani' buttons should not be translated.
+# Partially fixes issue #7026, related to PR #7035
+dlgEvapotranspiration_%_rdoPenmanMonteith
+dlgEvapotranspiration_%_rdoHargreavesSamani


### PR DESCRIPTION
Fixes issues described in PR #7035.

Changes to database:

![image](https://user-images.githubusercontent.com/57253949/145804100-598d2002-b9b5-4099-9bf2-6334db359710.png)

@rdstern @shadrackkibet There is nothing you can really test or review here. Please can you approve so that we can merge quickly and avoid potential merge conflicts with the database? Thanks