### PR TITLE
Added options for renaming and deleting column selections

### DIFF
--- a/instat/dlgDeleteObjects.Designer.vb
+++ b/instat/dlgDeleteObjects.Designer.vb
@@ -39,11 +39,11 @@ Partial Class dlgDeleteObjects
     <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
         Me.lblObjectsToDelete = New System.Windows.Forms.Label()
+        Me.lblType = New System.Windows.Forms.Label()
+        Me.ucrInputComboType = New instat.ucrInputComboBox()
         Me.ucrReceiverObjectsToDelete = New instat.ucrReceiverMultiple()
         Me.ucrSelectorDeleteObject = New instat.ucrSelectorByDataFrameAddRemove()
         Me.ucrBase = New instat.ucrButtons()
-        Me.ucrInputComboType = New instat.ucrInputComboBox()
-        Me.lblType = New System.Windows.Forms.Label()
         Me.SuspendLayout()
         '
         'lblObjectsToDelete
@@ -55,6 +55,26 @@ Partial Class dlgDeleteObjects
         Me.lblObjectsToDelete.TabIndex = 1
         Me.lblObjectsToDelete.Tag = "Objects_to_Delete"
         Me.lblObjectsToDelete.Text = "Objects to Delete:"
+        '
+        'lblType
+        '
+        Me.lblType.AutoSize = True
+        Me.lblType.Location = New System.Drawing.Point(251, 149)
+        Me.lblType.Name = "lblType"
+        Me.lblType.Size = New System.Drawing.Size(34, 13)
+        Me.lblType.TabIndex = 3
+        Me.lblType.Text = "Type:"
+        '
+        'ucrInputComboType
+        '
+        Me.ucrInputComboType.AddQuotesIfUnrecognised = True
+        Me.ucrInputComboType.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrInputComboType.GetSetSelectedIndex = -1
+        Me.ucrInputComboType.IsReadOnly = False
+        Me.ucrInputComboType.Location = New System.Drawing.Point(254, 165)
+        Me.ucrInputComboType.Name = "ucrInputComboType"
+        Me.ucrInputComboType.Size = New System.Drawing.Size(120, 21)
+        Me.ucrInputComboType.TabIndex = 4
         '
         'ucrReceiverObjectsToDelete
         '
@@ -89,26 +109,6 @@ Partial Class dlgDeleteObjects
         Me.ucrBase.Name = "ucrBase"
         Me.ucrBase.Size = New System.Drawing.Size(405, 52)
         Me.ucrBase.TabIndex = 5
-        '
-        'ucrInputComboType
-        '
-        Me.ucrInputComboType.AddQuotesIfUnrecognised = True
-        Me.ucrInputComboType.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrInputComboType.GetSetSelectedIndex = -1
-        Me.ucrInputComboType.IsReadOnly = False
-        Me.ucrInputComboType.Location = New System.Drawing.Point(254, 165)
-        Me.ucrInputComboType.Name = "ucrInputComboType"
-        Me.ucrInputComboType.Size = New System.Drawing.Size(92, 21)
-        Me.ucrInputComboType.TabIndex = 4
-        '
-        'lblType
-        '
-        Me.lblType.AutoSize = True
-        Me.lblType.Location = New System.Drawing.Point(251, 149)
-        Me.lblType.Name = "lblType"
-        Me.lblType.Size = New System.Drawing.Size(34, 13)
-        Me.lblType.TabIndex = 3
-        Me.lblType.Text = "Type:"
         '
         'dlgDeleteObjects
         '

--- a/instat/dlgDeleteObjects.vb
+++ b/instat/dlgDeleteObjects.vb
@@ -53,13 +53,13 @@ Public Class dlgDeleteObjects
         ucrInputComboType.SetParameter(New RParameter("object_type", 2))
         dctTypes.Add("Objects", Chr(34) & "object" & Chr(34))
         dctTypes.Add("Filters", Chr(34) & "filter" & Chr(34))
+        dctTypes.Add("Column selections", Chr(34) & "column_selection" & Chr(34))
         dctTypes.Add("Calculations", Chr(34) & "calculation" & Chr(34))
         dctTypes.Add("Tables", Chr(34) & "table" & Chr(34))
         dctTypes.Add("Graphs", Chr(34) & "graph" & Chr(34))
         dctTypes.Add("Models", Chr(34) & "model" & Chr(34))
         ucrInputComboType.SetItems(dctTypes)
         ucrInputComboType.SetDropDownStyleAsNonEditable()
