### PR TITLE
Renaming items and adding Three-Way Frequencies and Pivot-table(summaries) dialogs in Two/Three Variables sub-menu.

### DIFF
--- a/instat/dlgDuplicates.Designer.vb
+++ b/instat/dlgDuplicates.Designer.vb
@@ -1,5 +1,5 @@
 ﻿<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()>
-Partial Class dlgDuplicates
+Partial Class dlgDuplicateRows
     Inherits System.Windows.Forms.Form
 
     'Form overrides dispose to clean up the component list.
@@ -327,7 +327,7 @@ Partial Class dlgDuplicates
         Me.ucrSelectorDuplicateswithVariables.Size = New System.Drawing.Size(213, 183)
         Me.ucrSelectorDuplicateswithVariables.TabIndex = 4
         '
-        'dlgDuplicates
+        'dlgDuplicateRows
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
@@ -355,9 +355,9 @@ Partial Class dlgDuplicates
         Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow
         Me.MaximizeBox = False
         Me.MinimizeBox = False
-        Me.Name = "dlgDuplicates"
+        Me.Name = "dlgDuplicateRows"
         Me.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen
-        Me.Text = "Duplicates"
+        Me.Text = "Duplicate Rows"
         Me.grpOptions.ResumeLayout(False)
         Me.grpOptions.PerformLayout()
         Me.ResumeLayout(False)

--- a/instat/dlgDuplicates.vb
+++ b/instat/dlgDuplicates.vb
@@ -16,7 +16,7 @@
 
 Imports RDotNet
 Imports instat.Translations
-Public Class dlgDuplicates
+Public Class dlgDuplicateRows
     Private bReset As Boolean = True
     Private bFirstLoad As Boolean = True
     Private clsDuplicated2, clsDuplicated, clsStreakFunction, clsSubsetCol, clsDupCountIndex, clsSummaryFunction, clsGetColumnsFunction As New RFunction

--- a/instat/frmMain.Designer.vb
+++ b/instat/frmMain.Designer.vb
@@ -55,6 +55,7 @@ Partial Class frmMain
         Me.mnuDescribeTwoThreeVariablesCorrelations = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuDescribeTwoThreeVariablesTwoWayFrequencies = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuDescribeTwoThreeVariablesThreeWayFrequencies = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ToolStripSeparator36 = New System.Windows.Forms.ToolStripSeparator()
         Me.mnuDescribeTwoThreeVariablesPivotTable = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuDescribeSpecificTablesGraphs = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuDescribeSpecificFrequency = New System.Windows.Forms.ToolStripMenuItem()
@@ -441,6 +442,7 @@ Partial Class frmMain
         Me.mnuPrepareDataFrameConvertColumns = New System.Windows.Forms.ToolStripMenuItem()
         Me.ToolStripSeparator2 = New System.Windows.Forms.ToolStripSeparator()
         Me.mnuPrepareDataFrameReorderColumns = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuPrepareDataFrameAddMergeColumns = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuPrepareDataFrameInsertColumnsRows = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuPrepareDataFrameDeleteColumnsRows = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuPrepareDataFrameProtectColumn = New System.Windows.Forms.ToolStripMenuItem()
@@ -532,7 +534,7 @@ Partial Class frmMain
         Me.mnuPrepareKeysAndLinksAddLink = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuPrepareKeysAndLinksViewAndRemoveKeys = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuPrepareKeysAndLinksAddComment = New System.Windows.Forms.ToolStripMenuItem()
-        Me.mnuPrepareDataObject = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuPrepareDataBook = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuPrepareDataObjectDataFrameMetadata = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuPrepareDataObjectRenameDataFrame = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuPrepareDataObjectReorderDataFrames = New System.Windows.Forms.ToolStripMenuItem()
@@ -674,8 +676,6 @@ Partial Class frmMain
         Me.mnuDataFrameMetadata = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuScriptFile = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuLogFile = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ToolStripSeparator36 = New System.Windows.Forms.ToolStripSeparator()
-        Me.mnuPrepareDataFrameAddMergeColumns = New System.Windows.Forms.ToolStripMenuItem()
         Me.stsStrip.SuspendLayout()
         Me.Tool_strip.SuspendLayout()
         Me.mnuBar.SuspendLayout()
@@ -805,6 +805,11 @@ Partial Class frmMain
         Me.mnuDescribeTwoThreeVariablesThreeWayFrequencies.Name = "mnuDescribeTwoThreeVariablesThreeWayFrequencies"
         Me.mnuDescribeTwoThreeVariablesThreeWayFrequencies.Size = New System.Drawing.Size(206, 22)
         Me.mnuDescribeTwoThreeVariablesThreeWayFrequencies.Text = "Three-Way Frequencies..."
+        '
+        'ToolStripSeparator36
+        '
+        Me.ToolStripSeparator36.Name = "ToolStripSeparator36"
+        Me.ToolStripSeparator36.Size = New System.Drawing.Size(203, 6)
         '
         'mnuDescribeTwoThreeVariablesPivotTable
         '
@@ -3371,7 +3376,7 @@ Partial Class frmMain
         '
         'mnuPrepare
         '
-        Me.mnuPrepare.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuPrepareDataFrame, Me.mnuPrepareCheckData, Me.ToolStripSeparator6, Me.mnuPrepareCalculator, Me.mnuPrepareColumnCalculate, Me.mnuPrepareColumnFactor, Me.mnuPrepareColumnText, Me.mnuPrepareColumnDate, Me.mnuPrepareColumnDefine, Me.ToolStripSeparator4, Me.mnuPrepareDataReshape, Me.ToolStripSeparator7, Me.mnuPrepareKeysAndLinks, Me.mnuPrepareDataObject, Me.mnuPrepareRObjects})
+        Me.mnuPrepare.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuPrepareDataFrame, Me.mnuPrepareCheckData, Me.ToolStripSeparator6, Me.mnuPrepareCalculator, Me.mnuPrepareColumnCalculate, Me.mnuPrepareColumnFactor, Me.mnuPrepareColumnText, Me.mnuPrepareColumnDate, Me.mnuPrepareColumnDefine, Me.ToolStripSeparator4, Me.mnuPrepareDataReshape, Me.ToolStripSeparator7, Me.mnuPrepareKeysAndLinks, Me.mnuPrepareDataBook, Me.mnuPrepareRObjects})
         Me.mnuPrepare.Name = "mnuPrepare"
         Me.mnuPrepare.Size = New System.Drawing.Size(59, 20)
         Me.mnuPrepare.Tag = "Prepare"
