### PR TITLE
Updating the correlations dialog to use the newer corrr package

### DIFF
--- a/instat/dlgCorrelation.designer.vb
+++ b/instat/dlgCorrelation.designer.vb
@@ -38,35 +38,42 @@ Partial Class dlgCorrelation
     'Do not modify it using the code editor.
     <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
+        Me.components = New System.ComponentModel.Container()
         Me.lblFirstColumn = New System.Windows.Forms.Label()
         Me.lblSecondColumn = New System.Windows.Forms.Label()
         Me.grpMethod = New System.Windows.Forms.GroupBox()
         Me.rdoKendall = New System.Windows.Forms.RadioButton()
         Me.rdoPearson = New System.Windows.Forms.RadioButton()
         Me.rdoSpearman = New System.Windows.Forms.RadioButton()
+        Me.ucrPnlMethod = New instat.UcrPanel()
         Me.cmdOptions = New System.Windows.Forms.Button()
         Me.grpMissing = New System.Windows.Forms.GroupBox()
         Me.rdoCompleteRowsOnly = New System.Windows.Forms.RadioButton()
         Me.rdoPairwise = New System.Windows.Forms.RadioButton()
+        Me.ucrPnlCompletePairwise = New instat.UcrPanel()
         Me.lblConfInterval = New System.Windows.Forms.Label()
         Me.rdoTwoColumns = New System.Windows.Forms.RadioButton()
         Me.rdoMultipleColumns = New System.Windows.Forms.RadioButton()
         Me.lblSelectedVariables = New System.Windows.Forms.Label()
         Me.lblDisplayOnDiagonal = New System.Windows.Forms.Label()
+        Me.lblDecimalPlaces = New System.Windows.Forms.Label()
+        Me.lblDisplayNas = New System.Windows.Forms.Label()
+        Me.ttDisplayOnDiagonal = New System.Windows.Forms.ToolTip(Me.components)
+        Me.ucrInputDisplayNas = New instat.ucrInputComboBox()
+        Me.ucrChkLeadingZeros = New instat.ucrCheck()
+        Me.ucrSaveDataFrame = New instat.ucrSave()
+        Me.ucrNudDecimalPlaces = New instat.ucrNud()
         Me.ucrNudConfidenceInterval = New instat.ucrNud()
         Me.ucrChkCorrelationMatrix = New instat.ucrCheck()
         Me.ucrPnlColumns = New instat.UcrPanel()
-        Me.ucrPnlMethod = New instat.UcrPanel()
         Me.ucrReceiverMultipleColumns = New instat.ucrReceiverMultiple()
-        Me.ucrPnlCompletePairwise = New instat.UcrPanel()
         Me.ucrReceiverSecondColumn = New instat.ucrReceiverSingle()
         Me.ucrReceiverFirstColumn = New instat.ucrReceiverSingle()
         Me.ucrSelectorCorrelation = New instat.ucrSelectorByDataFrameAddRemove()
         Me.ucrBase = New instat.ucrButtons()
         Me.ucrSaveModel = New instat.ucrSave()
         Me.ucrInputDiagonal = New instat.ucrInputTextBox()
-        Me.ucrNudDecimalPlaces = New instat.ucrNud()
-        Me.lblDecimalPlaces = New System.Windows.Forms.Label()
+        Me.ucrChkShave = New instat.ucrCheck()
         Me.grpMethod.SuspendLayout()
         Me.grpMissing.SuspendLayout()
         Me.SuspendLayout()
@@ -145,10 +152,18 @@ Partial Class dlgCorrelation
         Me.rdoSpearman.Text = "Spearman"
         Me.rdoSpearman.UseVisualStyleBackColor = True
         '
+        'ucrPnlMethod
+        '
+        Me.ucrPnlMethod.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrPnlMethod.Location = New System.Drawing.Point(8, 16)
+        Me.ucrPnlMethod.Name = "ucrPnlMethod"
+        Me.ucrPnlMethod.Size = New System.Drawing.Size(229, 24)
+        Me.ucrPnlMethod.TabIndex = 0
+        '
         'cmdOptions
         '
         Me.cmdOptions.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdOptions.Location = New System.Drawing.Point(299, 349)
+        Me.cmdOptions.Location = New System.Drawing.Point(299, 425)
         Me.cmdOptions.Name = "cmdOptions"
         Me.cmdOptions.Size = New System.Drawing.Size(114, 25)
         Me.cmdOptions.TabIndex = 16
@@ -195,11 +210,19 @@ Partial Class dlgCorrelation
         Me.rdoPairwise.Text = "Pairwise"
         Me.rdoPairwise.UseVisualStyleBackColor = True
         '
+        'ucrPnlCompletePairwise
+        '
+        Me.ucrPnlCompletePairwise.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrPnlCompletePairwise.Location = New System.Drawing.Point(6, 16)
+        Me.ucrPnlCompletePairwise.Name = "ucrPnlCompletePairwise"
+        Me.ucrPnlCompletePairwise.Size = New System.Drawing.Size(152, 49)
+        Me.ucrPnlCompletePairwise.TabIndex = 0
+        '
         'lblConfInterval
         '
         Me.lblConfInterval.AutoSize = True
         Me.lblConfInterval.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblConfInterval.Location = New System.Drawing.Point(15, 286)
+        Me.lblConfInterval.Location = New System.Drawing.Point(11, 286)
         Me.lblConfInterval.Name = "lblConfInterval"
         Me.lblConfInterval.Size = New System.Drawing.Size(102, 13)
         Me.lblConfInterval.TabIndex = 12
@@ -260,12 +283,74 @@ Partial Class dlgCorrelation
         Me.lblDisplayOnDiagonal.TabIndex = 19
         Me.lblDisplayOnDiagonal.Text = "Display On Diagonal:"
         '
+        'lblDecimalPlaces
+        '
+        Me.lblDecimalPlaces.AutoSize = True
+        Me.lblDecimalPlaces.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.lblDecimalPlaces.Location = New System.Drawing.Point(11, 335)
+        Me.lblDecimalPlaces.Name = "lblDecimalPlaces"
+        Me.lblDecimalPlaces.Size = New System.Drawing.Size(83, 13)
+        Me.lblDecimalPlaces.TabIndex = 21
+        Me.lblDecimalPlaces.Text = "Decimal Places:"
+        '
+        'lblDisplayNas
+        '
+        Me.lblDisplayNas.AutoSize = True
+        Me.lblDisplayNas.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.lblDisplayNas.Location = New System.Drawing.Point(11, 364)
+        Me.lblDisplayNas.Name = "lblDisplayNas"
+        Me.lblDisplayNas.Size = New System.Drawing.Size(67, 13)
+        Me.lblDisplayNas.TabIndex = 24
+        Me.lblDisplayNas.Text = "Display NAs:"
+        '
+        'ucrInputDisplayNas
+        '
+        Me.ucrInputDisplayNas.AddQuotesIfUnrecognised = True
+        Me.ucrInputDisplayNas.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrInputDisplayNas.GetSetSelectedIndex = -1
+        Me.ucrInputDisplayNas.IsReadOnly = False
+        Me.ucrInputDisplayNas.Location = New System.Drawing.Point(129, 360)
+        Me.ucrInputDisplayNas.Name = "ucrInputDisplayNas"
+        Me.ucrInputDisplayNas.Size = New System.Drawing.Size(105, 21)
+        Me.ucrInputDisplayNas.TabIndex = 25
+        '
+        'ucrChkLeadingZeros
+        '
+        Me.ucrChkLeadingZeros.AutoSize = True
+        Me.ucrChkLeadingZeros.Checked = False
+        Me.ucrChkLeadingZeros.Location = New System.Drawing.Point(14, 386)
+        Me.ucrChkLeadingZeros.Name = "ucrChkLeadingZeros"
+        Me.ucrChkLeadingZeros.Size = New System.Drawing.Size(283, 23)
+        Me.ucrChkLeadingZeros.TabIndex = 23
+        '
+        'ucrSaveDataFrame
+        '
+        Me.ucrSaveDataFrame.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrSaveDataFrame.Location = New System.Drawing.Point(14, 430)
+        Me.ucrSaveDataFrame.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
+        Me.ucrSaveDataFrame.Name = "ucrSaveDataFrame"
+        Me.ucrSaveDataFrame.Size = New System.Drawing.Size(266, 24)
+        Me.ucrSaveDataFrame.TabIndex = 22
+        '
+        'ucrNudDecimalPlaces
+        '
+        Me.ucrNudDecimalPlaces.AutoSize = True
+        Me.ucrNudDecimalPlaces.DecimalPlaces = New Decimal(New Integer() {0, 0, 0, 0})
+        Me.ucrNudDecimalPlaces.Increment = New Decimal(New Integer() {1, 0, 0, 0})
+        Me.ucrNudDecimalPlaces.Location = New System.Drawing.Point(129, 330)
+        Me.ucrNudDecimalPlaces.Maximum = New Decimal(New Integer() {100, 0, 0, 0})
+        Me.ucrNudDecimalPlaces.Minimum = New Decimal(New Integer() {0, 0, 0, 0})
+        Me.ucrNudDecimalPlaces.Name = "ucrNudDecimalPlaces"
+        Me.ucrNudDecimalPlaces.Size = New System.Drawing.Size(50, 20)
+        Me.ucrNudDecimalPlaces.TabIndex = 20
+        Me.ucrNudDecimalPlaces.Value = New Decimal(New Integer() {0, 0, 0, 0})
+        '
         'ucrNudConfidenceInterval
         '
         Me.ucrNudConfidenceInterval.AutoSize = True
         Me.ucrNudConfidenceInterval.DecimalPlaces = New Decimal(New Integer() {0, 0, 0, 0})
         Me.ucrNudConfidenceInterval.Increment = New Decimal(New Integer() {1, 0, 0, 0})