-
     End Sub
 
     Private Sub SetDefaults()

--- a/instat/dlgRenameObjects.Designer.vb
+++ b/instat/dlgRenameObjects.Designer.vb
@@ -119,7 +119,7 @@ Partial Class dlgRenameObjects
         Me.ucrInputType.IsReadOnly = False
         Me.ucrInputType.Location = New System.Drawing.Point(262, 153)
         Me.ucrInputType.Name = "ucrInputType"
-        Me.ucrInputType.Size = New System.Drawing.Size(82, 21)
+        Me.ucrInputType.Size = New System.Drawing.Size(120, 21)
         Me.ucrInputType.TabIndex = 6
         '
         'lblType

--- a/instat/dlgRenameObjects.vb
+++ b/instat/dlgRenameObjects.vb
@@ -22,6 +22,7 @@ Public Class dlgRenameObjects
     Dim strSelectedColumn As String = ""
     Dim strSelectedDataFrame As String = ""
     Private clsDefaultFunction As New RFunction
+    Private dctTypes As New Dictionary(Of String, String)
 
     Private Sub dlgRenameObjects_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         If bFirstLoad Then
@@ -49,7 +50,6 @@ Public Class dlgRenameObjects
     End Sub
 
     Private Sub InitialiseDialog()
-        Dim dctType As New Dictionary(Of String, String)
         ucrBase.iHelpTopicID = 350
 
         'ucrSelector
@@ -67,13 +67,14 @@ Public Class dlgRenameObjects
         ucrInputNewName.SetValidationTypeAsRVariable()
 
         ucrInputType.SetParameter(New RParameter("object_type", 3))
-        dctType.Add("Objects", Chr(34) & "object" & Chr(34))
-        dctType.Add("Filters", Chr(34) & "filter" & Chr(34))
-        dctType.Add("Calculations", Chr(34) & "calculation" & Chr(34))
-        dctType.Add("Tables", Chr(34) & "table" & Chr(34))
-        dctType.Add("Graphs", Chr(34) & "graph" & Chr(34))
-        dctType.Add("Models", Chr(34) & "model" & Chr(34))
-        ucrInputType.SetItems(dctType)
+        dctTypes.Add("Objects", Chr(34) & "object" & Chr(34))
+        dctTypes.Add("Filters", Chr(34) & "filter" & Chr(34))
+        dctTypes.Add("Column selections", Chr(34) & "column_selection" & Chr(34))
+        dctTypes.Add("Calculations", Chr(34) & "calculation" & Chr(34))
+        dctTypes.Add("Tables", Chr(34) & "table" & Chr(34))
+        dctTypes.Add("Graphs", Chr(34) & "graph" & Chr(34))
+        dctTypes.Add("Models", Chr(34) & "model" & Chr(34))
+        ucrInputType.SetItems(dctTypes)
         ucrInputType.SetDropDownStyleAsNonEditable()
     End Sub
 
@@ -124,26 +125,13 @@ Public Class dlgRenameObjects
     End Sub
 
     Private Sub ucrInputType_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrInputType.ControlValueChanged
-        Select Case ucrInputType.GetValue()
-            Case "Objects"
-                ucrReceiverCurrentName.SetItemType("object")
-                ucrReceiverCurrentName.strSelectorHeading = "Objects"
-            Case "Filters"
-                ucrReceiverCurrentName.SetItemType("filter")
-                ucrReceiverCurrentName.strSelectorHeading = "Filters"
-            Case "Calculations"
-                ucrReceiverCurrentName.SetItemType("calculation")
-                ucrReceiverCurrentName.strSelectorHeading = "Calculations"
-            Case "Tables"
-                ucrReceiverCurrentName.SetItemType("table")
-                ucrReceiverCurrentName.strSelectorHeading = "Tables"
-            Case "Graphs"
-                ucrReceiverCurrentName.SetItemType("graph")
-                ucrReceiverCurrentName.strSelectorHeading = "Graphs"
-            Case "Models"
-                ucrReceiverCurrentName.SetItemType("model")
-                ucrReceiverCurrentName.strSelectorHeading = "Models"
-        End Select
+        Dim key As String = dctTypes.Keys(ucrInputType.cboInput.SelectedIndex)
+        Dim value As String = ""
+
+        If key IsNot Nothing AndAlso dctTypes.TryGetValue(key, value) Then
+            ucrReceiverCurrentName.strSelectorHeading = key
+            ucrReceiverCurrentName.SetItemType(value.Replace(Chr(34), ""))
+        End If
     End Sub
 
     Private Sub CoreControls_ContentsChanged() Handles ucrInputNewName.ControlContentsChanged, ucrSelectorForRenameObject.ControlContentsChanged, ucrReceiverCurrentName.ControlContentsChanged

