### PR TITLE
Fixes Bug in Regular Sequence

### DIFF
--- a/instat/dlgRegularSequence.vb
+++ b/instat/dlgRegularSequence.vb
@@ -179,7 +179,7 @@ Public Class dlgRegularSequence
         Dim dcmBy As Decimal
 
         bUpdateBy = False
-        ucrNudRepeatValues.AddAdditionalCodeParameterPair(clsSeqDateFunction, ucrNudRepeatValues.GetParameter(), iAdditionalPairNo:=1)
+        ucrNudRepeatValues.AddAdditionalCodeParameterPair(clsSeqDateFunction, New RParameter("each", 1), iAdditionalPairNo:=1)
 
         ucrDateTimePickerFrom.SetRCode(clsSeqDateFunction, bReset)
         ucrDateTimePickerTo.SetRCode(clsSeqDateFunction, bReset)

--- a/instat/dlgRegularSequence.vb
+++ b/instat/dlgRegularSequence.vb
@@ -137,7 +137,7 @@ Public Class dlgRegularSequence
 
         clsRepFunction.SetRCommand("rep")
         clsRepFunction.AddParameter("x", clsRFunctionParameter:=clsSeqFunction, iPosition:=0)
-        clsRepFunction.AddParameter("each", 1, iPosition:=2)
+        'clsRepFunction.AddParameter("each", 1, iPosition:=2)
         clsRepFunction.AddParameter("length.out", ucrSelectDataFrameRegularSequence.iDataFrameLength, iPosition:=3)
 
         clsByDateOperator.SetOperation(" ")

--- a/instat/dlgRegularSequence.vb
+++ b/instat/dlgRegularSequence.vb
@@ -137,7 +137,6 @@ Public Class dlgRegularSequence
 
         clsRepFunction.SetRCommand("rep")
         clsRepFunction.AddParameter("x", clsRFunctionParameter:=clsSeqFunction, iPosition:=0)
-        'clsRepFunction.AddParameter("each", 1, iPosition:=2)
         clsRepFunction.AddParameter("length.out", ucrSelectDataFrameRegularSequence.iDataFrameLength, iPosition:=3)
 
         clsByDateOperator.SetOperation(" ")


### PR DESCRIPTION
fixes issue #7199 

fixed the bug in `Regular sequence` by changing the code in `line 182` 
to 
`ucrNudRepeatValues.AddAdditionalCodeParameterPair(clsSeqDateFunction, New RParameter("each", 1), iAdditionalPairNo:=1)`

@africanmathsinitiative/developers  can anyone review this.