-        Me.ucrNudConfidenceInterval.Location = New System.Drawing.Point(130, 283)
+        Me.ucrNudConfidenceInterval.Location = New System.Drawing.Point(129, 283)
         Me.ucrNudConfidenceInterval.Maximum = New Decimal(New Integer() {100, 0, 0, 0})
         Me.ucrNudConfidenceInterval.Minimum = New Decimal(New Integer() {0, 0, 0, 0})
         Me.ucrNudConfidenceInterval.Name = "ucrNudConfidenceInterval"
@@ -290,14 +375,6 @@ Partial Class dlgCorrelation
         Me.ucrPnlColumns.Size = New System.Drawing.Size(284, 36)
         Me.ucrPnlColumns.TabIndex = 0
         '
-        'ucrPnlMethod
-        '
-        Me.ucrPnlMethod.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrPnlMethod.Location = New System.Drawing.Point(8, 16)
-        Me.ucrPnlMethod.Name = "ucrPnlMethod"
-        Me.ucrPnlMethod.Size = New System.Drawing.Size(229, 24)
-        Me.ucrPnlMethod.TabIndex = 0
-        '
         'ucrReceiverMultipleColumns
         '
         Me.ucrReceiverMultipleColumns.AutoSize = True
@@ -310,14 +387,6 @@ Partial Class dlgCorrelation
         Me.ucrReceiverMultipleColumns.strNcFilePath = ""
         Me.ucrReceiverMultipleColumns.TabIndex = 7
         Me.ucrReceiverMultipleColumns.ucrSelector = Nothing
-        '
-        'ucrPnlCompletePairwise
-        '
-        Me.ucrPnlCompletePairwise.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrPnlCompletePairwise.Location = New System.Drawing.Point(6, 16)
-        Me.ucrPnlCompletePairwise.Name = "ucrPnlCompletePairwise"
-        Me.ucrPnlCompletePairwise.Size = New System.Drawing.Size(152, 49)
-        Me.ucrPnlCompletePairwise.TabIndex = 0
         '
         'ucrReceiverSecondColumn
         '
@@ -361,7 +430,7 @@ Partial Class dlgCorrelation
         '
         Me.ucrBase.AutoSize = True
         Me.ucrBase.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrBase.Location = New System.Drawing.Point(14, 378)
+        Me.ucrBase.Location = New System.Drawing.Point(14, 451)
         Me.ucrBase.Name = "ucrBase"
         Me.ucrBase.Size = New System.Drawing.Size(405, 52)
         Me.ucrBase.TabIndex = 17
@@ -369,7 +438,7 @@ Partial Class dlgCorrelation
         'ucrSaveModel
         '
         Me.ucrSaveModel.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrSaveModel.Location = New System.Drawing.Point(14, 351)
+        Me.ucrSaveModel.Location = New System.Drawing.Point(14, 428)
         Me.ucrSaveModel.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
         Me.ucrSaveModel.Name = "ucrSaveModel"
         Me.ucrSaveModel.Size = New System.Drawing.Size(266, 24)
@@ -386,35 +455,26 @@ Partial Class dlgCorrelation
         Me.ucrInputDiagonal.Size = New System.Drawing.Size(52, 21)
         Me.ucrInputDiagonal.TabIndex = 18
         '
-        'ucrNudDecimalPlaces
+        'ucrChkShave
         '
-        Me.ucrNudDecimalPlaces.AutoSize = True
-        Me.ucrNudDecimalPlaces.DecimalPlaces = New Decimal(New Integer() {0, 0, 0, 0})
-        Me.ucrNudDecimalPlaces.Increment = New Decimal(New Integer() {1, 0, 0, 0})
-        Me.ucrNudDecimalPlaces.Location = New System.Drawing.Point(123, 329)
-        Me.ucrNudDecimalPlaces.Maximum = New Decimal(New Integer() {100, 0, 0, 0})
-        Me.ucrNudDecimalPlaces.Minimum = New Decimal(New Integer() {0, 0, 0, 0})
-        Me.ucrNudDecimalPlaces.Name = "ucrNudDecimalPlaces"
-        Me.ucrNudDecimalPlaces.Size = New System.Drawing.Size(50, 20)
-        Me.ucrNudDecimalPlaces.TabIndex = 20
-        Me.ucrNudDecimalPlaces.Value = New Decimal(New Integer() {0, 0, 0, 0})
-        '
-        'lblDecimalPlaces
-        '
-        Me.lblDecimalPlaces.AutoSize = True
-        Me.lblDecimalPlaces.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblDecimalPlaces.Location = New System.Drawing.Point(13, 333)
-        Me.lblDecimalPlaces.Name = "lblDecimalPlaces"
-        Me.lblDecimalPlaces.Size = New System.Drawing.Size(83, 13)
-        Me.lblDecimalPlaces.TabIndex = 21
-        Me.lblDecimalPlaces.Text = "Decimal Places:"
+        Me.ucrChkShave.AutoSize = True
+        Me.ucrChkShave.Checked = False
+        Me.ucrChkShave.Location = New System.Drawing.Point(15, 408)
+        Me.ucrChkShave.Name = "ucrChkShave"
+        Me.ucrChkShave.Size = New System.Drawing.Size(231, 23)
+        Me.ucrChkShave.TabIndex = 26
         '
         'dlgCorrelation
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
         Me.AutoSize = True
-        Me.ClientSize = New System.Drawing.Size(436, 442)
+        Me.ClientSize = New System.Drawing.Size(436, 505)
+        Me.Controls.Add(Me.ucrChkShave)
+        Me.Controls.Add(Me.ucrInputDisplayNas)
+        Me.Controls.Add(Me.lblDisplayNas)
+        Me.Controls.Add(Me.ucrChkLeadingZeros)
+        Me.Controls.Add(Me.ucrSaveDataFrame)
         Me.Controls.Add(Me.lblDecimalPlaces)
         Me.Controls.Add(Me.ucrNudDecimalPlaces)
         Me.Controls.Add(Me.lblSelectedVariables)
@@ -481,4 +541,10 @@ Partial Class dlgCorrelation
     Friend WithEvents ucrInputDiagonal As ucrInputTextBox
     Friend WithEvents lblDecimalPlaces As Label
     Friend WithEvents ucrNudDecimalPlaces As ucrNud
