### PR TITLE
Updated Merge Additional Data dialog

### DIFF
--- a/instat/dlgMergeAdditionalData.Designer.vb
+++ b/instat/dlgMergeAdditionalData.Designer.vb
@@ -24,19 +24,19 @@ Partial Class dlgMergeAdditionalData
     Private Sub InitializeComponent()
         Me.lblVariablesToIncludeSecond = New System.Windows.Forms.Label()
         Me.cmdModify = New System.Windows.Forms.Button()
+        Me.lblMergeBy = New System.Windows.Forms.Label()
         Me.ucrInputMergingBy = New instat.ucrInputTextBox()
         Me.ucrFirstDataFrame = New instat.ucrDataFrame()
         Me.ucrReceiverSecond = New instat.ucrReceiverMultiple()
         Me.ucrSecondSelector = New instat.ucrSelectorByDataFrameAddRemove()
         Me.ucrBase = New instat.ucrButtons()
-        Me.lblMergeBy = New System.Windows.Forms.Label()
         Me.SuspendLayout()
         '
         'lblVariablesToIncludeSecond
         '
         Me.lblVariablesToIncludeSecond.AutoSize = True
         Me.lblVariablesToIncludeSecond.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblVariablesToIncludeSecond.Location = New System.Drawing.Point(248, 121)
+        Me.lblVariablesToIncludeSecond.Location = New System.Drawing.Point(249, 88)
         Me.lblVariablesToIncludeSecond.Name = "lblVariablesToIncludeSecond"
         Me.lblVariablesToIncludeSecond.Size = New System.Drawing.Size(103, 13)
         Me.lblVariablesToIncludeSecond.TabIndex = 2
@@ -45,12 +45,21 @@ Partial Class dlgMergeAdditionalData
         'cmdModify
         '
         Me.cmdModify.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdModify.Location = New System.Drawing.Point(282, 332)
+        Me.cmdModify.Location = New System.Drawing.Point(273, 300)
         Me.cmdModify.Name = "cmdModify"
         Me.cmdModify.Size = New System.Drawing.Size(90, 23)
         Me.cmdModify.TabIndex = 6
         Me.cmdModify.Text = "Join Options"
         Me.cmdModify.UseVisualStyleBackColor = True
+        '
+        'lblMergeBy
+        '
+        Me.lblMergeBy.AutoSize = True
+        Me.lblMergeBy.Location = New System.Drawing.Point(9, 257)
+        Me.lblMergeBy.Name = "lblMergeBy"
+        Me.lblMergeBy.Size = New System.Drawing.Size(44, 13)
+        Me.lblMergeBy.TabIndex = 4
+        Me.lblMergeBy.Text = "Join By:"
         '
         'ucrInputMergingBy
         '
@@ -58,7 +67,7 @@ Partial Class dlgMergeAdditionalData
         Me.ucrInputMergingBy.AutoSize = True
         Me.ucrInputMergingBy.IsMultiline = False
         Me.ucrInputMergingBy.IsReadOnly = False
-        Me.ucrInputMergingBy.Location = New System.Drawing.Point(72, 286)
+        Me.ucrInputMergingBy.Location = New System.Drawing.Point(63, 254)
         Me.ucrInputMergingBy.Name = "ucrInputMergingBy"
         Me.ucrInputMergingBy.Size = New System.Drawing.Size(300, 40)
         Me.ucrInputMergingBy.TabIndex = 5
@@ -68,7 +77,7 @@ Partial Class dlgMergeAdditionalData
         Me.ucrFirstDataFrame.AutoSize = True
         Me.ucrFirstDataFrame.bDropUnusedFilterLevels = False
         Me.ucrFirstDataFrame.bUseCurrentFilter = True
-        Me.ucrFirstDataFrame.Location = New System.Drawing.Point(10, 10)
+        Me.ucrFirstDataFrame.Location = New System.Drawing.Point(9, 13)
         Me.ucrFirstDataFrame.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrFirstDataFrame.Name = "ucrFirstDataFrame"
         Me.ucrFirstDataFrame.Size = New System.Drawing.Size(151, 50)
@@ -78,11 +87,11 @@ Partial Class dlgMergeAdditionalData
         '
         Me.ucrReceiverSecond.AutoSize = True
         Me.ucrReceiverSecond.frmParent = Me
