### PR TITLE
Added option in Column Selection dialog to copy column selection into a separate data frame

### DIFF
--- a/instat/dlgSelect.Designer.vb
+++ b/instat/dlgSelect.Designer.vb
@@ -45,11 +45,12 @@ Partial Class dlgSelect
         Me.lblSelection = New System.Windows.Forms.Label()
         Me.cmdDefineNewSelect = New System.Windows.Forms.Button()
         Me.lblFilterPreview = New System.Windows.Forms.Label()
+        Me.lblNewDataFrameName = New System.Windows.Forms.Label()
+        Me.ucrInputNewDataFrameName = New instat.ucrInputComboBox()
         Me.ucrInputSelectPreview = New instat.ucrInputTextBox()
         Me.ucrReceiverSelect = New instat.ucrReceiverSingle()
         Me.ucrSelectorForSelectColumns = New instat.ucrSelectorByDataFrameAddRemove()
         Me.ucrBase = New instat.ucrButtons()
-        Me.ucrNewDataFrameName = New instat.ucrSave()
         Me.grpApplyOptions.SuspendLayout()
         Me.SuspendLayout()
         '
@@ -75,7 +76,6 @@ Partial Class dlgSelect
         Me.rdoApplyAsSubset.TabStop = True
         Me.rdoApplyAsSubset.Text = "As Subset"
         Me.rdoApplyAsSubset.UseVisualStyleBackColor = True
-        Me.rdoApplyAsSubset.Visible = False
         '
         'rdoApplyAsSelect
         '
@@ -123,9 +123,29 @@ Partial Class dlgSelect
         Me.lblFilterPreview.Location = New System.Drawing.Point(11, 303)
         Me.lblFilterPreview.Name = "lblFilterPreview"
         Me.lblFilterPreview.Size = New System.Drawing.Size(143, 22)
-        Me.lblFilterPreview.TabIndex = 6
+        Me.lblFilterPreview.TabIndex = 7
         Me.lblFilterPreview.Text = "Selection Preview:"
         Me.lblFilterPreview.Visible = False
+        '
+        'lblNewDataFrameName
+        '
+        Me.lblNewDataFrameName.AutoSize = True
+        Me.lblNewDataFrameName.Location = New System.Drawing.Point(21, 266)
+        Me.lblNewDataFrameName.Name = "lblNewDataFrameName"
+        Me.lblNewDataFrameName.Size = New System.Drawing.Size(121, 13)
+        Me.lblNewDataFrameName.TabIndex = 5
+        Me.lblNewDataFrameName.Text = "New Data Frame Name:"
+        '
+        'ucrInputNewDataFrameName
+        '
+        Me.ucrInputNewDataFrameName.AddQuotesIfUnrecognised = True
+        Me.ucrInputNewDataFrameName.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrInputNewDataFrameName.GetSetSelectedIndex = -1
+        Me.ucrInputNewDataFrameName.IsReadOnly = False
+        Me.ucrInputNewDataFrameName.Location = New System.Drawing.Point(146, 261)
+        Me.ucrInputNewDataFrameName.Name = "ucrInputNewDataFrameName"
+        Me.ucrInputNewDataFrameName.Size = New System.Drawing.Size(137, 21)
+        Me.ucrInputNewDataFrameName.TabIndex = 6
         '
         'ucrInputSelectPreview
         '
@@ -136,7 +156,7 @@ Partial Class dlgSelect
         Me.ucrInputSelectPreview.Location = New System.Drawing.Point(160, 294)
         Me.ucrInputSelectPreview.Name = "ucrInputSelectPreview"
         Me.ucrInputSelectPreview.Size = New System.Drawing.Size(255, 43)
-        Me.ucrInputSelectPreview.TabIndex = 7
+        Me.ucrInputSelectPreview.TabIndex = 8
         Me.ucrInputSelectPreview.Visible = False
         '
         'ucrReceiverSelect
@@ -171,16 +191,7 @@ Partial Class dlgSelect
         Me.ucrBase.Location = New System.Drawing.Point(11, 343)
         Me.ucrBase.Name = "ucrBase"
         Me.ucrBase.Size = New System.Drawing.Size(405, 52)
