### PR TITLE
Added an option to Add Key for the new column in Prepare>Data Frame>Row Numbers/Names dialog

### DIFF
--- a/instat/dlgConversions.vb
+++ b/instat/dlgConversions.vb
@@ -356,9 +356,9 @@ Public Class dlgConversions
                 ucrReceiverLetters.SetMeAsReceiver()
             End If
             If Not ucrReceiverLetters.IsEmpty Then
-                    clsConvertToDegreeFunction.AddParameter("dir", clsRFunctionParameter:=clsGetDirVariable, iPosition:=3)
-                End If
+                clsConvertToDegreeFunction.AddParameter("dir", clsRFunctionParameter:=clsGetDirVariable, iPosition:=3)
             End If
+        End If
         ChangeParameter()
     End Sub
 

--- a/instat/dlgRownamesOrNumbers.Designer.vb
+++ b/instat/dlgRownamesOrNumbers.Designer.vb
@@ -45,6 +45,7 @@ Partial Class dlgRowNamesOrNumbers
         Me.rdoSortDescending = New System.Windows.Forms.RadioButton()
         Me.rdoSortAscending = New System.Windows.Forms.RadioButton()
         Me.grpboxOptionsforRowNamesorNumbercols = New System.Windows.Forms.GroupBox()
+        Me.ucrChkMakeColumnIntoKey = New instat.ucrCheck()
         Me.ucrChkAsNumeric = New instat.ucrCheck()
         Me.ucrPnlSortOptions = New instat.UcrPanel()
         Me.ucrNewColumnName = New instat.ucrSave()
@@ -63,13 +64,13 @@ Partial Class dlgRowNamesOrNumbers
         Me.rdoCopyRowNamesIntoFirstColumn.Size = New System.Drawing.Size(267, 17)
         Me.rdoCopyRowNamesIntoFirstColumn.TabIndex = 1
         Me.rdoCopyRowNamesIntoFirstColumn.TabStop = True
-        Me.rdoCopyRowNamesIntoFirstColumn.Text = "Copy Row Names into Column"
+        Me.rdoCopyRowNamesIntoFirstColumn.Text = "Copy Row Numbers or Names into a Colum"
         Me.rdoCopyRowNamesIntoFirstColumn.UseVisualStyleBackColor = True
         '
         'rdoSetRowNamesFromColumn
         '
         Me.rdoSetRowNamesFromColumn.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.rdoSetRowNamesFromColumn.Location = New System.Drawing.Point(9, 72)
+        Me.rdoSetRowNamesFromColumn.Location = New System.Drawing.Point(9, 88)
         Me.rdoSetRowNamesFromColumn.Name = "rdoSetRowNamesFromColumn"
         Me.rdoSetRowNamesFromColumn.Size = New System.Drawing.Size(267, 17)
         Me.rdoSetRowNamesFromColumn.TabIndex = 3
@@ -80,7 +81,7 @@ Partial Class dlgRowNamesOrNumbers
         'rdoResetintoPositiveIntegers
         '
         Me.rdoResetintoPositiveIntegers.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.rdoResetintoPositiveIntegers.Location = New System.Drawing.Point(9, 127)
+        Me.rdoResetintoPositiveIntegers.Location = New System.Drawing.Point(9, 136)
         Me.rdoResetintoPositiveIntegers.Name = "rdoResetintoPositiveIntegers"
         Me.rdoResetintoPositiveIntegers.Size = New System.Drawing.Size(267, 17)
         Me.rdoResetintoPositiveIntegers.TabIndex = 5
@@ -91,7 +92,7 @@ Partial Class dlgRowNamesOrNumbers
         'rdoSortbyRowNames
         '
         Me.rdoSortbyRowNames.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.rdoSortbyRowNames.Location = New System.Drawing.Point(9, 156)
+        Me.rdoSortbyRowNames.Location = New System.Drawing.Point(9, 158)
         Me.rdoSortbyRowNames.Name = "rdoSortbyRowNames"
         Me.rdoSortbyRowNames.Size = New System.Drawing.Size(267, 17)
         Me.rdoSortbyRowNames.TabIndex = 6