-        Me.ucrReceiverSecond.Location = New System.Drawing.Point(248, 136)
+        Me.ucrReceiverSecond.Location = New System.Drawing.Point(249, 106)
         Me.ucrReceiverSecond.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverSecond.Name = "ucrReceiverSecond"
         Me.ucrReceiverSecond.Selector = Nothing
-        Me.ucrReceiverSecond.Size = New System.Drawing.Size(120, 119)
+        Me.ucrReceiverSecond.Size = New System.Drawing.Size(120, 88)
         Me.ucrReceiverSecond.strNcFilePath = ""
         Me.ucrReceiverSecond.TabIndex = 3
         Me.ucrReceiverSecond.ucrSelector = Nothing
@@ -93,7 +102,7 @@ Partial Class dlgMergeAdditionalData
         Me.ucrSecondSelector.bDropUnusedFilterLevels = False
         Me.ucrSecondSelector.bShowHiddenColumns = False
         Me.ucrSecondSelector.bUseCurrentFilter = True
-        Me.ucrSecondSelector.Location = New System.Drawing.Point(10, 86)
+        Me.ucrSecondSelector.Location = New System.Drawing.Point(9, 64)
         Me.ucrSecondSelector.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrSecondSelector.Name = "ucrSecondSelector"
         Me.ucrSecondSelector.Size = New System.Drawing.Size(213, 183)
@@ -103,26 +112,17 @@ Partial Class dlgMergeAdditionalData
         '
         Me.ucrBase.AutoSize = True
         Me.ucrBase.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrBase.Location = New System.Drawing.Point(10, 364)
+        Me.ucrBase.Location = New System.Drawing.Point(9, 329)
         Me.ucrBase.Name = "ucrBase"
         Me.ucrBase.Size = New System.Drawing.Size(405, 52)
         Me.ucrBase.TabIndex = 7
-        '
-        'lblMergeBy
-        '
-        Me.lblMergeBy.AutoSize = True
-        Me.lblMergeBy.Location = New System.Drawing.Point(12, 289)
-        Me.lblMergeBy.Name = "lblMergeBy"
-        Me.lblMergeBy.Size = New System.Drawing.Size(44, 13)
-        Me.lblMergeBy.TabIndex = 4
-        Me.lblMergeBy.Text = "Join By:"
         '
         'dlgMergeAdditionalData
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
         Me.AutoSize = True
-        Me.ClientSize = New System.Drawing.Size(420, 424)
+        Me.ClientSize = New System.Drawing.Size(425, 386)
         Me.Controls.Add(Me.lblMergeBy)
         Me.Controls.Add(Me.cmdModify)
         Me.Controls.Add(Me.ucrInputMergingBy)

--- a/instat/dlgMergeAdditionalData.Designer.vb
+++ b/instat/dlgMergeAdditionalData.Designer.vb
@@ -25,10 +25,11 @@ Partial Class dlgMergeAdditionalData
         Me.lblVariablesToIncludeSecond = New System.Windows.Forms.Label()
         Me.cmdModify = New System.Windows.Forms.Button()
         Me.lblMergeBy = New System.Windows.Forms.Label()
+        Me.ucrSaveDataFrame = New instat.ucrSave()
         Me.ucrInputMergingBy = New instat.ucrInputTextBox()
-        Me.ucrFirstDataFrame = New instat.ucrDataFrame()
+        Me.ucrToDataFrame = New instat.ucrDataFrame()
         Me.ucrReceiverSecond = New instat.ucrReceiverMultiple()
-        Me.ucrSecondSelector = New instat.ucrSelectorByDataFrameAddRemove()
+        Me.ucrFromDataFrame = New instat.ucrSelectorByDataFrameAddRemove()
         Me.ucrBase = New instat.ucrButtons()
         Me.SuspendLayout()
         '
@@ -45,7 +46,7 @@ Partial Class dlgMergeAdditionalData
         'cmdModify
         '
         Me.cmdModify.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdModify.Location = New System.Drawing.Point(273, 259)
+        Me.cmdModify.Location = New System.Drawing.Point(329, 219)
         Me.cmdModify.Name = "cmdModify"
         Me.cmdModify.Size = New System.Drawing.Size(90, 23)
         Me.cmdModify.TabIndex = 6
