### PR TITLE
Added options to select columns by variable type, labelled variables, empty variables and NA variables

### DIFF
--- a/instat/dlgSelect.vb
+++ b/instat/dlgSelect.vb
@@ -35,6 +35,8 @@ Public Class dlgSelect
 
     Private Sub InitialiseDialog()
         ucrBase.iHelpTopicID = 597
+        ucrBase.clsRsyntax.iCallType = 2
+
         ucrInputSelectPreview.txtInput.ReadOnly = True
         ucrReceiverSelect.SetItemType("column_selection")
         ucrReceiverSelect.strSelectorHeading = "Column selections"

--- a/instat/dlgSelectColumns.Designer.vb
+++ b/instat/dlgSelectColumns.Designer.vb
@@ -34,6 +34,7 @@ Partial Class dlgSelectColumns
         Me.lblTo = New System.Windows.Forms.Label()
         Me.lblFrom = New System.Windows.Forms.Label()
         Me.lblColumnType = New System.Windows.Forms.Label()
+        Me.ucrChkNot = New instat.ucrCheck()
         Me.ucrInputColumnType = New instat.ucrInputComboBox()
         Me.ucrNudTo = New instat.ucrNud()
         Me.ucrNudFrom = New instat.ucrNud()
@@ -103,7 +104,7 @@ Partial Class dlgSelectColumns
         '
         Me.cmdAddCondition.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!)
         Me.cmdAddCondition.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdAddCondition.Location = New System.Drawing.Point(275, 85)
+        Me.cmdAddCondition.Location = New System.Drawing.Point(276, 107)
         Me.cmdAddCondition.Name = "cmdAddCondition"
         Me.cmdAddCondition.Size = New System.Drawing.Size(112, 30)
         Me.cmdAddCondition.TabIndex = 12
@@ -171,6 +172,15 @@ Partial Class dlgSelectColumns
         Me.lblColumnType.TabIndex = 22
         Me.lblColumnType.Text = "Column Type:"
         Me.lblColumnType.Visible = False
+        '
+        'ucrChkNot
+        '
+        Me.ucrChkNot.AutoSize = True
+        Me.ucrChkNot.Checked = False
+        Me.ucrChkNot.Location = New System.Drawing.Point(276, 81)
+        Me.ucrChkNot.Name = "ucrChkNot"
+        Me.ucrChkNot.Size = New System.Drawing.Size(110, 23)
+        Me.ucrChkNot.TabIndex = 23
         '
         'ucrInputColumnType
         '
@@ -305,6 +315,7 @@ Partial Class dlgSelectColumns
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
         Me.AutoSize = True
         Me.ClientSize = New System.Drawing.Size(518, 464)
+        Me.Controls.Add(Me.ucrChkNot)
         Me.Controls.Add(Me.lblColumnType)
         Me.Controls.Add(Me.ucrInputColumnType)
         Me.Controls.Add(Me.lblFrom)
@@ -362,4 +373,5 @@ Partial Class dlgSelectColumns
     Friend WithEvents ucrNudFrom As ucrNud
     Friend WithEvents ucrInputColumnType As ucrInputComboBox
     Friend WithEvents lblColumnType As Label
+    Friend WithEvents ucrChkNot As ucrCheck
 End Class

--- a/instat/dlgSelectColumns.vb
+++ b/instat/dlgSelectColumns.vb
@@ -209,7 +209,7 @@ Public Class dlgSelectColumns
                     clsParametersList.AddParameter("fn", "is.character", iPosition:=0)
                 ElseIf strValue = "Logical" Then
                     clsParametersList.AddParameter("fn", "is.logical", iPosition:=0)
-                ElseIf strValue = "Labelled" Then
+                ElseIf strValue = "Variable label" Then
                     clsParametersList.AddParameter("fn", "is.containlabel", iPosition:=0)
                 ElseIf strValue = "Empty columns" Then
                     clsParametersList.AddParameter("fn", "is.emptyvariable", iPosition:=0)

--- a/instat/dlgSelectColumns.vb
+++ b/instat/dlgSelectColumns.vb
@@ -49,7 +49,7 @@ Public Class dlgSelectColumns
         ucrInputSelectOperation.SetItems({"Columns", "Starts with", "Ends with", "Contains", "Matches", "Numeric range", "Last column", "Where"})
         ucrInputSelectOperation.SetDropDownStyleAsNonEditable()
 
