### PR TITLE
Naming and adding textboxes into Qc temperature dialog

### DIFF
--- a/instat/dlgClimaticCheckDataTemperature.Designer.vb
+++ b/instat/dlgClimaticCheckDataTemperature.Designer.vb
@@ -503,7 +503,7 @@ Partial Class dlgClimaticCheckDataTemperature
         Me.ucrInputRangeElement1Max.AutoSize = True
         Me.ucrInputRangeElement1Max.IsMultiline = False
         Me.ucrInputRangeElement1Max.IsReadOnly = False
-        Me.ucrInputRangeElement1Max.Location = New System.Drawing.Point(296, 265)
+        Me.ucrInputRangeElement1Max.Location = New System.Drawing.Point(297, 265)
         Me.ucrInputRangeElement1Max.Name = "ucrInputRangeElement1Max"
         Me.ucrInputRangeElement1Max.Size = New System.Drawing.Size(44, 21)
         Me.ucrInputRangeElement1Max.TabIndex = 49

--- a/instat/dlgClimaticCheckDataTemperature.Designer.vb
+++ b/instat/dlgClimaticCheckDataTemperature.Designer.vb
@@ -35,7 +35,6 @@ Partial Class dlgClimaticCheckDataTemperature
         Me.rdoIndividual = New System.Windows.Forms.RadioButton()
         Me.rdoMultiple = New System.Windows.Forms.RadioButton()
         Me.lblNudSame = New System.Windows.Forms.Label()
-        Me.lblNudDiff = New System.Windows.Forms.Label()
         Me.ttOutliers = New System.Windows.Forms.ToolTip(Me.components)
         Me.lblCoeff = New System.Windows.Forms.Label()
         Me.grpLogicalCalculatedColumns = New System.Windows.Forms.GroupBox()
@@ -66,6 +65,8 @@ Partial Class dlgClimaticCheckDataTemperature
         Me.ucrInputRangeElement1Max = New instat.ucrInputTextBox()
         Me.ucrInputRangeElement2Min = New instat.ucrInputTextBox()
         Me.ucrInputRangeElement2Max = New instat.ucrInputTextBox()
+        Me.lblRangeElement1From = New System.Windows.Forms.Label()
+        Me.lblRangeElement2From = New System.Windows.Forms.Label()
         Me.grpLogicalCalculatedColumns.SuspendLayout()
         Me.SuspendLayout()
         '
@@ -206,16 +207,6 @@ Partial Class dlgClimaticCheckDataTemperature
         Me.lblNudSame.TabIndex = 34
         Me.lblNudSame.Text = "days"
         '
-        'lblNudDiff
-        '
-        Me.lblNudDiff.AutoSize = True
-        Me.lblNudDiff.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblNudDiff.Location = New System.Drawing.Point(236, 393)
-        Me.lblNudDiff.Name = "lblNudDiff"
-        Me.lblNudDiff.Size = New System.Drawing.Size(18, 13)
-        Me.lblNudDiff.TabIndex = 40
-        Me.lblNudDiff.Text = "°C"
-        '
         'lblCoeff
         '
         Me.lblCoeff.AutoSize = True
@@ -279,7 +270,7 @@ Partial Class dlgClimaticCheckDataTemperature
         Me.ucrChkRangeElement2.Checked = False
         Me.ucrChkRangeElement2.Location = New System.Drawing.Point(10, 293)
         Me.ucrChkRangeElement2.Name = "ucrChkRangeElement2"
-        Me.ucrChkRangeElement2.Size = New System.Drawing.Size(202, 23)
+        Me.ucrChkRangeElement2.Size = New System.Drawing.Size(165, 23)
         Me.ucrChkRangeElement2.TabIndex = 26
         '
         'ucrReceiverElement2
@@ -314,7 +305,7 @@ Partial Class dlgClimaticCheckDataTemperature
         Me.ucrChkRangeElement1.Checked = False
         Me.ucrChkRangeElement1.Location = New System.Drawing.Point(10, 264)
         Me.ucrChkRangeElement1.Name = "ucrChkRangeElement1"
-        Me.ucrChkRangeElement1.Size = New System.Drawing.Size(202, 23)
+        Me.ucrChkRangeElement1.Size = New System.Drawing.Size(165, 23)
         Me.ucrChkRangeElement1.TabIndex = 20
         '
         'ucrNudSame
@@ -503,7 +494,7 @@ Partial Class dlgClimaticCheckDataTemperature
         Me.ucrInputRangeElement1Max.AutoSize = True
         Me.ucrInputRangeElement1Max.IsMultiline = False
         Me.ucrInputRangeElement1Max.IsReadOnly = False
-        Me.ucrInputRangeElement1Max.Location = New System.Drawing.Point(297, 265)
+        Me.ucrInputRangeElement1Max.Location = New System.Drawing.Point(297, 264)
         Me.ucrInputRangeElement1Max.Name = "ucrInputRangeElement1Max"
         Me.ucrInputRangeElement1Max.Size = New System.Drawing.Size(44, 21)
         Me.ucrInputRangeElement1Max.TabIndex = 49
@@ -530,12 +521,34 @@ Partial Class dlgClimaticCheckDataTemperature
         Me.ucrInputRangeElement2Max.Size = New System.Drawing.Size(44, 21)
         Me.ucrInputRangeElement2Max.TabIndex = 51
         '
+        'lblRangeElement1From
+        '
+        Me.lblRangeElement1From.AutoSize = True
+        Me.lblRangeElement1From.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.lblRangeElement1From.Location = New System.Drawing.Point(185, 268)
+        Me.lblRangeElement1From.Name = "lblRangeElement1From"
+        Me.lblRangeElement1From.Size = New System.Drawing.Size(33, 13)
+        Me.lblRangeElement1From.TabIndex = 52
+        Me.lblRangeElement1From.Text = "From:"
+        '
+        'lblRangeElement2From
+        '
+        Me.lblRangeElement2From.AutoSize = True
+        Me.lblRangeElement2From.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.lblRangeElement2From.Location = New System.Drawing.Point(185, 297)
+        Me.lblRangeElement2From.Name = "lblRangeElement2From"
+        Me.lblRangeElement2From.Size = New System.Drawing.Size(33, 13)
+        Me.lblRangeElement2From.TabIndex = 53
+        Me.lblRangeElement2From.Text = "From:"
+        '
         'dlgClimaticCheckDataTemperature
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
         Me.AutoSize = True
         Me.ClientSize = New System.Drawing.Size(478, 561)
+        Me.Controls.Add(Me.lblRangeElement2From)
+        Me.Controls.Add(Me.lblRangeElement1From)
         Me.Controls.Add(Me.ucrInputRangeElement2Max)
         Me.Controls.Add(Me.ucrInputRangeElement2Min)
         Me.Controls.Add(Me.ucrInputRangeElement1Max)
@@ -544,7 +557,6 @@ Partial Class dlgClimaticCheckDataTemperature
         Me.Controls.Add(Me.ucrNudCoeff)
         Me.Controls.Add(Me.ucrChkIncludeLogicalColumns)
         Me.Controls.Add(Me.ucrChkRangeElement2)
-        Me.Controls.Add(Me.lblNudDiff)
         Me.Controls.Add(Me.lblNudSame)
         Me.Controls.Add(Me.rdoIndividual)
         Me.Controls.Add(Me.rdoMultiple)
@@ -618,7 +630,6 @@ Partial Class dlgClimaticCheckDataTemperature
     Friend WithEvents rdoIndividual As RadioButton
     Friend WithEvents rdoMultiple As RadioButton
     Friend WithEvents ucrPnlType As UcrPanel
-    Friend WithEvents lblNudDiff As Label
     Friend WithEvents lblNudSame As Label
     Friend WithEvents ucrChkRangeElement2 As ucrCheck
     Friend WithEvents ttOutliers As ToolTip
@@ -632,4 +643,6 @@ Partial Class dlgClimaticCheckDataTemperature
     Friend WithEvents ucrInputRangeElement1Max As ucrInputTextBox
     Friend WithEvents ucrInputRangeElement2Max As ucrInputTextBox
     Friend WithEvents ucrInputRangeElement2Min As ucrInputTextBox
+    Friend WithEvents lblRangeElement2From As Label
+    Friend WithEvents lblRangeElement1From As Label
 End Class

--- a/instat/dlgClimaticCheckDataTemperature.Designer.vb
+++ b/instat/dlgClimaticCheckDataTemperature.Designer.vb
@@ -35,12 +35,7 @@ Partial Class dlgClimaticCheckDataTemperature
         Me.rdoIndividual = New System.Windows.Forms.RadioButton()
         Me.rdoMultiple = New System.Windows.Forms.RadioButton()
         Me.lblNudSame = New System.Windows.Forms.Label()
-        Me.lblNudJump = New System.Windows.Forms.Label()
         Me.lblNudDiff = New System.Windows.Forms.Label()
-        Me.lblNudRangeElement1Min = New System.Windows.Forms.Label()
-        Me.lblNudRangeElement2Min = New System.Windows.Forms.Label()
-        Me.lblNudRangeElement1Max = New System.Windows.Forms.Label()
-        Me.lblNudRangeElement2Max = New System.Windows.Forms.Label()
         Me.ttOutliers = New System.Windows.Forms.ToolTip(Me.components)
         Me.lblCoeff = New System.Windows.Forms.Label()
         Me.grpLogicalCalculatedColumns = New System.Windows.Forms.GroupBox()
@@ -54,12 +49,8 @@ Partial Class dlgClimaticCheckDataTemperature
         Me.ucrChkRangeElement1 = New instat.ucrCheck()
         Me.ucrNudSame = New instat.ucrNud()
         Me.ucrNudDifference = New instat.ucrNud()
-        Me.ucrNudRangeElement2Max = New instat.ucrNud()
         Me.ucrChkOutlier = New instat.ucrCheck()