@@ -61,27 +62,36 @@ Partial Class dlgMergeAdditionalData
         Me.lblMergeBy.TabIndex = 4
         Me.lblMergeBy.Text = "Join By:"
         '
+        'ucrSaveDataFrame
+        '
+        Me.ucrSaveDataFrame.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrSaveDataFrame.Location = New System.Drawing.Point(13, 261)
+        Me.ucrSaveDataFrame.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
+        Me.ucrSaveDataFrame.Name = "ucrSaveDataFrame"
+        Me.ucrSaveDataFrame.Size = New System.Drawing.Size(320, 24)
+        Me.ucrSaveDataFrame.TabIndex = 26
+        '
         'ucrInputMergingBy
         '
         Me.ucrInputMergingBy.AddQuotesIfUnrecognised = True
         Me.ucrInputMergingBy.AutoSize = True
         Me.ucrInputMergingBy.IsMultiline = False
         Me.ucrInputMergingBy.IsReadOnly = False
-        Me.ucrInputMergingBy.Location = New System.Drawing.Point(63, 221)
+        Me.ucrInputMergingBy.Location = New System.Drawing.Point(57, 221)
         Me.ucrInputMergingBy.Name = "ucrInputMergingBy"
-        Me.ucrInputMergingBy.Size = New System.Drawing.Size(300, 32)
+        Me.ucrInputMergingBy.Size = New System.Drawing.Size(266, 32)
         Me.ucrInputMergingBy.TabIndex = 5
         '
-        'ucrFirstDataFrame
+        'ucrToDataFrame
         '
-        Me.ucrFirstDataFrame.AutoSize = True
-        Me.ucrFirstDataFrame.bDropUnusedFilterLevels = False
-        Me.ucrFirstDataFrame.bUseCurrentFilter = True
-        Me.ucrFirstDataFrame.Location = New System.Drawing.Point(249, 23)
-        Me.ucrFirstDataFrame.Margin = New System.Windows.Forms.Padding(0)
-        Me.ucrFirstDataFrame.Name = "ucrFirstDataFrame"
-        Me.ucrFirstDataFrame.Size = New System.Drawing.Size(151, 50)
-        Me.ucrFirstDataFrame.TabIndex = 0
+        Me.ucrToDataFrame.AutoSize = True
+        Me.ucrToDataFrame.bDropUnusedFilterLevels = False
+        Me.ucrToDataFrame.bUseCurrentFilter = True
+        Me.ucrToDataFrame.Location = New System.Drawing.Point(249, 23)
+        Me.ucrToDataFrame.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrToDataFrame.Name = "ucrToDataFrame"
+        Me.ucrToDataFrame.Size = New System.Drawing.Size(151, 50)
+        Me.ucrToDataFrame.TabIndex = 0
         '
         'ucrReceiverSecond
         '
@@ -96,17 +106,17 @@ Partial Class dlgMergeAdditionalData
         Me.ucrReceiverSecond.TabIndex = 3
         Me.ucrReceiverSecond.ucrSelector = Nothing
         '
-        'ucrSecondSelector
+        'ucrFromDataFrame
         '
-        Me.ucrSecondSelector.AutoSize = True
-        Me.ucrSecondSelector.bDropUnusedFilterLevels = False
-        Me.ucrSecondSelector.bShowHiddenColumns = False
-        Me.ucrSecondSelector.bUseCurrentFilter = True
-        Me.ucrSecondSelector.Location = New System.Drawing.Point(8, 23)
-        Me.ucrSecondSelector.Margin = New System.Windows.Forms.Padding(0)
-        Me.ucrSecondSelector.Name = "ucrSecondSelector"
-        Me.ucrSecondSelector.Size = New System.Drawing.Size(213, 183)
-        Me.ucrSecondSelector.TabIndex = 1
+        Me.ucrFromDataFrame.AutoSize = True
+        Me.ucrFromDataFrame.bDropUnusedFilterLevels = False
+        Me.ucrFromDataFrame.bShowHiddenColumns = False
+        Me.ucrFromDataFrame.bUseCurrentFilter = True
+        Me.ucrFromDataFrame.Location = New System.Drawing.Point(8, 23)
+        Me.ucrFromDataFrame.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrFromDataFrame.Name = "ucrFromDataFrame"
+        Me.ucrFromDataFrame.Size = New System.Drawing.Size(213, 183)
+        Me.ucrFromDataFrame.TabIndex = 1
         '
         'ucrBase
         '
