### PR TITLE
Renamed Dialogue controls texts in the database

### DIFF
--- a/instat/dlgFromLibrary.Designer.vb
+++ b/instat/dlgFromLibrary.Designer.vb
@@ -46,10 +46,10 @@ Partial Class dlgFromLibrary
         Me.cmdHelp = New System.Windows.Forms.Button()
         Me.rdoDefaultDatasets = New System.Windows.Forms.RadioButton()
         Me.rdoInstatCollection = New System.Windows.Forms.RadioButton()
+        Me.ucrNewDataFrameName = New instat.ucrSave()
         Me.ucrInputPackages = New instat.ucrInputComboBox()
         Me.ucrBase = New instat.ucrButtons()
         Me.ucrPnlOptions = New instat.UcrPanel()
-        Me.ucrNewDataFrameName = New instat.ucrSave()
         Me.SuspendLayout()
         '
         'cmdLibraryCollection
@@ -102,7 +102,7 @@ Partial Class dlgFromLibrary
         Me.cmdHelp.Name = "cmdHelp"
         Me.cmdHelp.Size = New System.Drawing.Size(75, 23)
         Me.cmdHelp.TabIndex = 8
-        Me.cmdHelp.Text = "Help"
+        Me.cmdHelp.Text = "R Help"
         Me.cmdHelp.UseVisualStyleBackColor = True
         '
         'rdoDefaultDatasets
@@ -141,6 +141,15 @@ Partial Class dlgFromLibrary
         Me.rdoInstatCollection.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
         Me.rdoInstatCollection.UseVisualStyleBackColor = False
         '
+        'ucrNewDataFrameName
+        '
+        Me.ucrNewDataFrameName.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrNewDataFrameName.Location = New System.Drawing.Point(10, 259)
+        Me.ucrNewDataFrameName.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
+        Me.ucrNewDataFrameName.Name = "ucrNewDataFrameName"
+        Me.ucrNewDataFrameName.Size = New System.Drawing.Size(315, 22)
+        Me.ucrNewDataFrameName.TabIndex = 7
+        '
         'ucrInputPackages
         '
         Me.ucrInputPackages.AddQuotesIfUnrecognised = True
@@ -172,15 +181,6 @@ Partial Class dlgFromLibrary
         Me.ucrPnlOptions.Size = New System.Drawing.Size(316, 44)
         Me.ucrPnlOptions.TabIndex = 0
         '
-        'ucrNewDataFrameName
-        '
-        Me.ucrNewDataFrameName.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrNewDataFrameName.Location = New System.Drawing.Point(10, 259)
-        Me.ucrNewDataFrameName.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
-        Me.ucrNewDataFrameName.Name = "ucrNewDataFrameName"
-        Me.ucrNewDataFrameName.Size = New System.Drawing.Size(315, 22)
-        Me.ucrNewDataFrameName.TabIndex = 7
-        '
         'dlgFromLibrary
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
@@ -201,7 +201,7 @@ Partial Class dlgFromLibrary
         Me.MinimizeBox = False
         Me.Name = "dlgFromLibrary"
         Me.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen
-        Me.Text = "Open Dataset from Library"
+        Me.Text = "Import From Library"
         Me.ResumeLayout(False)
         Me.PerformLayout()
 

--- a/instat/dlgFromLibrary.vb
+++ b/instat/dlgFromLibrary.vb
@@ -325,12 +325,4 @@ Public Class dlgFromLibrary
             clsImportFunction.AddParameter("data_tables", clsRFunctionParameter:=clsListFunction)
         End If
     End Sub
-
-    Private Sub ucrInputPackages_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrInputPackages.ControlValueChanged
-
-    End Sub
-
-    Private Sub ucrPnlOptions_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrPnlOptions.ControlValueChanged
-
-    End Sub
 End Class

--- a/instat/dlgFromLibrary.vb
+++ b/instat/dlgFromLibrary.vb
@@ -326,4 +326,11 @@ Public Class dlgFromLibrary
         End If
     End Sub
 
+    Private Sub ucrInputPackages_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrInputPackages.ControlValueChanged
+
+    End Sub
+
+    Private Sub ucrPnlOptions_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrPnlOptions.ControlValueChanged
+
+    End Sub
 End Class

--- a/instat/dlgViewLabelsAndLevels.Designer.vb
+++ b/instat/dlgViewLabelsAndLevels.Designer.vb
@@ -40,17 +40,17 @@ Partial Class dlgViewFactorLabels
     Private Sub InitializeComponent()
         Me.lblFactorColumns = New System.Windows.Forms.Label()
         Me.grpSummaryStatistics = New System.Windows.Forms.GroupBox()