-        Me.ucrNudRangeElement2Min = New instat.ucrNud()
-        Me.ucrNudRangeElement1Max = New instat.ucrNud()
         Me.ucrChkSame = New instat.ucrCheck()
-        Me.ucrNudRangeElement1Min = New instat.ucrNud()
         Me.ucrChkJump = New instat.ucrCheck()
         Me.ucrChkDifference = New instat.ucrCheck()
         Me.ucrReceiverElement1 = New instat.ucrReceiverSingle()
@@ -71,6 +62,10 @@ Partial Class dlgClimaticCheckDataTemperature
         Me.ucrSelectorTemperature = New instat.ucrSelectorByDataFrameAddRemove()
         Me.ucrBase = New instat.ucrButtons()
         Me.ucrPnlType = New instat.UcrPanel()
+        Me.ucrInputRangeElement1Min = New instat.ucrInputTextBox()
+        Me.ucrInputRangeElement1Max = New instat.ucrInputTextBox()
+        Me.ucrInputRangeElement2Min = New instat.ucrInputTextBox()
+        Me.ucrInputRangeElement2Max = New instat.ucrInputTextBox()
         Me.grpLogicalCalculatedColumns.SuspendLayout()
         Me.SuspendLayout()
         '
@@ -138,21 +133,21 @@ Partial Class dlgClimaticCheckDataTemperature
         '
         Me.lblRangeElement1to.AutoSize = True
         Me.lblRangeElement1to.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblRangeElement1to.Location = New System.Drawing.Point(254, 268)
+        Me.lblRangeElement1to.Location = New System.Drawing.Point(272, 268)
         Me.lblRangeElement1to.Name = "lblRangeElement1to"
-        Me.lblRangeElement1to.Size = New System.Drawing.Size(16, 13)
+        Me.lblRangeElement1to.Size = New System.Drawing.Size(23, 13)
         Me.lblRangeElement1to.TabIndex = 23
-        Me.lblRangeElement1to.Text = "to"
+        Me.lblRangeElement1to.Text = "To:"
         '
         'lblRangeElement2to
         '
         Me.lblRangeElement2to.AutoSize = True
         Me.lblRangeElement2to.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblRangeElement2to.Location = New System.Drawing.Point(254, 297)
+        Me.lblRangeElement2to.Location = New System.Drawing.Point(273, 297)
         Me.lblRangeElement2to.Name = "lblRangeElement2to"
-        Me.lblRangeElement2to.Size = New System.Drawing.Size(16, 13)
+        Me.lblRangeElement2to.Size = New System.Drawing.Size(23, 13)
         Me.lblRangeElement2to.TabIndex = 29
-        Me.lblRangeElement2to.Text = "to"
+        Me.lblRangeElement2to.Text = "To:"
         '
         'lblElement2
         '
@@ -211,16 +206,6 @@ Partial Class dlgClimaticCheckDataTemperature
         Me.lblNudSame.TabIndex = 34
         Me.lblNudSame.Text = "days"
         '
-        'lblNudJump
-        '
-        Me.lblNudJump.AutoSize = True
-        Me.lblNudJump.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblNudJump.Location = New System.Drawing.Point(236, 360)
-        Me.lblNudJump.Name = "lblNudJump"
-        Me.lblNudJump.Size = New System.Drawing.Size(18, 13)
-        Me.lblNudJump.TabIndex = 37
-        Me.lblNudJump.Text = "°C"
-        '
         'lblNudDiff
         '
         Me.lblNudDiff.AutoSize = True
@@ -231,46 +216,6 @@ Partial Class dlgClimaticCheckDataTemperature
         Me.lblNudDiff.TabIndex = 40
         Me.lblNudDiff.Text = "°C"
         '
-        'lblNudRangeElement1Min
-        '
-        Me.lblNudRangeElement1Min.AutoSize = True
-        Me.lblNudRangeElement1Min.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblNudRangeElement1Min.Location = New System.Drawing.Point(236, 268)
-        Me.lblNudRangeElement1Min.Name = "lblNudRangeElement1Min"
-        Me.lblNudRangeElement1Min.Size = New System.Drawing.Size(18, 13)
-        Me.lblNudRangeElement1Min.TabIndex = 22
-        Me.lblNudRangeElement1Min.Text = "°C"
-        '
-        'lblNudRangeElement2Min
-        '
-        Me.lblNudRangeElement2Min.AutoSize = True
-        Me.lblNudRangeElement2Min.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblNudRangeElement2Min.Location = New System.Drawing.Point(236, 297)
-        Me.lblNudRangeElement2Min.Name = "lblNudRangeElement2Min"
-        Me.lblNudRangeElement2Min.Size = New System.Drawing.Size(18, 13)
-        Me.lblNudRangeElement2Min.TabIndex = 28
-        Me.lblNudRangeElement2Min.Text = "°C"
-        '
-        'lblNudRangeElement1Max
-        '
-        Me.lblNudRangeElement1Max.AutoSize = True
-        Me.lblNudRangeElement1Max.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblNudRangeElement1Max.Location = New System.Drawing.Point(324, 268)
-        Me.lblNudRangeElement1Max.Name = "lblNudRangeElement1Max"
-        Me.lblNudRangeElement1Max.Size = New System.Drawing.Size(18, 13)
-        Me.lblNudRangeElement1Max.TabIndex = 25
-        Me.lblNudRangeElement1Max.Text = "°C"
-        '
-        'lblNudRangeElement2Max
-        '
-        Me.lblNudRangeElement2Max.AutoSize = True
-        Me.lblNudRangeElement2Max.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblNudRangeElement2Max.Location = New System.Drawing.Point(325, 297)
-        Me.lblNudRangeElement2Max.Name = "lblNudRangeElement2Max"
-        Me.lblNudRangeElement2Max.Size = New System.Drawing.Size(18, 13)
-        Me.lblNudRangeElement2Max.TabIndex = 31
-        Me.lblNudRangeElement2Max.Text = "°C"
-        '
         'lblCoeff
         '
         Me.lblCoeff.AutoSize = True
@@ -279,7 +224,7 @@ Partial Class dlgClimaticCheckDataTemperature
         Me.lblCoeff.Name = "lblCoeff"
         Me.lblCoeff.Size = New System.Drawing.Size(32, 13)
         Me.lblCoeff.TabIndex = 42
-        Me.lblCoeff.Text = "Coeff"
+        Me.lblCoeff.Text = "Coef:"
         '
         'grpLogicalCalculatedColumns
         '
@@ -334,7 +279,7 @@ Partial Class dlgClimaticCheckDataTemperature
         Me.ucrChkRangeElement2.Checked = False
         Me.ucrChkRangeElement2.Location = New System.Drawing.Point(10, 293)
         Me.ucrChkRangeElement2.Name = "ucrChkRangeElement2"
-        Me.ucrChkRangeElement2.Size = New System.Drawing.Size(172, 23)
+        Me.ucrChkRangeElement2.Size = New System.Drawing.Size(202, 23)
         Me.ucrChkRangeElement2.TabIndex = 26
         '
         'ucrReceiverElement2
@@ -369,7 +314,7 @@ Partial Class dlgClimaticCheckDataTemperature
         Me.ucrChkRangeElement1.Checked = False
         Me.ucrChkRangeElement1.Location = New System.Drawing.Point(10, 264)
         Me.ucrChkRangeElement1.Name = "ucrChkRangeElement1"
-        Me.ucrChkRangeElement1.Size = New System.Drawing.Size(172, 23)
+        Me.ucrChkRangeElement1.Size = New System.Drawing.Size(202, 23)
         Me.ucrChkRangeElement1.TabIndex = 20
         '
         'ucrNudSame
@@ -398,19 +343,6 @@ Partial Class dlgClimaticCheckDataTemperature
         Me.ucrNudDifference.TabIndex = 39
         Me.ucrNudDifference.Value = New Decimal(New Integer() {0, 0, 0, 0})
         '
-        'ucrNudRangeElement2Max
-        '
-        Me.ucrNudRangeElement2Max.AutoSize = True
-        Me.ucrNudRangeElement2Max.DecimalPlaces = New Decimal(New Integer() {0, 0, 0, 0})
-        Me.ucrNudRangeElement2Max.Increment = New Decimal(New Integer() {1, 0, 0, 0})
-        Me.ucrNudRangeElement2Max.Location = New System.Drawing.Point(274, 293)
-        Me.ucrNudRangeElement2Max.Maximum = New Decimal(New Integer() {100, 0, 0, 0})
-        Me.ucrNudRangeElement2Max.Minimum = New Decimal(New Integer() {0, 0, 0, 0})
-        Me.ucrNudRangeElement2Max.Name = "ucrNudRangeElement2Max"
-        Me.ucrNudRangeElement2Max.Size = New System.Drawing.Size(50, 20)
-        Me.ucrNudRangeElement2Max.TabIndex = 30
-        Me.ucrNudRangeElement2Max.Value = New Decimal(New Integer() {0, 0, 0, 0})
-        '
         'ucrChkOutlier
         '
         Me.ucrChkOutlier.AutoSize = True
@@ -420,32 +352,6 @@ Partial Class dlgClimaticCheckDataTemperature
         Me.ucrChkOutlier.Size = New System.Drawing.Size(100, 23)
         Me.ucrChkOutlier.TabIndex = 41
         '