@@ -123,13 +133,14 @@ Partial Class dlgMergeAdditionalData
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
         Me.AutoSize = True
         Me.ClientSize = New System.Drawing.Size(425, 349)
+        Me.Controls.Add(Me.ucrSaveDataFrame)
         Me.Controls.Add(Me.lblMergeBy)
         Me.Controls.Add(Me.cmdModify)
         Me.Controls.Add(Me.ucrInputMergingBy)
-        Me.Controls.Add(Me.ucrFirstDataFrame)
+        Me.Controls.Add(Me.ucrToDataFrame)
         Me.Controls.Add(Me.lblVariablesToIncludeSecond)
         Me.Controls.Add(Me.ucrReceiverSecond)
-        Me.Controls.Add(Me.ucrSecondSelector)
+        Me.Controls.Add(Me.ucrFromDataFrame)
         Me.Controls.Add(Me.ucrBase)
         Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow
         Me.MaximizeBox = False
@@ -137,7 +148,7 @@ Partial Class dlgMergeAdditionalData
         Me.Name = "dlgMergeAdditionalData"
         Me.ShowIcon = False
         Me.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen
-        Me.Text = "Merge Additional Data"
+        Me.Text = "Add (Merge) Data"
         Me.ResumeLayout(False)
         Me.PerformLayout()
 
@@ -146,9 +157,10 @@ Partial Class dlgMergeAdditionalData
     Friend WithEvents ucrBase As ucrButtons
     Friend WithEvents lblVariablesToIncludeSecond As Label
     Friend WithEvents ucrReceiverSecond As ucrReceiverMultiple
-    Friend WithEvents ucrSecondSelector As ucrSelectorByDataFrameAddRemove
-    Friend WithEvents ucrFirstDataFrame As ucrDataFrame
+    Friend WithEvents ucrFromDataFrame As ucrSelectorByDataFrameAddRemove
+    Friend WithEvents ucrToDataFrame As ucrDataFrame
     Friend WithEvents ucrInputMergingBy As ucrInputTextBox
     Friend WithEvents cmdModify As Button
     Friend WithEvents lblMergeBy As Label
+    Friend WithEvents ucrSaveDataFrame As ucrSave
 End Class

--- a/instat/dlgMergeAdditionalData.Designer.vb
+++ b/instat/dlgMergeAdditionalData.Designer.vb
@@ -25,12 +25,13 @@ Partial Class dlgMergeAdditionalData
         Me.lblVariablesToIncludeSecond = New System.Windows.Forms.Label()
         Me.cmdModify = New System.Windows.Forms.Button()
         Me.lblMergeBy = New System.Windows.Forms.Label()
-        Me.ucrSaveDataFrame = New instat.ucrSave()
         Me.ucrInputMergingBy = New instat.ucrInputTextBox()
         Me.ucrToDataFrame = New instat.ucrDataFrame()
         Me.ucrReceiverSecond = New instat.ucrReceiverMultiple()
         Me.ucrFromDataFrame = New instat.ucrSelectorByDataFrameAddRemove()
         Me.ucrBase = New instat.ucrButtons()
+        Me.ucrChkSaveDataFrame = New instat.ucrCheck()
+        Me.ucrInputSaveDataFrame = New instat.ucrInputTextBox()
         Me.SuspendLayout()
         '
         'lblVariablesToIncludeSecond
@@ -61,15 +62,6 @@ Partial Class dlgMergeAdditionalData
         Me.lblMergeBy.Size = New System.Drawing.Size(44, 13)
         Me.lblMergeBy.TabIndex = 4
         Me.lblMergeBy.Text = "Join By:"
-        '
-        'ucrSaveDataFrame
-        '
-        Me.ucrSaveDataFrame.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrSaveDataFrame.Location = New System.Drawing.Point(13, 261)
-        Me.ucrSaveDataFrame.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
-        Me.ucrSaveDataFrame.Name = "ucrSaveDataFrame"
-        Me.ucrSaveDataFrame.Size = New System.Drawing.Size(320, 24)
-        Me.ucrSaveDataFrame.TabIndex = 26
         '
         'ucrInputMergingBy
         '