@@ -125,6 +126,7 @@ Partial Class dlgRowNamesOrNumbers
         '
         'grpboxOptionsforRowNamesorNumbercols
         '
+        Me.grpboxOptionsforRowNamesorNumbercols.Controls.Add(Me.ucrChkMakeColumnIntoKey)
         Me.grpboxOptionsforRowNamesorNumbercols.Controls.Add(Me.ucrChkAsNumeric)
         Me.grpboxOptionsforRowNamesorNumbercols.Controls.Add(Me.rdoSortDescending)
         Me.grpboxOptionsforRowNamesorNumbercols.Controls.Add(Me.rdoSortAscending)
@@ -143,6 +145,15 @@ Partial Class dlgRowNamesOrNumbers
         Me.grpboxOptionsforRowNamesorNumbercols.TabStop = False
         Me.grpboxOptionsforRowNamesorNumbercols.Text = "Options"
         '
+        'ucrChkMakeColumnIntoKey
+        '
+        Me.ucrChkMakeColumnIntoKey.AutoSize = True
+        Me.ucrChkMakeColumnIntoKey.Checked = False
+        Me.ucrChkMakeColumnIntoKey.Location = New System.Drawing.Point(8, 64)
+        Me.ucrChkMakeColumnIntoKey.Name = "ucrChkMakeColumnIntoKey"
+        Me.ucrChkMakeColumnIntoKey.Size = New System.Drawing.Size(297, 23)
+        Me.ucrChkMakeColumnIntoKey.TabIndex = 10
+        '
         'ucrChkAsNumeric
         '
         Me.ucrChkAsNumeric.AutoSize = True
@@ -155,15 +166,15 @@ Partial Class dlgRowNamesOrNumbers
         'ucrPnlSortOptions
         '
         Me.ucrPnlSortOptions.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrPnlSortOptions.Location = New System.Drawing.Point(7, 171)
+        Me.ucrPnlSortOptions.Location = New System.Drawing.Point(7, 185)
         Me.ucrPnlSortOptions.Name = "ucrPnlSortOptions"
-        Me.ucrPnlSortOptions.Size = New System.Drawing.Size(206, 36)
+        Me.ucrPnlSortOptions.Size = New System.Drawing.Size(206, 22)
         Me.ucrPnlSortOptions.TabIndex = 7
         '
         'ucrNewColumnName
         '
         Me.ucrNewColumnName.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrNewColumnName.Location = New System.Drawing.Point(9, 44)
+        Me.ucrNewColumnName.Location = New System.Drawing.Point(9, 39)
         Me.ucrNewColumnName.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
         Me.ucrNewColumnName.Name = "ucrNewColumnName"
         Me.ucrNewColumnName.Size = New System.Drawing.Size(343, 21)
@@ -173,7 +184,7 @@ Partial Class dlgRowNamesOrNumbers
         '
         Me.ucrReceiverRowNames.AutoSize = True
         Me.ucrReceiverRowNames.frmParent = Me
-        Me.ucrReceiverRowNames.Location = New System.Drawing.Point(24, 92)
+        Me.ucrReceiverRowNames.Location = New System.Drawing.Point(24, 109)
         Me.ucrReceiverRowNames.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverRowNames.Name = "ucrReceiverRowNames"
         Me.ucrReceiverRowNames.Selector = Nothing
@@ -247,4 +258,5 @@ Partial Class dlgRowNamesOrNumbers
     Friend WithEvents rdoSetRowNamesFromColumn As RadioButton
     Friend WithEvents rdoCopyRowNamesIntoFirstColumn As RadioButton
     Friend WithEvents ucrPnlSortOptions As UcrPanel
+    Friend WithEvents ucrChkMakeColumnIntoKey As ucrCheck
 End Class

--- a/instat/dlgRownamesOrNumbers.vb
+++ b/instat/dlgRownamesOrNumbers.vb
@@ -20,6 +20,8 @@ Public Class dlgRowNamesOrNumbers
     Public bFirstLoad As Boolean = True
     Private bReset As Boolean = True
     Private clsRowNamesFunction As New RFunction