-        'ucrNudRangeElement2Min
-        '
-        Me.ucrNudRangeElement2Min.AutoSize = True
-        Me.ucrNudRangeElement2Min.DecimalPlaces = New Decimal(New Integer() {0, 0, 0, 0})
-        Me.ucrNudRangeElement2Min.Increment = New Decimal(New Integer() {1, 0, 0, 0})
-        Me.ucrNudRangeElement2Min.Location = New System.Drawing.Point(184, 293)
-        Me.ucrNudRangeElement2Min.Maximum = New Decimal(New Integer() {100, 0, 0, 0})
-        Me.ucrNudRangeElement2Min.Minimum = New Decimal(New Integer() {0, 0, 0, 0})
-        Me.ucrNudRangeElement2Min.Name = "ucrNudRangeElement2Min"
-        Me.ucrNudRangeElement2Min.Size = New System.Drawing.Size(50, 20)
-        Me.ucrNudRangeElement2Min.TabIndex = 27
-        Me.ucrNudRangeElement2Min.Value = New Decimal(New Integer() {0, 0, 0, 0})
-        '
-        'ucrNudRangeElement1Max
-        '
-        Me.ucrNudRangeElement1Max.AutoSize = True
-        Me.ucrNudRangeElement1Max.DecimalPlaces = New Decimal(New Integer() {0, 0, 0, 0})
-        Me.ucrNudRangeElement1Max.Increment = New Decimal(New Integer() {1, 0, 0, 0})
-        Me.ucrNudRangeElement1Max.Location = New System.Drawing.Point(274, 264)
-        Me.ucrNudRangeElement1Max.Maximum = New Decimal(New Integer() {100, 0, 0, 0})
-        Me.ucrNudRangeElement1Max.Minimum = New Decimal(New Integer() {0, 0, 0, 0})
-        Me.ucrNudRangeElement1Max.Name = "ucrNudRangeElement1Max"
-        Me.ucrNudRangeElement1Max.Size = New System.Drawing.Size(50, 20)
-        Me.ucrNudRangeElement1Max.TabIndex = 24
-        Me.ucrNudRangeElement1Max.Value = New Decimal(New Integer() {0, 0, 0, 0})
-        '
         'ucrChkSame
         '
         Me.ucrChkSame.AutoSize = True
@@ -454,19 +360,6 @@ Partial Class dlgClimaticCheckDataTemperature
         Me.ucrChkSame.Name = "ucrChkSame"
         Me.ucrChkSame.Size = New System.Drawing.Size(100, 23)
         Me.ucrChkSame.TabIndex = 32
-        '
-        'ucrNudRangeElement1Min
-        '
-        Me.ucrNudRangeElement1Min.AutoSize = True
-        Me.ucrNudRangeElement1Min.DecimalPlaces = New Decimal(New Integer() {0, 0, 0, 0})
-        Me.ucrNudRangeElement1Min.Increment = New Decimal(New Integer() {1, 0, 0, 0})
-        Me.ucrNudRangeElement1Min.Location = New System.Drawing.Point(184, 264)
-        Me.ucrNudRangeElement1Min.Maximum = New Decimal(New Integer() {100, 0, 0, 0})
-        Me.ucrNudRangeElement1Min.Minimum = New Decimal(New Integer() {0, 0, 0, 0})
-        Me.ucrNudRangeElement1Min.Name = "ucrNudRangeElement1Min"
-        Me.ucrNudRangeElement1Min.Size = New System.Drawing.Size(50, 20)
-        Me.ucrNudRangeElement1Min.TabIndex = 21
-        Me.ucrNudRangeElement1Min.Value = New Decimal(New Integer() {0, 0, 0, 0})
         '
         'ucrChkJump
         '
@@ -593,22 +486,65 @@ Partial Class dlgClimaticCheckDataTemperature
         Me.ucrPnlType.Size = New System.Drawing.Size(212, 60)
         Me.ucrPnlType.TabIndex = 0
         '
+        'ucrInputRangeElement1Min
+        '
+        Me.ucrInputRangeElement1Min.AddQuotesIfUnrecognised = True
+        Me.ucrInputRangeElement1Min.AutoSize = True
+        Me.ucrInputRangeElement1Min.IsMultiline = False
+        Me.ucrInputRangeElement1Min.IsReadOnly = False
+        Me.ucrInputRangeElement1Min.Location = New System.Drawing.Point(221, 264)
+        Me.ucrInputRangeElement1Min.Name = "ucrInputRangeElement1Min"
+        Me.ucrInputRangeElement1Min.Size = New System.Drawing.Size(44, 21)
+        Me.ucrInputRangeElement1Min.TabIndex = 48
+        '
+        'ucrInputRangeElement1Max
+        '
+        Me.ucrInputRangeElement1Max.AddQuotesIfUnrecognised = True
+        Me.ucrInputRangeElement1Max.AutoSize = True
+        Me.ucrInputRangeElement1Max.IsMultiline = False
+        Me.ucrInputRangeElement1Max.IsReadOnly = False
+        Me.ucrInputRangeElement1Max.Location = New System.Drawing.Point(296, 265)
+        Me.ucrInputRangeElement1Max.Name = "ucrInputRangeElement1Max"
+        Me.ucrInputRangeElement1Max.Size = New System.Drawing.Size(44, 21)
+        Me.ucrInputRangeElement1Max.TabIndex = 49
+        '
+        'ucrInputRangeElement2Min
+        '
+        Me.ucrInputRangeElement2Min.AddQuotesIfUnrecognised = True
+        Me.ucrInputRangeElement2Min.AutoSize = True
+        Me.ucrInputRangeElement2Min.IsMultiline = False
+        Me.ucrInputRangeElement2Min.IsReadOnly = False
+        Me.ucrInputRangeElement2Min.Location = New System.Drawing.Point(221, 293)
+        Me.ucrInputRangeElement2Min.Name = "ucrInputRangeElement2Min"
+        Me.ucrInputRangeElement2Min.Size = New System.Drawing.Size(44, 21)
+        Me.ucrInputRangeElement2Min.TabIndex = 50
+        '
+        'ucrInputRangeElement2Max
+        '
+        Me.ucrInputRangeElement2Max.AddQuotesIfUnrecognised = True
+        Me.ucrInputRangeElement2Max.AutoSize = True
+        Me.ucrInputRangeElement2Max.IsMultiline = False
+        Me.ucrInputRangeElement2Max.IsReadOnly = False
+        Me.ucrInputRangeElement2Max.Location = New System.Drawing.Point(297, 293)
+        Me.ucrInputRangeElement2Max.Name = "ucrInputRangeElement2Max"
+        Me.ucrInputRangeElement2Max.Size = New System.Drawing.Size(44, 21)
+        Me.ucrInputRangeElement2Max.TabIndex = 51
+        '
         'dlgClimaticCheckDataTemperature
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
         Me.AutoSize = True
         Me.ClientSize = New System.Drawing.Size(478, 561)
+        Me.Controls.Add(Me.ucrInputRangeElement2Max)
+        Me.Controls.Add(Me.ucrInputRangeElement2Min)
+        Me.Controls.Add(Me.ucrInputRangeElement1Max)
+        Me.Controls.Add(Me.ucrInputRangeElement1Min)
         Me.Controls.Add(Me.lblCoeff)
         Me.Controls.Add(Me.ucrNudCoeff)
         Me.Controls.Add(Me.ucrChkIncludeLogicalColumns)
         Me.Controls.Add(Me.ucrChkRangeElement2)
-        Me.Controls.Add(Me.lblNudRangeElement2Max)
-        Me.Controls.Add(Me.lblNudRangeElement1Max)
-        Me.Controls.Add(Me.lblNudRangeElement2Min)
-        Me.Controls.Add(Me.lblNudRangeElement1Min)
         Me.Controls.Add(Me.lblNudDiff)
-        Me.Controls.Add(Me.lblNudJump)
         Me.Controls.Add(Me.lblNudSame)
         Me.Controls.Add(Me.rdoIndividual)
         Me.Controls.Add(Me.rdoMultiple)
@@ -620,12 +556,8 @@ Partial Class dlgClimaticCheckDataTemperature
         Me.Controls.Add(Me.ucrNudSame)
         Me.Controls.Add(Me.lblRangeElement2to)
         Me.Controls.Add(Me.ucrNudDifference)
-        Me.Controls.Add(Me.ucrNudRangeElement2Max)
         Me.Controls.Add(Me.ucrChkOutlier)
-        Me.Controls.Add(Me.ucrNudRangeElement2Min)
-        Me.Controls.Add(Me.ucrNudRangeElement1Max)
         Me.Controls.Add(Me.ucrChkSame)
-        Me.Controls.Add(Me.ucrNudRangeElement1Min)
         Me.Controls.Add(Me.ucrChkJump)
         Me.Controls.Add(Me.ucrChkDifference)
         Me.Controls.Add(Me.lblElement1)
@@ -677,10 +609,6 @@ Partial Class dlgClimaticCheckDataTemperature
     Friend WithEvents ucrChkDifference As ucrCheck
     Friend WithEvents ucrNudSame As ucrNud
     Friend WithEvents ucrNudDifference As ucrNud
-    Friend WithEvents ucrNudRangeElement1Max As ucrNud
-    Friend WithEvents ucrNudRangeElement1Min As ucrNud
-    Friend WithEvents ucrNudRangeElement2Max As ucrNud
-    Friend WithEvents ucrNudRangeElement2Min As ucrNud
     Friend WithEvents lblRangeElement1to As Label
     Friend WithEvents lblRangeElement2to As Label
     Friend WithEvents ucrChkRangeElement1 As ucrCheck
@@ -691,12 +619,7 @@ Partial Class dlgClimaticCheckDataTemperature
     Friend WithEvents rdoMultiple As RadioButton
     Friend WithEvents ucrPnlType As UcrPanel
     Friend WithEvents lblNudDiff As Label
-    Friend WithEvents lblNudJump As Label
     Friend WithEvents lblNudSame As Label
-    Friend WithEvents lblNudRangeElement2Max As Label
-    Friend WithEvents lblNudRangeElement1Max As Label
-    Friend WithEvents lblNudRangeElement2Min As Label
-    Friend WithEvents lblNudRangeElement1Min As Label
     Friend WithEvents ucrChkRangeElement2 As ucrCheck
     Friend WithEvents ttOutliers As ToolTip
     Friend WithEvents ucrChkIncludeCalculatedColumns As ucrCheck
@@ -705,4 +628,8 @@ Partial Class dlgClimaticCheckDataTemperature
     Friend WithEvents lblCoeff As Label
     Friend WithEvents grpLogicalCalculatedColumns As GroupBox
     Friend WithEvents ttMultiple As ToolTip
