### PR TITLE
Fixed the bug on the result produced by PICSA when the Facets is by row or column

### DIFF
--- a/instat/dlgPICSARainfall.vb
+++ b/instat/dlgPICSARainfall.vb
@@ -852,18 +852,30 @@ Public Class dlgPICSARainfall
         SetPipeAssignTo()
     End Sub
 
+    Private Sub GetParameterValue(clsOperator As ROperator)
+        Dim i As Integer = 0
+        For Each clsTempParam As RParameter In clsOperator.clsParameters
+            If clsTempParam.strArgumentValue <> "" AndAlso clsTempParam.strArgumentValue <> "." Then
+                clsGroupByFunction.AddParameter(i, clsTempParam.strArgumentValue, bIncludeArgumentName:=False, iPosition:=i)
+                i = i + 1
+            End If
+        Next
+    End Sub
+
     Private Sub AddRemoveGroupBy()
         Dim i As Integer = 0
 
         If clsPipeOperator.ContainsParameter("mutate") Then
             clsGroupByFunction.ClearParameters()
             If clsBaseOperator.ContainsParameter("facets") Then
-                For Each clsTempParam As RParameter In clsFacetOperator.clsParameters
-                    If clsTempParam.strArgumentValue <> "" AndAlso clsTempParam.strArgumentValue <> "." Then
-                        clsGroupByFunction.AddParameter(i, clsTempParam.strArgumentValue, bIncludeArgumentName:=False, iPosition:=i)
-                        i = i + 1
-                    End If
-                Next
+                Select Case ucrInputStation.GetText()
+                    Case strFacetWrap
+                        GetParameterValue(clsFacetOperator)
+                    Case strFacetCol
+                        GetParameterValue(clsFacetColOp)
+                    Case strFacetRow
+                        GetParameterValue(clsFacetRowOp)
+                End Select
             End If
 
             If clsRaesFunction.ContainsParameter("colour") Then


### PR DESCRIPTION
Fixes #7332
@africanmathsinitiative/developers this is ready for review.
@rdstern the result produced when changing the facet option by row or column was still the same due to the missing of `dplyr::group_by(station)` in the R code. I have added that now, please test and confirm if everything is fine. Thanks.