### PR TITLE
Adding dates functionality in summary tables code

### DIFF
--- a/instat/static/InstatObject/R/Backend_Components/summary_functions.R
+++ b/instat/static/InstatObject/R/Backend_Components/summary_functions.R
@@ -1456,6 +1456,13 @@ DataBook$set("public", "summary_table", function(data_name, columns_to_summarise
       margin_tables_all <- margin_tables_all %>%
         dplyr::mutate_at(vars(-value), ~ replace(., is.na(.), margin_name))
 
+      for (i in factors){
+        shaped_cell_values_levels <- levels(shaped_cell_values[[i]])
+        margin_tables_all <- margin_tables_all %>%
+          dplyr::mutate_at(i, ~ forcats::fct_expand(., shaped_cell_values_levels),
+                           i, ~ forcats::fct_relevel(., shaped_cell_values_levels))
+      }
+      
       shaped_cell_values <- dplyr::bind_rows(shaped_cell_values, margin_tables_all) %>%
         dplyr::mutate_at(vars(-value), ~ replace(., is.na(.), margin_name)) %>%
         dplyr::mutate_at(vars(-value), ~ forcats::as_factor(forcats::fct_relevel(., margin_name, after = Inf)))

--- a/instat/static/InstatObject/R/Backend_Components/summary_functions.R
+++ b/instat/static/InstatObject/R/Backend_Components/summary_functions.R
@@ -1361,12 +1361,12 @@ DataBook$set("public", "summary_table", function(data_name, columns_to_summarise
     levels(cell_values[[i]]) <- c(levels(cell_values[[i]]), na_level_display)
     cell_values[[i]][is.na(cell_values[[i]])] <- na_level_display
   }
-  grps <- nrow(cell_values)
-  cell_values <- reshape2:::melt.data.frame(cell_values, id.vars = factors, variable.name = "summary-variable", value.name = "value")
+  cell_values <- cell_values %>% dplyr::mutate(dplyr::across(where(is.numeric), round, signif_fig))
+  cell_values <- cell_values %>%
+          tidyr::pivot_longer(cols = !factors, names_to = "summary-variable", values_to = "value", values_transform = list(value = as.character))
   if (treat_columns_as_factor) {
-    cell_values[["variable"]] <- rep(columns_to_summarise, each = nrow(cell_values) / length(columns_to_summarise))
-    cell_values[["summary"]] <- rep(summaries_display, each = grps, length.out = nrow(cell_values))
-    cell_values[["summary-variable"]] <- NULL
+  cell_values <- cell_values %>%
+          tidyr::separate(col = "summary-variable", into = c("summary", "variable"), sep = "-")
   }
   shaped_cell_values <- cell_values %>% dplyr::relocate(value, .after = last_col())
 
@@ -1386,12 +1386,16 @@ DataBook$set("public", "summary_table", function(data_name, columns_to_summarise
     for (facts in power_sets_outer) {
       if (length(facts) == 0) facts <- c()
       margin_tables[[length(margin_tables) + 1]] <- self$calculate_summary(data_name = data_name, columns_to_summarise = columns_to_summarise, summaries = summaries, factors = facts, store_results = FALSE, drop = drop, na.rm = na.rm, return_output = TRUE, weights = weights, result_names = result_names, percentage_type = percentage_type, perc_total_columns = perc_total_columns, perc_total_factors = perc_total_factors, perc_total_filter = perc_total_filter, perc_decimal = perc_decimal, margin_name = margin_name, additional_filter = additional_filter, perc_return_all = FALSE, sep = "-", ...)
-      margin_tables[[length(margin_tables)]] <- margin_tables[[length(margin_tables)]] %>% dplyr::select(c(all_of(facts), order_names))
+      margin_tables[[length(margin_tables)]] <- margin_tables[[length(margin_tables)]] %>% dplyr::select(c(tidyselect::all_of(facts), tidyselect::all_of(order_names)))
     }
     # for outer margins
     margin_item <- length(summaries) * length(columns_to_summarise)
-
     if (("outer" %in% margins) && (length(factors) > 0)) {
+    # to prevent changing all variables to dates/converting dates to numeric
+      for (i in 1:length(margin_tables)){
+            margin_tables[[i]] <- margin_tables[[i]] %>% dplyr::mutate(dplyr::across(where(is.numeric), round, signif_fig))
+            margin_tables[[i]] <- margin_tables[[i]] %>% purrr::modify_if(lubridate::is.Date, as.character)
+	  }
       outer_margins <- plyr::ldply(margin_tables)
       # Change shape
       if (length(margin_tables) == 1) {
@@ -1399,7 +1403,8 @@ DataBook$set("public", "summary_table", function(data_name, columns_to_summarise
         names(outer_margins) <- c("summary-variable", "value")
       } else {
         outer_margins <- outer_margins %>%
-          tidyr::pivot_longer(cols = 1:margin_item, values_to = "value", names_to = "summary-variable")
+          tidyr::pivot_longer(cols = 1:margin_item, values_to = "value", names_to = "summary-variable",
+                              values_transform = list(value = as.character))
       }
       if (treat_columns_as_factor) {
         outer_margins <- outer_margins %>%
@@ -1418,28 +1423,29 @@ DataBook$set("public", "summary_table", function(data_name, columns_to_summarise
       for (facts in power_sets_summary) {
         if (length(facts) == 0) facts <- c()
         summary_margins_df <- data_book$get_data_frame(data_name = data_name) %>%
-          dplyr::select(c(factors, columns_to_summarise)) %>%
-          tidyr::pivot_longer(cols = columns_to_summarise)
+          dplyr::select(c(tidyselect::all_of(factors), tidyselect::all_of(columns_to_summarise))) %>%
+          tidyr::pivot_longer(cols = columns_to_summarise, values_transform = list(value = as.character))
         data_book$import_data(data_tables = list(summary_margins_df = summary_margins_df))
         summary_margins[[length(summary_margins) + 1]] <- data_book$calculate_summary(data_name = "summary_margins_df", columns_to_summarise = "value", summaries = summaries, factors = facts, store_results = FALSE, drop = drop, na.rm = na.rm, return_output = TRUE, weights = weights, result_names = result_names, percentage_type = percentage_type, perc_total_columns = perc_total_columns, perc_total_factors = perc_total_factors, perc_total_filter = perc_total_filter, perc_decimal = perc_decimal, margin_name = margin_name, additional_filter = additional_filter, perc_return_all = FALSE, ...)
         data_book$delete_dataframes(data_names = "summary_margins_df")
       }
       summary_margins <- plyr::ldply(summary_margins)
-
       if (treat_columns_as_factor) {
         # remove "_value" in them
         for (col in 1:ncol(summary_margins)) {
           colnames(summary_margins)[col] <- sub("_value", "", colnames(summary_margins)[col])
         }
+        summary_margins <- summary_margins %>% dplyr::mutate(dplyr::across(where(is.numeric), round, signif_fig))
         summary_margins <- summary_margins %>%
-          tidyr::pivot_longer(cols = !factors, names_to = "summary", values_to = "value")
+          tidyr::pivot_longer(cols = !factors, names_to = "summary", values_to = "value", values_transform = list(value = as.character))
       } else {
         for (col in 1:ncol(summary_margins)) {
           # TODO: if the colname is the same as a factor, then do nothing
           colnames(summary_margins)[col] <- sub("_value", "_all", colnames(summary_margins)[col])
         }
+        summary_margins <- summary_margins %>% dplyr::mutate(dplyr::across(where(is.numeric), round, signif_fig))
         summary_margins <- summary_margins %>%
-          tidyr::pivot_longer(cols = !factors, names_to = "summary-variable", values_to = "value")
+          tidyr::pivot_longer(cols = !factors, names_to = "summary-variable", values_to = "value", values_transform = list(value = as.character))
       }
     } else {
       summary_margins <- NULL
@@ -1455,8 +1461,7 @@ DataBook$set("public", "summary_table", function(data_name, columns_to_summarise
         dplyr::mutate_at(vars(-value), ~ forcats::as_factor(forcats::fct_relevel(., margin_name, after = Inf)))
     }
   }
-  shaped_cell_values <- shaped_cell_values %>% dplyr::mutate(value = round(value, signif_fig))
-if (treat_columns_as_factor){
+  if (treat_columns_as_factor){
   shaped_cell_values <- shaped_cell_values %>%
       dplyr::mutate(summary = as.factor(summary)) %>% dplyr::mutate(summary = forcats::fct_relevel(summary, summaries_display)) %>%
       dplyr::mutate(variable = as.factor(variable)) %>% dplyr::mutate(variable= forcats::fct_relevel(variable, columns_to_summarise))


### PR DESCRIPTION
 @rdstern @Ivanluv this should allow dates to work in the `summary_tables` function regardless of margins.

@africanmathsinitiative/developers this is ready to review.

For example

```
# Setting working directory, sourcing R code and loading R packages
setwd(dir="C:/Users/user/Source/Repos/R-Instat/instat/static/InstatObject/R")

source(file="Rsetup.R")

data_book <- DataBook$new()

options(dplyr.summarise.inform=FALSE)

# Option: Number of digits to display
options(digits=4)

# Option: Show stars on summary tables of coefficients
options(show.signif.stars=FALSE)

# Code generated by the dialog, Import Dataset
new_RDS <- readRDS(file="C:/Users/user/Documents/dodoma.RDS")
data_book$import_RDS(data_RDS=new_RDS)

summary_table <- data_book$summary_table(data_name="dodoma", columns_to_summarise=c("date", "year"),
                                         factors = c("month_abbr"),
                                         summaries=c("summary_mean", "summary_min", "summary_max"),
                                         treat_columns_as_factor = TRUE, include_margins = TRUE,
                                         margins = "summary")

mmtable2::mmtable(data=summary_table, cells=value) + mmtable2::header_top_left(variable='summary') +
    mmtable2::header_left_top('month_abbr') +
  mmtable2::header_left_top('variable')
```