@@ -127,13 +119,34 @@ Partial Class dlgMergeAdditionalData
         Me.ucrBase.Size = New System.Drawing.Size(405, 52)
         Me.ucrBase.TabIndex = 7
         '
+        'ucrChkSaveDataFrame
+        '
+        Me.ucrChkSaveDataFrame.AutoSize = True
+        Me.ucrChkSaveDataFrame.Checked = False
+        Me.ucrChkSaveDataFrame.Location = New System.Drawing.Point(9, 262)
+        Me.ucrChkSaveDataFrame.Name = "ucrChkSaveDataFrame"
+        Me.ucrChkSaveDataFrame.Size = New System.Drawing.Size(100, 23)
+        Me.ucrChkSaveDataFrame.TabIndex = 8
+        '
+        'ucrInputSaveDataFrame
+        '
+        Me.ucrInputSaveDataFrame.AddQuotesIfUnrecognised = True
+        Me.ucrInputSaveDataFrame.AutoSize = True
+        Me.ucrInputSaveDataFrame.IsMultiline = False
+        Me.ucrInputSaveDataFrame.IsReadOnly = False
+        Me.ucrInputSaveDataFrame.Location = New System.Drawing.Point(116, 262)
+        Me.ucrInputSaveDataFrame.Name = "ucrInputSaveDataFrame"
+        Me.ucrInputSaveDataFrame.Size = New System.Drawing.Size(137, 21)
+        Me.ucrInputSaveDataFrame.TabIndex = 9
+        '
         'dlgMergeAdditionalData
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
         Me.AutoSize = True
         Me.ClientSize = New System.Drawing.Size(425, 349)
-        Me.Controls.Add(Me.ucrSaveDataFrame)
+        Me.Controls.Add(Me.ucrInputSaveDataFrame)
+        Me.Controls.Add(Me.ucrChkSaveDataFrame)
         Me.Controls.Add(Me.lblMergeBy)
         Me.Controls.Add(Me.cmdModify)
         Me.Controls.Add(Me.ucrInputMergingBy)
@@ -162,5 +175,6 @@ Partial Class dlgMergeAdditionalData
     Friend WithEvents ucrInputMergingBy As ucrInputTextBox
     Friend WithEvents cmdModify As Button
     Friend WithEvents lblMergeBy As Label
-    Friend WithEvents ucrSaveDataFrame As ucrSave
+    Friend WithEvents ucrInputSaveDataFrame As ucrInputTextBox
+    Friend WithEvents ucrChkSaveDataFrame As ucrCheck
 End Class

--- a/instat/dlgMergeAdditionalData.Designer.vb
+++ b/instat/dlgMergeAdditionalData.Designer.vb
@@ -125,7 +125,7 @@ Partial Class dlgMergeAdditionalData
         Me.ucrChkSaveDataFrame.Checked = False
         Me.ucrChkSaveDataFrame.Location = New System.Drawing.Point(9, 262)
         Me.ucrChkSaveDataFrame.Name = "ucrChkSaveDataFrame"
-        Me.ucrChkSaveDataFrame.Size = New System.Drawing.Size(100, 23)
+        Me.ucrChkSaveDataFrame.Size = New System.Drawing.Size(143, 23)
         Me.ucrChkSaveDataFrame.TabIndex = 8
         '
         'ucrInputSaveDataFrame
@@ -134,7 +134,7 @@ Partial Class dlgMergeAdditionalData
         Me.ucrInputSaveDataFrame.AutoSize = True
         Me.ucrInputSaveDataFrame.IsMultiline = False
         Me.ucrInputSaveDataFrame.IsReadOnly = False
-        Me.ucrInputSaveDataFrame.Location = New System.Drawing.Point(116, 262)
+        Me.ucrInputSaveDataFrame.Location = New System.Drawing.Point(158, 263)
         Me.ucrInputSaveDataFrame.Name = "ucrInputSaveDataFrame"
         Me.ucrInputSaveDataFrame.Size = New System.Drawing.Size(137, 21)
         Me.ucrInputSaveDataFrame.TabIndex = 9