-        Me.ucrBase.TabIndex = 8
-        '
-        'ucrNewDataFrameName
-        '
-        Me.ucrNewDataFrameName.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrNewDataFrameName.Location = New System.Drawing.Point(11, 267)
-        Me.ucrNewDataFrameName.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
-        Me.ucrNewDataFrameName.Name = "ucrNewDataFrameName"
-        Me.ucrNewDataFrameName.Size = New System.Drawing.Size(344, 24)
-        Me.ucrNewDataFrameName.TabIndex = 5
+        Me.ucrBase.TabIndex = 9
         '
         'dlgSelect
         '
@@ -188,6 +199,8 @@ Partial Class dlgSelect
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
         Me.AutoSize = True
         Me.ClientSize = New System.Drawing.Size(429, 401)
+        Me.Controls.Add(Me.ucrInputNewDataFrameName)
+        Me.Controls.Add(Me.lblNewDataFrameName)
         Me.Controls.Add(Me.lblFilterPreview)
         Me.Controls.Add(Me.grpApplyOptions)
         Me.Controls.Add(Me.ucrInputSelectPreview)
@@ -196,7 +209,6 @@ Partial Class dlgSelect
         Me.Controls.Add(Me.ucrSelectorForSelectColumns)
         Me.Controls.Add(Me.cmdDefineNewSelect)
         Me.Controls.Add(Me.ucrBase)
-        Me.Controls.Add(Me.ucrNewDataFrameName)
         Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow
         Me.MaximizeBox = False
         Me.MinimizeBox = False
@@ -218,7 +230,8 @@ Partial Class dlgSelect
     Friend WithEvents ucrSelectorForSelectColumns As ucrSelectorByDataFrameAddRemove
     Friend WithEvents cmdDefineNewSelect As Button
     Friend WithEvents ucrBase As ucrButtons
-    Friend WithEvents ucrNewDataFrameName As ucrSave
     Friend WithEvents lblFilterPreview As Label
     Friend WithEvents ucrPnlApplyOptions As UcrPanel
+    Friend WithEvents ucrInputNewDataFrameName As ucrInputComboBox
+    Friend WithEvents lblNewDataFrameName As Label
 End Class

--- a/instat/dlgSelect.vb
+++ b/instat/dlgSelect.vb
@@ -19,6 +19,8 @@ Public Class dlgSelect
     Private bFirstLoad As Boolean = True
     Private bReset As Boolean = True
     Private clsSetCurrentColumnSelection As RFunction
+    Private clsApplyAsSubset As New RFunction
+
     Private Sub dlgSelect_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         If bFirstLoad Then
             InitialiseDialog()
@@ -52,29 +54,36 @@ Public Class dlgSelect
 
         ucrPnlApplyOptions.AddRadioButton(rdoApplyAsSelect)
         ucrPnlApplyOptions.AddRadioButton(rdoApplyAsSubset)
-        rdoApplyAsSubset.Enabled = False
+        ucrPnlApplyOptions.AddFunctionNamesCondition(rdoApplyAsSelect, frmMain.clsRLink.strInstatDataObject & "$set_current_column_selection")
+        ucrPnlApplyOptions.AddFunctionNamesCondition(rdoApplyAsSubset, frmMain.clsRLink.strInstatDataObject & "$copy_data_object")
 
-        ucrPnlApplyOptions.AddToLinkedControls({ucrNewDataFrameName}, {rdoApplyAsSubset}, bNewLinkedHideIfParameterMissing:=True)
+        ucrInputNewDataFrameName.SetParameter(New RParameter("new_name", 1))
+        ucrInputNewDataFrameName.SetDataFrameSelector(ucrSelectorForSelectColumns.ucrAvailableDataFrames)
+        ucrInputNewDataFrameName.bAllowNonConditionValues = True
 
-        ucrNewDataFrameName.SetIsTextBox()
-        ucrNewDataFrameName.SetSaveTypeAsDataFrame()
-        ucrNewDataFrameName.SetDataFrameSelector(ucrSelectorForSelectColumns.ucrAvailableDataFrames)
-        ucrNewDataFrameName.SetLabelText("New Data Frame Name:")
+        ucrPnlApplyOptions.AddToLinkedControls({ucrInputNewDataFrameName}, {rdoApplyAsSubset}, bNewLinkedHideIfParameterMissing:=True)
+        ucrInputNewDataFrameName.SetLinkedDisplayControl(lblNewDataFrameName)
     End Sub
 
     Private Sub SetDefaults()
         clsSetCurrentColumnSelection = New RFunction
