### PR TITLE
Implemented the Ctrl+C on the new Output Window

### DIFF
--- a/instat/UserControl/ucrOutputPage.vb
+++ b/instat/UserControl/ucrOutputPage.vb
@@ -288,7 +288,7 @@ Public Class ucrOutputPage
                 If Line <> "" Then strClip &= Line & Environment.NewLine
             Next
             Clipboard.Clear()
-            Clipboard.SetDataObject(strClip, TextDataFormat.Text)
+            Clipboard.SetText(strClip, TextDataFormat.Text)
         End With
     End Sub
 

--- a/instat/UserControl/ucrOutputPage.vb
+++ b/instat/UserControl/ucrOutputPage.vb
@@ -283,13 +283,12 @@ Public Class ucrOutputPage
 
     Private Sub CopySelectedTextToClipBoard(richText As RichTextBox)
         Dim strClip As String = String.Empty
-        With richText
-            For Each Line As String In .Lines
-                If Line <> "" Then strClip &= Line & Environment.NewLine
-            Next
-            Clipboard.Clear()
-            Clipboard.SetText(strClip, TextDataFormat.Text)
-        End With
+
+        For Each Line As String In richText.Lines
+            strClip &= Line & Environment.NewLine
+        Next
+        Clipboard.Clear()
+        Clipboard.SetText(strClip, TextDataFormat.Text)
     End Sub
 
     Private Sub Panel_Resize(sender As Object, e As EventArgs)

--- a/instat/UserControl/ucrOutputPage.vb
+++ b/instat/UserControl/ucrOutputPage.vb
@@ -137,7 +137,7 @@ Public Class ucrOutputPage
         For Each element In SelectedElements
             AddElementToRichTextBox(element, richText)
         Next
-        CopySelectedTextToClipBoard(richText)
+        CopySelectedTextToClipBoard(richText, richText.Rtf)
     End Sub
 
     ''' <summary>
@@ -274,14 +274,14 @@ Public Class ucrOutputPage
                 Dim richText As RichTextBox = CType(sender, RichTextBox)
                 Dim richSelectedText As New RichTextBox
                 richSelectedText.AppendText(richText.SelectedText)
-                CopySelectedTextToClipBoard(richSelectedText)
+                CopySelectedTextToClipBoard(richSelectedText, richText.SelectedRtf)
             Catch ex As Exception
                 MsgBox(ex.Message)
             End Try
         End If
     End Sub
 
-    Private Sub CopySelectedTextToClipBoard(richText As RichTextBox)
+    Private Sub CopySelectedTextToClipBoard(richText As RichTextBox, richTextFormat As String)
         Dim strClip As String = String.Empty
         Dim dto As New DataObject()
 
@@ -289,7 +289,7 @@ Public Class ucrOutputPage
             strClip &= Line & Environment.NewLine
         Next
 
-        dto.SetText(richText.Rtf, TextDataFormat.Rtf)
+        dto.SetText(richTextFormat, TextDataFormat.Rtf)
         dto.SetText(strClip, TextDataFormat.UnicodeText)
         Clipboard.Clear()
         Clipboard.SetDataObject(dto)

--- a/instat/UserControl/ucrOutputPage.vb
+++ b/instat/UserControl/ucrOutputPage.vb
@@ -126,7 +126,7 @@ Public Class ucrOutputPage
     End Sub
 
     ''' <summary>
-    ''' Copies selected elenments to clipboard
+    ''' Copies selected elements to clipboard
     ''' </summary>
     Public Sub CopySelectedElementsToClipboard()
         If CopyOneImageOnly() Then
@@ -137,11 +137,14 @@ Public Class ucrOutputPage
         For Each element In SelectedElements
             AddElementToRichTextBox(element, richText)
         Next
-        Dim dto As New DataObject()
-        dto.SetText(richText.Rtf, TextDataFormat.Rtf)
-        dto.SetText(richText.Text, TextDataFormat.UnicodeText)
-        Clipboard.Clear()
-        Clipboard.SetDataObject(dto)
+        Dim strClip As String = String.Empty
+        With richText
+            For Each Line As String In .Lines
+                strClip &= Line & Environment.NewLine
+            Next
+            Clipboard.Clear()
+            Clipboard.SetText(strClip, TextDataFormat.Text)
+        End With
     End Sub
 
     ''' <summary>
