### PR TITLE
Added an option to include frequencies into the Prepare>Column: Factor> Factor Data Frame Dialogue

### DIFF
--- a/instat/dlgFactorDataFrame.Designer.vb
+++ b/instat/dlgFactorDataFrame.Designer.vb
@@ -46,6 +46,7 @@ Partial Class dlgFactorDataFrame
         Me.ucrBase = New instat.ucrButtons()
         Me.ucrReceiverFactorDataFrame = New instat.ucrReceiverSingle()
         Me.ucrSelectorFactorDataFrame = New instat.ucrSelectorByDataFrameAddRemove()
+        Me.ucrChkFrequencies = New instat.ucrCheck()
         Me.SuspendLayout()
         '
         'lblSelectedFactor
@@ -129,12 +130,22 @@ Partial Class dlgFactorDataFrame
         Me.ucrSelectorFactorDataFrame.Size = New System.Drawing.Size(213, 183)
         Me.ucrSelectorFactorDataFrame.TabIndex = 0
         '
+        'ucrChkFrequencies
+        '
+        Me.ucrChkFrequencies.AutoSize = True
+        Me.ucrChkFrequencies.Checked = False
+        Me.ucrChkFrequencies.Location = New System.Drawing.Point(238, 176)
+        Me.ucrChkFrequencies.Name = "ucrChkFrequencies"
+        Me.ucrChkFrequencies.Size = New System.Drawing.Size(165, 23)
+        Me.ucrChkFrequencies.TabIndex = 8
+        '
         'dlgFactorDataFrame
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
         Me.AutoSize = True
         Me.ClientSize = New System.Drawing.Size(428, 264)
+        Me.Controls.Add(Me.ucrChkFrequencies)
         Me.Controls.Add(Me.ucrChkAddCurrentContrasts)
         Me.Controls.Add(Me.ucrChkReplaceIfAlreadyExists)
         Me.Controls.Add(Me.ucrInputFactorNames)
@@ -162,4 +173,5 @@ Partial Class dlgFactorDataFrame
     Friend WithEvents ucrInputFactorNames As ucrInputTextBox
     Friend WithEvents ucrChkAddCurrentContrasts As ucrCheck
     Friend WithEvents ucrChkReplaceIfAlreadyExists As ucrCheck
+    Friend WithEvents ucrChkFrequencies As ucrCheck
 End Class

--- a/instat/dlgFactorDataFrame.vb
+++ b/instat/dlgFactorDataFrame.vb
@@ -18,6 +18,7 @@ Imports instat.Translations
 Public Class dlgFactorDataFrame
     Public bFirstLoad As Boolean = True
     Private bReset As Boolean = True
+    Private clsDefaultFunction As RFunction
 
     Private Sub ucrSelectorFactorDataFrame_Load(sender As Object, e As EventArgs) Handles ucrSelectorFactorDataFrame.Load
         If bFirstLoad Then
@@ -55,29 +56,31 @@ Public Class dlgFactorDataFrame
         ucrChkAddCurrentContrasts.SetText("Add Current Contrasts")
         ucrChkAddCurrentContrasts.SetParameter(New RParameter("include_contrasts", 3))
         ucrChkAddCurrentContrasts.SetValuesCheckedAndUnchecked("TRUE", "FALSE")
-        ucrChkAddCurrentContrasts.SetRDefault("TRUE")
+        ucrChkAddCurrentContrasts.SetRDefault("FALSE")
 
         ucrChkReplaceIfAlreadyExists.SetText("Replace if Already Exists")
         ucrChkReplaceIfAlreadyExists.SetParameter(New RParameter("replace", 4))
         ucrChkReplaceIfAlreadyExists.SetValuesCheckedAndUnchecked("TRUE", "FALSE")
-        ucrChkReplaceIfAlreadyExists.SetRDefault("TRUE")
+        ucrChkReplaceIfAlreadyExists.SetRDefault("FALSE")
+
+        ucrChkFrequencies.SetText("Frequencies")
+        ucrChkFrequencies.SetParameter(New RParameter("summary_count", 5))
+        ucrChkFrequencies.SetValuesCheckedAndUnchecked("TRUE", "FALSE")
+        ucrChkFrequencies.SetRDefault("TRUE")
     End Sub
 
     Private Sub SetDefaults()