+        clsApplyAsSubset = New RFunction
         ucrSelectorForSelectColumns.Reset()
-        rdoApplyAsSelect.Checked = True
 
         clsSetCurrentColumnSelection.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$set_current_column_selection")
+
+        clsApplyAsSubset.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$copy_data_object")
+        clsApplyAsSubset.AddParameter("data_name", Chr(34) & ucrSelectorForSelectColumns.strCurrentDataFrame & Chr(34), iPosition:=0)
 
         ucrBase.clsRsyntax.SetBaseRFunction(clsSetCurrentColumnSelection)
     End Sub
 
     Private Sub SetRcodeForControls(bReset As Boolean)
+        ucrReceiverSelect.AddAdditionalCodeParameterPair(clsApplyAsSubset, New RParameter("column_selection_name", 2), iAdditionalPairNo:=1)
         ucrSelectorForSelectColumns.SetRCode(clsSetCurrentColumnSelection, bReset)
         ucrReceiverSelect.SetRCode(clsSetCurrentColumnSelection, bReset)
+        ucrInputNewDataFrameName.SetRCode(clsApplyAsSubset, bReset)
+        ucrPnlApplyOptions.SetRCode(ucrBase.clsRsyntax.clsBaseFunction, bReset)
     End Sub
 
     Private Sub TestOkEnabled()
@@ -97,6 +106,30 @@ Public Class dlgSelect
         dlgSelectColumns.SetDefaultDataFrame(ucrSelectorForSelectColumns.ucrAvailableDataFrames.strCurrDataFrame)
         dlgSelectColumns.ShowDialog()
         ucrSelectorForSelectColumns.LoadList()
+    End Sub
+
+    Private Sub ucrPnlApplyOptions_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrPnlApplyOptions.ControlValueChanged
+        If rdoApplyAsSelect.Checked Then
+            ucrBase.clsRsyntax.SetBaseRFunction(clsSetCurrentColumnSelection)
+        Else
+            ucrBase.clsRsyntax.SetBaseRFunction(clsApplyAsSubset)
+        End If
+    End Sub
+
+    Private Sub ucrSelectorForSelectColumns_DataFrameChanged() Handles ucrSelectorForSelectColumns.DataFrameChanged
+        If Not ucrSelectorForSelectColumns.IsEmpty() Then
+            clsApplyAsSubset.AddParameter("data_name", Chr(34) & ucrSelectorForSelectColumns.ucrAvailableDataFrames.cboAvailableDataFrames.Text & Chr(34), iPosition:=0)
+        Else
+            clsApplyAsSubset.RemoveParameterByName("data_name")
+        End If
+    End Sub
+
+    Private Sub ucrReceiverSelect_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverSelect.ControlValueChanged
+        If Not ucrReceiverSelect.IsEmpty Then
+            ucrInputNewDataFrameName.SetName(ucrReceiverSelect.GetVariableNames.Trim(Chr(34)))
+        Else
+            ucrInputNewDataFrameName.SetName("")
+        End If
     End Sub
 
     Private Sub ucrReceiverSelect_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrReceiverSelect.ControlContentsChanged

--- a/instat/dlgSelect.vb
+++ b/instat/dlgSelect.vb
@@ -87,7 +87,11 @@ Public Class dlgSelect
     End Sub
 
     Private Sub TestOkEnabled()
-        ucrBase.OKEnabled(Not ucrReceiverSelect.IsEmpty)
+        If rdoApplyAsSubset.Checked Then
+            ucrBase.OKEnabled(Not ucrInputNewDataFrameName.IsEmpty AndAlso Not ucrReceiverSelect.IsEmpty)
+        Else
+            ucrBase.OKEnabled(Not ucrReceiverSelect.IsEmpty)
+        End If
     End Sub
 
     Private Sub ucrBase_ClickReset(sender As Object, e As EventArgs) Handles ucrBase.ClickReset
@@ -132,7 +136,7 @@ Public Class dlgSelect
         End If
     End Sub
 
-    Private Sub ucrReceiverSelect_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrReceiverSelect.ControlContentsChanged
+    Private Sub ucrReceiverSelect_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrReceiverSelect.ControlContentsChanged, ucrInputNewDataFrameName.ControlContentsChanged, ucrPnlApplyOptions.ControlContentsChanged
         TestOkEnabled()
     End Sub
 End Class