@@ -280,6 +283,7 @@ Public Class ucrOutputPage
                     For Each Line As String In .Lines
                         strClip &= Line & Environment.NewLine
                     Next
+                    Clipboard.Clear()
                     Clipboard.SetText(strClip, TextDataFormat.Text)
                 End With
             Catch ex As Exception

--- a/instat/UserControl/ucrOutputPage.vb
+++ b/instat/UserControl/ucrOutputPage.vb
@@ -282,7 +282,7 @@ Public Class ucrOutputPage
         Dim strClip As String = String.Empty
         With richText
             For Each Line As String In .Lines
-                strClip &= Line & Environment.NewLine
+                If Line <> "" Then strClip &= Line & Environment.NewLine
             Next
             Clipboard.Clear()
             Clipboard.SetText(strClip, TextDataFormat.Text)

--- a/instat/UserControl/ucrOutputPage.vb
+++ b/instat/UserControl/ucrOutputPage.vb
@@ -283,12 +283,16 @@ Public Class ucrOutputPage
 
     Private Sub CopySelectedTextToClipBoard(richText As RichTextBox)
         Dim strClip As String = String.Empty
+        Dim dto As New DataObject()
 
         For Each Line As String In richText.Lines
             strClip &= Line & Environment.NewLine
         Next
+
+        dto.SetText(strClip, TextDataFormat.Rtf)
+        dto.SetText(strClip, TextDataFormat.UnicodeText)
         Clipboard.Clear()
-        Clipboard.SetText(strClip, TextDataFormat.Text)
+        Clipboard.SetDataObject(dto)
     End Sub
 
     Private Sub Panel_Resize(sender As Object, e As EventArgs)

--- a/instat/UserControl/ucrOutputPage.vb
+++ b/instat/UserControl/ucrOutputPage.vb
@@ -193,6 +193,7 @@ Public Class ucrOutputPage
         panel.Controls.Add(richTextBox)
         panel.Controls.SetChildIndex(richTextBox, 0)
         SetRichTextBoxHeight(richTextBox)
+        AddHandler richTextBox.KeyUp, AddressOf richTextBox_CopySelectedText
     End Sub
 
     Private Function CopyOneImageOnly() As Boolean
@@ -270,51 +271,21 @@ Public Class ucrOutputPage
         RaiseEvent RefreshContextButtons()
     End Sub
 
-    'Private Sub r1_SelectionChanged(sender As Object, e As EventArgs)
-    '    For Each element In pnlMain.Controls
-    '        'For Each elt In panel.Controls
-    '        If TypeOf element Is RichTextBox Then
-    '            Dim richtext As RichTextBox = CType(sender, RichTextBox)
-    '            Dim dto As New DataObject()
-    '            Dim txt As String = richtext.SelectedText
-    '            dto.SetText(richtext.Rtf, TextDataFormat.Rtf)
-    '            dto.SetText(richtext.Text, TextDataFormat.UnicodeText)
-    '            Clipboard.Clear()
-    '            Clipboard.SetDataObject(dto)
-    '        End If
-    '        'Next
-    '    Next
-    'End Sub
-
-    Public Sub CopyToRichTextBox()
-        Try
-            For Each control In pnlMain.Controls
-                If TypeOf control Is Panel Then
-                    For Each element In control.Controls
-                        If TypeOf element Is RichTextBox Then
-                            Dim richtext As RichTextBox = CType(element, RichTextBox)
-                            AddHandler richtext.SelectionChanged, AddressOf richText_Event
-                            'Dim dto As New DataObject()
-                            'dto.SetText(richtext.Rtf, TextDataFormat.Rtf)
-                            'dto.SetText(richtext.Text, TextDataFormat.UnicodeText)
-                            'Clipboard.Clear()
-                            'Clipboard.SetDataObject(dto)
-                        End If
+    Private Sub richTextBox_CopySelectedText(sender As Object, e As KeyEventArgs)
+        If e.KeyData = Keys.Control + Keys.C Then
+            Try
+                Dim richText As RichTextBox = CType(sender, RichTextBox)
+                Dim strClip As String = String.Empty
+                With richText
+                    For Each Line As String In .Lines
+                        strClip &= Line & Environment.NewLine
                     Next