-        Me.ucrChkShowPercentage = New instat.ucrCheck()
-        Me.ucrChkShowFrequencies = New instat.ucrCheck()
-        Me.ucrChkShowMissingValues = New instat.ucrCheck()
         Me.grpDisplayOptions = New System.Windows.Forms.GroupBox()
-        Me.ucrChkSortByName = New instat.ucrCheck()
-        Me.ucrChkAlternateColour = New instat.ucrCheck()
-        Me.ucrChkShowId = New instat.ucrCheck()
         Me.grpLabels = New System.Windows.Forms.GroupBox()
         Me.ucrChkShowType = New instat.ucrCheck()
         Me.ucrChkShowValues = New instat.ucrCheck()
         Me.ucrChkShowLabels = New instat.ucrCheck()
+        Me.ucrChkSortByName = New instat.ucrCheck()
+        Me.ucrChkAlternateColour = New instat.ucrCheck()
+        Me.ucrChkShowId = New instat.ucrCheck()
+        Me.ucrChkShowPercentage = New instat.ucrCheck()
+        Me.ucrChkShowFrequencies = New instat.ucrCheck()
+        Me.ucrChkShowMissingValues = New instat.ucrCheck()
         Me.ucrBase = New instat.ucrButtons()
         Me.ucrReceiverVariables = New instat.ucrReceiverMultiple()
         Me.ucrSelectorViewLabelsAndLevels = New instat.ucrSelectorByDataFrameAddRemove()
@@ -81,33 +81,6 @@ Partial Class dlgViewFactorLabels
         Me.grpSummaryStatistics.TabStop = False
         Me.grpSummaryStatistics.Text = "Summary Statistics"
         '
-        'ucrChkShowPercentage
-        '
-        Me.ucrChkShowPercentage.AutoSize = True
-        Me.ucrChkShowPercentage.Checked = False
-        Me.ucrChkShowPercentage.Location = New System.Drawing.Point(7, 41)
-        Me.ucrChkShowPercentage.Name = "ucrChkShowPercentage"
-        Me.ucrChkShowPercentage.Size = New System.Drawing.Size(154, 23)
-        Me.ucrChkShowPercentage.TabIndex = 1
-        '
-        'ucrChkShowFrequencies
-        '
-        Me.ucrChkShowFrequencies.AutoSize = True
-        Me.ucrChkShowFrequencies.Checked = False
-        Me.ucrChkShowFrequencies.Location = New System.Drawing.Point(7, 17)
-        Me.ucrChkShowFrequencies.Name = "ucrChkShowFrequencies"
-        Me.ucrChkShowFrequencies.Size = New System.Drawing.Size(143, 23)
-        Me.ucrChkShowFrequencies.TabIndex = 0
-        '
-        'ucrChkShowMissingValues
-        '
-        Me.ucrChkShowMissingValues.AutoSize = True
-        Me.ucrChkShowMissingValues.Checked = False
-        Me.ucrChkShowMissingValues.Location = New System.Drawing.Point(7, 65)
-        Me.ucrChkShowMissingValues.Name = "ucrChkShowMissingValues"
-        Me.ucrChkShowMissingValues.Size = New System.Drawing.Size(143, 23)
-        Me.ucrChkShowMissingValues.TabIndex = 2
-        '
         'grpDisplayOptions
         '
         Me.grpDisplayOptions.Controls.Add(Me.ucrChkSortByName)
@@ -119,33 +92,6 @@ Partial Class dlgViewFactorLabels
         Me.grpDisplayOptions.TabIndex = 5
         Me.grpDisplayOptions.TabStop = False
         Me.grpDisplayOptions.Text = "Display Options"
-        '
-        'ucrChkSortByName
-        '
-        Me.ucrChkSortByName.AutoSize = True
-        Me.ucrChkSortByName.Checked = False
-        Me.ucrChkSortByName.Location = New System.Drawing.Point(4, 42)
-        Me.ucrChkSortByName.Name = "ucrChkSortByName"
-        Me.ucrChkSortByName.Size = New System.Drawing.Size(133, 23)
-        Me.ucrChkSortByName.TabIndex = 1
-        '
-        'ucrChkAlternateColour
-        '
-        Me.ucrChkAlternateColour.AutoSize = True
-        Me.ucrChkAlternateColour.Checked = False
-        Me.ucrChkAlternateColour.Location = New System.Drawing.Point(4, 66)
-        Me.ucrChkAlternateColour.Name = "ucrChkAlternateColour"
-        Me.ucrChkAlternateColour.Size = New System.Drawing.Size(142, 23)
-        Me.ucrChkAlternateColour.TabIndex = 2
-        '
-        'ucrChkShowId
-        '
-        Me.ucrChkShowId.AutoSize = True
-        Me.ucrChkShowId.Checked = False
-        Me.ucrChkShowId.Location = New System.Drawing.Point(4, 18)
-        Me.ucrChkShowId.Name = "ucrChkShowId"
-        Me.ucrChkShowId.Size = New System.Drawing.Size(133, 23)
-        Me.ucrChkShowId.TabIndex = 0
         '
         'grpLabels
         '