+    Private clsAddKeyFunction As New RFunction
+    Private clsAddKeyParam As New RParameter
 
     Private Sub dlgRowNamesOrNumbers_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         If bFirstLoad Then
@@ -88,6 +90,14 @@ Public Class dlgRowNamesOrNumbers
         ucrChkAsNumeric.SetValuesCheckedAndUnchecked("TRUE", "FALSE")
         ucrChkAsNumeric.SetRDefault("TRUE")
 
+        'ucrChkMakeColumnIntoKey
+        ucrChkMakeColumnIntoKey.SetText("Make the Column into a Key for the data Frame")
+        clsAddKeyParam.SetArgument(clsAddKeyFunction)
+        clsAddKeyParam.SetArgumentName("add_key")
+        ucrChkMakeColumnIntoKey.SetParameter(clsAddKeyParam, bNewChangeParameterValue:=False, bNewAddRemoveParameter:=True)
+        'ucrChkMakeColumnIntoKey.SetValuesCheckedAndUnchecked("TRUE", "FALSE")
+        'ucrChkMakeColumnIntoKey.SetRDefault("TRUE")
+
         'ucrNewColumnName
         ucrNewColumnName.SetIsComboBox()
         ucrNewColumnName.SetPrefix("row")
@@ -99,17 +109,22 @@ Public Class dlgRowNamesOrNumbers
 
     Private Sub SetDefaults()
         clsRowNamesFunction = New RFunction
+        clsAddKeyFunction = New RFunction
 
         ucrNewColumnName.Reset()
         ucrSelectorRowNames.Reset()
 
+        clsAddKeyFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$add_key")
+
         clsRowNamesFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_row_names")
+        clsRowNamesFunction.AddParameter("Add Key", clsRFunctionParameter:=clsAddKeyFunction, iPosition:=3)
         clsRowNamesFunction.SetAssignTo(strTemp:=ucrNewColumnName.GetText(), strTempDataframe:=ucrSelectorRowNames.ucrAvailableDataFrames.cboAvailableDataFrames.Text, strTempColumn:=ucrNewColumnName.GetText(), bInsertColumnBefore:=True)
         ucrBase.clsRsyntax.SetBaseRFunction(clsRowNamesFunction)
     End Sub
 
     Private Sub SetRCodeForControls(bReset As Boolean)
         SetRCode(Me, ucrBase.clsRsyntax.clsBaseFunction, bReset)
+        'ucrChkMakeColumnIntoKey.SetRCode(clsAddKeyFunction, bReset)
     End Sub
 
     Private Sub TestOKEnabled()
@@ -144,5 +159,13 @@ Public Class dlgRowNamesOrNumbers
 
     Private Sub CoreControls_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrSelectorRowNames.ControlContentsChanged, ucrPnlOverallOptions.ControlContentsChanged, ucrReceiverRowNames.ControlContentsChanged, ucrNewColumnName.ControlContentsChanged
         TestOKEnabled()
+    End Sub
+
+    Private Sub ucrChkMakeColumnIntoKey_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrChkMakeColumnIntoKey.ControlValueChanged
+        If ucrChkMakeColumnIntoKey.Checked Then
+            ucrBase.clsRsyntax.AddToAfterCodes(clsAddKeyFunction, iPosition:=0)
+        Else
+            ucrBase.clsRsyntax.RemoveFromAfterCodes(clsAddKeyFunction)
+        End If
     End Sub
 End Class

--- a/instat/dlgRownamesOrNumbers.vb
+++ b/instat/dlgRownamesOrNumbers.vb
@@ -87,9 +87,10 @@ Public Class dlgRowNamesOrNumbers
         ucrChkAsNumeric.SetRDefault("TRUE")
 
         'ucrChkMakeColumnIntoKey
-        ucrChkMakeColumnIntoKey.SetText("Make the Column into a Key for the data Frame")
+        ucrChkMakeColumnIntoKey.SetText("Make the Column a Key for the Data Frame")
         ucrChkMakeColumnIntoKey.SetParameter(New RParameter("check", 0))
         ucrChkMakeColumnIntoKey.SetValuesCheckedAndUnchecked("TRUE", "FALSE")