-                End If
-            Next
-        Catch ex As Exception
-            MsgBox(ex.Message)
-        End Try
-    End Sub
-
-    Private Sub richText_Event(sender As Object, e As EventArgs)
-        Dim richText = CType(sender, RichTextBox)
-        Dim dto As New DataObject()
-        dto.SetText(richText.Rtf, TextDataFormat.Rtf)
-        dto.SetText(richText.Text, TextDataFormat.UnicodeText)
-        Clipboard.Clear()
-        Clipboard.SetDataObject(dto)
+                    Clipboard.SetText(strClip, TextDataFormat.Text)
+                End With
+            Catch ex As Exception
+                MsgBox(ex.Message)
+            End Try
+        End If
     End Sub
 
     Private Sub Panel_Resize(sender As Object, e As EventArgs)

--- a/instat/UserControl/ucrOutputPage.vb
+++ b/instat/UserControl/ucrOutputPage.vb
@@ -242,6 +242,7 @@ Public Class ucrOutputPage
         panel.Controls.Add(richTextBox)
         panel.Controls.SetChildIndex(richTextBox, 0)
         SetRichTextBoxHeight(richTextBox)
+        AddHandler richTextBox.KeyUp, AddressOf richTextBox_CopySelectedText
     End Sub
 
     Private Sub AddNewImageOutput(outputElement As clsOutputElement)
@@ -271,7 +272,9 @@ Public Class ucrOutputPage
         If e.KeyData = Keys.Control + Keys.C Then
             Try
                 Dim richText As RichTextBox = CType(sender, RichTextBox)
-                CopySelectedTextToClipBoard(richText)
+                Dim richSelectedText As New RichTextBox
+                richSelectedText.AppendText(richText.SelectedText)
+                CopySelectedTextToClipBoard(richSelectedText)
             Catch ex As Exception
                 MsgBox(ex.Message)
             End Try
@@ -285,7 +288,7 @@ Public Class ucrOutputPage
                 If Line <> "" Then strClip &= Line & Environment.NewLine
             Next
             Clipboard.Clear()
-            Clipboard.SetText(strClip, TextDataFormat.Text)
+            Clipboard.SetDataObject(strClip, TextDataFormat.Text)
         End With
     End Sub
 

--- a/instat/UserControl/ucrOutputPage.vb
+++ b/instat/UserControl/ucrOutputPage.vb
@@ -270,6 +270,53 @@ Public Class ucrOutputPage
         RaiseEvent RefreshContextButtons()
     End Sub
 
+    'Private Sub r1_SelectionChanged(sender As Object, e As EventArgs)
+    '    For Each element In pnlMain.Controls
+    '        'For Each elt In panel.Controls
+    '        If TypeOf element Is RichTextBox Then
+    '            Dim richtext As RichTextBox = CType(sender, RichTextBox)
+    '            Dim dto As New DataObject()
+    '            Dim txt As String = richtext.SelectedText
+    '            dto.SetText(richtext.Rtf, TextDataFormat.Rtf)
+    '            dto.SetText(richtext.Text, TextDataFormat.UnicodeText)
+    '            Clipboard.Clear()
+    '            Clipboard.SetDataObject(dto)
+    '        End If
+    '        'Next
+    '    Next
+    'End Sub
+
+    Public Sub CopyToRichTextBox()
+        Try
+            For Each control In pnlMain.Controls
+                If TypeOf control Is Panel Then
+                    For Each element In control.Controls
+                        If TypeOf element Is RichTextBox Then
+                            Dim richtext As RichTextBox = CType(element, RichTextBox)
+                            AddHandler richtext.SelectionChanged, AddressOf richText_Event
+                            'Dim dto As New DataObject()
+                            'dto.SetText(richtext.Rtf, TextDataFormat.Rtf)
+                            'dto.SetText(richtext.Text, TextDataFormat.UnicodeText)
+                            'Clipboard.Clear()
+                            'Clipboard.SetDataObject(dto)
+                        End If
+                    Next
+                End If
+            Next
+        Catch ex As Exception
+            MsgBox(ex.Message)
+        End Try
+    End Sub
+
+    Private Sub richText_Event(sender As Object, e As EventArgs)
+        Dim richText = CType(sender, RichTextBox)
+        Dim dto As New DataObject()
+        dto.SetText(richText.Rtf, TextDataFormat.Rtf)
+        dto.SetText(richText.Text, TextDataFormat.UnicodeText)
+        Clipboard.Clear()
+        Clipboard.SetDataObject(dto)
+    End Sub
+
     Private Sub Panel_Resize(sender As Object, e As EventArgs)
         Dim panel As Panel = CType(sender, Panel)
         For Each control In panel.Controls