-        Dim clsDefaultFunction As New RFunction
+        clsDefaultFunction = New RFunction
 
         ucrInputFactorNames.Reset()
         ucrSelectorFactorDataFrame.Reset()
         ucrInputFactorNames.ResetText()
 
         clsDefaultFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$create_factor_data_frame")
+        clsDefaultFunction.AddParameter("replace", "TRUE", iPosition:=4)
+        clsDefaultFunction.AddParameter("summary_count", "TRUE", iPosition:=5)
 
-        ucrBase.clsRsyntax.SetBaseRFunction(clsDefaultFunction.Clone())
-
-        CheckAutoName()
-    End Sub
-
-    Private Sub ReopenDialog()
+        ucrBase.clsRsyntax.SetBaseRFunction(clsDefaultFunction)
     End Sub
 
     Private Sub SetRCodeforControls(bReset As Boolean)
@@ -98,17 +101,13 @@ Public Class dlgFactorDataFrame
         TestOKEnabled()
     End Sub
 
-    Private Sub ucrInputFactorNames_ContentsChanged() Handles ucrInputFactorNames.ControlContentsChanged, ucrReceiverFactorDataFrame.ControlContentsChanged, ucrSelectorFactorDataFrame.ControlContentsChanged
-        TestOKEnabled()
-    End Sub
-
     Private Sub ucrDataFrameToRename_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverFactorDataFrame.ControlValueChanged
-        CheckAutoName()
-    End Sub
-
-    Private Sub CheckAutoName()
         If Not ucrReceiverFactorDataFrame.IsEmpty AndAlso Not ucrInputFactorNames.bUserTyped Then
             ucrInputFactorNames.SetName(ucrReceiverFactorDataFrame.GetVariableNames(False))
         End If
+    End Sub
+
+    Private Sub ucrInputFactorNames_ContentsChanged() Handles ucrInputFactorNames.ControlContentsChanged, ucrReceiverFactorDataFrame.ControlContentsChanged, ucrSelectorFactorDataFrame.ControlContentsChanged
+        TestOKEnabled()
     End Sub
 End Class

--- a/instat/dlgFactorDataFrame.vb
+++ b/instat/dlgFactorDataFrame.vb
@@ -88,7 +88,7 @@ Public Class dlgFactorDataFrame
     End Sub
 
     Private Sub TestOKEnabled()
-        If Not ucrReceiverFactorDataFrame.IsEmpty AndAlso Not ucrInputFactorNames.IsEmpty Then
+        If Not ucrReceiverFactorDataFrame.IsEmpty AndAlso Not ucrInputFactorNames.IsEmpty AndAlso (ucrChkAddCurrentContrasts.Checked OrElse ucrChkFrequencies.Checked) Then
             ucrBase.OKEnabled(True)
         Else
             ucrBase.OKEnabled(False)
@@ -107,7 +107,8 @@ Public Class dlgFactorDataFrame
         End If
     End Sub
 
-    Private Sub ucrInputFactorNames_ContentsChanged() Handles ucrInputFactorNames.ControlContentsChanged, ucrReceiverFactorDataFrame.ControlContentsChanged, ucrSelectorFactorDataFrame.ControlContentsChanged
+    Private Sub ucrInputFactorNames_ContentsChanged() Handles ucrInputFactorNames.ControlContentsChanged, ucrReceiverFactorDataFrame.ControlContentsChanged,
+        ucrSelectorFactorDataFrame.ControlContentsChanged, ucrChkFrequencies.ControlContentsChanged, ucrChkAddCurrentContrasts.ControlContentsChanged
         TestOKEnabled()
     End Sub
 End Class

