### PR TITLE
Fixed bug when colour is applied in the dataset from Data View window

### DIFF
--- a/instat/Model/DataFrame/clsDataFramePage.vb
+++ b/instat/Model/DataFrame/clsDataFramePage.vb
@@ -291,7 +291,7 @@ Public Class clsDataFramePage
 
         For i = 0 To _clsDataFrame.ColumnNames.ToList.Count - 1
             columnHeader = GetColumnDispayDetails(_clsDataFrame.ColumnNames.ToList(i), vecColumnDataTypes(i))
-            If bApplyBackGroundColumnColours AndAlso vecColumnColours IsNot Nothing Then
+            If bApplyBackGroundColumnColours AndAlso vecColumnColours(i) > 0 Then
                 columnHeader.clsBackGroundColour = GetColumnBackGroundColor(i, vecColumnColours(i).ToString())
             End If
             _lstColumns.Add(columnHeader)

--- a/instat/Model/DataFrame/clsDataFramePage.vb
+++ b/instat/Model/DataFrame/clsDataFramePage.vb
@@ -294,14 +294,9 @@ Public Class clsDataFramePage
         _lstColumns.Clear()
 
 
-        For i = 0 To _clsDataFrame.ColumnNames.ToList.Count - 1
-            columnHeader = GetColumnDispayDetails(_clsDataFrame.ColumnNames.ToList(i), vecColumnDataTypes(i))
-            If bApplyBackGroundColumnColours AndAlso Not Double.IsNaN(vecColumnColours(i)) Then
-
         For i = 0 To _clsRDotNetDataFrame.ColumnNames.ToList.Count - 1
             columnHeader = GetColumnDispayDetails(_clsRDotNetDataFrame.ColumnNames.ToList(i), vecColumnDataTypes(i))
-            If bApplyBackGroundColumnColours AndAlso vecColumnColours IsNot Nothing Then
-
+            If bApplyBackGroundColumnColours AndAlso Not Double.IsNaN(vecColumnColours(i)) Then
                 columnHeader.clsBackGroundColour = GetColumnBackGroundColor(i, vecColumnColours(i).ToString())
             End If
             _lstColumns.Add(columnHeader)

--- a/instat/Model/DataFrame/clsDataFramePage.vb
+++ b/instat/Model/DataFrame/clsDataFramePage.vb
@@ -291,7 +291,7 @@ Public Class clsDataFramePage
 
         For i = 0 To _clsDataFrame.ColumnNames.ToList.Count - 1
             columnHeader = GetColumnDispayDetails(_clsDataFrame.ColumnNames.ToList(i), vecColumnDataTypes(i))
-            If bApplyBackGroundColumnColours AndAlso vecColumnColours IsNot Nothing Then
+            If bApplyBackGroundColumnColours AndAlso Not Double.IsNaN(vecColumnColours(i)) Then
                 columnHeader.clsBackGroundColour = GetColumnBackGroundColor(i, vecColumnColours(i).ToString())
             End If
             _lstColumns.Add(columnHeader)

--- a/instat/Model/DataFrame/clsDataFramePage.vb
+++ b/instat/Model/DataFrame/clsDataFramePage.vb
@@ -291,7 +291,7 @@ Public Class clsDataFramePage
 
         For i = 0 To _clsDataFrame.ColumnNames.ToList.Count - 1
             columnHeader = GetColumnDispayDetails(_clsDataFrame.ColumnNames.ToList(i), vecColumnDataTypes(i))
-            If bApplyBackGroundColumnColours AndAlso vecColumnColours(i) > 0 Then
+            If bApplyBackGroundColumnColours AndAlso vecColumnColours IsNot Nothing Then
                 columnHeader.clsBackGroundColour = GetColumnBackGroundColor(i, vecColumnColours(i).ToString())
             End If
             _lstColumns.Add(columnHeader)

--- a/instat/UserControls/DataGrid/ReoGrid/ucrReoGrid.vb
+++ b/instat/UserControls/DataGrid/ReoGrid/ucrReoGrid.vb
@@ -186,15 +186,24 @@ Public MustInherit Class ucrReoGrid
     End Function
 
     Private Sub UpdateWorksheetStyle(workSheet As Worksheet)
+        'issue with reo grid that means if RangePosition.EntireRange is used then the back color 
+        'changes. This would then override the back color set in R
         If frmMain.clsInstatOptions IsNot Nothing Then