+    Friend WithEvents ucrInputRangeElement1Min As ucrInputTextBox
+    Friend WithEvents ucrInputRangeElement1Max As ucrInputTextBox
+    Friend WithEvents ucrInputRangeElement2Max As ucrInputTextBox
+    Friend WithEvents ucrInputRangeElement2Min As ucrInputTextBox
 End Class

--- a/instat/dlgClimaticCheckDataTemperature.vb
+++ b/instat/dlgClimaticCheckDataTemperature.vb
@@ -68,7 +68,6 @@ Public Class dlgClimaticCheckDataTemperature
         Dim lstLabels2 As New List(Of Control)
         lstLabels2.AddRange({lblRangeElement2to})
 
-
         'Station Receiver
         ucrReceiverStation.Selector = ucrSelectorTemperature
         ucrReceiverStation.SetClimaticType("station")
@@ -133,7 +132,6 @@ Public Class dlgClimaticCheckDataTemperature
         ucrChkOutlier.AddToLinkedControls(ucrNudCoeff, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:=1.5)
         ucrInputRangeElement2Min.SetLinkedDisplayControl(lstLabels2)
         ucrInputRangeElement1Min.SetLinkedDisplayControl(lstLabels)
-        'ucrNudJump.SetLinkedDisplayControl(lblNudJump)
         ucrNudSame.SetLinkedDisplayControl(lblNudSame)
         ucrNudDifference.SetLinkedDisplayControl(lblNudDiff)
         ucrReceiverElement2.SetLinkedDisplayControl(lblElement2)
@@ -160,29 +158,15 @@ Public Class dlgClimaticCheckDataTemperature
         'Nuds for the respective options
         'Range Option
         ucrInputRangeElement1Min.SetParameter(New RParameter("from", 1, bNewIncludeArgumentName:=False))
-        'ucrNudRangeElement1Min.SetMinMax(-35, 65)
-        'ucrNudRangeElement1Min.DecimalPlaces = 1
-        'ucrInputRangeElement1Min.
-        'ucrInputRangeElement1Min.SetValidationTypeAsNumeric()
         ucrInputRangeElement1Min.SetValidationTypeAsNumeric(dcmMin:=-35.0, bIncludeMin:=True, dcmMax:=65.0, bIncludeMax:=True)
 
-
         ucrInputRangeElement1Max.SetParameter(New RParameter("To", 1, bNewIncludeArgumentName:=False))
-        'ucrNudRangeElement1Max.SetMinMax(-35, 65)
-        'ucrNudRangeElement1Max.DecimalPlaces = 1
-        'ucrNudRangeElement1Max.Increment = 0.
         ucrInputRangeElement1Max.SetValidationTypeAsNumeric(dcmMin:=-35.0, bIncludeMin:=True, dcmMax:=65.0, bIncludeMax:=True)
 
         ucrInputRangeElement2Min.SetParameter(New RParameter("from", 1, bNewIncludeArgumentName:=False))
-        'ucrNudRangeElement2Min.SetMinMax(-50, 40)
-        'ucrNudRangeElement2Min.DecimalPlaces = 1
-        'ucrNudRangeElement2Min.Increment = 0.1
         ucrInputRangeElement2Min.SetValidationTypeAsNumeric(dcmMin:=-50.0, bIncludeMin:=True, dcmMax:=40, bIncludeMax:=True)
 
         ucrInputRangeElement2Max.SetParameter(New RParameter("To", 1, bNewIncludeArgumentName:=False))
-        'ucrNudRangeElement2Max.SetMinMax(-50, 40)
-        'ucrNudRangeElement2Max.DecimalPlaces = 1
-        'ucrNudRangeElement2Max.Increment = 0.1
         ucrInputRangeElement2Max.SetValidationTypeAsNumeric(dcmMin:=-50.0, bIncludeMin:=True, dcmMax:=40, bIncludeMax:=True)
 
         'Same Option
@@ -210,7 +194,6 @@ Public Class dlgClimaticCheckDataTemperature
         ucrChkIncludeLogicalColumns.SetParameter(New RParameter("save", 4))
         ucrChkIncludeLogicalColumns.SetValuesCheckedAndUnchecked("2", "0")
 
-
         ttOutliers.SetToolTip(ucrChkOutlier, "Values that are further than this number of IQRs from the corresponding quartile.")
         ttMultiple.Show("Not yet implemented.", rdoMultiple)
     End Sub
@@ -219,10 +202,8 @@ Public Class dlgClimaticCheckDataTemperature
         clsGroupByFunc = New RFunction
         clsGroupingListFunc = New RFunction
         clsCalcFilterFunc = New RFunction
-        'clsFilterFunc = New RFunction
         clsFilterListFunc = New RFunction
         clsRunCalcFunc = New RFunction
-
         clsOrOperator = New ROperator
 
         ucrSelectorTemperature.Reset()
@@ -282,26 +263,15 @@ Public Class dlgClimaticCheckDataTemperature
         clsSameListSubCalc.SetOperation(",")
         clsDiffListSubCalc.SetOperation(",")
 
-
         'Main calculation filter
         clsCalcFilterFunc.SetRCommand("instat_calculation$new")
         clsCalcFilterFunc.AddParameter("type", Chr(34) & "filter" & Chr(34), iPosition:=0)
-        'clsCalcFilterFunc.AddParameter("result_name", Chr(34) & "QC" & Chr(34))
         clsCalcFilterFunc.AddParameter("function_exp", clsROperatorParameter:=clsOrOperator, iPosition:=1)
         clsCalcFilterFunc.AddParameter("sub_calculations", clsRFunctionParameter:=clsFilterListFunc, iPosition:=2)
-        'clsCalcFilterFunc.AddParameter("save", "2", iPosition:=3)
+        clsCalcFilterFunc.AddParameter("save", "2", iPosition:=3)
         clsCalcFilterFunc.AddParameter("sub_calculations", clsRFunctionParameter:=clsListSubCalc, iPosition:=4)
         clsCalcFilterFunc.AddParameter("result_data_frame", Chr(34) & "qcTemp" & Chr(34), iPosition:=5)
         clsCalcFilterFunc.SetAssignTo("filter_calculation")
-
-        'Logical columns 
-        'clsFilterFunc.SetRCommand("instat_calculation$new")
-        'clsFilterFunc.AddParameter("type", Chr(34) & "filter" & Chr(34), iPosition:=0)
-        'clsFilterFunc.AddParameter("function_exp", strParameterValue:=Chr(34) & "QC" & Chr(34), iPosition:=1)
-        'clsFilterFunc.AddParameter("sub_calculations", clsRFunctionParameter:=clsFilterListFunc, iPosition:=2)
-        'clsFilterFunc.AddParameter("save", "2", iPosition:=3)
-        'clsFilterFunc.AddParameter("result_data_frame", Chr(34) & "qcTemp" & Chr(34), iPosition:=4)
-        'clsFilterFunc.SetAssignTo("filtered_data")
 
         clsFilterListFunc.SetRCommand("list")
         clsFilterListFunc.AddParameter("sub", clsRFunctionParameter:=clsCalcFilterFunc, bIncludeArgumentName:=False)
@@ -346,22 +316,21 @@ Public Class dlgClimaticCheckDataTemperature
         ucrNudCoeff.AddAdditionalCodeParameterPair(clsOutliersElement1.clsOutlierUpperLimitFunc, New RParameter("coef"), iAdditionalPairNo:=3)
         ucrNudCoeff.AddAdditionalCodeParameterPair(clsOutliersElement2.clsOutlierUpperLimitFunc, New RParameter("coef"), iAdditionalPairNo:=3)
 
-        ucrChkIncludeLogicalColumns.AddAdditionalCodeParameterPair(clsJumpCodeElement1.clsJumpTestFunction, New RParameter("save"), iAdditionalPairNo:=1)
-        ucrChkIncludeLogicalColumns.AddAdditionalCodeParameterPair(clsJumpCodeElement2.clsJumpTestFunction, New RParameter("save"), iAdditionalPairNo:=2)
+        ucrChkIncludeLogicalColumns.AddAdditionalCodeParameterPair(clsJumpCodeElement2.clsJumpTestFunction, New RParameter("save"), iAdditionalPairNo:=1)
 
-        ucrChkIncludeLogicalColumns.AddAdditionalCodeParameterPair(clsSameCodeElement1.clsSameTestFunction, New RParameter("save"), iAdditionalPairNo:=3)
-        ucrChkIncludeLogicalColumns.AddAdditionalCodeParameterPair(clsSameCodeElement2.clsSameTestFunction, New RParameter("save"), iAdditionalPairNo:=4)
+        ucrChkIncludeLogicalColumns.AddAdditionalCodeParameterPair(clsSameCodeElement1.clsSameTestFunction, New RParameter("save"), iAdditionalPairNo:=2)
+        ucrChkIncludeLogicalColumns.AddAdditionalCodeParameterPair(clsSameCodeElement2.clsSameTestFunction, New RParameter("save"), iAdditionalPairNo:=3)
 
-        ucrChkIncludeLogicalColumns.AddAdditionalCodeParameterPair(clsQCDifferenceRCode.clsDiffTestFunction, New RParameter("save"), iAdditionalPairNo:=5)
+        ucrChkIncludeLogicalColumns.AddAdditionalCodeParameterPair(clsQCDifferenceRCode.clsDiffTestFunction, New RParameter("save"), iAdditionalPairNo:=4)
 
