### PR TITLE
Variables in summary tables to be in order they are put in the receiver

### DIFF
--- a/instat/static/InstatObject/R/Backend_Components/summary_functions.R
+++ b/instat/static/InstatObject/R/Backend_Components/summary_functions.R
@@ -1456,8 +1456,10 @@ DataBook$set("public", "summary_table", function(data_name, columns_to_summarise
     }
   }
   shaped_cell_values <- shaped_cell_values %>% dplyr::mutate(value = round(value, signif_fig))
-if (is.null(shaped_cell_values$`summary-variable`)){
-  shaped_cell_values <- shaped_cell_values %>% dplyr::mutate(summary = as.factor(summary)) %>% dplyr::mutate(summary = forcats::fct_relevel(summary, summaries_display))
+if (treat_columns_as_factor){
+  shaped_cell_values <- shaped_cell_values %>%
+  dplyr::mutate(summary = as.factor(summary)) %>% dplyr::mutate(summary = forcats::fct_relevel(summary, summaries_display)) %>%
+  dplyr::mutate(variable = as.factor(variable)) %>% dplyr::mutate(variable= forcats::fct_relevel(variable, columns_to_summarise))
 }
 if (store_table) {
     data_book$import_data(data_tables = list(shaped_cell_values = shaped_cell_values))

--- a/instat/static/InstatObject/R/Backend_Components/summary_functions.R
+++ b/instat/static/InstatObject/R/Backend_Components/summary_functions.R
@@ -1458,8 +1458,8 @@ DataBook$set("public", "summary_table", function(data_name, columns_to_summarise
   shaped_cell_values <- shaped_cell_values %>% dplyr::mutate(value = round(value, signif_fig))
 if (treat_columns_as_factor){
   shaped_cell_values <- shaped_cell_values %>%
-  dplyr::mutate(summary = as.factor(summary)) %>% dplyr::mutate(summary = forcats::fct_relevel(summary, summaries_display)) %>%
-  dplyr::mutate(variable = as.factor(variable)) %>% dplyr::mutate(variable= forcats::fct_relevel(variable, columns_to_summarise))
+      dplyr::mutate(summary = as.factor(summary)) %>% dplyr::mutate(summary = forcats::fct_relevel(summary, summaries_display)) %>%
+      dplyr::mutate(variable = as.factor(variable)) %>% dplyr::mutate(variable= forcats::fct_relevel(variable, columns_to_summarise))
 }
 if (store_table) {
     data_book$import_data(data_tables = list(shaped_cell_values = shaped_cell_values))


### PR DESCRIPTION
On PR #7107 @rdstern commented

"This is that the order of the variables in the table is not the same as the order in the receiver. I think it is alphabetical in the table. I can live with this temporarily if it is difficult to fix?"

This should fix that problem in the R code