@@ -185,6 +131,60 @@ Partial Class dlgViewFactorLabels
         Me.ucrChkShowLabels.Name = "ucrChkShowLabels"
         Me.ucrChkShowLabels.Size = New System.Drawing.Size(190, 23)
         Me.ucrChkShowLabels.TabIndex = 1
+        '
+        'ucrChkSortByName
+        '
+        Me.ucrChkSortByName.AutoSize = True
+        Me.ucrChkSortByName.Checked = False
+        Me.ucrChkSortByName.Location = New System.Drawing.Point(4, 42)
+        Me.ucrChkSortByName.Name = "ucrChkSortByName"
+        Me.ucrChkSortByName.Size = New System.Drawing.Size(133, 23)
+        Me.ucrChkSortByName.TabIndex = 1
+        '
+        'ucrChkAlternateColour
+        '
+        Me.ucrChkAlternateColour.AutoSize = True
+        Me.ucrChkAlternateColour.Checked = False
+        Me.ucrChkAlternateColour.Location = New System.Drawing.Point(4, 66)
+        Me.ucrChkAlternateColour.Name = "ucrChkAlternateColour"
+        Me.ucrChkAlternateColour.Size = New System.Drawing.Size(142, 23)
+        Me.ucrChkAlternateColour.TabIndex = 2
+        '
+        'ucrChkShowId
+        '
+        Me.ucrChkShowId.AutoSize = True
+        Me.ucrChkShowId.Checked = False
+        Me.ucrChkShowId.Location = New System.Drawing.Point(4, 18)
+        Me.ucrChkShowId.Name = "ucrChkShowId"
+        Me.ucrChkShowId.Size = New System.Drawing.Size(133, 23)
+        Me.ucrChkShowId.TabIndex = 0
+        '
+        'ucrChkShowPercentage
+        '
+        Me.ucrChkShowPercentage.AutoSize = True
+        Me.ucrChkShowPercentage.Checked = False
+        Me.ucrChkShowPercentage.Location = New System.Drawing.Point(7, 41)
+        Me.ucrChkShowPercentage.Name = "ucrChkShowPercentage"
+        Me.ucrChkShowPercentage.Size = New System.Drawing.Size(154, 23)
+        Me.ucrChkShowPercentage.TabIndex = 1
+        '
+        'ucrChkShowFrequencies
+        '
+        Me.ucrChkShowFrequencies.AutoSize = True
+        Me.ucrChkShowFrequencies.Checked = False
+        Me.ucrChkShowFrequencies.Location = New System.Drawing.Point(7, 17)
+        Me.ucrChkShowFrequencies.Name = "ucrChkShowFrequencies"
+        Me.ucrChkShowFrequencies.Size = New System.Drawing.Size(143, 23)
+        Me.ucrChkShowFrequencies.TabIndex = 0
+        '
+        'ucrChkShowMissingValues
+        '
+        Me.ucrChkShowMissingValues.AutoSize = True
+        Me.ucrChkShowMissingValues.Checked = False
+        Me.ucrChkShowMissingValues.Location = New System.Drawing.Point(7, 65)
+        Me.ucrChkShowMissingValues.Name = "ucrChkShowMissingValues"
+        Me.ucrChkShowMissingValues.Size = New System.Drawing.Size(143, 23)
+        Me.ucrChkShowMissingValues.TabIndex = 2
         '
         'ucrBase
         '
@@ -238,7 +238,7 @@ Partial Class dlgViewFactorLabels
         Me.MinimizeBox = False
         Me.Name = "dlgViewFactorLabels"
         Me.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen
-        Me.Text = "View Labels/Levels"
+        Me.Text = "View/Delete Labels"
         Me.grpSummaryStatistics.ResumeLayout(False)
         Me.grpSummaryStatistics.PerformLayout()
         Me.grpDisplayOptions.ResumeLayout(False)