@@ -3462,6 +3467,12 @@ Partial Class frmMain
         Me.mnuPrepareDataFrameReorderColumns.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataFrameReorderColumns.Tag = "Reorder_Columns..."
         Me.mnuPrepareDataFrameReorderColumns.Text = "Reorder Columns..."
+        '
+        'mnuPrepareDataFrameAddMergeColumns
+        '
+        Me.mnuPrepareDataFrameAddMergeColumns.Name = "mnuPrepareDataFrameAddMergeColumns"
+        Me.mnuPrepareDataFrameAddMergeColumns.Size = New System.Drawing.Size(201, 22)
+        Me.mnuPrepareDataFrameAddMergeColumns.Text = "Add (Merge) Columns..."
         '
         'mnuPrepareDataFrameInsertColumnsRows
         '
@@ -4058,13 +4069,13 @@ Partial Class frmMain
         Me.mnuPrepareKeysAndLinksAddComment.Size = New System.Drawing.Size(207, 22)
         Me.mnuPrepareKeysAndLinksAddComment.Text = "Add Comment..."
         '
-        'mnuPrepareDataObject
+        'mnuPrepareDataBook
         '
-        Me.mnuPrepareDataObject.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuPrepareDataObjectDataFrameMetadata, Me.mnuPrepareDataObjectRenameDataFrame, Me.mnuPrepareDataObjectReorderDataFrames, Me.mnuPrepareDataObjectCopyDataFrame, Me.mnuPrepareDataObjectDeleteDataFrame, Me.ToolStripSeparator21, Me.mnuPrepareDataObjectHideDataframes, Me.mnuPrepareDataObjectMetadata, Me.mnuPrepareDataObjectRenameMetadata, Me.mnuPrepareDataObjectReorderMetadata, Me.mnuPrepareDataObjectDeleteMetadata})
-        Me.mnuPrepareDataObject.Name = "mnuPrepareDataObject"
-        Me.mnuPrepareDataObject.Size = New System.Drawing.Size(186, 22)
-        Me.mnuPrepareDataObject.Tag = "Data_Object"
-        Me.mnuPrepareDataObject.Text = "Data Object"
+        Me.mnuPrepareDataBook.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuPrepareDataObjectDataFrameMetadata, Me.mnuPrepareDataObjectRenameDataFrame, Me.mnuPrepareDataObjectReorderDataFrames, Me.mnuPrepareDataObjectCopyDataFrame, Me.mnuPrepareDataObjectDeleteDataFrame, Me.ToolStripSeparator21, Me.mnuPrepareDataObjectHideDataframes, Me.mnuPrepareDataObjectMetadata, Me.mnuPrepareDataObjectRenameMetadata, Me.mnuPrepareDataObjectReorderMetadata, Me.mnuPrepareDataObjectDeleteMetadata})
+        Me.mnuPrepareDataBook.Name = "mnuPrepareDataBook"
+        Me.mnuPrepareDataBook.Size = New System.Drawing.Size(186, 22)
+        Me.mnuPrepareDataBook.Tag = "Data_Object"
+        Me.mnuPrepareDataBook.Text = "Data Book"
         '
         'mnuPrepareDataObjectDataFrameMetadata
         '
@@ -5071,17 +5082,6 @@ Partial Class frmMain
         Me.mnuLogFile.Text = "Log Window..."
         Me.mnuLogFile.ToolTipText = "Log Window"
         '
-        'ToolStripSeparator36
-        '
-        Me.ToolStripSeparator36.Name = "ToolStripSeparator36"
-        Me.ToolStripSeparator36.Size = New System.Drawing.Size(203, 6)
-        '
-        'mnuPrepareDataFrameAddMergeColumns
-        '
-        Me.mnuPrepareDataFrameAddMergeColumns.Name = "mnuPrepareDataFrameAddMergeColumns"
-        Me.mnuPrepareDataFrameAddMergeColumns.Size = New System.Drawing.Size(201, 22)
-        Me.mnuPrepareDataFrameAddMergeColumns.Text = "Add (Merge) Columns..."
-        '
         'frmMain
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
@@ -5200,7 +5200,7 @@ Partial Class frmMain
     Friend WithEvents mnuViewDataFrameMetadata As ToolStripMenuItem
     Friend WithEvents mnuViewLog As ToolStripMenuItem
     Friend WithEvents mnuViewScriptWindow As ToolStripMenuItem
-    Friend WithEvents mnuPrepareDataObject As ToolStripMenuItem
+    Friend WithEvents mnuPrepareDataBook As ToolStripMenuItem
     Friend WithEvents mnuPrepareDataObjectDeleteDataFrame As ToolStripMenuItem
     Friend WithEvents mnuPrepareDataObjectRenameDataFrame As ToolStripMenuItem
     Friend WithEvents mnuPrepareDataObjectReorderDataFrames As ToolStripMenuItem

--- a/instat/frmMain.Designer.vb
+++ b/instat/frmMain.Designer.vb
@@ -53,8 +53,8 @@ Partial Class frmMain
         Me.mnuDescribeTwoVariablesGraph = New System.Windows.Forms.ToolStripMenuItem()
         Me.ToolStripSeparator34 = New System.Windows.Forms.ToolStripSeparator()
         Me.mnuDescribeTwoThreeVariablesCorrelations = New System.Windows.Forms.ToolStripMenuItem()
-        Me.mnuDescribeTwoVariablesFrequencies = New System.Windows.Forms.ToolStripMenuItem()
-        Me.mnuDescribeTwoVariablesPivotTable = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuDescribeTwoThreeVariablesTwoWayFrequencies = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuDescribeTwoThreeVariablesPivotTableFrequencies = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuDescribeSpecificTablesGraphs = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuDescribeSpecificFrequency = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuDescribeSpecificSummary = New System.Windows.Forms.ToolStripMenuItem()
@@ -673,6 +673,8 @@ Partial Class frmMain
         Me.mnuDataFrameMetadata = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuScriptFile = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuLogFile = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuDescribeTwoThreeVariablesThreeWayFrequencies = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuDescribeTwoThreeVariablesPivotTableSummaries = New System.Windows.Forms.ToolStripMenuItem()
         Me.stsStrip.SuspendLayout()
         Me.Tool_strip.SuspendLayout()
         Me.mnuBar.SuspendLayout()