-        ucrInputColumnType.SetItems({"Numeric", "Factor", "Character", "Logical", "Labelled"})
+        ucrInputColumnType.SetItems({"Numeric", "Factor", "Character", "Logical", "Labelled", "Empty columns", "NA columns"})
         ucrInputColumnType.SetDropDownStyleAsNonEditable()
 
         ucrInputSelectOperation.AddToLinkedControls(ucrChkIgnoreCase, {"Starts with", "Ends with", "Contains", "Matches"}, bNewLinkedHideIfParameterMissing:=True)
@@ -209,6 +209,10 @@ Public Class dlgSelectColumns
                     clsParametersList.AddParameter("fn", "is.logical", iPosition:=0)
                 ElseIf strValue = "Labelled" Then
                     clsParametersList.AddParameter("fn", "is.labelled", iPosition:=0)
+                ElseIf strValue = "Empty columns" Then
+                    clsParametersList.AddParameter("fn", "is.emptyvariable", iPosition:=0)
+                ElseIf strValue = "NA columns" Then
+                    clsParametersList.AddParameter("fn", "is.NAvariable", iPosition:=0)
                 End If
             Case "Last column"
                 strValue = "Last column"

--- a/instat/sdgDataOptions.vb
+++ b/instat/sdgDataOptions.vb
@@ -148,8 +148,8 @@ Public Class sdgDataOptions
     End Sub
 
     Private Sub cmdDefineNewSelect_Click(sender As Object, e As EventArgs) Handles cmdDefineNewSelect.Click
+        dlgSelectColumns.SetDefaultDataFrame(strCurrentDataFrame)
         dlgSelectColumns.ShowDialog()
-        ucrReceiverSelect.Add(dlgSelectColumns.ucrInputSelectName.GetText)
         ucrSelectorForSelectColumns.LoadList()
     End Sub
 

--- a/instat/sdgDataOptions.vb
+++ b/instat/sdgDataOptions.vb
@@ -108,7 +108,7 @@ Public Class sdgDataOptions
                 clsSetCurrentColumnSelection.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$set_current_column_selection")
                 clsSetCurrentColumnSelection.AddParameter("data_name", Chr(34) & ucrSelectorForSelectColumns.ucrAvailableDataFrames.cboAvailableDataFrames.Text & Chr(34))
                 clsSetCurrentColumnSelection.AddParameter("name", ucrReceiverSelect.GetVariableNames())
-                frmMain.clsRLink.RunScript(clsSetCurrentColumnSelection.ToScript(), strComment:="Data Options subdialog: Set the current column selection")
+                frmMain.clsRLink.RunScript(clsSetCurrentColumnSelection.ToScript(), strComment:="Data Options subdialog: Set the current column selection", iCallType:=2)
             Else
                 'TODO: Set Local column selection
             End If

--- a/instat/static/InstatObject/R/data_object_R6.R
+++ b/instat/static/InstatObject/R/data_object_R6.R
@@ -1931,11 +1931,21 @@ DataSheet$set("public", "get_column_selection_column_names", function(name) {
                  "tidyselect::matches" = tidyselect::matches,
                  "tidyselect::num_range" = tidyselect::num_range,
                  "tidyselect::last_col" =  tidyselect::last_col,
+                 "tidyselect::where" = NULL,
                  NULL
                  )
-    if (op == "base::match") args$table <- all_column_names
-    else args$vars <- all_column_names
-    res[[i]] <- do.call(fn, args)
+    if (op == "base::match") {
+      args$table <- all_column_names
+      res[[i]] <- do.call(fn, args)
+      }else if (op == "tidyselect::where"){
+        selected_columns <- private$data |> 
+          dplyr::select(where(args$fn)) |> 
+          colnames()
+      res[[i]] <- which(all_column_names %in% selected_columns)
+      }else{
+        args$vars <- all_column_names
+        res[[i]] <- do.call(fn, args)
+        }
     if (neg) res[[i]] <- setdiff(1:length(all_column_names), res[[i]])
     i <- i + 1
   }