-        ucrChkIncludeLogicalColumns.AddAdditionalCodeParameterPair(clsQCAcceptableRangeElement1.clsAcceptableRangeTestFunc, New RParameter("save"), iAdditionalPairNo:=6)
-        ucrChkIncludeLogicalColumns.AddAdditionalCodeParameterPair(clsQCAcceptableRangeElement2.clsAcceptableRangeTestFunc, New RParameter("save"), iAdditionalPairNo:=7)
+        ucrChkIncludeLogicalColumns.AddAdditionalCodeParameterPair(clsQCAcceptableRangeElement1.clsAcceptableRangeTestFunc, New RParameter("save"), iAdditionalPairNo:=5)
+        ucrChkIncludeLogicalColumns.AddAdditionalCodeParameterPair(clsQCAcceptableRangeElement2.clsAcceptableRangeTestFunc, New RParameter("save"), iAdditionalPairNo:=6)
 
-        ucrChkIncludeLogicalColumns.AddAdditionalCodeParameterPair(clsOutliersElement1.clsOutlierUpperLimitTestCalc, New RParameter("save"), iAdditionalPairNo:=8)
-        ucrChkIncludeLogicalColumns.AddAdditionalCodeParameterPair(clsOutliersElement1.clsOutlierLowerLimitTestCalc, New RParameter("save"), iAdditionalPairNo:=9)
+        ucrChkIncludeLogicalColumns.AddAdditionalCodeParameterPair(clsOutliersElement1.clsOutlierUpperLimitTestCalc, New RParameter("save"), iAdditionalPairNo:=7)
+        ucrChkIncludeLogicalColumns.AddAdditionalCodeParameterPair(clsOutliersElement1.clsOutlierLowerLimitTestCalc, New RParameter("save"), iAdditionalPairNo:=8)
 
-        ucrChkIncludeLogicalColumns.AddAdditionalCodeParameterPair(clsOutliersElement2.clsOutlierUpperLimitTestCalc, New RParameter("save"), iAdditionalPairNo:=10)
-        ucrChkIncludeLogicalColumns.AddAdditionalCodeParameterPair(clsOutliersElement2.clsOutlierLowerLimitTestCalc, New RParameter("save"), iAdditionalPairNo:=11)
+        ucrChkIncludeLogicalColumns.AddAdditionalCodeParameterPair(clsOutliersElement2.clsOutlierUpperLimitTestCalc, New RParameter("save"), iAdditionalPairNo:=9)
+        ucrChkIncludeLogicalColumns.AddAdditionalCodeParameterPair(clsOutliersElement2.clsOutlierLowerLimitTestCalc, New RParameter("save"), iAdditionalPairNo:=10)
 
         ucrChkIncludeCalculatedColumns.AddAdditionalCodeParameterPair(clsJumpCodeElement2.clsJumpCalcFunction, New RParameter("save"), iAdditionalPairNo:=1)
 
@@ -393,7 +362,7 @@ Public Class dlgClimaticCheckDataTemperature
         ucrChkRangeElement2.SetRCode(clsOrOperator, bReset)
         ucrChkSame.SetRCode(clsOrOperator, bReset)
         ucrChkJump.SetRCode(clsOrOperator, bReset)
-        ucrChkIncludeLogicalColumns.SetRCode(clsCalcFilterFunc, bReset)
+        ucrChkIncludeLogicalColumns.SetRCode(clsJumpCodeElement1.clsJumpTestFunction, bReset)
         ucrChkIncludeCalculatedColumns.SetRCode(clsJumpCodeElement1.clsJumpCalcFunction, bReset)
         ucrChkOutlier.SetRCode(clsOrOperator, bReset)
         ucrNudCoeff.SetRCode(clsOutliersElement1.clsOutlierUpperLimitFunc)
@@ -466,7 +435,6 @@ Public Class dlgClimaticCheckDataTemperature
                 Exit Sub
             End If
         End If
-
         ucrBase.OKEnabled(bEnable)
 
     End Sub
@@ -481,10 +449,8 @@ Public Class dlgClimaticCheckDataTemperature
         If Not ucrReceiverStation.IsEmpty Then
             clsGroupByFunc.AddParameter("calculated_from", "list(" & strCurrDataFrame & "=" & ucrReceiverStation.GetVariableNames & ")", iPosition:=1)
             clsCalcFilterFunc.AddParameter("manipulations", clsRFunctionParameter:=clsGroupingListFunc, iPosition:=2)
-            'clsFilterFunc.AddParameter("manipulations", clsRFunctionParameter:=clsGroupingListFunc, iPosition:=3)
         Else
             clsCalcFilterFunc.RemoveParameterByName("manipulations")
-            'clsFilterFunc.RemoveParameterByName("manipulations")
         End If
     End Sub
 
@@ -593,7 +559,6 @@ Public Class dlgClimaticCheckDataTemperature
 
         If Not ucrReceiverElement1.IsEmpty AndAlso Not ucrReceiverElement2.IsEmpty Then
             clsCalcFilterFunc.AddParameter("calculated_from", "list(" & strCurrDataFrame & "=" & ucrReceiverElement1.GetVariableNames & "," & strCurrDataFrame & "=" & ucrReceiverElement2.GetVariableNames & ")", iPosition:=2)
-            'clsFilterFunc.AddParameter("calculated_from", "list(" & strCurrDataFrame & "=" & ucrReceiverElement1.GetVariableNames & "," & strCurrDataFrame & "=" & ucrReceiverElement2.GetVariableNames & ")", iPosition:=2)
             clsQCDifferenceRCode.clsDiffCalcFunction.AddParameter("calculated_from", "list(" & strCurrDataFrame & "=" & ucrReceiverElement1.GetVariableNames & "," & strCurrDataFrame & "=" & ucrReceiverElement2.GetVariableNames & ")", iPosition:=2)
             clsDiffOp.AddParameter("diff", strParameterValue:=clsQCDifferenceRCode.strTestName, bIncludeArgumentName:=False)
             clsJumpCodeElement1.clsJumpCalcFunction.AddParameter("calculated_from", "list(" & strCurrDataFrame & "=" & ucrReceiverElement1.GetVariableNames & "," & strCurrDataFrame & "=" & ucrReceiverElement2.GetVariableNames & ")", iPosition:=2)
@@ -604,7 +569,6 @@ Public Class dlgClimaticCheckDataTemperature
             clsQCAcceptableRangeElement2.clsAcceptableRangeTestFunc.AddParameter("calculated_from", "list(" & strCurrDataFrame & "=" & ucrReceiverElement1.GetVariableNames & "," & strCurrDataFrame & "=" & ucrReceiverElement2.GetVariableNames & ")", iPosition:=2)
         ElseIf Not ucrReceiverElement1.IsEmpty Then
             clsCalcFilterFunc.AddParameter("calculated_from", "list(" & strCurrDataFrame & "=" & ucrReceiverElement1.GetVariableNames & ")", iPosition:=2)
-            'clsFilterFunc.AddParameter("calculated_from", "list(" & strCurrDataFrame & "=" & ucrReceiverElement1.GetVariableNames & ")", iPosition:=2)
             clsJumpCodeElement1.clsJumpCalcFunction.AddParameter("calculated_from", "list(" & strCurrDataFrame & "=" & ucrReceiverElement1.GetVariableNames & ")", iPosition:=2)
             clsJumpCodeElement2.clsJumpCalcFunction.AddParameter("calculated_from", "list(" & strCurrDataFrame & "=" & ucrReceiverElement1.GetVariableNames & ")", iPosition:=2)
             clsSameCodeElement1.clsSameCalcFunction.AddParameter("calculated_from", "list(" & strCurrDataFrame & "=" & ucrReceiverElement1.GetVariableNames & ")", iPosition:=2)
@@ -615,7 +579,6 @@ Public Class dlgClimaticCheckDataTemperature
             clsOutliersElement1.clsOutlierLowerLimitCalc.AddParameter("calculated_from", "list(" & strCurrDataFrame & "=" & ucrReceiverElement1.GetVariableNames & ")", iPosition:=2)
         ElseIf Not ucrReceiverElement2.IsEmpty Then
             clsCalcFilterFunc.AddParameter("calculated_from", "list(" & strCurrDataFrame & "=" & ucrReceiverElement2.GetVariableNames & ")", iPosition:=2)
-            'clsFilterFunc.AddParameter("calculated_from", "list(" & strCurrDataFrame & "=" & ucrReceiverElement2.GetVariableNames & ")", iPosition:=2)
             clsJumpCodeElement1.clsJumpCalcFunction.AddParameter("calculated_from", "list(" & strCurrDataFrame & "=" & ucrReceiverElement2.GetVariableNames & ")", iPosition:=2)
             clsJumpCodeElement2.clsJumpCalcFunction.AddParameter("calculated_from", "list(" & strCurrDataFrame & "=" & ucrReceiverElement2.GetVariableNames & ")", iPosition:=2)
             clsSameCodeElement1.clsSameCalcFunction.AddParameter("calculated_from", "list(" & strCurrDataFrame & "=" & ucrReceiverElement2.GetVariableNames & ")", iPosition:=2)

--- a/instat/dlgClimaticCheckDataTemperature.vb
+++ b/instat/dlgClimaticCheckDataTemperature.vb
@@ -63,10 +63,10 @@ Public Class dlgClimaticCheckDataTemperature
         rdoIndividual.Checked = True
 
         Dim lstLabels As New List(Of Control)
-        lstLabels.AddRange({lblRangeElement1to})
+        lstLabels.AddRange({lblRangeElement1to, lblRangeElement1From})
 
         Dim lstLabels2 As New List(Of Control)
-        lstLabels2.AddRange({lblRangeElement2to})
+        lstLabels2.AddRange({lblRangeElement2to, lblRangeElement2From})
 
         'Station Receiver
         ucrReceiverStation.Selector = ucrSelectorTemperature
@@ -119,10 +119,10 @@ Public Class dlgClimaticCheckDataTemperature
 
         'Checkboxes for options
         ucrChkRangeElement1.SetParameter(New RParameter("range1", clsRangeOrOp, 1), bNewChangeParameterValue:=False)
-        ucrChkRangeElement1.SetText("Acceptable Range Element1: From:")
+        ucrChkRangeElement1.SetText("Acceptable Range Element1:")
 
         ucrChkRangeElement2.SetParameter(New RParameter("range2", clsRange2OrOp, 1), bNewChangeParameterValue:=False)