@@ -758,7 +760,7 @@ Partial Class frmMain
         '
         'mnuDescribeTwoThreeVariables
         '
-        Me.mnuDescribeTwoThreeVariables.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuDescribeTwoVariablesSummarise, Me.mnuDescribeTwoVariablesGraph, Me.ToolStripSeparator34, Me.mnuDescribeTwoThreeVariablesCorrelations, Me.mnuDescribeTwoVariablesFrequencies, Me.mnuDescribeTwoVariablesPivotTable})
+        Me.mnuDescribeTwoThreeVariables.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuDescribeTwoVariablesSummarise, Me.mnuDescribeTwoVariablesGraph, Me.ToolStripSeparator34, Me.mnuDescribeTwoThreeVariablesCorrelations, Me.mnuDescribeTwoThreeVariablesTwoWayFrequencies, Me.mnuDescribeTwoThreeVariablesThreeWayFrequencies, Me.mnuDescribeTwoThreeVariablesPivotTableFrequencies, Me.mnuDescribeTwoThreeVariablesPivotTableSummaries})
         Me.mnuDescribeTwoThreeVariables.Name = "mnuDescribeTwoThreeVariables"
         Me.mnuDescribeTwoThreeVariables.Size = New System.Drawing.Size(192, 22)
         Me.mnuDescribeTwoThreeVariables.Tag = "Two_Variables"
@@ -768,40 +770,40 @@ Partial Class frmMain
         '
         Me.mnuDescribeTwoVariablesSummarise.DoubleClickEnabled = True
         Me.mnuDescribeTwoVariablesSummarise.Name = "mnuDescribeTwoVariablesSummarise"
-        Me.mnuDescribeTwoVariablesSummarise.Size = New System.Drawing.Size(180, 22)
+        Me.mnuDescribeTwoVariablesSummarise.Size = New System.Drawing.Size(213, 22)
         Me.mnuDescribeTwoVariablesSummarise.Tag = "Summarise..."
         Me.mnuDescribeTwoVariablesSummarise.Text = "Summarise..."
         '
         'mnuDescribeTwoVariablesGraph
         '
         Me.mnuDescribeTwoVariablesGraph.Name = "mnuDescribeTwoVariablesGraph"
-        Me.mnuDescribeTwoVariablesGraph.Size = New System.Drawing.Size(180, 22)
+        Me.mnuDescribeTwoVariablesGraph.Size = New System.Drawing.Size(213, 22)
         Me.mnuDescribeTwoVariablesGraph.Tag = "Graph..."
         Me.mnuDescribeTwoVariablesGraph.Text = "Graph..."
         '
         'ToolStripSeparator34
         '
         Me.ToolStripSeparator34.Name = "ToolStripSeparator34"
-        Me.ToolStripSeparator34.Size = New System.Drawing.Size(177, 6)
+        Me.ToolStripSeparator34.Size = New System.Drawing.Size(210, 6)
         '
         'mnuDescribeTwoThreeVariablesCorrelations
         '
         Me.mnuDescribeTwoThreeVariablesCorrelations.Name = "mnuDescribeTwoThreeVariablesCorrelations"
-        Me.mnuDescribeTwoThreeVariablesCorrelations.Size = New System.Drawing.Size(180, 22)
+        Me.mnuDescribeTwoThreeVariablesCorrelations.Size = New System.Drawing.Size(213, 22)
         Me.mnuDescribeTwoThreeVariablesCorrelations.Text = "Correlations..."
         '
-        'mnuDescribeTwoVariablesFrequencies
+        'mnuDescribeTwoThreeVariablesTwoWayFrequencies
         '
-        Me.mnuDescribeTwoVariablesFrequencies.DoubleClickEnabled = True
-        Me.mnuDescribeTwoVariablesFrequencies.Name = "mnuDescribeTwoVariablesFrequencies"
-        Me.mnuDescribeTwoVariablesFrequencies.Size = New System.Drawing.Size(180, 22)
-        Me.mnuDescribeTwoVariablesFrequencies.Text = "Frequencies..."
+        Me.mnuDescribeTwoThreeVariablesTwoWayFrequencies.DoubleClickEnabled = True
+        Me.mnuDescribeTwoThreeVariablesTwoWayFrequencies.Name = "mnuDescribeTwoThreeVariablesTwoWayFrequencies"
+        Me.mnuDescribeTwoThreeVariablesTwoWayFrequencies.Size = New System.Drawing.Size(213, 22)
+        Me.mnuDescribeTwoThreeVariablesTwoWayFrequencies.Text = "Two-Way Frequencies..."
         '
-        'mnuDescribeTwoVariablesPivotTable
+        'mnuDescribeTwoThreeVariablesPivotTableFrequencies
         '
-        Me.mnuDescribeTwoVariablesPivotTable.Name = "mnuDescribeTwoVariablesPivotTable"
-        Me.mnuDescribeTwoVariablesPivotTable.Size = New System.Drawing.Size(180, 22)
-        Me.mnuDescribeTwoVariablesPivotTable.Text = "Pivot Table..."
+        Me.mnuDescribeTwoThreeVariablesPivotTableFrequencies.Name = "mnuDescribeTwoThreeVariablesPivotTableFrequencies"
+        Me.mnuDescribeTwoThreeVariablesPivotTableFrequencies.Size = New System.Drawing.Size(213, 22)
+        Me.mnuDescribeTwoThreeVariablesPivotTableFrequencies.Text = "Pivot-Table(Frequencies)..."
         '
         'mnuDescribeSpecificTablesGraphs
         '
@@ -5062,6 +5064,18 @@ Partial Class frmMain
         Me.mnuLogFile.Text = "Log Window..."
         Me.mnuLogFile.ToolTipText = "Log Window"
         '