+    Friend WithEvents ucrSaveDataFrame As ucrSave
+    Friend WithEvents ucrChkLeadingZeros As ucrCheck
+    Friend WithEvents ucrInputDisplayNas As ucrInputComboBox
+    Friend WithEvents lblDisplayNas As Label
+    Friend WithEvents ttDisplayOnDiagonal As ToolTip
+    Friend WithEvents ucrChkShave As ucrCheck
 End Class

--- a/instat/dlgCorrelation.designer.vb
+++ b/instat/dlgCorrelation.designer.vb
@@ -44,25 +44,29 @@ Partial Class dlgCorrelation
         Me.rdoKendall = New System.Windows.Forms.RadioButton()
         Me.rdoPearson = New System.Windows.Forms.RadioButton()
         Me.rdoSpearman = New System.Windows.Forms.RadioButton()
-        Me.ucrPnlMethod = New instat.UcrPanel()
         Me.cmdOptions = New System.Windows.Forms.Button()
         Me.grpMissing = New System.Windows.Forms.GroupBox()
         Me.rdoCompleteRowsOnly = New System.Windows.Forms.RadioButton()
         Me.rdoPairwise = New System.Windows.Forms.RadioButton()
-        Me.ucrPnlCompletePairwise = New instat.UcrPanel()
         Me.lblConfInterval = New System.Windows.Forms.Label()
         Me.rdoTwoColumns = New System.Windows.Forms.RadioButton()
         Me.rdoMultipleColumns = New System.Windows.Forms.RadioButton()
         Me.lblSelectedVariables = New System.Windows.Forms.Label()
-        Me.ucrSaveModel = New instat.ucrSave()
+        Me.lblDisplayOnDiagonal = New System.Windows.Forms.Label()
         Me.ucrNudConfidenceInterval = New instat.ucrNud()
         Me.ucrChkCorrelationMatrix = New instat.ucrCheck()
         Me.ucrPnlColumns = New instat.UcrPanel()
+        Me.ucrPnlMethod = New instat.UcrPanel()
         Me.ucrReceiverMultipleColumns = New instat.ucrReceiverMultiple()
+        Me.ucrPnlCompletePairwise = New instat.UcrPanel()
         Me.ucrReceiverSecondColumn = New instat.ucrReceiverSingle()
         Me.ucrReceiverFirstColumn = New instat.ucrReceiverSingle()
         Me.ucrSelectorCorrelation = New instat.ucrSelectorByDataFrameAddRemove()
         Me.ucrBase = New instat.ucrButtons()
+        Me.ucrSaveModel = New instat.ucrSave()
+        Me.ucrInputDiagonal = New instat.ucrInputTextBox()
+        Me.ucrNudDecimalPlaces = New instat.ucrNud()
+        Me.lblDecimalPlaces = New System.Windows.Forms.Label()
         Me.grpMethod.SuspendLayout()
         Me.grpMissing.SuspendLayout()
         Me.SuspendLayout()
@@ -141,18 +145,10 @@ Partial Class dlgCorrelation
         Me.rdoSpearman.Text = "Spearman"
         Me.rdoSpearman.UseVisualStyleBackColor = True
         '
-        'ucrPnlMethod
-        '
-        Me.ucrPnlMethod.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrPnlMethod.Location = New System.Drawing.Point(8, 16)
-        Me.ucrPnlMethod.Name = "ucrPnlMethod"
-        Me.ucrPnlMethod.Size = New System.Drawing.Size(229, 24)
-        Me.ucrPnlMethod.TabIndex = 0
-        '
         'cmdOptions
         '
         Me.cmdOptions.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdOptions.Location = New System.Drawing.Point(299, 334)
+        Me.cmdOptions.Location = New System.Drawing.Point(299, 349)
         Me.cmdOptions.Name = "cmdOptions"
         Me.cmdOptions.Size = New System.Drawing.Size(114, 25)
         Me.cmdOptions.TabIndex = 16
@@ -198,14 +194,6 @@ Partial Class dlgCorrelation
         Me.rdoPairwise.Tag = "Pairwise"
         Me.rdoPairwise.Text = "Pairwise"
         Me.rdoPairwise.UseVisualStyleBackColor = True
-        '
-        'ucrPnlCompletePairwise
-        '
-        Me.ucrPnlCompletePairwise.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrPnlCompletePairwise.Location = New System.Drawing.Point(6, 16)
-        Me.ucrPnlCompletePairwise.Name = "ucrPnlCompletePairwise"
-        Me.ucrPnlCompletePairwise.Size = New System.Drawing.Size(152, 49)
-        Me.ucrPnlCompletePairwise.TabIndex = 0
         '
         'lblConfInterval
         '
@@ -262,14 +250,15 @@ Partial Class dlgCorrelation
         Me.lblSelectedVariables.Tag = ""
         Me.lblSelectedVariables.Text = "Variables:"
         '
-        'ucrSaveModel
+        'lblDisplayOnDiagonal
         '
-        Me.ucrSaveModel.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrSaveModel.Location = New System.Drawing.Point(14, 335)
-        Me.ucrSaveModel.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
-        Me.ucrSaveModel.Name = "ucrSaveModel"
-        Me.ucrSaveModel.Size = New System.Drawing.Size(266, 24)
-        Me.ucrSaveModel.TabIndex = 15
+        Me.lblDisplayOnDiagonal.AutoSize = True
+        Me.lblDisplayOnDiagonal.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.lblDisplayOnDiagonal.Location = New System.Drawing.Point(13, 286)
+        Me.lblDisplayOnDiagonal.Name = "lblDisplayOnDiagonal"
+        Me.lblDisplayOnDiagonal.Size = New System.Drawing.Size(106, 13)
+        Me.lblDisplayOnDiagonal.TabIndex = 19
+        Me.lblDisplayOnDiagonal.Text = "Display On Diagonal:"
         '
         'ucrNudConfidenceInterval
         '
@@ -301,6 +290,14 @@ Partial Class dlgCorrelation
         Me.ucrPnlColumns.Size = New System.Drawing.Size(284, 36)
         Me.ucrPnlColumns.TabIndex = 0
         '
+        'ucrPnlMethod
+        '
+        Me.ucrPnlMethod.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrPnlMethod.Location = New System.Drawing.Point(8, 16)
+        Me.ucrPnlMethod.Name = "ucrPnlMethod"
+        Me.ucrPnlMethod.Size = New System.Drawing.Size(229, 24)
+        Me.ucrPnlMethod.TabIndex = 0
+        '
         'ucrReceiverMultipleColumns
         '
         Me.ucrReceiverMultipleColumns.AutoSize = True
@@ -313,6 +310,14 @@ Partial Class dlgCorrelation
         Me.ucrReceiverMultipleColumns.strNcFilePath = ""
         Me.ucrReceiverMultipleColumns.TabIndex = 7
         Me.ucrReceiverMultipleColumns.ucrSelector = Nothing
+        '
+        'ucrPnlCompletePairwise
+        '
+        Me.ucrPnlCompletePairwise.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrPnlCompletePairwise.Location = New System.Drawing.Point(6, 16)
+        Me.ucrPnlCompletePairwise.Name = "ucrPnlCompletePairwise"
+        Me.ucrPnlCompletePairwise.Size = New System.Drawing.Size(152, 49)
+        Me.ucrPnlCompletePairwise.TabIndex = 0
         '
         'ucrReceiverSecondColumn
         '
@@ -356,17 +361,62 @@ Partial Class dlgCorrelation
         '
         Me.ucrBase.AutoSize = True
         Me.ucrBase.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrBase.Location = New System.Drawing.Point(14, 361)
+        Me.ucrBase.Location = New System.Drawing.Point(14, 378)
         Me.ucrBase.Name = "ucrBase"
         Me.ucrBase.Size = New System.Drawing.Size(405, 52)
         Me.ucrBase.TabIndex = 17