--- a/instat/dlgMergeAdditionalData.Designer.vb
+++ b/instat/dlgMergeAdditionalData.Designer.vb
@@ -36,7 +36,7 @@ Partial Class dlgMergeAdditionalData
         '
         Me.lblVariablesToIncludeSecond.AutoSize = True
         Me.lblVariablesToIncludeSecond.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblVariablesToIncludeSecond.Location = New System.Drawing.Point(249, 88)
+        Me.lblVariablesToIncludeSecond.Location = New System.Drawing.Point(249, 78)
         Me.lblVariablesToIncludeSecond.Name = "lblVariablesToIncludeSecond"
         Me.lblVariablesToIncludeSecond.Size = New System.Drawing.Size(103, 13)
         Me.lblVariablesToIncludeSecond.TabIndex = 2
@@ -45,7 +45,7 @@ Partial Class dlgMergeAdditionalData
         'cmdModify
         '
         Me.cmdModify.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdModify.Location = New System.Drawing.Point(273, 300)
+        Me.cmdModify.Location = New System.Drawing.Point(273, 259)
         Me.cmdModify.Name = "cmdModify"
         Me.cmdModify.Size = New System.Drawing.Size(90, 23)
         Me.cmdModify.TabIndex = 6
@@ -55,7 +55,7 @@ Partial Class dlgMergeAdditionalData
         'lblMergeBy
         '
         Me.lblMergeBy.AutoSize = True
-        Me.lblMergeBy.Location = New System.Drawing.Point(9, 257)
+        Me.lblMergeBy.Location = New System.Drawing.Point(8, 224)
         Me.lblMergeBy.Name = "lblMergeBy"
         Me.lblMergeBy.Size = New System.Drawing.Size(44, 13)
         Me.lblMergeBy.TabIndex = 4
@@ -67,9 +67,9 @@ Partial Class dlgMergeAdditionalData
         Me.ucrInputMergingBy.AutoSize = True
         Me.ucrInputMergingBy.IsMultiline = False
         Me.ucrInputMergingBy.IsReadOnly = False
-        Me.ucrInputMergingBy.Location = New System.Drawing.Point(63, 254)
+        Me.ucrInputMergingBy.Location = New System.Drawing.Point(63, 221)
         Me.ucrInputMergingBy.Name = "ucrInputMergingBy"
-        Me.ucrInputMergingBy.Size = New System.Drawing.Size(300, 40)
+        Me.ucrInputMergingBy.Size = New System.Drawing.Size(300, 32)
         Me.ucrInputMergingBy.TabIndex = 5
         '
         'ucrFirstDataFrame
@@ -77,7 +77,7 @@ Partial Class dlgMergeAdditionalData
         Me.ucrFirstDataFrame.AutoSize = True
         Me.ucrFirstDataFrame.bDropUnusedFilterLevels = False
         Me.ucrFirstDataFrame.bUseCurrentFilter = True
-        Me.ucrFirstDataFrame.Location = New System.Drawing.Point(9, 13)
+        Me.ucrFirstDataFrame.Location = New System.Drawing.Point(249, 23)
         Me.ucrFirstDataFrame.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrFirstDataFrame.Name = "ucrFirstDataFrame"
         Me.ucrFirstDataFrame.Size = New System.Drawing.Size(151, 50)
@@ -87,7 +87,7 @@ Partial Class dlgMergeAdditionalData
         '
         Me.ucrReceiverSecond.AutoSize = True
         Me.ucrReceiverSecond.frmParent = Me
-        Me.ucrReceiverSecond.Location = New System.Drawing.Point(249, 106)
+        Me.ucrReceiverSecond.Location = New System.Drawing.Point(249, 96)
         Me.ucrReceiverSecond.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverSecond.Name = "ucrReceiverSecond"
         Me.ucrReceiverSecond.Selector = Nothing
@@ -102,7 +102,7 @@ Partial Class dlgMergeAdditionalData
         Me.ucrSecondSelector.bDropUnusedFilterLevels = False
         Me.ucrSecondSelector.bShowHiddenColumns = False
         Me.ucrSecondSelector.bUseCurrentFilter = True