+        'mnuDescribeTwoThreeVariablesThreeWayFrequencies
+        '
+        Me.mnuDescribeTwoThreeVariablesThreeWayFrequencies.Name = "mnuDescribeTwoThreeVariablesThreeWayFrequencies"
+        Me.mnuDescribeTwoThreeVariablesThreeWayFrequencies.Size = New System.Drawing.Size(213, 22)
+        Me.mnuDescribeTwoThreeVariablesThreeWayFrequencies.Text = "Three-Way Frequencies..."
+        '
+        'mnuDescribeTwoThreeVariablesPivotTableSummaries
+        '
+        Me.mnuDescribeTwoThreeVariablesPivotTableSummaries.Name = "mnuDescribeTwoThreeVariablesPivotTableSummaries"
+        Me.mnuDescribeTwoThreeVariablesPivotTableSummaries.Size = New System.Drawing.Size(213, 22)
+        Me.mnuDescribeTwoThreeVariablesPivotTableSummaries.Text = "Pivot-Table(Summaries)..."
+        '
         'frmMain
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
@@ -5457,7 +5471,7 @@ Partial Class frmMain
     Friend WithEvents mnuDescribeOneVariableFrequencies As ToolStripMenuItem
     Friend WithEvents ToolStripSeparator34 As ToolStripSeparator
     Friend WithEvents ToolStripMenuItem1 As ToolStripMenuItem
-    Friend WithEvents mnuDescribeTwoVariablesFrequencies As ToolStripMenuItem
+    Friend WithEvents mnuDescribeTwoThreeVariablesTwoWayFrequencies As ToolStripMenuItem
     Friend WithEvents mnuFileImportFromCSPRO As ToolStripMenuItem
     Friend WithEvents mnuFileImportFromDatabases As ToolStripMenuItem
     Friend WithEvents mnuClimaticFileImportandTidyNetCDF As ToolStripMenuItem
@@ -5733,7 +5747,7 @@ Partial Class frmMain
     Friend WithEvents mnuLastGraph As ToolStripSplitButton
     Friend WithEvents mnuViewer As ToolStripMenuItem
     Friend WithEvents mnuploty As ToolStripMenuItem
-    Friend WithEvents mnuDescribeTwoVariablesPivotTable As ToolStripMenuItem
+    Friend WithEvents mnuDescribeTwoThreeVariablesPivotTableFrequencies As ToolStripMenuItem
     Friend WithEvents ToolStripSeparator27 As ToolStripSeparator
     Friend WithEvents ToolStripSeparator71 As ToolStripSeparator
     Friend WithEvents mnuEditScript As ToolStripMenuItem
@@ -5750,4 +5764,6 @@ Partial Class frmMain
     Friend WithEvents mnuOptionsByContextDefineOnStation As ToolStripMenuItem
     Friend WithEvents mnuOptionsByContextDefineOnFarm As ToolStripMenuItem
     Friend WithEvents mnuDescribeTwoThreeVariablesCorrelations As ToolStripMenuItem
+    Friend WithEvents mnuDescribeTwoThreeVariablesThreeWayFrequencies As ToolStripMenuItem
+    Friend WithEvents mnuDescribeTwoThreeVariablesPivotTableSummaries As ToolStripMenuItem
 End Class

--- a/instat/frmMain.Designer.vb
+++ b/instat/frmMain.Designer.vb
@@ -54,7 +54,8 @@ Partial Class frmMain
         Me.ToolStripSeparator34 = New System.Windows.Forms.ToolStripSeparator()
         Me.mnuDescribeTwoThreeVariablesCorrelations = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuDescribeTwoThreeVariablesTwoWayFrequencies = New System.Windows.Forms.ToolStripMenuItem()
-        Me.mnuDescribeTwoThreeVariablesPivotTableFrequencies = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuDescribeTwoThreeVariablesThreeWayFrequencies = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuDescribeTwoThreeVariablesPivotTable = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuDescribeSpecificTablesGraphs = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuDescribeSpecificFrequency = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuDescribeSpecificSummary = New System.Windows.Forms.ToolStripMenuItem()
@@ -673,8 +674,8 @@ Partial Class frmMain
         Me.mnuDataFrameMetadata = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuScriptFile = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuLogFile = New System.Windows.Forms.ToolStripMenuItem()
-        Me.mnuDescribeTwoThreeVariablesThreeWayFrequencies = New System.Windows.Forms.ToolStripMenuItem()
-        Me.mnuDescribeTwoThreeVariablesPivotTableSummaries = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ToolStripSeparator36 = New System.Windows.Forms.ToolStripSeparator()
+        Me.mnuPrepareDataFrameAddMergeColumns = New System.Windows.Forms.ToolStripMenuItem()
         Me.stsStrip.SuspendLayout()
         Me.Tool_strip.SuspendLayout()
         Me.mnuBar.SuspendLayout()
@@ -760,7 +761,7 @@ Partial Class frmMain
         '
         'mnuDescribeTwoThreeVariables
         '
-        Me.mnuDescribeTwoThreeVariables.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuDescribeTwoVariablesSummarise, Me.mnuDescribeTwoVariablesGraph, Me.ToolStripSeparator34, Me.mnuDescribeTwoThreeVariablesCorrelations, Me.mnuDescribeTwoThreeVariablesTwoWayFrequencies, Me.mnuDescribeTwoThreeVariablesThreeWayFrequencies, Me.mnuDescribeTwoThreeVariablesPivotTableFrequencies, Me.mnuDescribeTwoThreeVariablesPivotTableSummaries})
+        Me.mnuDescribeTwoThreeVariables.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuDescribeTwoVariablesSummarise, Me.mnuDescribeTwoVariablesGraph, Me.ToolStripSeparator34, Me.mnuDescribeTwoThreeVariablesCorrelations, Me.mnuDescribeTwoThreeVariablesTwoWayFrequencies, Me.mnuDescribeTwoThreeVariablesThreeWayFrequencies, Me.ToolStripSeparator36, Me.mnuDescribeTwoThreeVariablesPivotTable})
         Me.mnuDescribeTwoThreeVariables.Name = "mnuDescribeTwoThreeVariables"
         Me.mnuDescribeTwoThreeVariables.Size = New System.Drawing.Size(192, 22)
         Me.mnuDescribeTwoThreeVariables.Tag = "Two_Variables"
@@ -770,40 +771,46 @@ Partial Class frmMain
         '
         Me.mnuDescribeTwoVariablesSummarise.DoubleClickEnabled = True
         Me.mnuDescribeTwoVariablesSummarise.Name = "mnuDescribeTwoVariablesSummarise"