--- a/instat/static/InstatObject/R/data_object_R6.R
+++ b/instat/static/InstatObject/R/data_object_R6.R
@@ -278,7 +278,7 @@ DataSheet$set("public", "set_metadata_changed", function(new_val) {
 }
 )
 
-DataSheet$set("public", "get_data_frame", function(convert_to_character = FALSE, include_hidden_columns = TRUE, use_current_filter = TRUE, use_column_selection = TRUE, filter_name = "", stack_data = FALSE, remove_attr = FALSE, retain_attr = FALSE, max_cols, max_rows, drop_unused_filter_levels = FALSE, start_row, start_col, ...) {
+DataSheet$set("public", "get_data_frame", function(convert_to_character = FALSE, include_hidden_columns = TRUE, use_current_filter = TRUE, use_column_selection = TRUE, filter_name = "", column_selection_name = "", stack_data = FALSE, remove_attr = FALSE, retain_attr = FALSE, max_cols, max_rows, drop_unused_filter_levels = FALSE, start_row, start_col, ...) {
   if(!stack_data) {
     if(!include_hidden_columns && self$is_variables_metadata(is_hidden_label)) {
       hidden <- self$get_variables_metadata(property = is_hidden_label)
@@ -304,6 +304,10 @@ DataSheet$set("public", "get_data_frame", function(convert_to_character = FALSE,
     }
     #TODO: consider removing include_hidden_columns argument from this function
     if(use_column_selection && self$column_selection_applied()) {
+      if(column_selection_name != "") {
+        selected_columns <- self$get_column_names()
+        out <- out[ ,selected_columns, drop = FALSE]
+      }else{
       old_metadata <- attributes(private$data)
       selected_columns <- self$get_column_names()
       out <- out[ ,selected_columns, drop = FALSE]
@@ -316,6 +320,7 @@ DataSheet$set("public", "get_data_frame", function(convert_to_character = FALSE,
       hidden_cols <- all_columns[!(all_columns %in% selected_columns)]
       self$append_to_variables_metadata(hidden_cols, is_hidden_label, TRUE)
       private$.variables_metadata_changed <- TRUE
+      }
     }
     if(!is.data.frame(out)) {
       out <- data.frame(out)

--- a/instat/static/InstatObject/R/data_object_R6.R
+++ b/instat/static/InstatObject/R/data_object_R6.R
@@ -302,12 +302,12 @@ DataSheet$set("public", "get_data_frame", function(convert_to_character = FALSE,
         out <- out[self$get_filter_as_logical(filter_name = filter_name), ]
       }
     }
+    if(column_selection_name != "") {
+      selected_columns <- self$get_column_selection_column_names(column_selection_name)
+      out <- out[ ,selected_columns, drop = FALSE]
+    }
     #TODO: consider removing include_hidden_columns argument from this function
     if(use_column_selection && self$column_selection_applied()) {
-      if(column_selection_name != "") {
-        selected_columns <- self$get_column_names()
-        out <- out[ ,selected_columns, drop = FALSE]
-      }else{
       old_metadata <- attributes(private$data)
       selected_columns <- self$get_column_names()
       out <- out[ ,selected_columns, drop = FALSE]
@@ -320,7 +320,6 @@ DataSheet$set("public", "get_data_frame", function(convert_to_character = FALSE,
       hidden_cols <- all_columns[!(all_columns %in% selected_columns)]
       self$append_to_variables_metadata(hidden_cols, is_hidden_label, TRUE)
       private$.variables_metadata_changed <- TRUE
-      }
     }
     if(!is.data.frame(out)) {
       out <- data.frame(out)

--- a/instat/static/InstatObject/R/instat_object_R6.R
+++ b/instat/static/InstatObject/R/instat_object_R6.R
@@ -132,12 +132,17 @@ DataBook$set("public", "set_data_objects", function(new_data_objects) {
 }
 )
 
-DataBook$set("public", "copy_data_object", function(data_name, new_name, filter_name = "", reset_row_names = TRUE) {
+DataBook$set("public", "copy_data_object", function(data_name, new_name, filter_name = "", column_selection_name = "", reset_row_names = TRUE) {
   new_obj <- self$get_data_objects(data_name)$data_clone()
   if(filter_name != "") {
     subset_data <- self$get_data_objects(data_name)$get_data_frame(use_current_filter = FALSE, filter_name = filter_name, retain_attr = TRUE)
     if(reset_row_names) rownames(subset_data) <- 1:nrow(subset_data)
     new_obj$remove_current_filter()
+    new_obj$set_data(subset_data)
+  }
+  if(column_selection_name != "") {
+    subset_data <- self$get_data_objects(data_name)$get_data_frame(use_current_filter = FALSE, filter_name = filter_name, column_selection_name = column_selection_name, use_column_selection = FALSE, retain_attr = TRUE)
+    new_obj$remove_current_column_selection()
     new_obj$set_data(subset_data)
   }
   self$append_data_object(new_name, new_obj)
@@ -328,17 +333,17 @@ DataBook$set("public", "get_data_objects", function(data_name, as_list = FALSE, 
 }
 )
 
-DataBook$set("public", "get_data_frame", function(data_name, convert_to_character = FALSE, stack_data = FALSE, include_hidden_columns = TRUE, use_current_filter = TRUE, use_column_selection = TRUE, filter_name = "", remove_attr = FALSE, retain_attr = FALSE, max_cols, max_rows, drop_unused_filter_levels = FALSE, start_row, start_col, ...) {
+DataBook$set("public", "get_data_frame", function(data_name, convert_to_character = FALSE, stack_data = FALSE, include_hidden_columns = TRUE, use_current_filter = TRUE, filter_name = "", use_column_selection = TRUE, column_selection_name = "", remove_attr = FALSE, retain_attr = FALSE, max_cols, max_rows, drop_unused_filter_levels = FALSE, start_row, start_col, ...) {
   if(!stack_data) {
     if(missing(data_name)) data_name <- self$get_data_names()
     if(length(data_name) > 1) {
       retlist <- list()
       for (curr_name in data_name) {
-        retlist[[curr_name]] = self$get_data_objects(curr_name)$get_data_frame(convert_to_character = convert_to_character, include_hidden_columns = include_hidden_columns, use_current_filter = use_current_filter, use_column_selection = use_column_selection, filter_name = filter_name, remove_attr = remove_attr, retain_attr = retain_attr, max_cols = max_cols, max_rows = max_rows, drop_unused_filter_levels = drop_unused_filter_levels, start_row = start_row, start_col = start_col)
+        retlist[[curr_name]] = self$get_data_objects(curr_name)$get_data_frame(convert_to_character = convert_to_character, include_hidden_columns = include_hidden_columns, use_current_filter = use_current_filter, use_column_selection = use_column_selection, filter_name = filter_name, column_selection_name = column_selection_name, remove_attr = remove_attr, retain_attr = retain_attr, max_cols = max_cols, max_rows = max_rows, drop_unused_filter_levels = drop_unused_filter_levels, start_row = start_row, start_col = start_col)
       }
       return(retlist)
     }
-    else return(self$get_data_objects(data_name)$get_data_frame(convert_to_character = convert_to_character, include_hidden_columns = include_hidden_columns, use_current_filter = use_current_filter, use_column_selection = use_column_selection, filter_name = filter_name, remove_attr = remove_attr, retain_attr = retain_attr, max_cols = max_cols, max_rows = max_rows, drop_unused_filter_levels = drop_unused_filter_levels, start_row = start_row, start_col = start_col))
+    else return(self$get_data_objects(data_name)$get_data_frame(convert_to_character = convert_to_character, include_hidden_columns = include_hidden_columns, use_current_filter = use_current_filter, use_column_selection = use_column_selection, filter_name = filter_name, column_selection_name = column_selection_name, remove_attr = remove_attr, retain_attr = retain_attr, max_cols = max_cols, max_rows = max_rows, drop_unused_filter_levels = drop_unused_filter_levels, start_row = start_row, start_col = start_col))
   }
   else {
     if(missing(data_name)) stop("data to be stacked is missing")


### PR DESCRIPTION
fixes #

This PR adds an option to copy column selection as a separate data frame.

![image](https://user-images.githubusercontent.com/26301973/157046192-a20b3ee8-cad0-4161-bda8-db579b9df41b.png)


@africanmathsinitiative/developers this is ready for review.