### PR TITLE
remove Windows progress bar for Linux version and sizes Library dialog display

### DIFF
--- a/instat/dlgFromLibrary.Designer.vb
+++ b/instat/dlgFromLibrary.Designer.vb
@@ -144,14 +144,13 @@ Partial Class dlgFromLibrary
         'ucrInputPackages
         '
         Me.ucrInputPackages.AddQuotesIfUnrecognised = True
-        Me.ucrInputPackages.AutoSize = True
         Me.ucrInputPackages.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.ucrInputPackages.GetSetSelectedIndex = -1
         Me.ucrInputPackages.IsReadOnly = False
         Me.ucrInputPackages.Location = New System.Drawing.Point(108, 51)
         Me.ucrInputPackages.Margin = New System.Windows.Forms.Padding(6, 8, 6, 8)
         Me.ucrInputPackages.Name = "ucrInputPackages"
-        Me.ucrInputPackages.Size = New System.Drawing.Size(0, 0)
+        Me.ucrInputPackages.Size = New System.Drawing.Size(144, 23)
         Me.ucrInputPackages.TabIndex = 4
         '
         'ucrBase

--- a/instat/static/InstatObject/R/instat_object_R6.R
+++ b/instat/static/InstatObject/R/instat_object_R6.R
@@ -2663,7 +2663,8 @@ DataBook$set("public", "import_from_cds", function(user, dataset, elements, star
   all_dates <- seq(start_date, end_date, by = 1)
   all_periods <- unique(paste(lubridate::year(all_dates), sprintf("%02d", lubridate::month(all_dates)), sep = "-"))
   area <- c(lat[2], lon[1], lat[1], lon[2])
-  pb <- winProgressBar(title = "Requesting data from CDS", min = 0, max = length(all_periods))
+  is_win <- Sys.info()['sysname'] == "Windows"
+  if (is_win) pb <- winProgressBar(title = "Requesting data from CDS", min = 0, max = length(all_periods))
   nc_files <- vector(mode = "character", length = length(all_periods))
   for (i in seq_along(all_periods)) {
     y <- substr(all_periods[i], 1, 4)
@@ -2683,7 +2684,7 @@ DataBook$set("public", "import_from_cds", function(user, dataset, elements, star
       target = paste0(dataset, "-", paste(elements, collapse = "_"), "-", all_periods[i], ".nc")
     )
     info <- paste0("Requesting data for ", all_periods[i], " - ", round(100 * i / length(all_periods)), "%")
-    setWinProgressBar(pb, value = i, title = info, label = info)
+    if (is_win) setWinProgressBar(pb, value = i, title = info, label = info)
     ncfile <- ecmwfr::wf_request(user = user, request = request,
                                  transfer = TRUE, path = path,
                                  time_out = 3 * 3600)
@@ -2693,7 +2694,7 @@ DataBook$set("public", "import_from_cds", function(user, dataset, elements, star
       ncdf4::nc_close(nc = nc)
     }
   }
-  close(pb)
+  if (is_win) close(pb)
 })
 
 DataBook$set("public", "add_flag_fields", function(data_name, col_names, key_column_names) {

--- a/instat/static/InstatObject/R/stand_alone_functions.R
+++ b/instat/static/InstatObject/R/stand_alone_functions.R
@@ -613,16 +613,17 @@ multiple_nc_as_data_frame <- function(path, vars, keep_raw_time = TRUE, include_
   nc_list <- list()
   
   n_files <- length(filepaths)
-  pb <- winProgressBar(title = "Reading files", min = 0, max = n_files)
+  is_win <- Sys.info()['sysname'] == "Windows"
+  if (is_win) pb <- winProgressBar(title = "Reading files", min = 0, max = n_files)
   for(i in seq_along(filepaths)) {
     nc <- ncdf4::nc_open(filename = filepaths[i])
     dat <- nc_as_data_frame(nc = nc, vars = vars, keep_raw_time = keep_raw_time, include_metadata = include_metadata, boundary = boundary, lon_points = lon_points, lat_points = lat_points, id_points = id_points, show_requested_points = show_requested_points, great_circle_dist = great_circle_dist)
     nc_list[[length(nc_list) + 1]] <- dat
     ncdf4::nc_close(nc)
     info <- paste0("Reading file ", i, " of ", n_files, " - ", round(100*i/n_files), "%")
-    setWinProgressBar(pb, value = i, title = info, label = info)
+    if (is_win) setWinProgressBar(pb, value = i, title = info, label = info)
   }
-  close(pb)
+  if (is_win) close(pb)
   names(nc_list) <- tools::file_path_sans_ext(filenames)
   merged_data <- dplyr::bind_rows(nc_list, .id = id)
   return(merged_data)


### PR DESCRIPTION
- fixes #7101
- progress bar removed when importing multiple NetCDF files on Linux version to avoid error (see #7103)

@africanmathsinitiative/developers Please confirm this fixes issue in 7101