-        Me.mnuDescribeTwoVariablesSummarise.Size = New System.Drawing.Size(213, 22)
+        Me.mnuDescribeTwoVariablesSummarise.Size = New System.Drawing.Size(206, 22)
         Me.mnuDescribeTwoVariablesSummarise.Tag = "Summarise..."
         Me.mnuDescribeTwoVariablesSummarise.Text = "Summarise..."
         '
         'mnuDescribeTwoVariablesGraph
         '
         Me.mnuDescribeTwoVariablesGraph.Name = "mnuDescribeTwoVariablesGraph"
-        Me.mnuDescribeTwoVariablesGraph.Size = New System.Drawing.Size(213, 22)
+        Me.mnuDescribeTwoVariablesGraph.Size = New System.Drawing.Size(206, 22)
         Me.mnuDescribeTwoVariablesGraph.Tag = "Graph..."
         Me.mnuDescribeTwoVariablesGraph.Text = "Graph..."
         '
         'ToolStripSeparator34
         '
         Me.ToolStripSeparator34.Name = "ToolStripSeparator34"
-        Me.ToolStripSeparator34.Size = New System.Drawing.Size(210, 6)
+        Me.ToolStripSeparator34.Size = New System.Drawing.Size(203, 6)
         '
         'mnuDescribeTwoThreeVariablesCorrelations
         '
         Me.mnuDescribeTwoThreeVariablesCorrelations.Name = "mnuDescribeTwoThreeVariablesCorrelations"
-        Me.mnuDescribeTwoThreeVariablesCorrelations.Size = New System.Drawing.Size(213, 22)
+        Me.mnuDescribeTwoThreeVariablesCorrelations.Size = New System.Drawing.Size(206, 22)
         Me.mnuDescribeTwoThreeVariablesCorrelations.Text = "Correlations..."
         '
         'mnuDescribeTwoThreeVariablesTwoWayFrequencies
         '
         Me.mnuDescribeTwoThreeVariablesTwoWayFrequencies.DoubleClickEnabled = True
         Me.mnuDescribeTwoThreeVariablesTwoWayFrequencies.Name = "mnuDescribeTwoThreeVariablesTwoWayFrequencies"
-        Me.mnuDescribeTwoThreeVariablesTwoWayFrequencies.Size = New System.Drawing.Size(213, 22)
+        Me.mnuDescribeTwoThreeVariablesTwoWayFrequencies.Size = New System.Drawing.Size(206, 22)
         Me.mnuDescribeTwoThreeVariablesTwoWayFrequencies.Text = "Two-Way Frequencies..."
         '
-        'mnuDescribeTwoThreeVariablesPivotTableFrequencies
+        'mnuDescribeTwoThreeVariablesThreeWayFrequencies
         '
-        Me.mnuDescribeTwoThreeVariablesPivotTableFrequencies.Name = "mnuDescribeTwoThreeVariablesPivotTableFrequencies"
-        Me.mnuDescribeTwoThreeVariablesPivotTableFrequencies.Size = New System.Drawing.Size(213, 22)
-        Me.mnuDescribeTwoThreeVariablesPivotTableFrequencies.Text = "Pivot-Table(Frequencies)..."
+        Me.mnuDescribeTwoThreeVariablesThreeWayFrequencies.Name = "mnuDescribeTwoThreeVariablesThreeWayFrequencies"
+        Me.mnuDescribeTwoThreeVariablesThreeWayFrequencies.Size = New System.Drawing.Size(206, 22)
+        Me.mnuDescribeTwoThreeVariablesThreeWayFrequencies.Text = "Three-Way Frequencies..."
+        '
+        'mnuDescribeTwoThreeVariablesPivotTable
+        '
+        Me.mnuDescribeTwoThreeVariablesPivotTable.Name = "mnuDescribeTwoThreeVariablesPivotTable"
+        Me.mnuDescribeTwoThreeVariablesPivotTable.Size = New System.Drawing.Size(206, 22)
+        Me.mnuDescribeTwoThreeVariablesPivotTable.Text = "Pivot Table..."
         '
         'mnuDescribeSpecificTablesGraphs
         '
@@ -3372,7 +3379,7 @@ Partial Class frmMain
         '
         'mnuPrepareDataFrame
         '
-        Me.mnuPrepareDataFrame.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuPrepareDataFrameViewData, Me.mnuPrepareDataFrameRenameColumn, Me.mnuPrepareDataFrameDuplicateColumn, Me.mnuPrepareDataFrameRowNumbersNames, Me.ToolStripSeparator1, Me.mnuPrepareDataFrameSort, Me.mnuPrepareDataFrameFilterRows, Me.mnuPrepareDataFrameSelectColumns, Me.mnuPrepareDataFrameReplaceValues, Me.mnuPrepareDataFrameConvertColumns, Me.ToolStripSeparator2, Me.mnuPrepareDataFrameReorderColumns, Me.mnuPrepareDataFrameInsertColumnsRows, Me.mnuPrepareDataFrameDeleteColumnsRows, Me.mnuPrepareDataFrameProtectColumn, Me.mnuPrepareDataFrameHideColumns, Me.mnuPrepareDataFrameFreezeColumns, Me.mnuPrepareDataframeColourByProperty})
+        Me.mnuPrepareDataFrame.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuPrepareDataFrameViewData, Me.mnuPrepareDataFrameRenameColumn, Me.mnuPrepareDataFrameDuplicateColumn, Me.mnuPrepareDataFrameRowNumbersNames, Me.ToolStripSeparator1, Me.mnuPrepareDataFrameSort, Me.mnuPrepareDataFrameFilterRows, Me.mnuPrepareDataFrameSelectColumns, Me.mnuPrepareDataFrameReplaceValues, Me.mnuPrepareDataFrameConvertColumns, Me.ToolStripSeparator2, Me.mnuPrepareDataFrameReorderColumns, Me.mnuPrepareDataFrameAddMergeColumns, Me.mnuPrepareDataFrameInsertColumnsRows, Me.mnuPrepareDataFrameDeleteColumnsRows, Me.mnuPrepareDataFrameProtectColumn, Me.mnuPrepareDataFrameHideColumns, Me.mnuPrepareDataFrameFreezeColumns, Me.mnuPrepareDataframeColourByProperty})
         Me.mnuPrepareDataFrame.Name = "mnuPrepareDataFrame"
         Me.mnuPrepareDataFrame.Size = New System.Drawing.Size(186, 22)
         Me.mnuPrepareDataFrame.Tag = "Data_Frame"