-            workSheet.SetRangeStyles(RangePosition.EntireRange, New WorksheetRangeStyle() With {
+            'Set enitre range apart from top row
+            workSheet.SetRangeStyles(New RangePosition(1, 0, workSheet.RowCount, workSheet.ColumnCount), New WorksheetRangeStyle() With {
+                                .Flag = PlainStyleFlag.TextColor Or PlainStyleFlag.FontSize Or PlainStyleFlag.FontName,
+                                .TextColor = frmMain.clsInstatOptions.clrEditor,
+                                .FontSize = frmMain.clsInstatOptions.fntEditor.Size,
+                                .FontName = frmMain.clsInstatOptions.fntEditor.Name
+                                })
+            'Set top row
+            workSheet.SetRangeStyles(New RangePosition(0, 0, 1, workSheet.ColumnCount), New WorksheetRangeStyle() With {
                                 .Flag = PlainStyleFlag.TextColor Or PlainStyleFlag.FontSize Or PlainStyleFlag.FontName,
                                 .TextColor = frmMain.clsInstatOptions.clrEditor,
                                 .FontSize = frmMain.clsInstatOptions.fntEditor.Size,
                                 .FontName = frmMain.clsInstatOptions.fntEditor.Name
                                 })
         End If
-
     End Sub
 
     Private Sub ucrReoGrid_Load(sender As Object, e As EventArgs) Handles MyBase.Load

--- a/instat/dlgColourbyProperty.Designer.vb
+++ b/instat/dlgColourbyProperty.Designer.vb
@@ -49,7 +49,7 @@ Partial Class dlgColourbyProperty
         '
         Me.lblMetadataProp.AutoSize = True
         Me.lblMetadataProp.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblMetadataProp.Location = New System.Drawing.Point(263, 45)
+        Me.lblMetadataProp.Location = New System.Drawing.Point(263, 57)
         Me.lblMetadataProp.Name = "lblMetadataProp"
         Me.lblMetadataProp.Size = New System.Drawing.Size(97, 13)
         Me.lblMetadataProp.TabIndex = 3
@@ -59,7 +59,7 @@ Partial Class dlgColourbyProperty
         '
         Me.ucrChkRemoveColours.AutoSize = True
         Me.ucrChkRemoveColours.Checked = False
-        Me.ucrChkRemoveColours.Location = New System.Drawing.Point(263, 84)
+        Me.ucrChkRemoveColours.Location = New System.Drawing.Point(264, 30)
         Me.ucrChkRemoveColours.Name = "ucrChkRemoveColours"
         Me.ucrChkRemoveColours.Size = New System.Drawing.Size(147, 23)
         Me.ucrChkRemoveColours.TabIndex = 4
@@ -68,7 +68,7 @@ Partial Class dlgColourbyProperty
         '
         Me.ucrReceiverMetadataProperty.AutoSize = True
         Me.ucrReceiverMetadataProperty.frmParent = Me
-        Me.ucrReceiverMetadataProperty.Location = New System.Drawing.Point(263, 60)
+        Me.ucrReceiverMetadataProperty.Location = New System.Drawing.Point(263, 72)
         Me.ucrReceiverMetadataProperty.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverMetadataProperty.Name = "ucrReceiverMetadataProperty"
         Me.ucrReceiverMetadataProperty.Selector = Nothing

--- a/instat/dlgColourbyProperty.Designer.vb
+++ b/instat/dlgColourbyProperty.Designer.vb
@@ -49,7 +49,7 @@ Partial Class dlgColourbyProperty
         '
         Me.lblMetadataProp.AutoSize = True
         Me.lblMetadataProp.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblMetadataProp.Location = New System.Drawing.Point(263, 57)
+        Me.lblMetadataProp.Location = New System.Drawing.Point(263, 36)
         Me.lblMetadataProp.Name = "lblMetadataProp"
         Me.lblMetadataProp.Size = New System.Drawing.Size(97, 13)
         Me.lblMetadataProp.TabIndex = 3
@@ -59,7 +59,7 @@ Partial Class dlgColourbyProperty
         '
         Me.ucrChkRemoveColours.AutoSize = True
         Me.ucrChkRemoveColours.Checked = False
-        Me.ucrChkRemoveColours.Location = New System.Drawing.Point(264, 30)
+        Me.ucrChkRemoveColours.Location = New System.Drawing.Point(263, 82)
         Me.ucrChkRemoveColours.Name = "ucrChkRemoveColours"
         Me.ucrChkRemoveColours.Size = New System.Drawing.Size(147, 23)
         Me.ucrChkRemoveColours.TabIndex = 4
@@ -68,7 +68,7 @@ Partial Class dlgColourbyProperty
         '
         Me.ucrReceiverMetadataProperty.AutoSize = True
         Me.ucrReceiverMetadataProperty.frmParent = Me
-        Me.ucrReceiverMetadataProperty.Location = New System.Drawing.Point(263, 72)
+        Me.ucrReceiverMetadataProperty.Location = New System.Drawing.Point(263, 51)
         Me.ucrReceiverMetadataProperty.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverMetadataProperty.Name = "ucrReceiverMetadataProperty"
         Me.ucrReceiverMetadataProperty.Selector = Nothing

--- a/instat/dlgColourbyProperty.vb
+++ b/instat/dlgColourbyProperty.vb
@@ -50,9 +50,6 @@ Public Class dlgColourbyProperty
         ucrReceiverMetadataProperty.SetItemType("metadata")
         ucrReceiverMetadataProperty.strSelectorHeading = "Metadata Property"
 
-        ucrChkRemoveColours.AddToLinkedControls(ucrReceiverMetadataProperty, {Not True}, bNewLinkedHideIfParameterMissing:=True)
-        ucrReceiverMetadataProperty.SetLinkedDisplayControl(lblMetadataProp)
-
         ucrChkRemoveColours.SetText("Remove Colour")
         ucrChkRemoveColours.AddFunctionNamesCondition(True, frmMain.clsRLink.strInstatDataObject & "$remove_column_colours")
         ucrChkRemoveColours.AddFunctionNamesCondition(False, frmMain.clsRLink.strInstatDataObject & "$set_column_colours_by_metadata")
@@ -113,6 +110,7 @@ Public Class dlgColourbyProperty
                     End If
                 Next
             End If
+            ucrChkRemoveColours.Visible = bApplyColumnColours
         End If
     End Sub
 

--- a/instat/dlgColourbyProperty.vb
+++ b/instat/dlgColourbyProperty.vb
@@ -21,6 +21,7 @@ Public Class dlgColourbyProperty
     Private clsColourByMetadata As New RFunction
     Private clsRemoveColour As New RFunction
     Private bReset As Boolean = True
+    Private bApplyColumnColours As Boolean
 
     Private Sub dlgColourbyProperty_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         If bFirstLoad Then
@@ -34,6 +35,7 @@ Public Class dlgColourbyProperty
         bReset = False
         TestOKEnabled()
         AutoFill()
+        SetBaseFunction()
         autoTranslate(Me)
     End Sub
 
@@ -87,18 +89,10 @@ Public Class dlgColourbyProperty
         TestOKEnabled()
     End Sub
 
-    Private Sub ucrChkRemoveColours_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrChkRemoveColours.ControlValueChanged
-        If ucrChkRemoveColours.Checked Then
-            ucrBase.clsRsyntax.SetBaseRFunction(clsRemoveColour)
-        Else
-            ucrBase.clsRsyntax.SetBaseRFunction(clsColourByMetadata)
-        End If
-    End Sub
 
     Private Sub AutoFill()
         If ucrSelectorColourByMetadata.lstAvailableVariable.Items.Count > 0 Then
             Dim clsHasColoursFunc As New RFunction
-            Dim bApplyColumnColours As Boolean
             clsHasColoursFunc.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$has_colours")
             clsHasColoursFunc.AddParameter("data_name", Chr(34) & ucrSelectorColourByMetadata.ucrAvailableDataFrames.strCurrDataFrame & Chr(34))
             bApplyColumnColours = frmMain.clsRLink.RunInternalScriptGetValue(clsHasColoursFunc.ToScript()).AsLogical(0)
@@ -112,6 +106,18 @@ Public Class dlgColourbyProperty
             End If
             ucrChkRemoveColours.Visible = bApplyColumnColours
         End If
+    End Sub
+
+    Private Sub SetBaseFunction()
+        If ucrChkRemoveColours.Checked AndAlso bApplyColumnColours Then
+            ucrBase.clsRsyntax.SetBaseRFunction(clsRemoveColour)
+        Else
+            ucrBase.clsRsyntax.SetBaseRFunction(clsColourByMetadata)
+        End If
+    End Sub
+
+    Private Sub ucrChkRemoveColours_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrChkRemoveColours.ControlValueChanged
+        SetBaseFunction()
     End Sub
 
     Private Sub ucrSelectorColourByMetadata_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrSelectorColourByMetadata.ControlValueChanged

--- a/instat/dlgColourbyProperty.vb
+++ b/instat/dlgColourbyProperty.vb
@@ -48,6 +48,9 @@ Public Class dlgColourbyProperty
         ucrReceiverMetadataProperty.SetItemType("metadata")
         ucrReceiverMetadataProperty.strSelectorHeading = "Metadata Property"
 
+        ucrChkRemoveColours.AddToLinkedControls(ucrReceiverMetadataProperty, {Not True}, bNewLinkedHideIfParameterMissing:=True)
+        ucrReceiverMetadataProperty.SetLinkedDisplayControl(lblMetadataProp)
+
         ucrChkRemoveColours.SetText("Remove Colour")
         ucrChkRemoveColours.AddFunctionNamesCondition(True, frmMain.clsRLink.strInstatDataObject & "$remove_column_colours")
         ucrChkRemoveColours.AddFunctionNamesCondition(False, frmMain.clsRLink.strInstatDataObject & "$set_column_colours_by_metadata")
@@ -73,7 +76,7 @@ Public Class dlgColourbyProperty
     End Sub
 
     Private Sub TestOKEnabled()
-        If Not ucrReceiverMetadataProperty.IsEmpty AndAlso (ucrChkRemoveColours.Checked OrElse Not ucrChkRemoveColours.Checked) Then
+        If Not ucrReceiverMetadataProperty.IsEmpty OrElse ucrChkRemoveColours.Checked Then
             ucrBase.OKEnabled(True)
         Else
             ucrBase.OKEnabled(False)

--- a/instat/dlgColourbyProperty.vb
+++ b/instat/dlgColourbyProperty.vb
@@ -73,7 +73,7 @@ Public Class dlgColourbyProperty
     End Sub
 
     Private Sub TestOKEnabled()
-        If Not ucrReceiverMetadataProperty.IsEmpty Then
+        If Not ucrReceiverMetadataProperty.IsEmpty AndAlso (ucrChkRemoveColours.Checked OrElse Not ucrChkRemoveColours.Checked) Then
             ucrBase.OKEnabled(True)
         Else
             ucrBase.OKEnabled(False)

--- a/instat/dlgColourbyProperty.vb
+++ b/instat/dlgColourbyProperty.vb
@@ -15,6 +15,7 @@
 ' along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 Imports instat.Translations
+Imports RDotNet
 Public Class dlgColourbyProperty
     Public bFirstLoad As Boolean = True
     Private clsColourByMetadata As New RFunction
@@ -32,6 +33,7 @@ Public Class dlgColourbyProperty
         SetRCodeForControls(bReset)
         bReset = False
         TestOKEnabled()
+        AutoFill()
         autoTranslate(Me)
     End Sub
 
@@ -64,7 +66,6 @@ Public Class dlgColourbyProperty
 
         clsColourByMetadata.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$set_column_colours_by_metadata")
         clsRemoveColour.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$remove_column_colours")
-
         ucrBase.clsRsyntax.SetBaseRFunction(clsColourByMetadata)
     End Sub
 
@@ -95,6 +96,28 @@ Public Class dlgColourbyProperty
         Else
             ucrBase.clsRsyntax.SetBaseRFunction(clsColourByMetadata)
         End If
+    End Sub
+
+    Private Sub AutoFill()
+        If ucrSelectorColourByMetadata.lstAvailableVariable.Items.Count > 0 Then
+            Dim clsHasColoursFunc As New RFunction
+            Dim bApplyColumnColours As Boolean
+            clsHasColoursFunc.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$has_colours")
+            clsHasColoursFunc.AddParameter("data_name", Chr(34) & ucrSelectorColourByMetadata.ucrAvailableDataFrames.strCurrDataFrame & Chr(34))
+            bApplyColumnColours = frmMain.clsRLink.RunInternalScriptGetValue(clsHasColoursFunc.ToScript()).AsLogical(0)
+            If Not bApplyColumnColours Then
+                For Each lviItem As ListViewItem In ucrSelectorColourByMetadata.lstAvailableVariable.Items
+                    If lviItem.Text = "class" Then
+                        ucrReceiverMetadataProperty.Add(lviItem.Text, ucrSelectorColourByMetadata.ucrAvailableDataFrames.strCurrDataFrame)
+                        Exit For
+                    End If
+                Next
+            End If
+        End If
+    End Sub
+
+    Private Sub ucrSelectorColourByMetadata_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrSelectorColourByMetadata.ControlValueChanged
+        AutoFill()
     End Sub
 
     Private Sub Controls_ControContententsChanged(ucrChangedControl As ucrCore) Handles ucrSelectorColourByMetadata.ControlContentsChanged, ucrReceiverMetadataProperty.ControlContentsChanged, ucrChkRemoveColours.ControlContentsChanged

--- a/instat/dlgMergeAdditionalData.vb
+++ b/instat/dlgMergeAdditionalData.vb
@@ -280,6 +280,7 @@ Public Class dlgMergeAdditionalData
     Private Sub ucrInputMergingBy_TextChanged(sender As Object, e As EventArgs) Handles ucrInputMergingBy.TextChanged
         AddColumns()
         CheckUnique()
+        SetDataFrameAssign()
         SetInputCheckVisibility(False)
     End Sub
 

--- a/instat/static/InstatObject/R/data_object_R6.R
+++ b/instat/static/InstatObject/R/data_object_R6.R
@@ -2309,7 +2309,7 @@ DataSheet$set("public", "add_dependent_columns", function(columns, dependent_col
 
 DataSheet$set("public", "set_column_colours", function(columns, colours) {
   if(missing(columns)) columns <- self$get_column_names()
-  #if(length(columns) != length(colours)) stop("columns must be the same length as colours")
+  if(length(columns) != length(colours)) stop("columns must be the same length as colours")
   
   for(i in 1:length(columns)) {
     self$append_to_variables_metadata(columns[i], colour_label, colours[i])

--- a/instat/static/InstatObject/R/data_object_R6.R
+++ b/instat/static/InstatObject/R/data_object_R6.R
@@ -1067,8 +1067,8 @@ DataSheet$set("public", "append_to_variables_metadata", function(col_names, prop
     for (curr_col in col_names) {
       #see comments in  PR #7247 to understand why ' property == labels_label && new_val == "" ' check was added
       #see comments in issue #7337 to understand why the !is.null(new_val) check was added. 
-      if (property == labels_label && !is.null(new_val) && new_val == "") {
-        #reset the column labels property 
+      if (((property == labels_label && new_val == "") ||(property == colour_label && new_val == -1)) && !is.null(new_val)) {
+        #reset the column labels or colour property 
         attr(private$data[[curr_col]], property) <- NULL
       } else {
         attr(private$data[[curr_col]], property) <- new_val
@@ -1079,8 +1079,8 @@ DataSheet$set("public", "append_to_variables_metadata", function(col_names, prop
     for (col_name in self$get_column_names()) {
       #see comments in  PR #7247 to understand why ' property == labels_label && new_val == "" ' check was added
       #see comments in issue #7337 to understand why the !is.null(new_val) check was added. 
-      if (property == labels_label && !is.null(new_val) && new_val == "") {
-        #reset the column labels property 
+      if (((property == labels_label && new_val == "") ||(property == colour_label && new_val == -1)) && !is.null(new_val)) {
+        #reset the column labels or colour property 
         attr(private$data[[col_name]], property) <- NULL
       } else {
         attr(private$data[[col_name]], property) <- new_val

--- a/instat/static/InstatObject/R/data_object_R6.R
+++ b/instat/static/InstatObject/R/data_object_R6.R
@@ -2324,7 +2324,8 @@ DataSheet$set("public", "has_colours", function(columns) {
 }
 )
 
-DataSheet$set("public", "set_column_colours_by_metadata", function(columns, property) {
+DataSheet$set("public", "set_column_colours_by_metadata", function(data_name, columns, property) {
+if(!missing(data_name) && missing(columns)) columns <- names(self$get_data_frame(data_name = data_name))
   if(missing(columns)) property_values <- self$get_variables_metadata(property = property)
   else property_values <- self$get_variables_metadata(property = property, column = columns)
   

--- a/instat/static/InstatObject/R/data_object_R6.R
+++ b/instat/static/InstatObject/R/data_object_R6.R
@@ -2309,7 +2309,7 @@ DataSheet$set("public", "add_dependent_columns", function(columns, dependent_col
 
 DataSheet$set("public", "set_column_colours", function(columns, colours) {
   if(missing(columns)) columns <- self$get_column_names()
-  if(length(columns) != length(colours)) stop("columns must be the same length as colours")
+  #if(length(columns) != length(colours)) stop("columns must be the same length as colours")
   
   for(i in 1:length(columns)) {
     self$append_to_variables_metadata(columns[i], colour_label, colours[i])

--- a/instat/static/InstatObject/R/data_object_R6.R
+++ b/instat/static/InstatObject/R/data_object_R6.R
@@ -1067,7 +1067,7 @@ DataSheet$set("public", "append_to_variables_metadata", function(col_names, prop
     for (curr_col in col_names) {
       #see comments in  PR #7247 to understand why ' property == labels_label && new_val == "" ' check was added
       #see comments in issue #7337 to understand why the !is.null(new_val) check was added. 
-      if (((property == labels_label && new_val == "") ||(property == colour_label && new_val == -1)) && !is.null(new_val)) {
+      if (((property == labels_label && new_val == "") || (property == colour_label && new_val == -1)) && !is.null(new_val)) {
         #reset the column labels or colour property 
         attr(private$data[[curr_col]], property) <- NULL
       } else {
@@ -1079,7 +1079,7 @@ DataSheet$set("public", "append_to_variables_metadata", function(col_names, prop
     for (col_name in self$get_column_names()) {
       #see comments in  PR #7247 to understand why ' property == labels_label && new_val == "" ' check was added
       #see comments in issue #7337 to understand why the !is.null(new_val) check was added. 
-      if (((property == labels_label && new_val == "") ||(property == colour_label && new_val == -1)) && !is.null(new_val)) {
+      if (((property == labels_label && new_val == "") || (property == colour_label && new_val == -1)) && !is.null(new_val)) {
         #reset the column labels or colour property 
         attr(private$data[[col_name]], property) <- NULL
       } else {

--- a/instat/static/InstatObject/R/instat_object_R6.R
+++ b/instat/static/InstatObject/R/instat_object_R6.R
@@ -1379,7 +1379,7 @@ DataBook$set("public", "remove_column_colours", function(data_name) {
 )
 
 DataBook$set("public","set_column_colours_by_metadata", function(data_name, columns, property) {
-  self$get_data_objects(data_name)$set_column_colours_by_metadata(columns, property)
+  self$get_data_objects(data_name)$set_column_colours_by_metadata(data_name, columns, property)
 }
 )
 

--- a/instat/ucrDataView.vb
+++ b/instat/ucrDataView.vb
@@ -100,7 +100,6 @@ Public Class ucrDataView
         _grid.CurrentWorksheet = fillWorkSheet
         _grid.AddColumns(dataFrame.clsVisiblePage)
         _grid.AddRowData(dataFrame)
-        _grid.UpdateWorksheetStyle(fillWorkSheet)
         dataFrame.clsVisiblePage.HasChanged = False
         RefreshDisplayInformation()
     End Sub

--- a/instat/ucrDataView.vb
+++ b/instat/ucrDataView.vb
@@ -100,6 +100,7 @@ Public Class ucrDataView
         _grid.CurrentWorksheet = fillWorkSheet
         _grid.AddColumns(dataFrame.clsVisiblePage)
         _grid.AddRowData(dataFrame)
+        _grid.UpdateAllWorksheetStyles()
         dataFrame.clsVisiblePage.HasChanged = False
         RefreshDisplayInformation()
     End Sub

--- a/instat/ucrDataView.vb
+++ b/instat/ucrDataView.vb
@@ -100,13 +100,8 @@ Public Class ucrDataView
         _grid.CurrentWorksheet = fillWorkSheet
         _grid.AddColumns(dataFrame.clsVisibleDataFramePage)
         _grid.AddRowData(dataFrame)
-
-        _grid.UpdateAllWorksheetStyles()
-        dataFrame.clsVisiblePage.HasChanged = False
-
         _grid.UpdateWorksheetStyle(fillWorkSheet)
         dataFrame.clsVisibleDataFramePage.HasChanged = False
-
         RefreshDisplayInformation()
     End Sub
 


### PR DESCRIPTION
Fixes #7232
@africanmathsinitiative/developers this is ready for review.
@rdstern I have fixed the bug on not setting the colour to the dataset in the `Data View`, in addition while testing I fixed one small bug I found in the `Merge Additional Dialogue`. I also realised in version `0.7.2` that with dataset you shared in Skype, the merge dialogue seems to not apply the colour though the second or first dataframe has colour applied but with this version, it seems to keep the colour if applied from one of the dataset in the merged dataset. Please could test on your side and see if I'm right? Thanks.