### PR TITLE
Resolved 'argument "x" is missing, with no default' error in Climatic>Boxplot dialog 

### DIFF
--- a/instat/dlgClimaticBoxPlot.vb
+++ b/instat/dlgClimaticBoxPlot.vb
@@ -269,6 +269,7 @@ Public Class dlgClimaticBoxPlot
         clsRaesFunction.AddParameter("x", Chr(34) & Chr(34))
 
         clsAsFactorFunction.SetRCommand("make_factor")
+        clsAsFactorFunction.AddParameter("x", Chr(34) & Chr(34), bIncludeArgumentName:=False)
 
         clsRgeomPlotFunction.SetPackageName("ggplot2")
         clsRgeomPlotFunction.SetRCommand("geom_boxplot")


### PR DESCRIPTION
Fixes #6185 
@africanmathsinitiative/developers this is ready for review. Thanks.