@@ -3381,92 +3388,92 @@ Partial Class frmMain
         'mnuPrepareDataFrameViewData
         '
         Me.mnuPrepareDataFrameViewData.Name = "mnuPrepareDataFrameViewData"
-        Me.mnuPrepareDataFrameViewData.Size = New System.Drawing.Size(200, 22)
+        Me.mnuPrepareDataFrameViewData.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataFrameViewData.Tag = "View_Data..."
         Me.mnuPrepareDataFrameViewData.Text = "View Data..."
         '
         'mnuPrepareDataFrameRenameColumn
         '
         Me.mnuPrepareDataFrameRenameColumn.Name = "mnuPrepareDataFrameRenameColumn"
-        Me.mnuPrepareDataFrameRenameColumn.Size = New System.Drawing.Size(200, 22)
+        Me.mnuPrepareDataFrameRenameColumn.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataFrameRenameColumn.Tag = "Rename_Column..."
         Me.mnuPrepareDataFrameRenameColumn.Text = "Rename Columns..."
         '
         'mnuPrepareDataFrameDuplicateColumn
         '
         Me.mnuPrepareDataFrameDuplicateColumn.Name = "mnuPrepareDataFrameDuplicateColumn"
-        Me.mnuPrepareDataFrameDuplicateColumn.Size = New System.Drawing.Size(200, 22)
+        Me.mnuPrepareDataFrameDuplicateColumn.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataFrameDuplicateColumn.Text = "Duplicate Column..."
         '
         'mnuPrepareDataFrameRowNumbersNames
         '
         Me.mnuPrepareDataFrameRowNumbersNames.Name = "mnuPrepareDataFrameRowNumbersNames"
-        Me.mnuPrepareDataFrameRowNumbersNames.Size = New System.Drawing.Size(200, 22)
+        Me.mnuPrepareDataFrameRowNumbersNames.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataFrameRowNumbersNames.Tag = "Row_Numbers/Names..."
         Me.mnuPrepareDataFrameRowNumbersNames.Text = "Row Numbers/Names..."
         '
         'ToolStripSeparator1
         '
         Me.ToolStripSeparator1.Name = "ToolStripSeparator1"
-        Me.ToolStripSeparator1.Size = New System.Drawing.Size(197, 6)
+        Me.ToolStripSeparator1.Size = New System.Drawing.Size(198, 6)
         '
         'mnuPrepareDataFrameSort
         '
         Me.mnuPrepareDataFrameSort.Name = "mnuPrepareDataFrameSort"
-        Me.mnuPrepareDataFrameSort.Size = New System.Drawing.Size(200, 22)
+        Me.mnuPrepareDataFrameSort.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataFrameSort.Tag = "Sort..."
         Me.mnuPrepareDataFrameSort.Text = "Sort..."
         '
         'mnuPrepareDataFrameFilterRows
         '
         Me.mnuPrepareDataFrameFilterRows.Name = "mnuPrepareDataFrameFilterRows"
-        Me.mnuPrepareDataFrameFilterRows.Size = New System.Drawing.Size(200, 22)
+        Me.mnuPrepareDataFrameFilterRows.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataFrameFilterRows.Tag = "Filter..."
         Me.mnuPrepareDataFrameFilterRows.Text = "Filter Rows..."
         '
         'mnuPrepareDataFrameSelectColumns
         '
         Me.mnuPrepareDataFrameSelectColumns.Name = "mnuPrepareDataFrameSelectColumns"
-        Me.mnuPrepareDataFrameSelectColumns.Size = New System.Drawing.Size(200, 22)
+        Me.mnuPrepareDataFrameSelectColumns.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataFrameSelectColumns.Text = "Select Columns..."
         '
         'mnuPrepareDataFrameReplaceValues
         '
         Me.mnuPrepareDataFrameReplaceValues.Name = "mnuPrepareDataFrameReplaceValues"
-        Me.mnuPrepareDataFrameReplaceValues.Size = New System.Drawing.Size(200, 22)
+        Me.mnuPrepareDataFrameReplaceValues.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataFrameReplaceValues.Tag = "Replace_Values..."
         Me.mnuPrepareDataFrameReplaceValues.Text = "Replace Values..."
         '
         'mnuPrepareDataFrameConvertColumns
         '
         Me.mnuPrepareDataFrameConvertColumns.Name = "mnuPrepareDataFrameConvertColumns"
-        Me.mnuPrepareDataFrameConvertColumns.Size = New System.Drawing.Size(200, 22)
+        Me.mnuPrepareDataFrameConvertColumns.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataFrameConvertColumns.Tag = "Convert_Columns..."
         Me.mnuPrepareDataFrameConvertColumns.Text = "Convert Columns..."
         '
         'ToolStripSeparator2
         '
         Me.ToolStripSeparator2.Name = "ToolStripSeparator2"
-        Me.ToolStripSeparator2.Size = New System.Drawing.Size(197, 6)
+        Me.ToolStripSeparator2.Size = New System.Drawing.Size(198, 6)
         '
         'mnuPrepareDataFrameReorderColumns
         '
         Me.mnuPrepareDataFrameReorderColumns.Name = "mnuPrepareDataFrameReorderColumns"
-        Me.mnuPrepareDataFrameReorderColumns.Size = New System.Drawing.Size(200, 22)
+        Me.mnuPrepareDataFrameReorderColumns.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataFrameReorderColumns.Tag = "Reorder_Columns..."
         Me.mnuPrepareDataFrameReorderColumns.Text = "Reorder Columns..."
         '
         'mnuPrepareDataFrameInsertColumnsRows
         '
         Me.mnuPrepareDataFrameInsertColumnsRows.Name = "mnuPrepareDataFrameInsertColumnsRows"