+        '
+        'ucrSaveModel
+        '
+        Me.ucrSaveModel.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrSaveModel.Location = New System.Drawing.Point(14, 351)
+        Me.ucrSaveModel.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
+        Me.ucrSaveModel.Name = "ucrSaveModel"
+        Me.ucrSaveModel.Size = New System.Drawing.Size(266, 24)
+        Me.ucrSaveModel.TabIndex = 15
+        '
+        'ucrInputDiagonal
+        '
+        Me.ucrInputDiagonal.AddQuotesIfUnrecognised = True
+        Me.ucrInputDiagonal.AutoSize = True
+        Me.ucrInputDiagonal.IsMultiline = False
+        Me.ucrInputDiagonal.IsReadOnly = False
+        Me.ucrInputDiagonal.Location = New System.Drawing.Point(128, 282)
+        Me.ucrInputDiagonal.Name = "ucrInputDiagonal"
+        Me.ucrInputDiagonal.Size = New System.Drawing.Size(52, 21)
+        Me.ucrInputDiagonal.TabIndex = 18
+        '
+        'ucrNudDecimalPlaces
+        '
+        Me.ucrNudDecimalPlaces.AutoSize = True
+        Me.ucrNudDecimalPlaces.DecimalPlaces = New Decimal(New Integer() {0, 0, 0, 0})
+        Me.ucrNudDecimalPlaces.Increment = New Decimal(New Integer() {1, 0, 0, 0})
+        Me.ucrNudDecimalPlaces.Location = New System.Drawing.Point(123, 329)
+        Me.ucrNudDecimalPlaces.Maximum = New Decimal(New Integer() {100, 0, 0, 0})
+        Me.ucrNudDecimalPlaces.Minimum = New Decimal(New Integer() {0, 0, 0, 0})
+        Me.ucrNudDecimalPlaces.Name = "ucrNudDecimalPlaces"
+        Me.ucrNudDecimalPlaces.Size = New System.Drawing.Size(50, 20)
+        Me.ucrNudDecimalPlaces.TabIndex = 20
+        Me.ucrNudDecimalPlaces.Value = New Decimal(New Integer() {0, 0, 0, 0})
+        '
+        'lblDecimalPlaces
+        '
+        Me.lblDecimalPlaces.AutoSize = True
+        Me.lblDecimalPlaces.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.lblDecimalPlaces.Location = New System.Drawing.Point(13, 333)
+        Me.lblDecimalPlaces.Name = "lblDecimalPlaces"
+        Me.lblDecimalPlaces.Size = New System.Drawing.Size(83, 13)
+        Me.lblDecimalPlaces.TabIndex = 21
+        Me.lblDecimalPlaces.Text = "Decimal Places:"
         '
         'dlgCorrelation
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
         Me.AutoSize = True
-        Me.ClientSize = New System.Drawing.Size(436, 416)
+        Me.ClientSize = New System.Drawing.Size(436, 442)
+        Me.Controls.Add(Me.lblDecimalPlaces)
+        Me.Controls.Add(Me.ucrNudDecimalPlaces)
         Me.Controls.Add(Me.lblSelectedVariables)
         Me.Controls.Add(Me.ucrNudConfidenceInterval)
         Me.Controls.Add(Me.ucrChkCorrelationMatrix)
@@ -385,6 +435,8 @@ Partial Class dlgCorrelation
         Me.Controls.Add(Me.ucrSelectorCorrelation)
         Me.Controls.Add(Me.ucrBase)
         Me.Controls.Add(Me.ucrSaveModel)
+        Me.Controls.Add(Me.lblDisplayOnDiagonal)
+        Me.Controls.Add(Me.ucrInputDiagonal)
         Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow
         Me.MaximizeBox = False
         Me.MinimizeBox = False
@@ -425,4 +477,8 @@ Partial Class dlgCorrelation
     Friend WithEvents ucrNudConfidenceInterval As ucrNud
     Friend WithEvents ucrSaveModel As ucrSave
     Friend WithEvents lblSelectedVariables As Label
+    Friend WithEvents lblDisplayOnDiagonal As Label
+    Friend WithEvents ucrInputDiagonal As ucrInputTextBox
+    Friend WithEvents lblDecimalPlaces As Label
+    Friend WithEvents ucrNudDecimalPlaces As ucrNud
 End Class

--- a/instat/dlgCorrelation.designer.vb
+++ b/instat/dlgCorrelation.designer.vb
@@ -38,7 +38,6 @@ Partial Class dlgCorrelation
     'Do not modify it using the code editor.
     <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
-        Me.components = New System.ComponentModel.Container()
         Me.lblFirstColumn = New System.Windows.Forms.Label()
         Me.lblSecondColumn = New System.Windows.Forms.Label()
         Me.grpMethod = New System.Windows.Forms.GroupBox()
@@ -58,7 +57,7 @@ Partial Class dlgCorrelation
         Me.lblDisplayOnDiagonal = New System.Windows.Forms.Label()
         Me.lblDecimalPlaces = New System.Windows.Forms.Label()
         Me.lblDisplayNas = New System.Windows.Forms.Label()
-        Me.ttDisplayOnDiagonal = New System.Windows.Forms.ToolTip(Me.components)
+        Me.ucrChkShave = New instat.ucrCheck()
         Me.ucrInputDisplayNas = New instat.ucrInputComboBox()
         Me.ucrChkLeadingZeros = New instat.ucrCheck()
         Me.ucrSaveDataFrame = New instat.ucrSave()
@@ -72,8 +71,7 @@ Partial Class dlgCorrelation
         Me.ucrSelectorCorrelation = New instat.ucrSelectorByDataFrameAddRemove()
         Me.ucrBase = New instat.ucrButtons()
         Me.ucrSaveModel = New instat.ucrSave()
-        Me.ucrInputDiagonal = New instat.ucrInputTextBox()
-        Me.ucrChkShave = New instat.ucrCheck()
+        Me.ucrInputDiagonal = New instat.ucrInputComboBox()
         Me.grpMethod.SuspendLayout()
         Me.grpMissing.SuspendLayout()
         Me.SuspendLayout()
@@ -163,7 +161,7 @@ Partial Class dlgCorrelation
         'cmdOptions
         '
         Me.cmdOptions.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdOptions.Location = New System.Drawing.Point(299, 425)
+        Me.cmdOptions.Location = New System.Drawing.Point(299, 451)
         Me.cmdOptions.Name = "cmdOptions"
         Me.cmdOptions.Size = New System.Drawing.Size(114, 25)
         Me.cmdOptions.TabIndex = 16
@@ -222,7 +220,7 @@ Partial Class dlgCorrelation
         '
         Me.lblConfInterval.AutoSize = True
         Me.lblConfInterval.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblConfInterval.Location = New System.Drawing.Point(11, 286)
+        Me.lblConfInterval.Location = New System.Drawing.Point(11, 313)
         Me.lblConfInterval.Name = "lblConfInterval"
         Me.lblConfInterval.Size = New System.Drawing.Size(102, 13)
         Me.lblConfInterval.TabIndex = 12
@@ -277,7 +275,7 @@ Partial Class dlgCorrelation
         '
         Me.lblDisplayOnDiagonal.AutoSize = True
         Me.lblDisplayOnDiagonal.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblDisplayOnDiagonal.Location = New System.Drawing.Point(13, 286)
+        Me.lblDisplayOnDiagonal.Location = New System.Drawing.Point(11, 314)
         Me.lblDisplayOnDiagonal.Name = "lblDisplayOnDiagonal"
         Me.lblDisplayOnDiagonal.Size = New System.Drawing.Size(106, 13)
         Me.lblDisplayOnDiagonal.TabIndex = 19
@@ -287,7 +285,7 @@ Partial Class dlgCorrelation
         '
         Me.lblDecimalPlaces.AutoSize = True
         Me.lblDecimalPlaces.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblDecimalPlaces.Location = New System.Drawing.Point(11, 335)
+        Me.lblDecimalPlaces.Location = New System.Drawing.Point(11, 348)
         Me.lblDecimalPlaces.Name = "lblDecimalPlaces"
         Me.lblDecimalPlaces.Size = New System.Drawing.Size(83, 13)
         Me.lblDecimalPlaces.TabIndex = 21