+        ucrChkMakeColumnIntoKey.SetRDefault("TRUE")
 
         'ucrNewColumnName
         ucrNewColumnName.SetIsComboBox()
@@ -97,7 +98,6 @@ Public Class dlgRowNamesOrNumbers
         ucrNewColumnName.SetSaveTypeAsColumn()
         ucrNewColumnName.SetDataFrameSelector(ucrSelectorRowNames.ucrAvailableDataFrames)
         ucrNewColumnName.SetLabelText("Column Name:")
-        ucrNewColumnName.SetAssignToBooleans(bTempInsertColumnBefore:=True)
     End Sub
 
     Private Sub SetDefaults()
@@ -114,7 +114,7 @@ Public Class dlgRowNamesOrNumbers
         clsAddKeyFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$add_key")
 
         clsRowNamesFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_row_names")
-        clsRowNamesFunction.SetAssignTo(strTemp:=ucrNewColumnName.GetText(), strTempDataframe:=ucrSelectorRowNames.ucrAvailableDataFrames.cboAvailableDataFrames.Text, strTempColumn:=ucrNewColumnName.GetText(), bInsertColumnBefore:=True)
+        clsRowNamesFunction.SetAssignTo(strTemp:=ucrNewColumnName.GetText(), strTempDataframe:=ucrSelectorRowNames.ucrAvailableDataFrames.cboAvailableDataFrames.Text, strTempColumn:=ucrNewColumnName.GetText())
         ucrBase.clsRsyntax.SetBaseRFunction(clsRowNamesFunction)
     End Sub
 
@@ -142,6 +142,7 @@ Public Class dlgRowNamesOrNumbers
     End Sub
 
     Private Sub ucrPnl_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrPnlOverallOptions.ControlValueChanged, ucrChkMakeColumnIntoKey.ControlValueChanged, ucrNewColumnName.ControlValueChanged
+        ucrNewColumnName.SetAssignToBooleans(bTempInsertColumnBefore:=True)
         If rdoSetRowNamesFromColumn.Checked Then
             ucrBase.clsRsyntax.SetFunction(frmMain.clsRLink.strInstatDataObject & "$set_row_names")
             clsDummyFunction.AddParameter("checked_rdo", "set_row", iPosition:=1)

--- a/instat/dlgRownamesOrNumbers.vb
+++ b/instat/dlgRownamesOrNumbers.vb
@@ -21,6 +21,8 @@ Public Class dlgRowNamesOrNumbers
     Private bReset As Boolean = True
     Private clsRowNamesFunction As New RFunction
     Private clsAddKeyFunction As New RFunction
+    Private clsDummyFunction As New RFunction
+    Private ResetRCode As Boolean = True
 
     Private Sub dlgRowNamesOrNumbers_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         If bFirstLoad Then
@@ -57,15 +59,10 @@ Public Class dlgRowNamesOrNumbers
         ucrPnlOverallOptions.AddRadioButton(rdoResetintoPositiveIntegers)
         ucrPnlOverallOptions.AddRadioButton(rdoSortbyRowNames)
 