-        ucrChkRangeElement2.SetText("Acceptable Range Element2: From:")
+        ucrChkRangeElement2.SetText("Acceptable Range Element2:")
 
         'Linking controls
         ucrChkRangeElement1.AddToLinkedControls(ucrInputRangeElement1Min, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:=10)
@@ -133,7 +133,6 @@ Public Class dlgClimaticCheckDataTemperature
         ucrInputRangeElement2Min.SetLinkedDisplayControl(lstLabels2)
         ucrInputRangeElement1Min.SetLinkedDisplayControl(lstLabels)
         ucrNudSame.SetLinkedDisplayControl(lblNudSame)
-        ucrNudDifference.SetLinkedDisplayControl(lblNudDiff)
         ucrReceiverElement2.SetLinkedDisplayControl(lblElement2)
         ucrNudCoeff.SetLinkedDisplayControl(lblCoeff)
 

--- a/instat/dlgClimaticCheckDataTemperature.vb
+++ b/instat/dlgClimaticCheckDataTemperature.vb
@@ -21,7 +21,7 @@ Public Class dlgClimaticCheckDataTemperature
     Private strCurrDataFrame As String
     Private clsGroupByFunc, clsGroupingListFunc, clsCalcFilterFunc, clsRunCalcFunc As New RFunction
     'logical columns
-    Private clsFilterListFunc, clsFilterFunc As New RFunction
+    Private clsFilterListFunc As New RFunction
     'Jump
     Private clsJumpCodeElement1, clsJumpCodeElement2 As New clsQCJumpRCode
     Private clsJumpOp, clsJumpListSubCalc As New ROperator
@@ -63,10 +63,11 @@ Public Class dlgClimaticCheckDataTemperature
         rdoIndividual.Checked = True
 
         Dim lstLabels As New List(Of Control)
-        lstLabels.AddRange({lblRangeElement1to, lblNudRangeElement1Min, lblNudRangeElement1Max})
+        lstLabels.AddRange({lblRangeElement1to})
 
         Dim lstLabels2 As New List(Of Control)
-        lstLabels2.AddRange({lblNudRangeElement2Min, lblRangeElement2to, lblNudRangeElement2Max})
+        lstLabels2.AddRange({lblRangeElement2to})
+
 
         'Station Receiver
         ucrReceiverStation.Selector = ucrSelectorTemperature
@@ -119,38 +120,38 @@ Public Class dlgClimaticCheckDataTemperature
 
         'Checkboxes for options
         ucrChkRangeElement1.SetParameter(New RParameter("range1", clsRangeOrOp, 1), bNewChangeParameterValue:=False)
-        ucrChkRangeElement1.SetText("Acceptable Range (Element1)")
+        ucrChkRangeElement1.SetText("Acceptable Range Element1: From:")
 
         ucrChkRangeElement2.SetParameter(New RParameter("range2", clsRange2OrOp, 1), bNewChangeParameterValue:=False)
-        ucrChkRangeElement2.SetText("Acceptable Range (Element2)")
+        ucrChkRangeElement2.SetText("Acceptable Range Element2: From:")
 
         'Linking controls
-        ucrChkRangeElement1.AddToLinkedControls(ucrNudRangeElement1Min, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:=10)
-        ucrChkRangeElement1.AddToLinkedControls(ucrNudRangeElement1Max, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:=50)
-        ucrChkRangeElement2.AddToLinkedControls(ucrNudRangeElement2Min, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:=1)
-        ucrChkRangeElement2.AddToLinkedControls(ucrNudRangeElement2Max, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:=30)
+        ucrChkRangeElement1.AddToLinkedControls(ucrInputRangeElement1Min, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:=10)
+        ucrChkRangeElement1.AddToLinkedControls(ucrInputRangeElement1Max, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:=50)
+        ucrChkRangeElement2.AddToLinkedControls(ucrInputRangeElement2Min, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:=1)
+        ucrChkRangeElement2.AddToLinkedControls(ucrInputRangeElement2Max, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:=30)
         ucrChkOutlier.AddToLinkedControls(ucrNudCoeff, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:=1.5)
-        ucrNudRangeElement2Min.SetLinkedDisplayControl(lstLabels2)
-        ucrNudRangeElement1Min.SetLinkedDisplayControl(lstLabels)
-        ucrNudJump.SetLinkedDisplayControl(lblNudJump)
+        ucrInputRangeElement2Min.SetLinkedDisplayControl(lstLabels2)
+        ucrInputRangeElement1Min.SetLinkedDisplayControl(lstLabels)
+        'ucrNudJump.SetLinkedDisplayControl(lblNudJump)
         ucrNudSame.SetLinkedDisplayControl(lblNudSame)
         ucrNudDifference.SetLinkedDisplayControl(lblNudDiff)
         ucrReceiverElement2.SetLinkedDisplayControl(lblElement2)
         ucrNudCoeff.SetLinkedDisplayControl(lblCoeff)
 
         ucrChkSame.SetParameter(New RParameter("same", clsSameOp, 1), bNewChangeParameterValue:=False)
-        ucrChkSame.SetText("Same (Element1)")
+        ucrChkSame.SetText("Days: (Element1)")
         ucrChkSame.AddToLinkedControls(ucrNudSame, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:=4)
 
         ucrChkJump.SetParameter(New RParameter("jump", clsJumpOp, 1), bNewChangeParameterValue:=False)
-        ucrChkJump.SetText("Jump (Element1)")
+        ucrChkJump.SetText("Jump: (Element1)")
         ucrChkJump.AddToLinkedControls(ucrNudJump, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:=10)
 
         ucrChkDifference.SetParameter(New RParameter("diff", clsDiffOp, 1), bNewChangeParameterValue:=False)
-        ucrChkDifference.SetText("Difference")
+        ucrChkDifference.SetText("Difference:")
 
         ucrChkOutlier.SetParameter(New RParameter("Combined_outlier", clsOutlierCombinedOperator, 1), bNewChangeParameterValue:=False)
-        ucrChkOutlier.SetText("Outlier")
+        ucrChkOutlier.SetText("Outlier:")
 
         ucrNudCoeff.SetParameter(New RParameter("coef"))
         ucrNudCoeff.DecimalPlaces = 1
@@ -158,25 +159,31 @@ Public Class dlgClimaticCheckDataTemperature
 
         'Nuds for the respective options
         'Range Option
-        ucrNudRangeElement1Min.SetParameter(New RParameter("from", 1, bNewIncludeArgumentName:=False))
-        ucrNudRangeElement1Min.SetMinMax(-35, 65)
-        ucrNudRangeElement1Min.DecimalPlaces = 1
-        ucrNudRangeElement1Min.Increment = 0.1
+        ucrInputRangeElement1Min.SetParameter(New RParameter("from", 1, bNewIncludeArgumentName:=False))
+        'ucrNudRangeElement1Min.SetMinMax(-35, 65)
+        'ucrNudRangeElement1Min.DecimalPlaces = 1
+        'ucrInputRangeElement1Min.
+        'ucrInputRangeElement1Min.SetValidationTypeAsNumeric()
+        ucrInputRangeElement1Min.SetValidationTypeAsNumeric(dcmMin:=-35.0, bIncludeMin:=True, dcmMax:=65.0, bIncludeMax:=True)
 
-        ucrNudRangeElement1Max.SetParameter(New RParameter("To", 1, bNewIncludeArgumentName:=False))
-        ucrNudRangeElement1Max.SetMinMax(-35, 65)
-        ucrNudRangeElement1Max.DecimalPlaces = 1
-        ucrNudRangeElement1Max.Increment = 0.1
 
-        ucrNudRangeElement2Min.SetParameter(New RParameter("from", 1, bNewIncludeArgumentName:=False))
-        ucrNudRangeElement2Min.SetMinMax(-50, 40)
-        ucrNudRangeElement2Min.DecimalPlaces = 1
-        ucrNudRangeElement2Min.Increment = 0.1
+        ucrInputRangeElement1Max.SetParameter(New RParameter("To", 1, bNewIncludeArgumentName:=False))
+        'ucrNudRangeElement1Max.SetMinMax(-35, 65)
+        'ucrNudRangeElement1Max.DecimalPlaces = 1
+        'ucrNudRangeElement1Max.Increment = 0.
+        ucrInputRangeElement1Max.SetValidationTypeAsNumeric(dcmMin:=-35.0, bIncludeMin:=True, dcmMax:=65.0, bIncludeMax:=True)
 
-        ucrNudRangeElement2Max.SetParameter(New RParameter("To", 1, bNewIncludeArgumentName:=False))
-        ucrNudRangeElement2Max.SetMinMax(-50, 40)
-        ucrNudRangeElement2Max.DecimalPlaces = 1
-        ucrNudRangeElement2Max.Increment = 0.1
+        ucrInputRangeElement2Min.SetParameter(New RParameter("from", 1, bNewIncludeArgumentName:=False))
+        'ucrNudRangeElement2Min.SetMinMax(-50, 40)
+        'ucrNudRangeElement2Min.DecimalPlaces = 1
+        'ucrNudRangeElement2Min.Increment = 0.1
+        ucrInputRangeElement2Min.SetValidationTypeAsNumeric(dcmMin:=-50.0, bIncludeMin:=True, dcmMax:=40, bIncludeMax:=True)
+
+        ucrInputRangeElement2Max.SetParameter(New RParameter("To", 1, bNewIncludeArgumentName:=False))
+        'ucrNudRangeElement2Max.SetMinMax(-50, 40)
+        'ucrNudRangeElement2Max.DecimalPlaces = 1
+        'ucrNudRangeElement2Max.Increment = 0.1
+        ucrInputRangeElement2Max.SetValidationTypeAsNumeric(dcmMin:=-50.0, bIncludeMin:=True, dcmMax:=40, bIncludeMax:=True)
 
         'Same Option
         ucrNudSame.SetParameter(New RParameter("n", 1, bNewIncludeArgumentName:=False))