-        Me.mnuPrepareDataFrameInsertColumnsRows.Size = New System.Drawing.Size(200, 22)
+        Me.mnuPrepareDataFrameInsertColumnsRows.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataFrameInsertColumnsRows.Tag = "Insert_Columns/Rows..."
         Me.mnuPrepareDataFrameInsertColumnsRows.Text = "Insert Columns/Rows..."
         '
         'mnuPrepareDataFrameDeleteColumnsRows
         '
         Me.mnuPrepareDataFrameDeleteColumnsRows.Name = "mnuPrepareDataFrameDeleteColumnsRows"
-        Me.mnuPrepareDataFrameDeleteColumnsRows.Size = New System.Drawing.Size(200, 22)
+        Me.mnuPrepareDataFrameDeleteColumnsRows.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataFrameDeleteColumnsRows.Tag = "Delete_Columns/Rows..."
         Me.mnuPrepareDataFrameDeleteColumnsRows.Text = "Delete Columns/Rows..."
         '
@@ -3474,7 +3481,7 @@ Partial Class frmMain
         '
         Me.mnuPrepareDataFrameProtectColumn.Enabled = False
         Me.mnuPrepareDataFrameProtectColumn.Name = "mnuPrepareDataFrameProtectColumn"
-        Me.mnuPrepareDataFrameProtectColumn.Size = New System.Drawing.Size(200, 22)
+        Me.mnuPrepareDataFrameProtectColumn.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataFrameProtectColumn.Tag = "..."
         Me.mnuPrepareDataFrameProtectColumn.Text = "Protect Column..."
         Me.mnuPrepareDataFrameProtectColumn.Visible = False
@@ -3482,7 +3489,7 @@ Partial Class frmMain
         'mnuPrepareDataFrameHideColumns
         '
         Me.mnuPrepareDataFrameHideColumns.Name = "mnuPrepareDataFrameHideColumns"
-        Me.mnuPrepareDataFrameHideColumns.Size = New System.Drawing.Size(200, 22)
+        Me.mnuPrepareDataFrameHideColumns.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataFrameHideColumns.Tag = "Hide_Columns..."
         Me.mnuPrepareDataFrameHideColumns.Text = "Hide/Show Columns..."
         '
@@ -3490,7 +3497,7 @@ Partial Class frmMain
         '
         Me.mnuPrepareDataFrameFreezeColumns.Enabled = False
         Me.mnuPrepareDataFrameFreezeColumns.Name = "mnuPrepareDataFrameFreezeColumns"
-        Me.mnuPrepareDataFrameFreezeColumns.Size = New System.Drawing.Size(200, 22)
+        Me.mnuPrepareDataFrameFreezeColumns.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataFrameFreezeColumns.Tag = "Freeze_Columns..."
         Me.mnuPrepareDataFrameFreezeColumns.Text = "Freeze Columns..."
         Me.mnuPrepareDataFrameFreezeColumns.Visible = False
@@ -3498,7 +3505,7 @@ Partial Class frmMain
         'mnuPrepareDataframeColourByProperty
         '
         Me.mnuPrepareDataframeColourByProperty.Name = "mnuPrepareDataframeColourByProperty"
-        Me.mnuPrepareDataframeColourByProperty.Size = New System.Drawing.Size(200, 22)
+        Me.mnuPrepareDataframeColourByProperty.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataframeColourByProperty.Text = "Colour by Property..."
         '
         'mnuPrepareCheckData
@@ -5064,17 +5071,16 @@ Partial Class frmMain
         Me.mnuLogFile.Text = "Log Window..."
         Me.mnuLogFile.ToolTipText = "Log Window"
         '
-        'mnuDescribeTwoThreeVariablesThreeWayFrequencies
+        'ToolStripSeparator36
         '
-        Me.mnuDescribeTwoThreeVariablesThreeWayFrequencies.Name = "mnuDescribeTwoThreeVariablesThreeWayFrequencies"
-        Me.mnuDescribeTwoThreeVariablesThreeWayFrequencies.Size = New System.Drawing.Size(213, 22)
-        Me.mnuDescribeTwoThreeVariablesThreeWayFrequencies.Text = "Three-Way Frequencies..."
+        Me.ToolStripSeparator36.Name = "ToolStripSeparator36"
+        Me.ToolStripSeparator36.Size = New System.Drawing.Size(203, 6)
         '
-        'mnuDescribeTwoThreeVariablesPivotTableSummaries
+        'mnuPrepareDataFrameAddMergeColumns
         '
-        Me.mnuDescribeTwoThreeVariablesPivotTableSummaries.Name = "mnuDescribeTwoThreeVariablesPivotTableSummaries"
-        Me.mnuDescribeTwoThreeVariablesPivotTableSummaries.Size = New System.Drawing.Size(213, 22)
-        Me.mnuDescribeTwoThreeVariablesPivotTableSummaries.Text = "Pivot-Table(Summaries)..."
+        Me.mnuPrepareDataFrameAddMergeColumns.Name = "mnuPrepareDataFrameAddMergeColumns"
+        Me.mnuPrepareDataFrameAddMergeColumns.Size = New System.Drawing.Size(201, 22)
+        Me.mnuPrepareDataFrameAddMergeColumns.Text = "Add (Merge) Columns..."
         '
         'frmMain
         '
@@ -5747,7 +5753,6 @@ Partial Class frmMain
     Friend WithEvents mnuLastGraph As ToolStripSplitButton
     Friend WithEvents mnuViewer As ToolStripMenuItem
     Friend WithEvents mnuploty As ToolStripMenuItem
-    Friend WithEvents mnuDescribeTwoThreeVariablesPivotTableFrequencies As ToolStripMenuItem
     Friend WithEvents ToolStripSeparator27 As ToolStripSeparator
     Friend WithEvents ToolStripSeparator71 As ToolStripSeparator
     Friend WithEvents mnuEditScript As ToolStripMenuItem
@@ -5765,5 +5770,7 @@ Partial Class frmMain
     Friend WithEvents mnuOptionsByContextDefineOnFarm As ToolStripMenuItem
     Friend WithEvents mnuDescribeTwoThreeVariablesCorrelations As ToolStripMenuItem
     Friend WithEvents mnuDescribeTwoThreeVariablesThreeWayFrequencies As ToolStripMenuItem
