### PR TITLE
Ensured that Delete Cells works correctly for Linux grids

### DIFF
--- a/instat/UserControls/DataGrid/Linux/ucrDataViewLinuxGrid.vb
+++ b/instat/UserControls/DataGrid/Linux/ucrDataViewLinuxGrid.vb
@@ -114,6 +114,9 @@ Public Class ucrDataViewLinuxGrid
         If ctrlV Or shiftIns Then
             RaiseEvent PasteValuesToDataframe()
         End If
+        If e.KeyCode = Keys.Delete OrElse e.KeyCode = Keys.Back Then
+            RaiseEvent DeleteValueToDataframe()
+        End If
     End Sub
 
     Private Function GetCurrentDataFrameFocus() As clsDataFrame
@@ -143,10 +146,4 @@ Public Class ucrDataViewLinuxGrid
     Private Sub tcTabs_SelectedIndexChanged(sender As Object, e As EventArgs) Handles tcTabs.SelectedIndexChanged
         RaiseEvent WorksheetChanged()
     End Sub
-    Private Sub DataGridView_BeforeCellKeyDown(sender As Object, e As KeyEventArgs)
-        If e.KeyCode = unvell.ReoGrid.Interaction.KeyCode.Delete OrElse e.KeyCode = unvell.ReoGrid.Interaction.KeyCode.Back Then
-            RaiseEvent DeleteValueToDataframe()
-        End If
-    End Sub
-
 End Class

--- a/instat/UserControls/DataGrid/Linux/ucrLinuxGrid.vb
+++ b/instat/UserControls/DataGrid/Linux/ucrLinuxGrid.vb
@@ -112,9 +112,13 @@ Public MustInherit Class ucrLinuxGrid
     Public Function GetSelectedRows() As List(Of String) Implements IGrid.GetSelectedRows
         Dim lstSelectedRows As New List(Of String)
         Dim dataGrid = GetGrid(tcTabs.SelectedTab)
-        For Each row As DataGridViewRow In dataGrid.SelectedRows
-            lstSelectedRows.Add(row.HeaderCell.Value)
+        'For Each row As DataGridViewRow In dataGrid.SelectedRows
+        '    lstSelectedRows.Add(row.HeaderCell.Value)
+        'Next
+        For i As Integer = 0 To dataGrid.GetCellCount(DataGridViewElementStates.Selected) - 1
+            lstSelectedRows.Add(dataGrid.SelectedCells(i).RowIndex.ToString + 1)
         Next
+        lstSelectedRows = lstSelectedRows.Distinct.ToList
         Return lstSelectedRows
     End Function
 
@@ -122,9 +126,13 @@ Public MustInherit Class ucrLinuxGrid
     Public Function GetSelectedColumnIndexes() As List(Of String) Implements IGrid.GetSelectedColumnIndexes
         Dim lstSelectedColumnIndexes As New List(Of String)
         Dim dataGrid = GetGrid(tcTabs.SelectedTab)
-        For Each column As DataGridViewColumn In dataGrid.SelectedColumns
-            lstSelectedColumnIndexes.Add(Column.HeaderCell.Value)
+        'For Each column As DataGridViewColumn In dataGrid.SelectedColumns
+        '    lstSelectedColumnIndexes.Add(column.HeaderCell.Value)
+        'Next
+        For i As Integer = 0 To dataGrid.GetCellCount(DataGridViewElementStates.Selected) - 1
+            lstSelectedColumnIndexes.Add(dataGrid.SelectedCells(i).ColumnIndex.ToString + 1)
         Next
+        lstSelectedColumnIndexes = lstSelectedColumnIndexes.Distinct.ToList
         Return lstSelectedColumnIndexes
     End Function
 

--- a/instat/ucrDataView.vb
+++ b/instat/ucrDataView.vb
@@ -838,8 +838,8 @@ Public Class ucrDataView
         StartWait()
         GetCurrentDataFrameFocus().clsPrepareFunctions.RemoveCurrentColumnSelection()
         EndWait()
-    End Sub                      
-                          
+    End Sub
+
     Private Sub ucrDataView_Resize(sender As Object, e As EventArgs) Handles TblPanPageDisplay.Resize
         ResizeLabels()
     End Sub


### PR DESCRIPTION
fixes issue #7246 
Delete cells seems to not work on the Linux grid 

i have enabled the delete function for the Linux grid 

@N-thony can you test this