--- a/instat/frmMain.Designer.vb
+++ b/instat/frmMain.Designer.vb
@@ -3735,104 +3735,104 @@ Partial Class frmMain
         'mnuPrepareColumnFactorConvertToFactor
         '
         Me.mnuPrepareColumnFactorConvertToFactor.Name = "mnuPrepareColumnFactorConvertToFactor"
-        Me.mnuPrepareColumnFactorConvertToFactor.Size = New System.Drawing.Size(179, 22)
+        Me.mnuPrepareColumnFactorConvertToFactor.Size = New System.Drawing.Size(182, 22)
         Me.mnuPrepareColumnFactorConvertToFactor.Tag = "Convert_To_Factor"
         Me.mnuPrepareColumnFactorConvertToFactor.Text = "Convert To Factor..."
         '
         'mnuPrepareColumnFactorRecodeNumeric
         '
         Me.mnuPrepareColumnFactorRecodeNumeric.Name = "mnuPrepareColumnFactorRecodeNumeric"
-        Me.mnuPrepareColumnFactorRecodeNumeric.Size = New System.Drawing.Size(179, 22)
+        Me.mnuPrepareColumnFactorRecodeNumeric.Size = New System.Drawing.Size(182, 22)
         Me.mnuPrepareColumnFactorRecodeNumeric.Tag = "Recode_Numeric..."
         Me.mnuPrepareColumnFactorRecodeNumeric.Text = "Recode Numeric..."
         '
         'mnuPrepareColumnFactorCountInFactor
         '
         Me.mnuPrepareColumnFactorCountInFactor.Name = "mnuPrepareColumnFactorCountInFactor"
-        Me.mnuPrepareColumnFactorCountInFactor.Size = New System.Drawing.Size(179, 22)
+        Me.mnuPrepareColumnFactorCountInFactor.Size = New System.Drawing.Size(182, 22)
         Me.mnuPrepareColumnFactorCountInFactor.Text = "Count in Factor..."
         '
         'ToolStripSeparator12
         '
         Me.ToolStripSeparator12.Name = "ToolStripSeparator12"
-        Me.ToolStripSeparator12.Size = New System.Drawing.Size(176, 6)
+        Me.ToolStripSeparator12.Size = New System.Drawing.Size(179, 6)
         '
         'mnuPrepareColumnFactorRecodeFactor
         '
         Me.mnuPrepareColumnFactorRecodeFactor.Name = "mnuPrepareColumnFactorRecodeFactor"
-        Me.mnuPrepareColumnFactorRecodeFactor.Size = New System.Drawing.Size(179, 22)
+        Me.mnuPrepareColumnFactorRecodeFactor.Size = New System.Drawing.Size(182, 22)
         Me.mnuPrepareColumnFactorRecodeFactor.Tag = "Recode_Factor..."
         Me.mnuPrepareColumnFactorRecodeFactor.Text = "Recode Factor..."
         '
         'mnuPrepareColumnFactorCombineFactors
         '
         Me.mnuPrepareColumnFactorCombineFactors.Name = "mnuPrepareColumnFactorCombineFactors"
-        Me.mnuPrepareColumnFactorCombineFactors.Size = New System.Drawing.Size(179, 22)
+        Me.mnuPrepareColumnFactorCombineFactors.Size = New System.Drawing.Size(182, 22)
         Me.mnuPrepareColumnFactorCombineFactors.Tag = "Combine_Factors..."
         Me.mnuPrepareColumnFactorCombineFactors.Text = "Combine Factors..."
         '
         'mnuPrepareColumnFactorDummyVariables
         '
         Me.mnuPrepareColumnFactorDummyVariables.Name = "mnuPrepareColumnFactorDummyVariables"
-        Me.mnuPrepareColumnFactorDummyVariables.Size = New System.Drawing.Size(179, 22)
+        Me.mnuPrepareColumnFactorDummyVariables.Size = New System.Drawing.Size(182, 22)
         Me.mnuPrepareColumnFactorDummyVariables.Tag = "Dummy_Variables..."
         Me.mnuPrepareColumnFactorDummyVariables.Text = "Dummy Variables..."
         '
         'ToolStripSeparator14
         '
         Me.ToolStripSeparator14.Name = "ToolStripSeparator14"
-        Me.ToolStripSeparator14.Size = New System.Drawing.Size(176, 6)
+        Me.ToolStripSeparator14.Size = New System.Drawing.Size(179, 6)
         '
         'mnuPrepareColumnFactorLevelsLabels
         '
         Me.mnuPrepareColumnFactorLevelsLabels.Name = "mnuPrepareColumnFactorLevelsLabels"