-    Friend WithEvents mnuDescribeTwoThreeVariablesPivotTableSummaries As ToolStripMenuItem
+    Friend WithEvents mnuDescribeTwoThreeVariablesPivotTable As ToolStripMenuItem
+    Friend WithEvents ToolStripSeparator36 As ToolStripSeparator
+    Friend WithEvents mnuPrepareDataFrameAddMergeColumns As ToolStripMenuItem
 End Class

--- a/instat/frmMain.vb
+++ b/instat/frmMain.vb
@@ -2380,10 +2380,6 @@ Public Class frmMain
         dlgPasteNewColumns.ShowDialog()
     End Sub
 
-    Private Sub mnuDescribeTwoVariablesPivotTable_Click(sender As Object, e As EventArgs) Handles mnuDescribeTwoThreeVariablesPivotTableFrequencies.Click
-        dlgPivotTable.ShowDialog()
-    End Sub
-
     Private Sub mnuEditScript_Click(sender As Object, e As EventArgs) Handles mnuEditScript.Click
         dlgScript.ShowDialog()
     End Sub
@@ -2432,7 +2428,11 @@ Public Class frmMain
         dlgThreeVariableFrequencies.ShowDialog()
     End Sub
 
-    Private Sub mnuDescribeTwoThreeVariablesPivotTableSummaries_Click(sender As Object, e As EventArgs) Handles mnuDescribeTwoThreeVariablesPivotTableSummaries.Click
+    Private Sub mnuDescribeTwoThreeVariablesPivotTableSummaries_Click(sender As Object, e As EventArgs) Handles mnuDescribeTwoThreeVariablesPivotTable.Click
         dlgThreeVariablePivotTable.ShowDialog()
+    End Sub
+
+    Private Sub mnuPrepareDataFrameAddMergeColumns_Click(sender As Object, e As EventArgs) Handles mnuPrepareDataFrameAddMergeColumns.Click
+        dlgMergeAdditionalData.ShowDialog()
     End Sub
 End Class

--- a/instat/frmMain.vb
+++ b/instat/frmMain.vb
@@ -1332,7 +1332,7 @@ Public Class frmMain
         dlgDefineRedFlags.ShowDialog()
     End Sub
 
-    Private Sub mnuDescribeTwoVariablesFrequencies_Click(sender As Object, e As EventArgs) Handles mnuDescribeTwoVariablesFrequencies.Click
+    Private Sub mnuDescribeTwoVariablesFrequencies_Click(sender As Object, e As EventArgs) Handles mnuDescribeTwoThreeVariablesTwoWayFrequencies.Click
         dlgTwoWayFrequencies.ShowDialog()
     End Sub
 
@@ -2380,7 +2380,7 @@ Public Class frmMain
         dlgPasteNewColumns.ShowDialog()
     End Sub
 
-    Private Sub mnuDescribeTwoVariablesPivotTable_Click(sender As Object, e As EventArgs) Handles mnuDescribeTwoVariablesPivotTable.Click
+    Private Sub mnuDescribeTwoVariablesPivotTable_Click(sender As Object, e As EventArgs) Handles mnuDescribeTwoThreeVariablesPivotTableFrequencies.Click
         dlgPivotTable.ShowDialog()
     End Sub
 
@@ -2426,5 +2426,13 @@ Public Class frmMain
 
     Private Sub mnuDescribeTwoThreeVariablesCorrelations_Click(sender As Object, e As EventArgs) Handles mnuDescribeTwoThreeVariablesCorrelations.Click
         dlgCorrelation.ShowDialog()
+    End Sub
+
+    Private Sub mnuDescribeTwoThreeVariablesThreeWayFrequencies_Click(sender As Object, e As EventArgs) Handles mnuDescribeTwoThreeVariablesThreeWayFrequencies.Click
+        dlgThreeVariableFrequencies.ShowDialog()
+    End Sub
+
+    Private Sub mnuDescribeTwoThreeVariablesPivotTableSummaries_Click(sender As Object, e As EventArgs) Handles mnuDescribeTwoThreeVariablesPivotTableSummaries.Click
+        dlgThreeVariablePivotTable.ShowDialog()
     End Sub
 End Class

--- a/instat/frmMain.vb
+++ b/instat/frmMain.vb
@@ -1580,7 +1580,7 @@ Public Class frmMain
     End Sub
 
     Private Sub mnuPrepareCheckDataDuplicates_Click(sender As Object, e As EventArgs) Handles mnuPrepareCheckDataDuplicates.Click
-        dlgDuplicates.ShowDialog()
+        dlgDuplicateRows.ShowDialog()
     End Sub
 
     Private Sub mnuClimaticCheckDataBoxplot_Click_1(sender As Object, e As EventArgs) Handles mnuClimaticCheckDataBoxplot.Click
@@ -1835,7 +1835,7 @@ Public Class frmMain
     End Sub
 
     Private Sub mnuOptionsByContextsCheckDataDuplicates_Click(sender As Object, e As EventArgs) Handles mnuOptionsByContextCheckDataDuplicateRows.Click
-        dlgDuplicates.ShowDialog()
+        dlgDuplicateRows.ShowDialog()
     End Sub
 
     Private Sub mnuOptionsByContextsCheckDataCompareColumns_Click(sender As Object, e As EventArgs) Handles mnuOptionsByContextCheckDataCompareColumns.Click
@@ -1998,7 +1998,7 @@ Public Class frmMain
     End Sub
 
     Private Sub mnuClimaticTidyandExamineDuplicates_Click(sender As Object, e As EventArgs) Handles mnuClimaticTidyandExamineDuplicateRows.Click
-        dlgDuplicates.ShowDialog()
+        dlgDuplicateRows.ShowDialog()
     End Sub
 
     Private Sub mnuCumExeedenceGraph_Click(sender As Object, e As EventArgs) Handles mnuClimaticPICSACumExeedenceGraph.Click


### PR DESCRIPTION
Fixes #7259 
@rdstern @shadrackkibet, in this PR which affects Two/Three variables sub-menu;
Renames Frequencies to Two-way Frequencies and also adds Three-way Frequencies. 
Renames pivot table to Pivot-Table (Frequencies) and also adds Pivot-Table (Summaries)
Also, here is updated database screenshot.

![image](https://user-images.githubusercontent.com/89011415/159665142-910c85e4-da95-458e-bf18-ad6b9c8ceb44.png)