@@ -297,11 +295,20 @@ Partial Class dlgCorrelation
         '
         Me.lblDisplayNas.AutoSize = True
         Me.lblDisplayNas.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblDisplayNas.Location = New System.Drawing.Point(11, 364)
+        Me.lblDisplayNas.Location = New System.Drawing.Point(11, 379)
         Me.lblDisplayNas.Name = "lblDisplayNas"
         Me.lblDisplayNas.Size = New System.Drawing.Size(67, 13)
         Me.lblDisplayNas.TabIndex = 24
         Me.lblDisplayNas.Text = "Display NAs:"
+        '
+        'ucrChkShave
+        '
+        Me.ucrChkShave.AutoSize = True
+        Me.ucrChkShave.Checked = False
+        Me.ucrChkShave.Location = New System.Drawing.Point(14, 428)
+        Me.ucrChkShave.Name = "ucrChkShave"
+        Me.ucrChkShave.Size = New System.Drawing.Size(231, 23)
+        Me.ucrChkShave.TabIndex = 26
         '
         'ucrInputDisplayNas
         '
@@ -309,16 +316,16 @@ Partial Class dlgCorrelation
         Me.ucrInputDisplayNas.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.ucrInputDisplayNas.GetSetSelectedIndex = -1
         Me.ucrInputDisplayNas.IsReadOnly = False
-        Me.ucrInputDisplayNas.Location = New System.Drawing.Point(129, 360)
+        Me.ucrInputDisplayNas.Location = New System.Drawing.Point(129, 376)
         Me.ucrInputDisplayNas.Name = "ucrInputDisplayNas"
-        Me.ucrInputDisplayNas.Size = New System.Drawing.Size(105, 21)
+        Me.ucrInputDisplayNas.Size = New System.Drawing.Size(94, 21)
         Me.ucrInputDisplayNas.TabIndex = 25
         '
         'ucrChkLeadingZeros
         '
         Me.ucrChkLeadingZeros.AutoSize = True
         Me.ucrChkLeadingZeros.Checked = False
-        Me.ucrChkLeadingZeros.Location = New System.Drawing.Point(14, 386)
+        Me.ucrChkLeadingZeros.Location = New System.Drawing.Point(14, 404)
         Me.ucrChkLeadingZeros.Name = "ucrChkLeadingZeros"
         Me.ucrChkLeadingZeros.Size = New System.Drawing.Size(283, 23)
         Me.ucrChkLeadingZeros.TabIndex = 23
@@ -326,7 +333,7 @@ Partial Class dlgCorrelation
         'ucrSaveDataFrame
         '
         Me.ucrSaveDataFrame.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrSaveDataFrame.Location = New System.Drawing.Point(14, 430)
+        Me.ucrSaveDataFrame.Location = New System.Drawing.Point(14, 452)
         Me.ucrSaveDataFrame.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
         Me.ucrSaveDataFrame.Name = "ucrSaveDataFrame"
         Me.ucrSaveDataFrame.Size = New System.Drawing.Size(266, 24)
@@ -337,7 +344,7 @@ Partial Class dlgCorrelation
         Me.ucrNudDecimalPlaces.AutoSize = True
         Me.ucrNudDecimalPlaces.DecimalPlaces = New Decimal(New Integer() {0, 0, 0, 0})
         Me.ucrNudDecimalPlaces.Increment = New Decimal(New Integer() {1, 0, 0, 0})
-        Me.ucrNudDecimalPlaces.Location = New System.Drawing.Point(129, 330)
+        Me.ucrNudDecimalPlaces.Location = New System.Drawing.Point(129, 344)
         Me.ucrNudDecimalPlaces.Maximum = New Decimal(New Integer() {100, 0, 0, 0})
         Me.ucrNudDecimalPlaces.Minimum = New Decimal(New Integer() {0, 0, 0, 0})
         Me.ucrNudDecimalPlaces.Name = "ucrNudDecimalPlaces"
@@ -350,7 +357,7 @@ Partial Class dlgCorrelation
         Me.ucrNudConfidenceInterval.AutoSize = True
         Me.ucrNudConfidenceInterval.DecimalPlaces = New Decimal(New Integer() {0, 0, 0, 0})
         Me.ucrNudConfidenceInterval.Increment = New Decimal(New Integer() {1, 0, 0, 0})
-        Me.ucrNudConfidenceInterval.Location = New System.Drawing.Point(129, 283)
+        Me.ucrNudConfidenceInterval.Location = New System.Drawing.Point(129, 312)
         Me.ucrNudConfidenceInterval.Maximum = New Decimal(New Integer() {100, 0, 0, 0})
         Me.ucrNudConfidenceInterval.Minimum = New Decimal(New Integer() {0, 0, 0, 0})
         Me.ucrNudConfidenceInterval.Name = "ucrNudConfidenceInterval"
@@ -362,9 +369,9 @@ Partial Class dlgCorrelation
         '
         Me.ucrChkCorrelationMatrix.AutoSize = True
         Me.ucrChkCorrelationMatrix.Checked = False
-        Me.ucrChkCorrelationMatrix.Location = New System.Drawing.Point(14, 309)
+        Me.ucrChkCorrelationMatrix.Location = New System.Drawing.Point(14, 281)
         Me.ucrChkCorrelationMatrix.Name = "ucrChkCorrelationMatrix"
-        Me.ucrChkCorrelationMatrix.Size = New System.Drawing.Size(283, 23)
+        Me.ucrChkCorrelationMatrix.Size = New System.Drawing.Size(241, 23)
         Me.ucrChkCorrelationMatrix.TabIndex = 14
         '
         'ucrPnlColumns
@@ -430,7 +437,7 @@ Partial Class dlgCorrelation
         '
         Me.ucrBase.AutoSize = True
         Me.ucrBase.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrBase.Location = New System.Drawing.Point(14, 451)
+        Me.ucrBase.Location = New System.Drawing.Point(14, 476)
         Me.ucrBase.Name = "ucrBase"
         Me.ucrBase.Size = New System.Drawing.Size(405, 52)
         Me.ucrBase.TabIndex = 17
@@ -438,7 +445,7 @@ Partial Class dlgCorrelation
         'ucrSaveModel
         '
         Me.ucrSaveModel.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrSaveModel.Location = New System.Drawing.Point(14, 428)
+        Me.ucrSaveModel.Location = New System.Drawing.Point(14, 451)
         Me.ucrSaveModel.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
         Me.ucrSaveModel.Name = "ucrSaveModel"
         Me.ucrSaveModel.Size = New System.Drawing.Size(266, 24)
@@ -447,29 +454,20 @@ Partial Class dlgCorrelation
         'ucrInputDiagonal
         '
         Me.ucrInputDiagonal.AddQuotesIfUnrecognised = True
-        Me.ucrInputDiagonal.AutoSize = True
-        Me.ucrInputDiagonal.IsMultiline = False
+        Me.ucrInputDiagonal.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrInputDiagonal.GetSetSelectedIndex = -1
         Me.ucrInputDiagonal.IsReadOnly = False
-        Me.ucrInputDiagonal.Location = New System.Drawing.Point(128, 282)
+        Me.ucrInputDiagonal.Location = New System.Drawing.Point(129, 311)
         Me.ucrInputDiagonal.Name = "ucrInputDiagonal"
-        Me.ucrInputDiagonal.Size = New System.Drawing.Size(52, 21)
-        Me.ucrInputDiagonal.TabIndex = 18
-        '
-        'ucrChkShave
-        '
-        Me.ucrChkShave.AutoSize = True
-        Me.ucrChkShave.Checked = False
-        Me.ucrChkShave.Location = New System.Drawing.Point(15, 408)
-        Me.ucrChkShave.Name = "ucrChkShave"
-        Me.ucrChkShave.Size = New System.Drawing.Size(231, 23)
-        Me.ucrChkShave.TabIndex = 26
+        Me.ucrInputDiagonal.Size = New System.Drawing.Size(94, 21)
+        Me.ucrInputDiagonal.TabIndex = 27
         '
         'dlgCorrelation
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
         Me.AutoSize = True