@@ -212,7 +219,7 @@ Public Class dlgClimaticCheckDataTemperature
         clsGroupByFunc = New RFunction
         clsGroupingListFunc = New RFunction
         clsCalcFilterFunc = New RFunction
-        clsFilterFunc = New RFunction
+        'clsFilterFunc = New RFunction
         clsFilterListFunc = New RFunction
         clsRunCalcFunc = New RFunction
 
@@ -229,21 +236,21 @@ Public Class dlgClimaticCheckDataTemperature
         clsGroupingListFunc.AddParameter("list", bIncludeArgumentName:=False, clsRFunctionParameter:=clsGroupByFunc, iPosition:=0)
 
         'Range
-        clsQCAcceptableRangeElement1.SetDefaults("_tmax")
-        clsQCAcceptableRangeElement2.SetDefaults("_tmin")
+        clsQCAcceptableRangeElement1.SetDefaults("_e1")
+        clsQCAcceptableRangeElement2.SetDefaults("_e2")
 
         clsRangeOrOp.SetOperation("|")
         clsRange2OrOp.SetOperation("|")
 
         'Same
-        clsSameCodeElement1.SetDefaults("_tmax")
-        clsSameCodeElement2.SetDefaults("_tmin")
+        clsSameCodeElement1.SetDefaults("_e1")
+        clsSameCodeElement2.SetDefaults("_e2")
 
         clsSameOp.SetOperation("|")
 
         'Jump
-        clsJumpCodeElement1.SetDefaults("_tmax")
-        clsJumpCodeElement2.SetDefaults("_tmin")
+        clsJumpCodeElement1.SetDefaults("_e1")
+        clsJumpCodeElement2.SetDefaults("_e2")
 
         clsJumpOp.SetOperation("|")
 
@@ -261,8 +268,8 @@ Public Class dlgClimaticCheckDataTemperature
         clsListForOutlierManipulations.AddParameter("sub1", clsRFunctionParameter:=clsGroupByMonth, bIncludeArgumentName:=False, iPosition:=0)
 
         'Outliers
-        clsOutliersElement1.SetDefaults("_tmax")
-        clsOutliersElement2.SetDefaults("_tmin")
+        clsOutliersElement1.SetDefaults("_e1")
+        clsOutliersElement2.SetDefaults("_e2")
 
         clsOutlierCombinedOperator.SetOperation("|")
         clsOutlierCombinedOperator.bBrackets = False
@@ -278,20 +285,23 @@ Public Class dlgClimaticCheckDataTemperature
 
         'Main calculation filter
         clsCalcFilterFunc.SetRCommand("instat_calculation$new")
-        clsCalcFilterFunc.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
-        clsCalcFilterFunc.AddParameter("result_name", Chr(34) & "QC" & Chr(34))
+        clsCalcFilterFunc.AddParameter("type", Chr(34) & "filter" & Chr(34), iPosition:=0)
+        'clsCalcFilterFunc.AddParameter("result_name", Chr(34) & "QC" & Chr(34))
         clsCalcFilterFunc.AddParameter("function_exp", clsROperatorParameter:=clsOrOperator, iPosition:=1)
-        clsCalcFilterFunc.AddParameter("sub_calculations", clsRFunctionParameter:=clsListSubCalc, iPosition:=3)
+        clsCalcFilterFunc.AddParameter("sub_calculations", clsRFunctionParameter:=clsFilterListFunc, iPosition:=2)
+        'clsCalcFilterFunc.AddParameter("save", "2", iPosition:=3)
+        clsCalcFilterFunc.AddParameter("sub_calculations", clsRFunctionParameter:=clsListSubCalc, iPosition:=4)
+        clsCalcFilterFunc.AddParameter("result_data_frame", Chr(34) & "qcTemp" & Chr(34), iPosition:=5)
         clsCalcFilterFunc.SetAssignTo("filter_calculation")
 
         'Logical columns 
-        clsFilterFunc.SetRCommand("instat_calculation$new")
-        clsFilterFunc.AddParameter("type", Chr(34) & "filter" & Chr(34), iPosition:=0)
-        clsFilterFunc.AddParameter("function_exp", strParameterValue:=Chr(34) & "QC" & Chr(34), iPosition:=1)
-        clsFilterFunc.AddParameter("sub_calculations", clsRFunctionParameter:=clsFilterListFunc, iPosition:=2)
-        clsFilterFunc.AddParameter("save", "2", iPosition:=3)
-        clsFilterFunc.AddParameter("result_data_frame", Chr(34) & "qcTemp" & Chr(34), iPosition:=4)
-        clsFilterFunc.SetAssignTo("filtered_data")
+        'clsFilterFunc.SetRCommand("instat_calculation$new")
+        'clsFilterFunc.AddParameter("type", Chr(34) & "filter" & Chr(34), iPosition:=0)
+        'clsFilterFunc.AddParameter("function_exp", strParameterValue:=Chr(34) & "QC" & Chr(34), iPosition:=1)
+        'clsFilterFunc.AddParameter("sub_calculations", clsRFunctionParameter:=clsFilterListFunc, iPosition:=2)
+        'clsFilterFunc.AddParameter("save", "2", iPosition:=3)
+        'clsFilterFunc.AddParameter("result_data_frame", Chr(34) & "qcTemp" & Chr(34), iPosition:=4)
+        'clsFilterFunc.SetAssignTo("filtered_data")
 
         clsFilterListFunc.SetRCommand("list")
         clsFilterListFunc.AddParameter("sub", clsRFunctionParameter:=clsCalcFilterFunc, bIncludeArgumentName:=False)
@@ -302,7 +312,7 @@ Public Class dlgClimaticCheckDataTemperature
         clsOrOperator.bToScriptAsRString = True
 
         clsRunCalcFunc.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$run_instat_calculation")
-        clsRunCalcFunc.AddParameter("calc", clsRFunctionParameter:=clsFilterFunc, iPosition:=0)
+        clsRunCalcFunc.AddParameter("calc", clsRFunctionParameter:=clsCalcFilterFunc, iPosition:=0)
         clsRunCalcFunc.AddParameter("display", "FALSE")
         ucrBase.clsRsyntax.SetBaseRFunction(clsRunCalcFunc)
     End Sub
@@ -369,11 +379,11 @@ Public Class dlgClimaticCheckDataTemperature
         ucrNudJump.AddAdditionalCodeParameterPair(clsJumpCodeElement2.clsGreaterJumpOperator, (New RParameter("n", 1, bNewIncludeArgumentName:=False)))
         ucrNudSame.AddAdditionalCodeParameterPair(clsSameCodeElement2.clsSameGreaterOperator, (New RParameter("n", 1, bNewIncludeArgumentName:=False)))
 
-        ucrNudRangeElement2Max.SetRCode(clsQCAcceptableRangeElement2.clsGreaterEqualToOperator, bReset)
-        ucrNudRangeElement2Min.SetRCode(clsQCAcceptableRangeElement2.clsLessEqualToOperator, bReset)
+        ucrInputRangeElement2Max.SetRCode(clsQCAcceptableRangeElement2.clsGreaterEqualToOperator, bReset)
+        ucrInputRangeElement2Min.SetRCode(clsQCAcceptableRangeElement2.clsLessEqualToOperator, bReset)
         ucrReceiverElement1.SetRCode(clsQCAcceptableRangeElement1.clsLessEqualToOperator, bReset)
-        ucrNudRangeElement1Min.SetRCode(clsQCAcceptableRangeElement1.clsLessEqualToOperator, bReset)
-        ucrNudRangeElement1Max.SetRCode(clsQCAcceptableRangeElement1.clsGreaterEqualToOperator, bReset)
+        ucrInputRangeElement1Min.SetRCode(clsQCAcceptableRangeElement1.clsLessEqualToOperator, bReset)
+        ucrInputRangeElement1Max.SetRCode(clsQCAcceptableRangeElement1.clsGreaterEqualToOperator, bReset)
         ucrNudJump.SetRCode(clsJumpCodeElement1.clsGreaterJumpOperator, bReset)
         ucrReceiverElement2.SetRCode(clsQCDifferenceRCode.clsDiffOperator, bReset)
         ucrNudDifference.SetRCode(clsQCDifferenceRCode.clsLessDiffOperator, bReset)
@@ -408,7 +418,7 @@ Public Class dlgClimaticCheckDataTemperature
         End If
 
         If ucrChkRangeElement1.Checked Then
-            If ucrNudRangeElement1Min.GetText <> "" AndAlso ucrNudRangeElement1Max.GetText <> "" Then
+            If ucrInputRangeElement1Min.GetText <> "" AndAlso ucrInputRangeElement1Max.GetText <> "" Then
                 bEnable = True
             Else
                 ucrBase.OKEnabled(False)
@@ -416,7 +426,7 @@ Public Class dlgClimaticCheckDataTemperature
             End If
         End If
         If ucrChkRangeElement2.Checked Then
-            If ucrNudRangeElement2Min.GetText <> "" AndAlso ucrNudRangeElement2Max.GetText <> "" Then
+            If ucrInputRangeElement2Min.GetText <> "" AndAlso ucrInputRangeElement2Max.GetText <> "" Then
                 bEnable = True
             Else
                 ucrBase.OKEnabled(False)
@@ -471,10 +481,10 @@ Public Class dlgClimaticCheckDataTemperature
         If Not ucrReceiverStation.IsEmpty Then
             clsGroupByFunc.AddParameter("calculated_from", "list(" & strCurrDataFrame & "=" & ucrReceiverStation.GetVariableNames & ")", iPosition:=1)
             clsCalcFilterFunc.AddParameter("manipulations", clsRFunctionParameter:=clsGroupingListFunc, iPosition:=2)
-            clsFilterFunc.AddParameter("manipulations", clsRFunctionParameter:=clsGroupingListFunc, iPosition:=3)
+            'clsFilterFunc.AddParameter("manipulations", clsRFunctionParameter:=clsGroupingListFunc, iPosition:=3)
         Else
             clsCalcFilterFunc.RemoveParameterByName("manipulations")