-        ucrPnlOverallOptions.AddFunctionNamesCondition(rdoCopyRowNamesIntoFirstColumn, frmMain.clsRLink.strInstatDataObject & "$get_row_names")
-
-        ucrPnlOverallOptions.AddFunctionNamesCondition(rdoSetRowNamesFromColumn, frmMain.clsRLink.strInstatDataObject & "$set_row_names")
-        ucrPnlOverallOptions.AddParameterPresentCondition(rdoSetRowNamesFromColumn, "row_names")
-
-        ucrPnlOverallOptions.AddFunctionNamesCondition(rdoResetintoPositiveIntegers, frmMain.clsRLink.strInstatDataObject & "$set_row_names")
-        ucrPnlOverallOptions.AddParameterPresentCondition(rdoResetintoPositiveIntegers, "row_names", bNewIsPositive:=False)
-
-        ucrPnlOverallOptions.AddFunctionNamesCondition(rdoSortbyRowNames, frmMain.clsRLink.strInstatDataObject & "$sort_dataframe")
+        ucrPnlOverallOptions.AddParameterValuesCondition(rdoCopyRowNamesIntoFirstColumn, "checked_rdo", "copy_row")
+        ucrPnlOverallOptions.AddParameterValuesCondition(rdoSetRowNamesFromColumn, "checked_rdo", "set_row")
+        ucrPnlOverallOptions.AddParameterValuesCondition(rdoResetintoPositiveIntegers, "checked_rdo", "reset_row")
+        ucrPnlOverallOptions.AddParameterValuesCondition(rdoSortbyRowNames, "checked_rdo", "sort_row")
 
         ucrPnlOverallOptions.AddToLinkedControls({ucrNewColumnName, ucrChkMakeColumnIntoKey}, {rdoCopyRowNamesIntoFirstColumn}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
         ucrPnlOverallOptions.AddToLinkedControls(ucrReceiverRowNames, {rdoSetRowNamesFromColumn}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
@@ -91,8 +88,8 @@ Public Class dlgRowNamesOrNumbers
 
         'ucrChkMakeColumnIntoKey
         ucrChkMakeColumnIntoKey.SetText("Make the Column into a Key for the data Frame")
-        ucrChkMakeColumnIntoKey.AddFunctionNamesCondition(True, frmMain.clsRLink.strInstatDataObject & "$add_key")
-        ucrChkMakeColumnIntoKey.AddFunctionNamesCondition(False,frmMain.clsRLink.strInstatDataObject & "$get_row_names")
+        ucrChkMakeColumnIntoKey.SetParameter(New RParameter("check", 0))
+        ucrChkMakeColumnIntoKey.SetValuesCheckedAndUnchecked("TRUE", "FALSE")
 
         'ucrNewColumnName
         ucrNewColumnName.SetIsComboBox()
@@ -106,9 +103,13 @@ Public Class dlgRowNamesOrNumbers
     Private Sub SetDefaults()
         clsRowNamesFunction = New RFunction
         clsAddKeyFunction = New RFunction
+        clsDummyFunction = New RFunction
 
         ucrNewColumnName.Reset()
         ucrSelectorRowNames.Reset()
+
+        clsDummyFunction.AddParameter("check", "TRUE", iPosition:=0)
+        clsDummyFunction.AddParameter("checked_rdo", "copy_row", iPosition:=1)
 
         clsAddKeyFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$add_key")
 
@@ -118,8 +119,12 @@ Public Class dlgRowNamesOrNumbers
     End Sub
 
     Private Sub SetRCodeForControls(bReset As Boolean)
-        SetRCode(Me, ucrBase.clsRsyntax.clsBaseFunction, bReset)
-        ucrChkMakeColumnIntoKey.SetRCode(clsAddKeyFunction, bReset)
+        ucrChkAsNumeric.SetRCode(ucrBase.clsRsyntax.clsBaseFunction, bReset)
+        ucrSelectorRowNames.SetRCode(ucrBase.clsRsyntax.clsBaseFunction, bReset)
+        ucrReceiverRowNames.SetRCode(ucrBase.clsRsyntax.clsBaseFunction, bReset)
+        ucrPnlOverallOptions.SetRCode(clsDummyFunction, bReset)
+        ucrNewColumnName.SetRCode(ucrBase.clsRsyntax.clsBaseFunction, bReset)
+        ucrChkMakeColumnIntoKey.SetRCode(clsDummyFunction, bReset)
     End Sub
 
     Private Sub TestOKEnabled()
@@ -136,36 +141,41 @@ Public Class dlgRowNamesOrNumbers
         TestOKEnabled()
     End Sub
 
-    Private Sub ucrPnl_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrPnlOverallOptions.ControlValueChanged
+    Private Sub ucrPnl_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrPnlOverallOptions.ControlValueChanged, ucrChkMakeColumnIntoKey.ControlValueChanged, ucrNewColumnName.ControlValueChanged
         If rdoSetRowNamesFromColumn.Checked Then
             ucrBase.clsRsyntax.SetFunction(frmMain.clsRLink.strInstatDataObject & "$set_row_names")
+            clsDummyFunction.AddParameter("checked_rdo", "set_row", iPosition:=1)
             ucrSelectorRowNames.SetVariablesVisible(True)
         Else
             ucrSelectorRowNames.SetVariablesVisible(False)
             If rdoCopyRowNamesIntoFirstColumn.Checked Then
                 ucrBase.clsRsyntax.SetFunction(frmMain.clsRLink.strInstatDataObject & "$get_row_names")
+                clsDummyFunction.AddParameter("checked_rdo", "copy_row", iPosition:=1)
+                If ucrChkMakeColumnIntoKey.Checked Then
+                    clsAddKeyFunction.AddParameter("col_names", Chr(34) & ucrNewColumnName.GetText & Chr(34), iPosition:=1)
+                    ucrBase.clsRsyntax.AddToAfterCodes(clsAddKeyFunction, iPosition:=0)
+                Else
+                    clsAddKeyFunction.RemoveParameterByName("col_names")
+                    ucrBase.clsRsyntax.RemoveFromAfterCodes(clsAddKeyFunction)
+                End If
             ElseIf rdoResetintoPositiveIntegers.Checked Then
                 ucrBase.clsRsyntax.SetFunction(frmMain.clsRLink.strInstatDataObject & "$set_row_names")
+                clsDummyFunction.AddParameter("checked_rdo", "reset_row", iPosition:=1)
             ElseIf rdoSortbyRowNames.Checked Then
                 ucrBase.clsRsyntax.SetFunction(frmMain.clsRLink.strInstatDataObject & "$sort_dataframe")
+                clsDummyFunction.AddParameter("checked_rdo", "sort_row", iPosition:=1)
             End If
         End If
+        If Not rdoCopyRowNamesIntoFirstColumn.Checked Then
+            ucrBase.clsRsyntax.RemoveFromAfterCodes(clsAddKeyFunction)
+        End If
+    End Sub
+
+    Private Sub ucrSelectorRowNames_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrSelectorRowNames.ControlValueChanged
+        clsAddKeyFunction.AddParameter("data_name", Chr(34) & ucrSelectorRowNames.strCurrentDataFrame & Chr(34), iPosition:=0)
     End Sub
 
     Private Sub CoreControls_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrSelectorRowNames.ControlContentsChanged, ucrPnlOverallOptions.ControlContentsChanged, ucrReceiverRowNames.ControlContentsChanged, ucrNewColumnName.ControlContentsChanged
         TestOKEnabled()
-    End Sub
-
-    Private Sub ucrChkMakeColumnIntoKey_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrChkMakeColumnIntoKey.ControlValueChanged, ucrNewColumnName.ControlValueChanged, ucrSelectorRowNames.ControlValueChanged
-        If rdoCopyRowNamesIntoFirstColumn.Checked Then
-            If ucrChkMakeColumnIntoKey.Checked Then
-                clsAddKeyFunction.AddParameter("data_name", Chr(34) & ucrSelectorRowNames.strCurrentDataFrame & Chr(34), iPosition:=0)
-                clsAddKeyFunction.AddParameter("col_names", Chr(34) & ucrNewColumnName.GetText & Chr(34), iPosition:=1)
-                ucrBase.clsRsyntax.AddToAfterCodes(clsAddKeyFunction, iPosition:=0)
-            Else
-                clsAddKeyFunction.RemoveParameterByName("col_names")
-                ucrBase.clsRsyntax.RemoveFromAfterCodes(clsAddKeyFunction)
-            End If
-        End If
     End Sub
 End Class

--- a/instat/dlgRownamesOrNumbers.vb
+++ b/instat/dlgRownamesOrNumbers.vb
@@ -22,7 +22,6 @@ Public Class dlgRowNamesOrNumbers
     Private clsRowNamesFunction As New RFunction
     Private clsAddKeyFunction As New RFunction
     Private clsDummyFunction As New RFunction
-    Private ResetRCode As Boolean = True
 
     Private Sub dlgRowNamesOrNumbers_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         If bFirstLoad Then


### PR DESCRIPTION
This fixes #7323 
@rdstern and @shadrackkibet, I have added a checkbox to Add Keys to the New column created by the first option (Copy row names into Column). The checkbox is checked by default. I have been using the mtcars dataset to test the dialogue.
I have also fixed some other bug issues on the dialog. You can have a look at it.