### PR TITLE
Fixed bug on the factor levels control being hidden in some dialogs

### DIFF
--- a/instat/dlgCalculateTreatmentDifferences.Designer.vb
+++ b/instat/dlgCalculateTreatmentDifferences.Designer.vb
@@ -82,25 +82,23 @@ Partial Class dlgCalculateTreatmentDifferences
         'ucrInputFactorOption2
         '
         Me.ucrInputFactorOption2.AddQuotesIfUnrecognised = True
-        Me.ucrInputFactorOption2.AutoSize = True
         Me.ucrInputFactorOption2.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.ucrInputFactorOption2.GetSetSelectedIndex = -1
         Me.ucrInputFactorOption2.IsReadOnly = False
         Me.ucrInputFactorOption2.Location = New System.Drawing.Point(272, 164)
         Me.ucrInputFactorOption2.Name = "ucrInputFactorOption2"
-        Me.ucrInputFactorOption2.Size = New System.Drawing.Size(0, 0)
+        Me.ucrInputFactorOption2.Size = New System.Drawing.Size(120, 24)
         Me.ucrInputFactorOption2.TabIndex = 24
         '
         'ucrInputFactorOption1
         '
         Me.ucrInputFactorOption1.AddQuotesIfUnrecognised = True
-        Me.ucrInputFactorOption1.AutoSize = True
         Me.ucrInputFactorOption1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.ucrInputFactorOption1.GetSetSelectedIndex = -1
         Me.ucrInputFactorOption1.IsReadOnly = False
         Me.ucrInputFactorOption1.Location = New System.Drawing.Point(272, 122)
         Me.ucrInputFactorOption1.Name = "ucrInputFactorOption1"
-        Me.ucrInputFactorOption1.Size = New System.Drawing.Size(0, 0)
+        Me.ucrInputFactorOption1.Size = New System.Drawing.Size(120, 24)
         Me.ucrInputFactorOption1.TabIndex = 22
         '
         'ucrReceiverID

--- a/instat/dlgClimaticDataEntry.Designer.vb
+++ b/instat/dlgClimaticDataEntry.Designer.vb
@@ -310,7 +310,7 @@ Partial Class dlgClimaticDataEntry
         Me.ucrBase.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.ucrBase.Location = New System.Drawing.Point(7, 466)
         Me.ucrBase.Name = "ucrBase"
-        Me.ucrBase.Size = New System.Drawing.Size(405, 52)
+        Me.ucrBase.Size = New System.Drawing.Size(401, 52)
         Me.ucrBase.TabIndex = 22
         '
         'ucrPnlOptions
@@ -352,13 +352,12 @@ Partial Class dlgClimaticDataEntry
         'ucrInputSelectStation
         '
         Me.ucrInputSelectStation.AddQuotesIfUnrecognised = True
-        Me.ucrInputSelectStation.AutoSize = True
         Me.ucrInputSelectStation.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.ucrInputSelectStation.GetSetSelectedIndex = -1
         Me.ucrInputSelectStation.IsReadOnly = False
         Me.ucrInputSelectStation.Location = New System.Drawing.Point(273, 127)
         Me.ucrInputSelectStation.Name = "ucrInputSelectStation"
-        Me.ucrInputSelectStation.Size = New System.Drawing.Size(0, 0)
+        Me.ucrInputSelectStation.Size = New System.Drawing.Size(120, 23)
         Me.ucrInputSelectStation.TabIndex = 91
         '
         'lblNbCommentEntered

--- a/instat/dlgCompareTreatmentLines.Designer.vb
+++ b/instat/dlgCompareTreatmentLines.Designer.vb
@@ -393,25 +393,23 @@ Partial Class dlgCompareTreatmentLines
         'ucrInputFactorOption2
         '
         Me.ucrInputFactorOption2.AddQuotesIfUnrecognised = True
-        Me.ucrInputFactorOption2.AutoSize = True
         Me.ucrInputFactorOption2.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.ucrInputFactorOption2.GetSetSelectedIndex = -1
         Me.ucrInputFactorOption2.IsReadOnly = False
