### PR TITLE
Ensure output window always scrolls to bottom when new output is added

### DIFF
--- a/instat/UserControl/ucrOutputPage.vb
+++ b/instat/UserControl/ucrOutputPage.vb
@@ -166,7 +166,6 @@ Public Class ucrOutputPage
         }
         pnlMain.Controls.Add(panel)
         pnlMain.Controls.SetChildIndex(panel, 0)
-        panel.Focus()
         AddCheckBoxToElementPanel(panel, outputElement)
         AddHandler panel.Resize, AddressOf Panel_Resize
         Return panel
@@ -183,6 +182,7 @@ Public Class ucrOutputPage
         panel.Controls.Add(checkBox)
         _checkBoxes.Add(checkBox)
         AddHandler checkBox.Click, AddressOf checkButton_Click
+        AddHandler checkBox.MouseLeave, AddressOf panelContents_MouseLeave
     End Sub
 
     Private Sub AddNewScript(outputElement As clsOutputElement)
@@ -196,6 +196,7 @@ Public Class ucrOutputPage
         panel.Controls.SetChildIndex(richTextBox, 0)
         SetRichTextBoxHeight(richTextBox)
         AddHandler richTextBox.KeyUp, AddressOf richTextBox_CopySelectedText
+        AddHandler richTextBox.MouseLeave, AddressOf panelContents_MouseLeave
     End Sub
 
     Private Function CopyOneImageOnly() As Boolean
@@ -257,6 +258,7 @@ Public Class ucrOutputPage
         panel.Controls.SetChildIndex(richTextBox, 0)
         SetRichTextBoxHeight(richTextBox)
         AddHandler richTextBox.KeyUp, AddressOf richTextBox_CopySelectedText
+        AddHandler richTextBox.MouseLeave, AddressOf panelContents_MouseLeave
     End Sub
 
     Private Sub AddNewImageOutput(outputElement As clsOutputElement)
@@ -293,6 +295,10 @@ Public Class ucrOutputPage
                 MsgBox(ex.Message)
             End Try
         End If
+    End Sub
+
+    Private Sub panelContents_MouseLeave(sender As Object, e As EventArgs)
+        pnlMain.Focus()
     End Sub
 
     Private Sub CopySelectedTextToClipBoard(richText As RichTextBox, richTextFormat As String)

--- a/instat/UserControl/ucrOutputPage.vb
+++ b/instat/UserControl/ucrOutputPage.vb
@@ -166,6 +166,7 @@ Public Class ucrOutputPage
         }
         pnlMain.Controls.Add(panel)
         pnlMain.Controls.SetChildIndex(panel, 0)
+        panel.Focus()
         AddCheckBoxToElementPanel(panel, outputElement)
         AddHandler panel.Resize, AddressOf Panel_Resize
         Return panel

--- a/instat/frmMain.vb
+++ b/instat/frmMain.vb
@@ -394,11 +394,13 @@ Public Class frmMain
     End Sub
 
     Private Sub mnuFileNewDataFrame_Click(sender As Object, e As EventArgs) Handles mnuFileNewDataFrame.Click
+        ActiveControl = Nothing 'this can be done in a general way
         dlgNewDataFrame.ShowDialog()
     End Sub
 
     Private Sub mnuPrepareColumnNumericRegularSequence_Click(sender As Object, e As EventArgs) Handles mnuPrepareColumnNumericRegularSequence.Click
         dlgRegularSequence.bNumericIsDefault = True
+        ActiveControl = Nothing 'this can be done in a general way
         dlgRegularSequence.ShowDialog()
     End Sub
 
@@ -588,6 +590,7 @@ Public Class frmMain
 
     Private Sub EditLastDialogueToolStrip_Click(sender As Object, e As EventArgs) Handles mnuTbEditLastDialog.Click
         If clsRecentItems.lstRecentDialogs.Count > 0 Then
+            ActiveControl = Nothing 'this can be done in a general way
             clsRecentItems.lstRecentDialogs.Last.ShowDialog()
         End If
     End Sub

--- a/instat/frmMain.vb
+++ b/instat/frmMain.vb
@@ -394,13 +394,11 @@ Public Class frmMain
     End Sub
 
     Private Sub mnuFileNewDataFrame_Click(sender As Object, e As EventArgs) Handles mnuFileNewDataFrame.Click
-        ActiveControl = Nothing 'this can be done in a general way
         dlgNewDataFrame.ShowDialog()
     End Sub
 
     Private Sub mnuPrepareColumnNumericRegularSequence_Click(sender As Object, e As EventArgs) Handles mnuPrepareColumnNumericRegularSequence.Click
         dlgRegularSequence.bNumericIsDefault = True
-        ActiveControl = Nothing 'this can be done in a general way
         dlgRegularSequence.ShowDialog()
     End Sub
 
@@ -590,7 +588,6 @@ Public Class frmMain
 
     Private Sub EditLastDialogueToolStrip_Click(sender As Object, e As EventArgs) Handles mnuTbEditLastDialog.Click
         If clsRecentItems.lstRecentDialogs.Count > 0 Then
-            ActiveControl = Nothing 'this can be done in a general way
             clsRecentItems.lstRecentDialogs.Last.ShowDialog()
         End If
     End Sub


### PR DESCRIPTION
Fixes #6996. 
@africanmathsinitiative/developers this is ready for review.
