### PR TITLE
Allowing multiple levels and labels to be edited at once

### DIFF
--- a/instat/static/InstatObject/R/data_object_R6.R
+++ b/instat/static/InstatObject/R/data_object_R6.R
@@ -1417,7 +1417,7 @@ DataSheet$set("public", "drop_unused_factor_levels", function(col_name) {
 } 
 )
 
-DataSheet$set("public", "set_factor_levels", function(col_name, new_labels, new_levels, set_new_labels = TRUE) {
+DataSheet$set("public", "set_factor_levels", function(col_name, new_labels, new_levels, other_col_names, set_new_labels = TRUE) {
   if(!col_name %in% self$get_column_names()) stop(col_name, " not found in data.")
   col_data <- self$get_columns_from_data(col_name, use_current_filter = FALSE)
   if(!is.factor(col_data)) stop(col_name, " is not a factor.")
@@ -1427,6 +1427,17 @@ DataSheet$set("public", "set_factor_levels", function(col_name, new_labels, new_
   # Must be private$data because setting an attribute
   levels(private$data[[col_name]]) <- new_labels
   
+  if (!missing(other_col_names)){
+  if(!all(other_col_names %in% self$get_column_names())) stop("Some column names not found in the data")
+  for (i in 1:length(other_col_names)){
+    if (length(levels(private$data[[other_col_names[i]]])) != length(new_labels)){
+      warning("Number of levels differ between ", other_col_names[i], " and ", col_name, ". No change to levels will occur.")
+    } else {
+      levels(private$data[[other_col_names[i]]]) <- new_labels
+    }
+  }
+  }
+
   if(!missing(new_levels)) {
     labels_list <- new_levels
     names(labels_list) <- new_labels

--- a/instat/static/InstatObject/R/instat_object_R6.R
+++ b/instat/static/InstatObject/R/instat_object_R6.R
@@ -1109,8 +1109,8 @@ DataBook$set("public", "drop_unused_factor_levels", function(data_name, col_name
 } 
 )
 
-DataBook$set("public", "set_factor_levels", function(data_name, col_name, new_labels, new_levels, set_new_labels = TRUE) {
-  self$get_data_objects(data_name)$set_factor_levels(col_name = col_name, new_labels = new_labels, new_levels = new_levels, set_new_labels = set_new_labels)
+DataBook$set("public", "set_factor_levels", function(data_name, col_name, new_labels, new_levels, other_col_names, set_new_labels = TRUE) {
+  self$get_data_objects(data_name)$set_factor_levels(col_name = col_name, new_labels = new_labels, new_levels = new_levels, other_col_names = other_col_names, set_new_labels = set_new_labels)
 } 
 )
 


### PR DESCRIPTION
@dannyparsons @rdstern I wasn't sure if I should put this as an issue or PR. I put as an issue so it could be tested, but, still want to discuss a few bits - or you may think of a simpler approach

@rdstern set the task to allow relabelling/relevelling multiple variables at the same time. Currently, the current levels/labels code (and dialog therefore) only does one variable at a time.

In R, this can be achieved with the `across` function. E.g.

```
library(tidyverse)

x1 <- factor(rbinom(n = 6, size = 1, prob = 0.5))
x2 <- factor(rep(0, 6))
x3 <- factor(rbinom(n = 6, size = 1, prob = 0.5))
x4 <- factor(rbinom(n = 6, size = 1, prob = 0.5))
df <- data.frame(x1, x2, x3, x4)

df %>%
  mutate(across(c("x1", "x2", "x3", "x4"), ~fct_expand(., c("yes", "no")))) %>%
  mutate(across(c("x1", "x2", "x3", "x4"), ~fct_recode(., `yes` = "1", `no` = "0")))
```

In R-Instat we use the `set_factor_levels` function.
Currently on the dialog to change factor level names is a single receiver and a factor grid where the user can put a variable in the receiver, and change the level names in the factor grid.
When the user rename levels, we change the name of the old factor levels to the new factor levels, and so we "lose" the names of the old factor levels. So I can't see how having a new dialog to "apply factor levels to other variables" would work.
Instead, could we have a checkbox in the Labels/Levels dialog under the factor grid that says something like "Apply factor level changes to other variables". When checked, a multiple receiver comes up, and then the user can put in multiple variables to apply the changes to.

In terms of the code, we can add a new parameter to the  `set_factor_levels` function called `other_col_names` and make some edits to the function. To then test in R:

```
# Setting working directory, sourcing R code and loading R packages
setwd(dir="C:/Users/user/Source/Repos/R-Instat2/instat/static/InstatObject/R") # your setwd()

source(file="Rsetup.R")

data_book <- DataBook$new()

options(dplyr.summarise.inform=FALSE)

# Option: Number of digits to display
options(digits=4)

# Option: Show stars on summary tables of coefficients
options(show.signif.stars=FALSE)

# Code generated by script
x1 <- factor(rbinom(n = 6, size = 1, prob = 0.5))
x2 <- factor(rep(0, 6))
x3 <- factor(rbinom(n = 6, size = 1, prob = 0.5))
x4 <- factor(rbinom(n = 6, size = 1, prob = 0.5))
df <- data.frame(x1, x2, x3, x4)
data_book$import_data(data_tables = list(df = df))

# Code generated by the dialog, Labels/Levels
#data_book$set_factor_levels(data_name="df", col_name=c("x1"), new_labels=c("No", "Yes"))
data_book$set_factor_levels(data_name="df", col_name=c("x1"), other_col_names = c("x2", "x3"), new_labels=c("No", "Yes"))

data_book$get_data_frame(df=df)
```

@dannyparsons @rdstern does this suggestion sound reasonable, or can you think of a different alternative?