-        Me.ClientSize = New System.Drawing.Size(436, 505)
+        Me.ClientSize = New System.Drawing.Size(436, 526)
         Me.Controls.Add(Me.ucrChkShave)
         Me.Controls.Add(Me.ucrInputDisplayNas)
         Me.Controls.Add(Me.lblDisplayNas)
@@ -478,14 +476,12 @@ Partial Class dlgCorrelation
         Me.Controls.Add(Me.lblDecimalPlaces)
         Me.Controls.Add(Me.ucrNudDecimalPlaces)
         Me.Controls.Add(Me.lblSelectedVariables)
-        Me.Controls.Add(Me.ucrNudConfidenceInterval)
         Me.Controls.Add(Me.ucrChkCorrelationMatrix)
         Me.Controls.Add(Me.rdoTwoColumns)
         Me.Controls.Add(Me.rdoMultipleColumns)
         Me.Controls.Add(Me.ucrPnlColumns)
         Me.Controls.Add(Me.grpMethod)
         Me.Controls.Add(Me.ucrReceiverMultipleColumns)
-        Me.Controls.Add(Me.lblConfInterval)
         Me.Controls.Add(Me.grpMissing)
         Me.Controls.Add(Me.cmdOptions)
         Me.Controls.Add(Me.lblSecondColumn)
@@ -496,7 +492,9 @@ Partial Class dlgCorrelation
         Me.Controls.Add(Me.ucrBase)
         Me.Controls.Add(Me.ucrSaveModel)
         Me.Controls.Add(Me.lblDisplayOnDiagonal)
+        Me.Controls.Add(Me.lblConfInterval)
         Me.Controls.Add(Me.ucrInputDiagonal)
+        Me.Controls.Add(Me.ucrNudConfidenceInterval)
         Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow
         Me.MaximizeBox = False
         Me.MinimizeBox = False
@@ -538,13 +536,12 @@ Partial Class dlgCorrelation
     Friend WithEvents ucrSaveModel As ucrSave
     Friend WithEvents lblSelectedVariables As Label
     Friend WithEvents lblDisplayOnDiagonal As Label
-    Friend WithEvents ucrInputDiagonal As ucrInputTextBox
     Friend WithEvents lblDecimalPlaces As Label
     Friend WithEvents ucrNudDecimalPlaces As ucrNud
     Friend WithEvents ucrSaveDataFrame As ucrSave
     Friend WithEvents ucrChkLeadingZeros As ucrCheck
     Friend WithEvents ucrInputDisplayNas As ucrInputComboBox
     Friend WithEvents lblDisplayNas As Label
-    Friend WithEvents ttDisplayOnDiagonal As ToolTip
     Friend WithEvents ucrChkShave As ucrCheck
+    Friend WithEvents ucrInputDiagonal As ucrInputComboBox
 End Class

--- a/instat/dlgCorrelation.resx
+++ b/instat/dlgCorrelation.resx
@@ -117,4 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="ttDisplayOnDiagonal.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>25</value>
+  </metadata>
 </root>

--- a/instat/dlgCorrelation.resx
+++ b/instat/dlgCorrelation.resx
@@ -117,9 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="ttDisplayOnDiagonal.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>25</value>
   </metadata>

--- a/instat/dlgCorrelation.vb
+++ b/instat/dlgCorrelation.vb
@@ -102,7 +102,6 @@ Public Class dlgCorrelation
         ucrInputDiagonal.SetItems(dctDiagonal)
         ucrInputDiagonal.AddQuotesIfUnrecognised = False
 
-
         ucrPnlColumns.AddRadioButton(rdoTwoColumns)
         ucrPnlColumns.AddRadioButton(rdoMultipleColumns)
         ucrPnlColumns.AddFunctionNamesCondition(rdoTwoColumns, "cor.test")
@@ -134,7 +133,8 @@ Public Class dlgCorrelation
         ucrNudDecimalPlaces.SetLinkedDisplayControl(lblDecimalPlaces)
         ucrPnlColumns.AddToLinkedControls(ucrPnlCompletePairwise, {rdoMultipleColumns}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:=rdoCompleteRowsOnly)
         ucrPnlColumns.AddToLinkedControls(ucrInputDiagonal, {rdoMultipleColumns}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:="NA")