-        Me.ucrInputFactorOption2.Location = New System.Drawing.Point(267, 219)
+        Me.ucrInputFactorOption2.Location = New System.Drawing.Point(267, 220)
         Me.ucrInputFactorOption2.Name = "ucrInputFactorOption2"
-        Me.ucrInputFactorOption2.Size = New System.Drawing.Size(0, 0)
+        Me.ucrInputFactorOption2.Size = New System.Drawing.Size(124, 23)
         Me.ucrInputFactorOption2.TabIndex = 11
         '
         'ucrInputFactorOption1
         '
         Me.ucrInputFactorOption1.AddQuotesIfUnrecognised = True
-        Me.ucrInputFactorOption1.AutoSize = True
         Me.ucrInputFactorOption1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.ucrInputFactorOption1.GetSetSelectedIndex = -1
         Me.ucrInputFactorOption1.IsReadOnly = False
-        Me.ucrInputFactorOption1.Location = New System.Drawing.Point(267, 177)
+        Me.ucrInputFactorOption1.Location = New System.Drawing.Point(267, 178)
         Me.ucrInputFactorOption1.Name = "ucrInputFactorOption1"
-        Me.ucrInputFactorOption1.Size = New System.Drawing.Size(0, 0)
+        Me.ucrInputFactorOption1.Size = New System.Drawing.Size(124, 22)
         Me.ucrInputFactorOption1.TabIndex = 9
         '
         'ucrReceiverID

--- a/instat/dlgSetupForDataEntry.Designer.vb
+++ b/instat/dlgSetupForDataEntry.Designer.vb
@@ -94,7 +94,7 @@ Partial Class dlgSetupForDataEntry
         '
         Me.lblStation.AutoSize = True
         Me.lblStation.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblStation.Location = New System.Drawing.Point(262, 55)
+        Me.lblStation.Location = New System.Drawing.Point(262, 56)
         Me.lblStation.Name = "lblStation"
         Me.lblStation.Size = New System.Drawing.Size(43, 13)
         Me.lblStation.TabIndex = 4
@@ -351,13 +351,12 @@ Partial Class dlgSetupForDataEntry
         'ucrInputSelectStation
         '
         Me.ucrInputSelectStation.AddQuotesIfUnrecognised = True
-        Me.ucrInputSelectStation.AutoSize = True
         Me.ucrInputSelectStation.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.ucrInputSelectStation.GetSetSelectedIndex = -1
         Me.ucrInputSelectStation.IsReadOnly = False
-        Me.ucrInputSelectStation.Location = New System.Drawing.Point(261, 112)
+        Me.ucrInputSelectStation.Location = New System.Drawing.Point(261, 111)
         Me.ucrInputSelectStation.Name = "ucrInputSelectStation"
-        Me.ucrInputSelectStation.Size = New System.Drawing.Size(0, 0)
+        Me.ucrInputSelectStation.Size = New System.Drawing.Size(120, 23)
         Me.ucrInputSelectStation.TabIndex = 5
         '
         'ucrReceiverStation

--- a/instat/ucrInputFactorLevels.Designer.vb
+++ b/instat/ucrInputFactorLevels.Designer.vb
@@ -28,9 +28,8 @@ Partial Class ucrInputFactorLevels
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
-        Me.AutoSize = True
         Me.Name = "ucrInputFactorLevels"
-        Me.Size = New System.Drawing.Size(0, 0)
+        Me.Size = New System.Drawing.Size(164, 21)
         Me.ResumeLayout(False)
 
     End Sub


### PR DESCRIPTION
Fixes #7269 
@rdstern  I had a quick discussion on this with @ChrisMarsh82 and then found that the problem was more general mainly under the following dialogues and ucrInputFacotrLevels itself:

- dlgCalculateTreatementDifferences
- dlgClimaticDataEntry
- dlgCalculateTreatementLines
- dlgSetupForDataEntry
- ucrInputFacotrLevels 
To fix this, we just set the `AutoSize property to False` and also adjusted the `Size` of ucrInputFacotrLevels and it corresponds to the above dialogues.

Please take a look. Thanks.