--- a/instat/static/InstatObject/R/instat_object_R6.R
+++ b/instat/static/InstatObject/R/instat_object_R6.R
@@ -1401,7 +1401,6 @@ DataBook$set("public","create_factor_data_frame", function(data_name, factor, fa
   curr_data_obj <- self$get_data_objects(data_name)
   if(!factor %in% names(curr_data_obj$get_data_frame())) stop(factor, " not found in the data")
   if(!is.factor(curr_data_obj$get_columns_from_data(factor))) stop(factor, " is not a factor column.")
-  create <- TRUE
   if(self$link_exists_from(data_name, factor)) {
     message("Factor data frame already exists.")
     if(replace) {
@@ -1414,10 +1413,9 @@ DataBook$set("public","create_factor_data_frame", function(data_name, factor, fa
     }
     else {
       warning("replace = FALSE so no action will be taken.")
-      create <- FALSE
     }
   }
-  if(create) {
+
     data_frame_list <- list()
     if(missing(factor_data_frame_name)) factor_data_frame_name <- paste0(data_name, "_", factor)
     factor_data_frame_name <- make.names(factor_data_frame_name)
@@ -1440,7 +1438,6 @@ DataBook$set("public","create_factor_data_frame", function(data_name, factor, fa
     names(factor) <- factor
     self$add_link(from_data_frame = data_name, to_data_frame = factor_data_frame_name, link_pairs = factor, type = keyed_link_label)
   }
-}
 )
 
 DataBook$set("public","split_date", function(data_name, col_name = "", year_val = FALSE, year_name = FALSE, leap_year = FALSE,  month_val = FALSE, month_abbr = FALSE, month_name = FALSE, week_val = FALSE, week_abbr = FALSE, week_name = FALSE, weekday_val = FALSE, weekday_abbr = FALSE, weekday_name = FALSE,  day = FALSE, day_in_month = FALSE, day_in_year = FALSE, day_in_year_366 = FALSE, pentad_val = FALSE, pentad_abbr = FALSE, dekad_val = FALSE, dekad_abbr = FALSE, quarter_val = FALSE, quarter_abbr = FALSE, with_year = FALSE, s_start_month = 1, s_start_day_in_month = 1, days_in_month = FALSE) {

--- a/instat/static/InstatObject/R/instat_object_R6.R
+++ b/instat/static/InstatObject/R/instat_object_R6.R
@@ -1397,7 +1397,7 @@ DataBook$set("public","set_contrasts_of_factor", function(data_name, col_name, n
 }
 )
 
-DataBook$set("public","create_factor_data_frame", function(data_name, factor, factor_data_frame_name, include_contrasts = TRUE, replace = FALSE) {
+DataBook$set("public","create_factor_data_frame", function(data_name, factor, factor_data_frame_name, include_contrasts = FALSE, replace = FALSE, summary_count = TRUE) {
   curr_data_obj <- self$get_data_objects(data_name)
   if(!factor %in% names(curr_data_obj$get_data_frame())) stop(factor, " not found in the data")
   if(!is.factor(curr_data_obj$get_columns_from_data(factor))) stop(factor, " is not a factor column.")
@@ -1410,7 +1410,7 @@ DataBook$set("public","create_factor_data_frame", function(data_name, factor, fa
       names(factor_named) <- factor
       curr_factor_df_name <- self$get_linked_to_data_name(data_name, factor_named)
       # TODO what if there is more than 1?
-      if(length(curr_factor_df_name) > 0) self$delete_dataframe(curr_factor_df_name[1])
+      if(length(curr_factor_df_name) > 0) self$delete_dataframes(curr_factor_df_name[1])
     }
     else {
       warning("replace = FALSE so no action will be taken.")
@@ -1426,11 +1426,12 @@ DataBook$set("public","create_factor_data_frame", function(data_name, factor, fa
     factor_column <- curr_data_obj$get_columns_from_data(factor)
     factor_data_frame <- data.frame(levels(factor_column))
     names(factor_data_frame) <- factor
-    if(include_contrasts) {
-      factor_data_frame <- cbind(factor_data_frame, contrasts(factor_column))
-    }
+    if(include_contrasts) factor_data_frame <- cbind(factor_data_frame, contrasts(factor_column))
+    if(summary_count) factor_data_frame <- cbind(factor_data_frame, summary(factor_column))
+
     row.names(factor_data_frame) <- 1:nrow(factor_data_frame)
     names(factor_data_frame)[2:ncol(factor_data_frame)] <- paste0("C", 1:(ncol(factor_data_frame)-1))
+    if(summary_count) colnames(factor_data_frame)[ncol(factor_data_frame)] <- "Frequencies"
     data_frame_list[[factor_data_frame_name]] <- factor_data_frame
     self$import_data(data_frame_list)
     factor_data_obj <- self$get_data_objects(factor_data_frame_name)


### PR DESCRIPTION
This fixes #7229
Hello @rdstern and @shadrackkibet, The dialog now works. The replace checkbox is checked by default as well as the frequencies checkbox. 
When the Contrasts checkbox is unchecked, we have the levels and frequencies only, when checked we have the contrasts included. The same thing happens to the Frequencies checkbox, when its unchecked we don't have the frequencies in the output displayed.