--- a/instat/UserControl/ucrOutputPage.vb
+++ b/instat/UserControl/ucrOutputPage.vb
@@ -289,7 +289,7 @@ Public Class ucrOutputPage
             strClip &= Line & Environment.NewLine
         Next
 
-        dto.SetText(strClip, TextDataFormat.Rtf)
+        dto.SetText(richText.Rtf, TextDataFormat.Rtf)
         dto.SetText(strClip, TextDataFormat.UnicodeText)
         Clipboard.Clear()
         Clipboard.SetDataObject(dto)

--- a/instat/UserControl/ucrOutputPage.vb
+++ b/instat/UserControl/ucrOutputPage.vb
@@ -137,14 +137,7 @@ Public Class ucrOutputPage
         For Each element In SelectedElements
             AddElementToRichTextBox(element, richText)
         Next
-        Dim strClip As String = String.Empty
-        With richText
-            For Each Line As String In .Lines
-                strClip &= Line & Environment.NewLine
-            Next
-            Clipboard.Clear()
-            Clipboard.SetText(strClip, TextDataFormat.Text)
-        End With
+        CopySelectedTextToClipBoard(richText)
     End Sub
 
     ''' <summary>
@@ -278,18 +271,22 @@ Public Class ucrOutputPage
         If e.KeyData = Keys.Control + Keys.C Then
             Try
                 Dim richText As RichTextBox = CType(sender, RichTextBox)
-                Dim strClip As String = String.Empty
-                With richText
-                    For Each Line As String In .Lines
-                        strClip &= Line & Environment.NewLine
-                    Next
-                    Clipboard.Clear()
-                    Clipboard.SetText(strClip, TextDataFormat.Text)
-                End With
+                CopySelectedTextToClipBoard(richText)
             Catch ex As Exception
                 MsgBox(ex.Message)
             End Try
         End If
+    End Sub
+
+    Private Sub CopySelectedTextToClipBoard(richText As RichTextBox)
+        Dim strClip As String = String.Empty
+        With richText
+            For Each Line As String In .Lines
+                strClip &= Line & Environment.NewLine
+            Next
+            Clipboard.Clear()
+            Clipboard.SetText(strClip, TextDataFormat.Text)
+        End With
     End Sub
 
     Private Sub Panel_Resize(sender As Object, e As EventArgs)

--- a/instat/UserControl/ucrOutputPages.vb
+++ b/instat/UserControl/ucrOutputPages.vb
@@ -293,4 +293,10 @@ Public Class ucrOutputPages
             End If
         Next
     End Sub
+
+    Private Sub tabControl_KeyDown(sender As Object, e As KeyEventArgs) Handles tabControl.KeyDown
+        If e.Control AndAlso e.KeyCode = Keys.C Then
+            Clipboard.SetText(tabControl.SelectedTab.Text)
+        End If
+    End Sub
 End Class

--- a/instat/UserControl/ucrOutputPages.vb
+++ b/instat/UserControl/ucrOutputPages.vb
@@ -295,8 +295,8 @@ Public Class ucrOutputPages
     End Sub
 
     Private Sub tabControl_KeyDown(sender As Object, e As KeyEventArgs) Handles tabControl.KeyDown
-        If e.Control AndAlso e.KeyCode = Keys.C Then
-            Clipboard.SetText(tabControl.SelectedTab.Text)
+        If e.Control  Then
+            _selectedOutputPage.CopyToRichTextBox()
         End If
     End Sub
 End Class

--- a/instat/UserControl/ucrOutputPages.vb
+++ b/instat/UserControl/ucrOutputPages.vb
@@ -293,10 +293,4 @@ Public Class ucrOutputPages
             End If
         Next
     End Sub
-
-    Private Sub tabControl_KeyDown(sender As Object, e As KeyEventArgs) Handles tabControl.KeyDown
-        If e.Control  Then
-            _selectedOutputPage.CopyToRichTextBox()
-        End If
-    End Sub
 End Class


### PR DESCRIPTION
Fixes #7000
@dannyparsons I have here implemented the Ctrl+C as you suggested in the corresponding issue with the Output Window.
@africanmathsinitiative/developers @rdstern this is ready for review. Thanks.
@ChrisMarsh82 I have additionally fixed the bug when copying text from `Output Window` to `Script Window` by Clicking on `Copy Tab` as I have explained in the issue. The change is made in `CopySelectedElementsToClipboard()`