-        Me.ucrSecondSelector.Location = New System.Drawing.Point(9, 64)
+        Me.ucrSecondSelector.Location = New System.Drawing.Point(8, 23)
         Me.ucrSecondSelector.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrSecondSelector.Name = "ucrSecondSelector"
         Me.ucrSecondSelector.Size = New System.Drawing.Size(213, 183)
@@ -112,7 +112,7 @@ Partial Class dlgMergeAdditionalData
         '
         Me.ucrBase.AutoSize = True
         Me.ucrBase.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrBase.Location = New System.Drawing.Point(9, 329)
+        Me.ucrBase.Location = New System.Drawing.Point(8, 289)
         Me.ucrBase.Name = "ucrBase"
         Me.ucrBase.Size = New System.Drawing.Size(405, 52)
         Me.ucrBase.TabIndex = 7
@@ -122,7 +122,7 @@ Partial Class dlgMergeAdditionalData
         Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
         Me.AutoSize = True
-        Me.ClientSize = New System.Drawing.Size(425, 386)
+        Me.ClientSize = New System.Drawing.Size(425, 349)
         Me.Controls.Add(Me.lblMergeBy)
         Me.Controls.Add(Me.cmdModify)
         Me.Controls.Add(Me.ucrInputMergingBy)

--- a/instat/dlgMergeAdditionalData.vb
+++ b/instat/dlgMergeAdditionalData.vb
@@ -68,7 +68,7 @@ Public Class dlgMergeAdditionalData
         ucrFromDataFrame.Reset()
         ucrReceiverSecond.SetMeAsReceiver()
         ucrInputMergingBy.SetName("")
-        ucrInputSaveDataFrame.SetName("new_data_frame")
+        ucrInputSaveDataFrame.SetName("merge")
 
         clsInsertColumnFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$add_columns_to_data")
 

--- a/instat/dlgMergeAdditionalData.vb
+++ b/instat/dlgMergeAdditionalData.vb
@@ -42,9 +42,9 @@ Public Class dlgMergeAdditionalData
     Private Sub InitialiseDialog()
         ucrFirstDataFrame.SetParameter(New RParameter("x", 0))
         ucrFirstDataFrame.SetParameterIsRFunction()
-        'ucrFirstDataFrame.SetLabelText("Main Data Frame:")
+        ucrFirstDataFrame.SetLabelText("To Data Frame:")
 
-        'ucrSecondSelector.SetLabelText("Additional Data Frame:")
+        ucrSecondSelector.SetLabelText("From Data Frame:")
 
         ucrReceiverSecond.SetParameter(New RParameter("y", 1))
         ucrReceiverSecond.SetParameterIsRFunction()

--- a/instat/dlgMergeAdditionalData.vb
+++ b/instat/dlgMergeAdditionalData.vb
@@ -42,9 +42,9 @@ Public Class dlgMergeAdditionalData
     Private Sub InitialiseDialog()
         ucrFirstDataFrame.SetParameter(New RParameter("x", 0))
         ucrFirstDataFrame.SetParameterIsRFunction()
-        ucrFirstDataFrame.SetLabelText("Main Data Frame:")
+        'ucrFirstDataFrame.SetLabelText("Main Data Frame:")
 
-        ucrSecondSelector.SetLabelText("Additional Data Frame:")
+        'ucrSecondSelector.SetLabelText("Additional Data Frame:")
 
         ucrReceiverSecond.SetParameter(New RParameter("y", 1))
         ucrReceiverSecond.SetParameterIsRFunction()

--- a/instat/frmMain.Designer.vb
+++ b/instat/frmMain.Designer.vb
@@ -4664,7 +4664,7 @@ Partial Class frmMain
         '
         Me.mnuOptionsByContextCheckData.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuOptionsByContextCheckDataDuplicates, Me.mnuOptionsByContextCheckDataCompareColumns, Me.ToolStripSeparator47, Me.mnuOptionsByContextCheckDataOneVariableSummarise, Me.mnuOptionsByContextCheckDataOneVariableGraph, Me.mnuOptionsByContextCheckDataOneVariableFrequencies})
         Me.mnuOptionsByContextCheckData.Name = "mnuOptionsByContextCheckData"