--- a/instat/static/InstatObject/R/data_object_R6.R
+++ b/instat/static/InstatObject/R/data_object_R6.R
@@ -1883,11 +1883,13 @@ DataSheet$set("public", "get_current_column_selection", function() {
 )
 
 DataSheet$set("public", "set_current_column_selection", function(name = "") {
-  if(!name %in% names(private$column_selections)) stop(name, " not found as a column selection.")
-  if(length(self$get_column_selection_column_names(name))==0) stop(name, " has no columns selected.")
-  self$current_column_selection <- private$column_selections[[name]]
-}
-)
+  if (!name %in% names(private$column_selections)) stop(name, " not found as a column selection.")
+  if (length(self$get_column_selection_column_names(name)) == 0) {
+    cat(name, " has no columns selected.")
+  } else {
+    self$current_column_selection <- private$column_selections[[name]]
+  }
+})
 
 DataSheet$set("public", "get_column_selection_names", function(as_list = FALSE, include = list(), exclude = list(), excluded_items = c()) {
   out <- names(private$column_selections)

--- a/instat/static/InstatObject/R/data_object_R6.R
+++ b/instat/static/InstatObject/R/data_object_R6.R
@@ -1884,6 +1884,7 @@ DataSheet$set("public", "get_current_column_selection", function() {
 
 DataSheet$set("public", "set_current_column_selection", function(name = "") {
   if(!name %in% names(private$column_selections)) stop(name, " not found as a column selection.")
+  if(length(self$get_column_selection_column_names(name))==0) stop(name, " has no columns selected.")
   self$current_column_selection <- private$column_selections[[name]]
 }
 )

--- a/instat/static/InstatObject/R/labels_and_defaults.R
+++ b/instat/static/InstatObject/R/labels_and_defaults.R
@@ -69,4 +69,4 @@ keyed_link_label="keyed_link"
 max_labels_display=4
 
 # Column Selection Operations
-column_selection_operations <- c("base::match", "tidyselect::starts_with", "tidyselect::ends_with", "tidyselect::contains", "tidyselect::matches", "tidyselect::num_range", "tidyselect::last_col")
+column_selection_operations <- c("base::match", "tidyselect::starts_with", "tidyselect::ends_with", "tidyselect::contains", "tidyselect::matches", "tidyselect::num_range", "tidyselect::last_col", "tidyselect::where")

--- a/instat/static/InstatObject/R/stand_alone_functions.R
+++ b/instat/static/InstatObject/R/stand_alone_functions.R
@@ -2518,3 +2518,8 @@ get_quarter_label <-   function(quarter, start_month){
   paste(mabb[start_pos:(start_pos+2)], collapse = "")})
   return(factor(x = qtr, levels = unique(qtr)))
 }
+
+
+is.labelled <- function(x){
+  return(isTRUE(sjlabelled::get_label(x) != ""))
+}

--- a/instat/static/InstatObject/R/stand_alone_functions.R
+++ b/instat/static/InstatObject/R/stand_alone_functions.R
@@ -2519,7 +2519,7 @@ get_quarter_label <-   function(quarter, start_month){
   return(factor(x = qtr, levels = unique(qtr)))
 }
 
-is.labelled <- function(x){
+is.containlabel <- function(x){
   return(isTRUE(sjlabelled::get_label(x) != ""))
 }
 

--- a/instat/static/InstatObject/R/stand_alone_functions.R
+++ b/instat/static/InstatObject/R/stand_alone_functions.R
@@ -2519,7 +2519,14 @@ get_quarter_label <-   function(quarter, start_month){
   return(factor(x = qtr, levels = unique(qtr)))
 }
 
-
 is.labelled <- function(x){
   return(isTRUE(sjlabelled::get_label(x) != ""))
+}
+
+is.emptyvariable <- function(x){
+ return(isTRUE(length(x) == sum(x == "")))
+}
+
+is.NAvariable <- function(x){
+  return(isTRUE(length(x) == sum(is.na(x))))
 }

--- a/instat/static/InstatObject/R/stand_alone_functions.R
+++ b/instat/static/InstatObject/R/stand_alone_functions.R
@@ -2530,3 +2530,7 @@ is.emptyvariable <- function(x){
 is.NAvariable <- function(x){
   return(isTRUE(length(x) == sum(is.na(x))))
 }
+
+is.levelscount <- function(x, n){
+ return(isTRUE(sum(levels(x)) == n))
+}


### PR DESCRIPTION
fixes #7190

@rdstern  this PR add more options to select columns. I have enabled the following options under select.
![image](https://user-images.githubusercontent.com/26301973/153667361-b095d2cb-6b3b-4267-a860-c7d3e6115150.png)
The remaining bit is an option to select by the number of factor levels.

I used the following dataset to test it.
[dfid2_ug_210803.zip](https://github.com/africanmathsinitiative/R-Instat/files/8051556/dfid2_ug_210803.zip)