-        ucrPnlColumns.AddToLinkedControls({ucrChkLeadingZeros, ucrChkShave, ucrSaveDataFrame}, {rdoMultipleColumns}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
+        ucrPnlColumns.AddToLinkedControls({ucrChkShave, ucrSaveDataFrame}, {rdoMultipleColumns}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
+        ucrPnlColumns.AddToLinkedControls(ucrChkLeadingZeros, {rdoMultipleColumns}, bNewLinkedHideIfParameterMissing:=True)
         ucrPnlColumns.AddToLinkedControls(ucrInputDisplayNas, {rdoMultipleColumns}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:="blank")
         ucrPnlColumns.AddToLinkedControls(ucrNudDecimalPlaces, {rdoMultipleColumns}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:=2)
         ucrPnlCompletePairwise.SetLinkedDisplayControl(grpMissing)
@@ -144,14 +144,12 @@ Public Class dlgCorrelation
         ucrSaveModel.SetDataFrameSelector(ucrSelectorCorrelation.ucrAvailableDataFrames)
         ucrSaveModel.SetCheckBoxText("Result Name")
         ucrSaveModel.SetIsComboBox()
-        'ucrSaveModel.SetAssignToIfUncheckedValue("last_model")
 
         ucrSaveDataFrame.SetPrefix("corr")
         ucrSaveDataFrame.SetSaveTypeAsDataFrame()
         ucrSaveDataFrame.SetDataFrameSelector(ucrSelectorCorrelation.ucrAvailableDataFrames)
         ucrSaveDataFrame.SetCheckBoxText("Result Name")
         ucrSaveDataFrame.SetIsComboBox()
-        'ucrSaveDataFrame.SetAssignToIfUncheckedValue("last_correlation")
     End Sub
 
     Private Sub SetDefaults()
@@ -356,7 +354,6 @@ Public Class dlgCorrelation
 
     Private Sub ReceiverColumns()
         Dim strTwoColumns As String
-
         If rdoTwoColumns.Checked Then
             strTwoColumns = "c(" & ucrReceiverFirstColumn.GetVariableNames() & ", " & ucrReceiverSecondColumn.GetVariableNames() & ")"
             clsRGraphicsFuction.AddParameter("columns", strTwoColumns, iPosition:=1)

--- a/instat/dlgCorrelation.vb
+++ b/instat/dlgCorrelation.vb
@@ -20,7 +20,7 @@ Public Class dlgCorrelation
     Private bReset As Boolean = True
     Private clsCorrelationTestFunction, clsRGGcorrGraphicsFunction,
         clsRGGscatMatrixFunction, clsCorrelationFunction, clsCurrentDataFrameFunction,
-        clsGuidesFunction, clsGuideLegendFunction, clsDummyFunction As New RFunction
+        clsGuidesFunction, clsGuideLegendFunction, clsDummyFunction, clsFashionFunction As New RFunction
     Private clsRGraphicsFuction, clsListFunction, clsWrapFunction As New RFunction
     Private clsRGGscatMatricReverseOperator As New ROperator
     Private strColFunction As String
@@ -76,6 +76,14 @@ Public Class dlgCorrelation
         ucrNudConfidenceInterval.Increment = 0.05
         ucrNudConfidenceInterval.SetRDefault(0.95)
 
+        ucrNudDecimalPlaces.SetParameter(New RParameter("decimals", 1))
+        ucrNudDecimalPlaces.SetMinMax(0, 5)
+        ucrNudDecimalPlaces.Increment = 1
+        ucrNudDecimalPlaces.SetRDefault(2)
+
+        ucrInputDiagonal.SetParameter(New RParameter("diagonal", 6))
+        ucrInputDiagonal.AddQuotesIfUnrecognised = False
+
         ucrPnlColumns.AddRadioButton(rdoTwoColumns)
         ucrPnlColumns.AddRadioButton(rdoMultipleColumns)
         ucrPnlColumns.AddFunctionNamesCondition(rdoTwoColumns, "cor.test")
@@ -102,7 +110,11 @@ Public Class dlgCorrelation
         ucrPnlColumns.AddToLinkedControls({ucrReceiverMultipleColumns}, {rdoMultipleColumns}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
         ucrReceiverMultipleColumns.SetLinkedDisplayControl(lblSelectedVariables)
         ucrNudConfidenceInterval.SetLinkedDisplayControl(lblConfInterval)
+        ucrInputDiagonal.SetLinkedDisplayControl(lblDisplayOnDiagonal)
+        ucrNudDecimalPlaces.SetLinkedDisplayControl(lblDecimalPlaces)
         ucrPnlColumns.AddToLinkedControls(ucrPnlCompletePairwise, {rdoMultipleColumns}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:=rdoCompleteRowsOnly)
+        ucrPnlColumns.AddToLinkedControls(ucrInputDiagonal, {rdoMultipleColumns}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:="NA")
+        ucrPnlColumns.AddToLinkedControls(ucrNudDecimalPlaces, {rdoMultipleColumns}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:=2)
         ucrPnlCompletePairwise.SetLinkedDisplayControl(grpMissing)
 
         ucrSaveModel.SetPrefix("cor")
@@ -127,6 +139,7 @@ Public Class dlgCorrelation
         clsGuideLegendFunction = New RFunction
         clsDummyFunction = New RFunction
         clsCurrentDataFrameFunction = New RFunction
+        clsFashionFunction = New RFunction
         bResetSubdialog = True
 
         ucrSelectorCorrelation.Reset()
@@ -175,9 +188,14 @@ Public Class dlgCorrelation
         clsCorrelationTestFunction.AddParameter("conf.level", "0.95")
         clsCorrelationTestFunction.AddParameter("method", Chr(34) & "pearson" & Chr(34))
 
-        clsCorrelationFunction.SetRCommand("cor")
+        clsCorrelationFunction.SetRCommand("correlate ")
+        clsCorrelationFunction.SetPackageName("corrr")
         clsCorrelationFunction.iCallType = 2
         clsCorrelationFunction.AddParameter("use", Chr(34) & "complete.obs" & Chr(34))
+
+        'clsFashionFunction.SetRCommand("fashion")
+        'clsFashionFunction.AddParameter("x", clsRFunctionParameter:=clsCorrelationFunction, iPosition:=0)
+        'clsFashionFunction.AddParameter("decimals", "2", iPosition:=1)
 
         clsRGGcorrGraphicsFunction.SetPackageName("GGally")
         clsRGGcorrGraphicsFunction.SetRCommand("ggcorr")
@@ -200,9 +218,12 @@ Public Class dlgCorrelation
         ucrPnlMethod.AddAdditionalCodeParameterPair(clsRGGcorrGraphicsFunction, New RParameter("method", 2), iAdditionalPairNo:=3)
         ucrPnlMethod.AddAdditionalCodeParameterPair(clsRGGscatMatrixFunction, New RParameter("corMethod", 4), iAdditionalPairNo:=4)
         ucrReceiverMultipleColumns.SetRCode(clsCorrelationFunction, bReset)
+        ucrInputDiagonal.SetRCode(clsCorrelationFunction, bReset)
         ucrNudConfidenceInterval.SetRCode(clsCorrelationTestFunction, bReset)
         ucrReceiverFirstColumn.SetRCode(clsCorrelationTestFunction, bReset)
         ucrReceiverSecondColumn.SetRCode(clsCorrelationTestFunction, bReset)
+        'ucrNudDecimalPlaces.SetRCode(clsCorrelationFunction, bReset)
+        'ucrNudDecimalPlaces.AddAdditionalCodeParameterPair(clsFashionFunction, New RParameter("decimals", 1), iAdditionalPairNo:=1)
         If bReset Then
             ucrPnlColumns.SetRCode(clsCorrelationTestFunction, bReset)
         End If

--- a/instat/dlgCorrelation.vb
+++ b/instat/dlgCorrelation.vb
@@ -22,6 +22,7 @@ Public Class dlgCorrelation
         clsRGGscatMatrixFunction, clsCorrelationFunction, clsCurrentDataFrameFunction,
         clsGuidesFunction, clsGuideLegendFunction, clsDummyFunction, clsFashionFunction, clsShaveFunction As New RFunction
     Private clsRGraphicsFuction, clsListFunction, clsWrapFunction As New RFunction
+    Private clsDummyShave As New RFunction
     Private clsRGGscatMatricReverseOperator As New ROperator
     Private strColFunction As String
     Private bResetSubdialog As Boolean = False
@@ -45,6 +46,7 @@ Public Class dlgCorrelation
 
     Private Sub InitialiseDialog()
         Dim dctNaPrint As New Dictionary(Of String, String)
+        Dim dctDiagonal As New Dictionary(Of String, String)
         ucrBase.iHelpTopicID = 421
         ucrBase.clsRsyntax.iCallType = 2
 
@@ -83,23 +85,23 @@ Public Class dlgCorrelation
 
         ucrChkLeadingZeros.SetParameter(New RParameter("leading_zeros", 2))
         ucrChkLeadingZeros.SetText("Leading Zeros")
-        'ucrChkLeadingZeros.AddParameterValueFunctionNamesCondition(True, "leading", "False")
-        'ucrChkLeadingZeros.AddParameterValueFunctionNamesCondition(False, "leading", "True")
         ucrChkLeadingZeros.SetValuesCheckedAndUnchecked("TRUE", "FALSE")
 
-        ucrChkShave.SetParameter(New RParameter("x", 0))
         ucrChkShave.SetText("Shave")
-        'ucrChkShave.SetValuesCheckedAndUnchecked("TRUE", "FALSE")
+        ucrChkShave.SetParameter(New RParameter("checked", 0))
+        ucrChkShave.SetValuesCheckedAndUnchecked(True, False)
 
         ucrInputDisplayNas.SetParameter(New RParameter("na_print", 3))
         dctNaPrint.Add("blank", Chr(34) & " " & Chr(34))
-        dctNaPrint.Add("Default", Chr(34) & "default" & Chr(34))
         dctNaPrint.Add("1", Chr(34) & 1 & Chr(34))
         ucrInputDisplayNas.SetItems(dctNaPrint)
 
         ucrInputDiagonal.SetParameter(New RParameter("diagonal", 6))
+        dctDiagonal.Add("NA", "NA")
+        dctDiagonal.Add("1", 1)
+        ucrInputDiagonal.SetItems(dctDiagonal)
         ucrInputDiagonal.AddQuotesIfUnrecognised = False
-        ttDisplayOnDiagonal.SetToolTip(ucrInputDiagonal.txtInput, "Value to set the diagonal to is typically numeric or NA")
+
 
         ucrPnlColumns.AddRadioButton(rdoTwoColumns)
         ucrPnlColumns.AddRadioButton(rdoMultipleColumns)
@@ -133,24 +135,23 @@ Public Class dlgCorrelation
         ucrPnlColumns.AddToLinkedControls(ucrPnlCompletePairwise, {rdoMultipleColumns}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:=rdoCompleteRowsOnly)
         ucrPnlColumns.AddToLinkedControls(ucrInputDiagonal, {rdoMultipleColumns}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:="NA")
         ucrPnlColumns.AddToLinkedControls({ucrChkLeadingZeros, ucrChkShave, ucrSaveDataFrame}, {rdoMultipleColumns}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
-        ucrPnlColumns.AddToLinkedControls(ucrInputDisplayNas, {rdoMultipleColumns}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:="default")
+        ucrPnlColumns.AddToLinkedControls(ucrInputDisplayNas, {rdoMultipleColumns}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:="blank")
         ucrPnlColumns.AddToLinkedControls(ucrNudDecimalPlaces, {rdoMultipleColumns}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:=2)
         ucrPnlCompletePairwise.SetLinkedDisplayControl(grpMissing)
 
-        ucrSaveModel.SetPrefix("cor")
+        ucrSaveModel.SetPrefix("model")
         ucrSaveModel.SetSaveTypeAsModel()
         ucrSaveModel.SetDataFrameSelector(ucrSelectorCorrelation.ucrAvailableDataFrames)
         ucrSaveModel.SetCheckBoxText("Result Name")
         ucrSaveModel.SetIsComboBox()
-        ucrSaveModel.SetAssignToIfUncheckedValue("last_model")
+        'ucrSaveModel.SetAssignToIfUncheckedValue("last_model")
 
-        ucrSaveDataFrame.SetPrefix("cor")
+        ucrSaveDataFrame.SetPrefix("corr")
         ucrSaveDataFrame.SetSaveTypeAsDataFrame()
         ucrSaveDataFrame.SetDataFrameSelector(ucrSelectorCorrelation.ucrAvailableDataFrames)
         ucrSaveDataFrame.SetCheckBoxText("Result Name")
         ucrSaveDataFrame.SetIsComboBox()
-        ' ucrSaveDataFrame.SetAssignToIfUncheckedValue("last_correlation")
-
+        'ucrSaveDataFrame.SetAssignToIfUncheckedValue("last_correlation")
     End Sub
 
     Private Sub SetDefaults()
@@ -168,6 +169,7 @@ Public Class dlgCorrelation
         clsCurrentDataFrameFunction = New RFunction
         clsFashionFunction = New RFunction
         clsShaveFunction = New RFunction
+        clsDummyShave = New RFunction
         bResetSubdialog = True
 
         ucrSelectorCorrelation.Reset()
@@ -175,8 +177,7 @@ Public Class dlgCorrelation
         ucrReceiverFirstColumn.SetMeAsReceiver()
 
         clsDummyFunction.AddParameter("checked", "none", iPosition:=0)
-        'clsDummyFunction.AddParameter("leading", "False", iPosition:=1)
-
+        'cls
         clsRGGscatMatricReverseOperator.SetOperation("+")
         clsRGGscatMatricReverseOperator.AddParameter("matrix", clsRFunctionParameter:=clsRGGscatMatrixFunction, iPosition:=0)
         clsRGGscatMatricReverseOperator.iCallType = 3
@@ -224,7 +225,7 @@ Public Class dlgCorrelation
 
         clsFashionFunction.SetPackageName("corrr")
         clsFashionFunction.SetRCommand("fashion")
-        clsFashionFunction.AddParameter("x", clsRFunctionParameter:=clsCorrelationFunction, iPosition:=0)
+        clsFashionFunction.AddParameter("x", clsRFunctionParameter:=clsShaveFunction, iPosition:=0)
         clsFashionFunction.AddParameter("decimals", "2", iPosition:=1)
         clsFashionFunction.AddParameter("leading_zeros", "FALSE", iPosition:=2)
         clsFashionFunction.AddParameter("na_print", "default", iPosition:=3)
@@ -232,7 +233,7 @@ Public Class dlgCorrelation
 
         clsShaveFunction.SetPackageName("corrr")
         clsShaveFunction.SetRCommand("shave")
-        clsShaveFunction.AddParameter("x", clsRFunctionParameter:=clsFashionFunction, iPosition:=0)
+        clsShaveFunction.AddParameter("x", clsRFunctionParameter:=clsCorrelationFunction, iPosition:=0)
 
         clsRGGcorrGraphicsFunction.SetPackageName("GGally")
         clsRGGcorrGraphicsFunction.SetRCommand("ggcorr")
@@ -262,8 +263,7 @@ Public Class dlgCorrelation
         ucrNudDecimalPlaces.SetRCode(clsFashionFunction, bReset)
         ucrChkLeadingZeros.SetRCode(clsFashionFunction, bReset)
         ucrInputDisplayNas.SetRCode(clsFashionFunction, bReset)
-        'ucrChkShave.SetRCode(clsShaveFunction, bReset)
-        'ucrChkLeadingZeros.AddAdditionalCodeParameterPair(clsCorrelationFunction, New RParameter("leading_zeros", 2), iAdditionalPairNo:=1)
+        ucrChkShave.SetRCode(clsDummyShave, bReset)
         If bReset Then
             ucrPnlColumns.SetRCode(clsCorrelationTestFunction, bReset)
         End If
@@ -316,14 +316,6 @@ Public Class dlgCorrelation
         bResetSubdialog = False
     End Sub
 
-    'Private Sub ucrBase_BeforeClickOk(sender As Object, e As EventArgs) Handles ucrBase.BeforeClickOk
-    '    If rdoTwoColumns.Checked Then
-    '        ucrBase.clsRsyntax.SetBaseRFunction(clsCorrelationTestFunction)
-    '    ElseIf rdoMultipleColumns.Checked Then
-    '        ucrBase.clsRsyntax.SetBaseRFunction(clsCorrelationFunction)
-    '    End If
-    'End Sub
-
     ' This is here because otherwise the panel cannot be set up correctly if you reopen the dialog when on the 2-variable rdo button
     Private Sub ucrPnlCompletePairwise_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrPnlCompletePairwise.ControlValueChanged
         If rdoPairwise.Checked Then
@@ -333,22 +325,20 @@ Public Class dlgCorrelation
         End If
     End Sub
 
-    Private Sub ucrPnlColumns_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrPnlColumns.ControlValueChanged
+    Private Sub ucrPnlColumns_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrPnlColumns.ControlValueChanged, ucrChkShave.ControlValueChanged
         If rdoTwoColumns.Checked Then
             ucrReceiverFirstColumn.SetMeAsReceiver()
             ucrBase.clsRsyntax.RemoveFromAfterCodes(clsRGGcorrGraphicsFunction)
             ucrBase.clsRsyntax.SetBaseRFunction(clsCorrelationTestFunction)
-        ElseIf rdoMultipleColumns.Checked AndAlso ucrChkShave.Checked Then
+        ElseIf rdoMultipleColumns.Checked Then
             ucrReceiverMultipleColumns.SetMeAsReceiver()
-            ucrBase.clsRsyntax.SetBaseRFunction(clsShaveFunction)
-        Else
+            If ucrChkShave.Checked Then
+                clsFashionFunction.AddParameter("x", clsRFunctionParameter:=clsShaveFunction, iPosition:=0)
+            Else
+                clsFashionFunction.AddParameter("x", clsRFunctionParameter:=clsCorrelationFunction, iPosition:=0)
+            End If
             ucrBase.clsRsyntax.SetBaseRFunction(clsFashionFunction)
         End If
-        'If ucrChkShave.Checked Then
-        '    ucrBase.clsRsyntax.SetBaseRFunction(clsShaveFunction)
-        'Else
-        '    ucrBase.clsRsyntax.SetBaseRFunction(clsFashionFunction)
-        'End If
         ReceiverColumns()
     End Sub
 
@@ -356,7 +346,7 @@ Public Class dlgCorrelation
         ReceiverColumns()
     End Sub
 
-    Private Sub ucrReceiverFirstColumn_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrReceiverFirstColumn.ControlContentsChanged, ucrReceiverSecondColumn.ControlContentsChanged, ucrReceiverMultipleColumns.ControlContentsChanged, ucrPnlColumns.ControlContentsChanged, ucrPnlCompletePairwise.ControlContentsChanged, ucrPnlMethod.ControlContentsChanged
+    Private Sub ucrReceiverFirstColumn_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrReceiverFirstColumn.ControlContentsChanged, ucrReceiverSecondColumn.ControlContentsChanged, ucrReceiverMultipleColumns.ControlContentsChanged, ucrPnlColumns.ControlContentsChanged, ucrPnlCompletePairwise.ControlContentsChanged, ucrPnlMethod.ControlContentsChanged, ucrChkShave.ControlContentsChanged
         TestOKEnabled()
     End Sub
 


### PR DESCRIPTION
Fixes #7257 
@rdstern @shadrackkibet ,  this PR;

- Replaces the function in the "Multiple Columns" tab with correlate from the corrr package.
- Adds `diagonal` parameter 
- Adds `decimals ` parameter from `fashion` function
- Adds `na_print` parameter from `fashion` function
- Adds ` leading_zeros` parameter from `fashion` function 
- Adds `shave` function
- Saves the correlations in a new data frame