-            clsFilterFunc.RemoveParameterByName("manipulations")
+            'clsFilterFunc.RemoveParameterByName("manipulations")
         End If
     End Sub
 
@@ -583,7 +593,7 @@ Public Class dlgClimaticCheckDataTemperature
 
         If Not ucrReceiverElement1.IsEmpty AndAlso Not ucrReceiverElement2.IsEmpty Then
             clsCalcFilterFunc.AddParameter("calculated_from", "list(" & strCurrDataFrame & "=" & ucrReceiverElement1.GetVariableNames & "," & strCurrDataFrame & "=" & ucrReceiverElement2.GetVariableNames & ")", iPosition:=2)
-            clsFilterFunc.AddParameter("calculated_from", "list(" & strCurrDataFrame & "=" & ucrReceiverElement1.GetVariableNames & "," & strCurrDataFrame & "=" & ucrReceiverElement2.GetVariableNames & ")", iPosition:=2)
+            'clsFilterFunc.AddParameter("calculated_from", "list(" & strCurrDataFrame & "=" & ucrReceiverElement1.GetVariableNames & "," & strCurrDataFrame & "=" & ucrReceiverElement2.GetVariableNames & ")", iPosition:=2)
             clsQCDifferenceRCode.clsDiffCalcFunction.AddParameter("calculated_from", "list(" & strCurrDataFrame & "=" & ucrReceiverElement1.GetVariableNames & "," & strCurrDataFrame & "=" & ucrReceiverElement2.GetVariableNames & ")", iPosition:=2)
             clsDiffOp.AddParameter("diff", strParameterValue:=clsQCDifferenceRCode.strTestName, bIncludeArgumentName:=False)
             clsJumpCodeElement1.clsJumpCalcFunction.AddParameter("calculated_from", "list(" & strCurrDataFrame & "=" & ucrReceiverElement1.GetVariableNames & "," & strCurrDataFrame & "=" & ucrReceiverElement2.GetVariableNames & ")", iPosition:=2)
@@ -594,7 +604,7 @@ Public Class dlgClimaticCheckDataTemperature
             clsQCAcceptableRangeElement2.clsAcceptableRangeTestFunc.AddParameter("calculated_from", "list(" & strCurrDataFrame & "=" & ucrReceiverElement1.GetVariableNames & "," & strCurrDataFrame & "=" & ucrReceiverElement2.GetVariableNames & ")", iPosition:=2)
         ElseIf Not ucrReceiverElement1.IsEmpty Then
             clsCalcFilterFunc.AddParameter("calculated_from", "list(" & strCurrDataFrame & "=" & ucrReceiverElement1.GetVariableNames & ")", iPosition:=2)
-            clsFilterFunc.AddParameter("calculated_from", "list(" & strCurrDataFrame & "=" & ucrReceiverElement1.GetVariableNames & ")", iPosition:=2)
+            'clsFilterFunc.AddParameter("calculated_from", "list(" & strCurrDataFrame & "=" & ucrReceiverElement1.GetVariableNames & ")", iPosition:=2)
             clsJumpCodeElement1.clsJumpCalcFunction.AddParameter("calculated_from", "list(" & strCurrDataFrame & "=" & ucrReceiverElement1.GetVariableNames & ")", iPosition:=2)
             clsJumpCodeElement2.clsJumpCalcFunction.AddParameter("calculated_from", "list(" & strCurrDataFrame & "=" & ucrReceiverElement1.GetVariableNames & ")", iPosition:=2)
             clsSameCodeElement1.clsSameCalcFunction.AddParameter("calculated_from", "list(" & strCurrDataFrame & "=" & ucrReceiverElement1.GetVariableNames & ")", iPosition:=2)
@@ -605,7 +615,7 @@ Public Class dlgClimaticCheckDataTemperature
             clsOutliersElement1.clsOutlierLowerLimitCalc.AddParameter("calculated_from", "list(" & strCurrDataFrame & "=" & ucrReceiverElement1.GetVariableNames & ")", iPosition:=2)
         ElseIf Not ucrReceiverElement2.IsEmpty Then
             clsCalcFilterFunc.AddParameter("calculated_from", "list(" & strCurrDataFrame & "=" & ucrReceiverElement2.GetVariableNames & ")", iPosition:=2)
-            clsFilterFunc.AddParameter("calculated_from", "list(" & strCurrDataFrame & "=" & ucrReceiverElement2.GetVariableNames & ")", iPosition:=2)
+            'clsFilterFunc.AddParameter("calculated_from", "list(" & strCurrDataFrame & "=" & ucrReceiverElement2.GetVariableNames & ")", iPosition:=2)
             clsJumpCodeElement1.clsJumpCalcFunction.AddParameter("calculated_from", "list(" & strCurrDataFrame & "=" & ucrReceiverElement2.GetVariableNames & ")", iPosition:=2)
             clsJumpCodeElement2.clsJumpCalcFunction.AddParameter("calculated_from", "list(" & strCurrDataFrame & "=" & ucrReceiverElement2.GetVariableNames & ")", iPosition:=2)
             clsSameCodeElement1.clsSameCalcFunction.AddParameter("calculated_from", "list(" & strCurrDataFrame & "=" & ucrReceiverElement2.GetVariableNames & ")", iPosition:=2)
@@ -647,7 +657,7 @@ Public Class dlgClimaticCheckDataTemperature
         EnableOrDisableDifferenceControls()
     End Sub
 
-    Private Sub CoreControls_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrReceiverElement1.ControlContentsChanged, ucrReceiverElement2.ControlContentsChanged, ucrNudSame.ControlContentsChanged, ucrNudRangeElement1Min.ControlContentsChanged, ucrNudRangeElement1Max.ControlContentsChanged, ucrNudRangeElement2Min.ControlContentsChanged, ucrNudRangeElement2Max.ControlContentsChanged, ucrNudJump.ControlContentsChanged, ucrNudRangeElement2Min.ControlContentsChanged, ucrNudRangeElement2Max.ControlContentsChanged, ucrNudDifference.ControlContentsChanged, ucrChkRangeElement1.ControlContentsChanged, ucrChkRangeElement2.ControlContentsChanged, ucrChkJump.ControlContentsChanged, ucrChkDifference.ControlContentsChanged, ucrChkSame.ControlContentsChanged, ucrChkOutlier.ControlContentsChanged
+    Private Sub CoreControls_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrReceiverElement1.ControlContentsChanged, ucrReceiverElement2.ControlContentsChanged, ucrNudSame.ControlContentsChanged, ucrNudJump.ControlContentsChanged, ucrInputRangeElement2Min.ControlContentsChanged, ucrInputRangeElement2Max.ControlContentsChanged, ucrNudDifference.ControlContentsChanged, ucrChkRangeElement1.ControlContentsChanged, ucrChkRangeElement2.ControlContentsChanged, ucrChkJump.ControlContentsChanged, ucrChkDifference.ControlContentsChanged, ucrChkSame.ControlContentsChanged, ucrChkOutlier.ControlContentsChanged
         TestOkEnabled()
     End Sub
 End Class

--- a/instat/dlgClimaticCheckDataTemperature.vb
+++ b/instat/dlgClimaticCheckDataTemperature.vb
@@ -158,16 +158,16 @@ Public Class dlgClimaticCheckDataTemperature
         'Nuds for the respective options
         'Range Option
         ucrInputRangeElement1Min.SetParameter(New RParameter("from", 1, bNewIncludeArgumentName:=False))
-        ucrInputRangeElement1Min.SetValidationTypeAsNumeric(dcmMin:=-35.0, bIncludeMin:=True, dcmMax:=65.0, bIncludeMax:=True)
+        ucrInputRangeElement1Min.SetValidationTypeAsNumeric(dcmMin:=-35.0, dcmMax:=65.0)
 
         ucrInputRangeElement1Max.SetParameter(New RParameter("To", 1, bNewIncludeArgumentName:=False))
-        ucrInputRangeElement1Max.SetValidationTypeAsNumeric(dcmMin:=-35.0, bIncludeMin:=True, dcmMax:=65.0, bIncludeMax:=True)
+        ucrInputRangeElement1Max.SetValidationTypeAsNumeric(dcmMin:=-35.0, dcmMax:=65.0)
 
         ucrInputRangeElement2Min.SetParameter(New RParameter("from", 1, bNewIncludeArgumentName:=False))
-        ucrInputRangeElement2Min.SetValidationTypeAsNumeric(dcmMin:=-50.0, bIncludeMin:=True, dcmMax:=40, bIncludeMax:=True)
+        ucrInputRangeElement2Min.SetValidationTypeAsNumeric(dcmMin:=-50.0, dcmMax:=40.0)
 
         ucrInputRangeElement2Max.SetParameter(New RParameter("To", 1, bNewIncludeArgumentName:=False))
-        ucrInputRangeElement2Max.SetValidationTypeAsNumeric(dcmMin:=-50.0, bIncludeMin:=True, dcmMax:=40, bIncludeMax:=True)
+        ucrInputRangeElement2Max.SetValidationTypeAsNumeric(dcmMin:=-50.0, dcmMax:=40.0)
 
         'Same Option
         ucrNudSame.SetParameter(New RParameter("n", 1, bNewIncludeArgumentName:=False))


### PR DESCRIPTION
Fixes #7025 
@rdstern @dannyparsons @shadrackkibet ,  this PR makes the following changes ;
- Changing the nud to textboxes in Acceptable Range
- produced column names to have standard name such as _e1 and _e2 (for element 1 and element 2)
- Removing QC column which was being created at the end
- Removing  "oC" label from Acceptable Range and Jump and Changing "Same" label to "Days:"

@N-thony  made the following changes in database #7243 
changing "to" to [box] To: [box] in Acceptable Range
Adding : to "Coef:" in Outlier.