-        Me.mnuPrepareColumnFactorLevelsLabels.Size = New System.Drawing.Size(179, 22)
+        Me.mnuPrepareColumnFactorLevelsLabels.Size = New System.Drawing.Size(182, 22)
         Me.mnuPrepareColumnFactorLevelsLabels.Tag = "Levels/Labels..."
         Me.mnuPrepareColumnFactorLevelsLabels.Text = "Levels/Labels..."
         '
         'mnuPrepareFactorViewLabels
         '
         Me.mnuPrepareFactorViewLabels.Name = "mnuPrepareFactorViewLabels"
-        Me.mnuPrepareFactorViewLabels.Size = New System.Drawing.Size(179, 22)
-        Me.mnuPrepareFactorViewLabels.Text = "View Labels..."
+        Me.mnuPrepareFactorViewLabels.Size = New System.Drawing.Size(182, 22)
+        Me.mnuPrepareFactorViewLabels.Text = "View/Delete Labels..."
         '
         'mnuPrepareColumnFactorReorderLevels
         '
         Me.mnuPrepareColumnFactorReorderLevels.Name = "mnuPrepareColumnFactorReorderLevels"
-        Me.mnuPrepareColumnFactorReorderLevels.Size = New System.Drawing.Size(179, 22)
+        Me.mnuPrepareColumnFactorReorderLevels.Size = New System.Drawing.Size(182, 22)
         Me.mnuPrepareColumnFactorReorderLevels.Tag = "Reorder_Levels..."
         Me.mnuPrepareColumnFactorReorderLevels.Text = "Reorder Levels..."
         '
         'mnuPrepareColumnFactorReferenceLevel
         '
         Me.mnuPrepareColumnFactorReferenceLevel.Name = "mnuPrepareColumnFactorReferenceLevel"
-        Me.mnuPrepareColumnFactorReferenceLevel.Size = New System.Drawing.Size(179, 22)
+        Me.mnuPrepareColumnFactorReferenceLevel.Size = New System.Drawing.Size(182, 22)
         Me.mnuPrepareColumnFactorReferenceLevel.Tag = "Reference_Level..."
         Me.mnuPrepareColumnFactorReferenceLevel.Text = "Reference Level..."
         '
         'mnuPrepareColumnFactorUnusedLevels
         '
         Me.mnuPrepareColumnFactorUnusedLevels.Name = "mnuPrepareColumnFactorUnusedLevels"
-        Me.mnuPrepareColumnFactorUnusedLevels.Size = New System.Drawing.Size(179, 22)
+        Me.mnuPrepareColumnFactorUnusedLevels.Size = New System.Drawing.Size(182, 22)
         Me.mnuPrepareColumnFactorUnusedLevels.Tag = "Unused_Levels..."
         Me.mnuPrepareColumnFactorUnusedLevels.Text = "Unused Levels..."
         '
         'mnuPrepareColumnFactorContrasts
         '
         Me.mnuPrepareColumnFactorContrasts.Name = "mnuPrepareColumnFactorContrasts"
-        Me.mnuPrepareColumnFactorContrasts.Size = New System.Drawing.Size(179, 22)
+        Me.mnuPrepareColumnFactorContrasts.Size = New System.Drawing.Size(182, 22)
         Me.mnuPrepareColumnFactorContrasts.Tag = "Contrasts..."
         Me.mnuPrepareColumnFactorContrasts.Text = "Contrasts..."
         '
         'ToolStripSeparator19
         '
         Me.ToolStripSeparator19.Name = "ToolStripSeparator19"
-        Me.ToolStripSeparator19.Size = New System.Drawing.Size(176, 6)
+        Me.ToolStripSeparator19.Size = New System.Drawing.Size(179, 6)
         '
         'mnuPrepareColumnFactorFactorDataFrame
         '
         Me.mnuPrepareColumnFactorFactorDataFrame.Name = "mnuPrepareColumnFactorFactorDataFrame"
-        Me.mnuPrepareColumnFactorFactorDataFrame.Size = New System.Drawing.Size(179, 22)
+        Me.mnuPrepareColumnFactorFactorDataFrame.Size = New System.Drawing.Size(182, 22)
         Me.mnuPrepareColumnFactorFactorDataFrame.Tag = "Factor_Data_Frame"
         Me.mnuPrepareColumnFactorFactorDataFrame.Text = "Factor Data Frame..."
         '


### PR DESCRIPTION
Fixes (partially) #7073 
@lloyddewit @shadrackkibet this just update the database by renaming the menu and dialogue text to `View/Delete Labels` for View Label dialogue.
![image](https://user-images.githubusercontent.com/68591383/154516768-53bb0aef-4e5d-4d91-aef2-789ce940da16.png)