-        Me.mnuOptionsByContextCheckData.Size = New System.Drawing.Size(134, 22)
+        Me.mnuOptionsByContextCheckData.Size = New System.Drawing.Size(180, 22)
         Me.mnuOptionsByContextCheckData.Text = "Check Data"
         '
         'mnuOptionsByContextCheckDataDuplicates
@@ -4706,7 +4706,7 @@ Partial Class frmMain
         '
         Me.mnuOptionsByContextDefine.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuOptionsByContextDefineOnStation, Me.mnuOptionsByContextDefineOnFarm})
         Me.mnuOptionsByContextDefine.Name = "mnuOptionsByContextDefine"
-        Me.mnuOptionsByContextDefine.Size = New System.Drawing.Size(134, 22)
+        Me.mnuOptionsByContextDefine.Size = New System.Drawing.Size(180, 22)
         Me.mnuOptionsByContextDefine.Text = "Define"
         '
         'mnuOptionsByContextDefineOnStation
@@ -4725,7 +4725,7 @@ Partial Class frmMain
         '
         Me.mnuOptionsByContextPrepare.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuOptionsByContextPrepareCalculateDIfferenceBetweenOptions, Me.ToolStripSeparator48, Me.mnuOptionsByContextMergeAdditionalData, Me.mnuOptionsByContextPrepareStack, Me.mnuOptionsByContextPrepareUnstack})
         Me.mnuOptionsByContextPrepare.Name = "mnuOptionsByContextPrepare"
-        Me.mnuOptionsByContextPrepare.Size = New System.Drawing.Size(134, 22)
+        Me.mnuOptionsByContextPrepare.Size = New System.Drawing.Size(180, 22)
         Me.mnuOptionsByContextPrepare.Text = "Prepare"
         '
         'mnuOptionsByContextPrepareCalculateDIfferenceBetweenOptions
@@ -4743,7 +4743,7 @@ Partial Class frmMain
         '
         Me.mnuOptionsByContextMergeAdditionalData.Name = "mnuOptionsByContextMergeAdditionalData"
         Me.mnuOptionsByContextMergeAdditionalData.Size = New System.Drawing.Size(282, 22)
-        Me.mnuOptionsByContextMergeAdditionalData.Text = "Merge Additional Data..."
+        Me.mnuOptionsByContextMergeAdditionalData.Text = "Add (Merge) Data..."
         '
         'mnuOptionsByContextPrepareStack
         '
@@ -4761,7 +4761,7 @@ Partial Class frmMain
         '
         Me.mnuOptionsByContextDescribe.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuOptionsByContextDescribeCompareTwoTreatments, Me.mnuOptionsByContextDescribeCompareMultipleTreatments, Me.mnuOptionsByContextDescribeBoxplot})
         Me.mnuOptionsByContextDescribe.Name = "mnuOptionsByContextDescribe"
-        Me.mnuOptionsByContextDescribe.Size = New System.Drawing.Size(134, 22)
+        Me.mnuOptionsByContextDescribe.Size = New System.Drawing.Size(180, 22)
         Me.mnuOptionsByContextDescribe.Text = "Describe"
         '
         'mnuOptionsByContextDescribeCompareTwoTreatments
@@ -4787,7 +4787,7 @@ Partial Class frmMain
         '
         Me.mnuOptionsByContextModel.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuOptionsByContextModelFitModel, Me.mnuOptionsByContextGeneralFitModel})
         Me.mnuOptionsByContextModel.Name = "mnuOptionsByContextModel"
-        Me.mnuOptionsByContextModel.Size = New System.Drawing.Size(134, 22)
+        Me.mnuOptionsByContextModel.Size = New System.Drawing.Size(180, 22)
         Me.mnuOptionsByContextModel.Text = "Model"
         '
         'mnuOptionsByContextModelFitModel


### PR DESCRIPTION
Fixes #7029 
In this PR I have made the following changes:

- Changed the texts the dialogue and menu also updated the database from `Merge Additional Data dialog` to `Add (Merge) Data`
- Also added two possilities of saving the data either in the current dataframe or the new dataframe
I had a discussion with @Patowhiz where we decided on the use of `add_columns_to_data` for the option of saving the merged dataframe to the current dataframe.
I also made change in the database requested in #7297 items a.1) b.1) c.2)
@africanmathsinitiative/developers @rdstern this is ready for review. Thanks.