--- a/instat/static/InstatObject/R/data_object_R6.R
+++ b/instat/static/InstatObject/R/data_object_R6.R
@@ -2057,7 +2057,7 @@ DataSheet$set("public", "get_last_graph", function() {
 )
 
 DataSheet$set("public", "rename_object", function(object_name, new_name, object_type = "object") {
-  if(!object_type %in% c("object", "filter", "calculation", "graph", "table","model")) stop(object_type, " must be either object (graph, table or model), filter or a calculation.")
+  if(!object_type %in% c("object", "filter", "calculation", "graph", "table","model", "column_selection")) stop(object_type, " must be either object (graph, table or model), filter, column_selection or a calculation.")
   #Temp fix:: added graph, table and model so as to distinguish this when implementing it in the dialog. Otherwise they remain as objects
   if (object_type %in% c("object", "graph", "table","model")){
     if(!object_name %in% names(private$objects)) stop(object_name, " not found in objects list")
@@ -2076,12 +2076,19 @@ DataSheet$set("public", "rename_object", function(object_name, new_name, object_
     if(new_name %in% names(private$calculations)) stop(new_name, " is already a calculation name. Cannot rename ", object_name, " to ", new_name)
     names(private$calculations)[names(private$calculations) == object_name] <- new_name
   }
+  else if (object_type == "column_selection"){
+    if(!object_name %in% names(private$column_selections)) stop(object_name, " not found in column selections list")
+    if(new_name %in% names(private$column_selections)) stop(new_name, " is already a column selection name. Cannot rename ", object_name, " to ", new_name)
+    if(".everything" == object_name) stop("Renaming .everything is not allowed.")
+    names(private$column_selections)[names(private$column_selections) == object_name] <- new_name
+    if(private$.current_column_selection$name == object_name){private$.current_column_selection$name <- new_name}
+  } 
 }
 )
 
 DataSheet$set("public", "delete_objects", function(data_name, object_names, object_type = "object") {
-  if(!object_type %in% c("object", "graph", "table","model","filter", "calculation")) stop(object_type, " must be either object (graph, table or model), filter or a calculation.")
-  if(any(object_type == c("object", "graph", "table","model"))){
+  if(!object_type %in% c("object", "graph", "table","model","filter", "calculation", "column_selection")) stop(object_type, " must be either object (graph, table or model), filter, column selection or a calculation.")
+  if(any(object_type %in% c("object", "graph", "table","model"))){
       if(!all(object_names %in% names(private$objects))) stop("Not all object_names found in overall objects list.")
       private$objects[names(private$objects) %in% object_names] <- NULL
     }else if(object_type == "filter"){
@@ -2092,6 +2099,11 @@ DataSheet$set("public", "delete_objects", function(data_name, object_names, obje
     }else if(object_type == "calculation"){
       if(!object_names %in% names(private$calculations)) stop(object_names, " not found in calculations list.")
       private$calculations[names(private$calculations) %in% object_names] <- NULL
+    }else if(object_type == "column_selection"){
+      if(!all(object_names %in% names(private$column_selections))) stop(object_names, " not found in column selections list.")
+      if(".everything" %in% object_names) stop(".everything cannot be deleted.")
+      if(any(private$.current_column_selection$name %in% object_names))stop(private$.current_column_selection$name, " is currently in use and cannot be deleted.")
+      private$column_selections[names(private$column_selections) %in% object_names] <- NULL
     }
   if(!is.null(private$.last_graph) && length(private$.last_graph) == 2 && private$.last_graph[1] == data_name && private$.last_graph[2] %in% object_names) {
     private$.last_graph <- NULL


### PR DESCRIPTION
fixes #can't trace the issue at the moment but it should be somewhere. Apologies, I will try to find it. @rdstern please help.

This PR adds options for renaming and deleting column selections into **Rename Objects** and **Delete Objects** dialogs. To test it;
- Create column selections using **Prepare> Data frame> Column selection**
- Rename column selection using **Prepare> R Objects> Rename Objects**
- Delete column selection using  **Prepare> R Objects>Delete Objects**

**Note**: You have to select **Type** - "Column selections" while using these dialogs.

@africanmathsinitiative/developers this is ready for review.