### PR TITLE
If error thrown when retrieving data frames from R, then handle error and display user message

### DIFF
--- a/instat/Model/DataFrame/clsDataBook.vb
+++ b/instat/Model/DataFrame/clsDataBook.vb
@@ -108,7 +108,7 @@ Public Class clsDataBook
     ''' Updates all the dataframes and metadata where the data has changed
     ''' </summary>
     Public Sub RefreshData()
-        'if no R Instant object exists then just clear all data frames in the databook
+        'if no R Instat object exists then just clear all data frames in the databook
         'and refresh the data frame metadata from R
         If Not _RLink.bInstatObjectExists Then
             _lstDataFrames.Clear()

--- a/instat/Model/DataFrame/clsDataBook.vb
+++ b/instat/Model/DataFrame/clsDataBook.vb
@@ -145,7 +145,10 @@ Public Class clsDataBook
             End If
             'if data not refreshed successfully, remove the data frame from the data book
             If Not dataFrame.RefreshData() Then
-                'todo. display an error too??
+                MessageBox.Show("Error: Could not retrieve data frame:" & strDataFrameName & " from R" &
+                                Environment.NewLine & "Data displayed in spreadsheet may not be up to date." &
+                                Environment.NewLine & "We strongly suggest restarting R-Instat before continuing.",
+                                "Cannot retrieve data", MessageBoxButtons.OK, MessageBoxIcon.Warning)
                 _lstDataFrames.Remove(dataFrame)
             End If
         Next

--- a/instat/Model/DataFrame/clsDataBook.vb
+++ b/instat/Model/DataFrame/clsDataBook.vb
@@ -21,7 +21,7 @@ Imports RDotNet
 ''' </summary>
 Public Class clsDataBook
     Private _RLink As RLink
-    Private _dataFrames As List(Of clsDataFrame)
+    Private _lstDataFrames As List(Of clsDataFrame)
     Private _clsDataFrameMetaData As clsDataFrameMetaData
 
     ''' <summary>
@@ -30,10 +30,10 @@ Public Class clsDataBook
     ''' <returns></returns>
     Public Property DataFrames() As List(Of clsDataFrame)
         Get
-            Return _dataFrames
+            Return _lstDataFrames
         End Get
         Set(value As List(Of clsDataFrame))
-            _dataFrames = value
+            _lstDataFrames = value
         End Set
     End Property
     ''' <summary>
@@ -53,7 +53,7 @@ Public Class clsDataBook
     ''' <param name="rLink"></param>
     Public Sub New(rLink As RLink)
         _RLink = rLink
-        _dataFrames = New List(Of clsDataFrame)
+        _lstDataFrames = New List(Of clsDataFrame)
         _clsDataFrameMetaData = New clsDataFrameMetaData(rLink)
     End Sub
 
@@ -86,74 +86,77 @@ Public Class clsDataBook
         _RLink.RunScript(clsHideDataFrame.ToScript(), strComment:="Right click menu: Hide Data Frame")
     End Sub
 
-    Private Function CreateNewGridTab(strDataFrameName As String) As clsDataFrame
-        Dim dataframe As New clsDataFrame(_RLink, strDataFrameName)
-        _dataFrames.Add(dataframe)
-        Return dataframe
-    End Function
-
     ''' <summary>
     ''' Gets the dataframe within the databook corresponding to the given name
     ''' </summary>
     ''' <param name="strName"></param>
     ''' <returns></returns>
     Public Function GetDataFrame(strName As String) As clsDataFrame
-        Return _dataFrames.Where(Function(x) x.strName = strName).FirstOrDefault
+        Return _lstDataFrames.Where(Function(x) x.strName = strName).FirstOrDefault
     End Function
+
     ''' <summary>
     ''' Gets the Column Metadata for the dataframe name given
     ''' </summary>
     ''' <param name="strName"></param>
     ''' <returns></returns>
     Public Function GetColumnMetaData(strName As String) As clsColumnMetaData
-        Return _dataFrames.Where(Function(x) x.strName = strName).FirstOrDefault().clsColumnMetaData
+        Return _lstDataFrames.Where(Function(x) x.strName = strName).FirstOrDefault().clsColumnMetaData
     End Function
 
     ''' <summary>
     ''' Updates all the dataframes and metadata where the data has changed
     ''' </summary>
     Public Sub RefreshData()
+        'if no R Instant object exists then just clear all data frames in the databook
+        'and refresh the data frame metadata from R
         If Not _RLink.bInstatObjectExists Then
-            DeleteAllDataFrames()
+            _lstDataFrames.Clear()
             _clsDataFrameMetaData = New clsDataFrameMetaData(_RLink)
             Exit Sub
         End If
+
+        'else if the R Instat object data has changed
+        'refresh data frames data and metadata 
         If HasDataChanged() Then
-            Dim listOfDataFrames As List(Of String) = GetDataFrameNames()
-            DeleteOldDataFrames(listOfDataFrames)
-            For Each strDataFrameName In listOfDataFrames
-                Dim dataFrame As clsDataFrame = GetOrCreateDataFrame(strDataFrameName)
-                dataFrame.RefreshData()
-            Next
+            RefreshDataFrames()
             _clsDataFrameMetaData.RefreshData()
         End If
     End Sub
 
-    Private Sub DeleteAllDataFrames()
-        Dim listOfDataFrames As New List(Of String)
-        DeleteOldDataFrames(listOfDataFrames)
-    End Sub
+    ''' <summary>
+    ''' refreshes data book with recent R data frames and the data frames with recent R data
+    ''' </summary>
+    Private Sub RefreshDataFrames()
+        'get the recent list of data frame names from R Instant
+        Dim lstOfCurrentRDataFrameNames As List(Of String) = GetDataFrameNamesFromR()
 
-    Private Function GetOrCreateDataFrame(strDataFrameName As String) As clsDataFrame
+        'remove any data frames from this data book that are not in the R Instat object
+        _lstDataFrames.RemoveAll(Function(x) Not lstOfCurrentRDataFrameNames.Contains(x.strName))
+
+        'add any R Instat object data frames missing in the data book
+        'and also refresh data of the data book data frames 
         Dim dataFrame As clsDataFrame
-        dataFrame = _dataFrames.Where(Function(x) x.strName = strDataFrameName).SingleOrDefault
-        If dataFrame Is Nothing Then
-            dataFrame = CreateNewGridTab(strDataFrameName)
-        End If
-        Return dataFrame
-    End Function
-
-    Private Sub DeleteOldDataFrames(currentDataFrames As List(Of String))
-        Dim gridTab As clsDataFrame
-        For i = _dataFrames.Count - 1 To 0 Step -1
-            gridTab = _dataFrames(i)
-            If Not currentDataFrames.Contains(gridTab.strName) Then
-                _dataFrames.RemoveAt(i)
+        For Each strDataFrameName In lstOfCurrentRDataFrameNames
+            dataFrame = _lstDataFrames.Where(Function(x) x.strName = strDataFrameName).SingleOrDefault
+            If dataFrame Is Nothing Then
+                dataFrame = New clsDataFrame(_RLink, strDataFrameName)
+                _lstDataFrames.Add(dataFrame)
+            End If
+            'if data not refreshed successfully, remove the data frame from the data book
+            If Not dataFrame.RefreshData() Then
+                'todo. display an error too??
+                _lstDataFrames.Remove(dataFrame)
             End If
         Next
     End Sub
 
-    Private Function GetDataFrameNames() As List(Of String)
+
+    ''' <summary>
+    ''' Gets current data frame names from R (the R Instant object).
+    ''' </summary>
+    ''' <returns>list of data frame names. If no data frame names found, an empty list is returned</returns>
+    Private Function GetDataFrameNamesFromR() As List(Of String)
         Dim clsGetDataFrameNames As New RFunction
         Dim expTemp As SymbolicExpression
         Dim listOfDataFrames As New List(Of String)

--- a/instat/Model/DataFrame/clsDataBook.vb
+++ b/instat/Model/DataFrame/clsDataBook.vb
@@ -125,7 +125,7 @@ Public Class clsDataBook
     End Sub
 
     ''' <summary>
-    ''' refreshes data book with recent R data frames and the data frames with recent R data
+    ''' refreshes data book with recent R data frames and the data frames with their recent R data
     ''' </summary>
     Private Sub RefreshDataFrames()
         'get the recent list of data frame names from R Instant

--- a/instat/Model/DataFrame/clsDataFramePage.vb
+++ b/instat/Model/DataFrame/clsDataFramePage.vb
@@ -17,7 +17,8 @@
 Imports RDotNet
 
 ''' <summary>
-''' Holds a subset dataset for the dataframe
+''' Holds a subset dataset of an R dataframe.
+''' The subset is determined by the rows and columns indexes and count
 ''' </summary>
 Public Class clsDataFramePage
     Private _iRowStart As Integer
@@ -26,7 +27,7 @@ Public Class clsDataFramePage
     Private _iTotalColumnCount As Integer
     Private _strDataFrameName As String
     Private _clsRLink As RLink
-    Private _clsDataFrame As DataFrame
+    Private _clsRDotNetDataFrame As DataFrame
     Private _lstColumns As List(Of clsColumnHeaderDisplay)
     Private _hasChanged As Boolean
 
@@ -58,7 +59,7 @@ Public Class clsDataFramePage
     ''' <returns></returns>
     Public ReadOnly Property RowNames() As String()
         Get
-            Return _clsDataFrame.RowNames()
+            Return _clsRDotNetDataFrame.RowNames()
         End Get
     End Property
 
@@ -78,7 +79,7 @@ Public Class clsDataFramePage
     ''' <returns></returns>
     Public ReadOnly Property intEndRow As Integer
         Get
-            Return _iRowStart + _clsDataFrame.RowCount - 1
+            Return _iRowStart + _clsRDotNetDataFrame.RowCount - 1
         End Get
     End Property
 
@@ -98,7 +99,7 @@ Public Class clsDataFramePage
     ''' <returns></returns>
     Public ReadOnly Property intEndColumn As Integer
         Get
-            Return _iColumnStart + _clsDataFrame.ColumnCount - 1
+            Return _iColumnStart + _clsRDotNetDataFrame.ColumnCount - 1
         End Get
     End Property
 
@@ -110,7 +111,7 @@ Public Class clsDataFramePage
     ''' <returns></returns>
     Public ReadOnly Property Data(iRow As Integer, iColumn As Integer) As Object
         Get
-            Return _clsDataFrame(iRow, iColumn)
+            Return _clsRDotNetDataFrame(iRow, iColumn)
             'ToDo Need better error handling if out of range
         End Get
     End Property
@@ -121,7 +122,7 @@ Public Class clsDataFramePage
     ''' <returns></returns>
     Public ReadOnly Property DisplayedRowCount As Integer
         Get
-            Return _clsDataFrame.RowCount
+            Return _clsRDotNetDataFrame.RowCount
         End Get
     End Property
 
@@ -153,15 +154,18 @@ Public Class clsDataFramePage
     End Sub
 
     ''' <summary>
-    ''' Refreshes data. Note: always refreshes regardless whether dataset has changed.
+    ''' Refreshes data. 
+    ''' When called, a new R.Net data frame will be set. 
+    ''' If data frame set is not successful, a null object will be set.
+    ''' <para>Note: always refreshes regardless whether dataset has changed.</para>
     ''' </summary>
-    ''' <returns></returns>
+    ''' <returns>Returns true if R.Net data frame is set, false if not set</returns>
     Public Function RefreshData()
-        _clsDataFrame = GetDataFrameFromRCommand()
-        If _clsDataFrame IsNot Nothing Then
+        _clsRDotNetDataFrame = GetDataFrameFromRCommand()
+        If _clsRDotNetDataFrame IsNot Nothing Then
             SetHeaders()
         End If
-        Return _clsDataFrame IsNot Nothing 'Returns a success value
+        Return _clsRDotNetDataFrame IsNot Nothing 'Returns a success value
     End Function
 
     ''' <summary>
@@ -215,7 +219,7 @@ Public Class clsDataFramePage
         Dim clsRFunction As New RFunction
         clsRFunction.SetRCommand(_clsRLink.strInstatDataObject & "$get_column_data_types")
         clsRFunction.AddParameter("data_name", Chr(34) & _strDataFrameName & Chr(34))
-        clsRFunction.AddParameter("columns", _clsRLink.GetListAsRString(_clsDataFrame.ColumnNames.ToList))
+        clsRFunction.AddParameter("columns", _clsRLink.GetListAsRString(_clsRDotNetDataFrame.ColumnNames.ToList))
         Return _clsRLink.RunInternalScriptGetValue(clsRFunction.ToScript()).AsCharacter
     End Function
 
@@ -224,7 +228,7 @@ Public Class clsDataFramePage
         clsRFunction.SetRCommand(_clsRLink.strInstatDataObject & "$get_variables_metadata")
         clsRFunction.AddParameter("data_name", Chr(34) & _strDataFrameName & Chr(34))
         clsRFunction.AddParameter("property", "colour_label")
-        clsRFunction.AddParameter("column", _clsRLink.GetListAsRString(_clsDataFrame.ColumnNames.ToList))
+        clsRFunction.AddParameter("column", _clsRLink.GetListAsRString(_clsRDotNetDataFrame.ColumnNames.ToList))
         Return _clsRLink.RunInternalScriptGetValue(clsRFunction.ToScript()).AsNumeric
     End Function
 
@@ -233,7 +237,7 @@ Public Class clsDataFramePage
         clsRFunction.ClearParameters()
         clsRFunction.SetRCommand(_clsRLink.strInstatDataObject & "$has_colours")
         clsRFunction.AddParameter("data_name", Chr(34) & _strDataFrameName & Chr(34))
-        clsRFunction.AddParameter("columns", _clsRLink.GetListAsRString(_clsDataFrame.ColumnNames.ToList))
+        clsRFunction.AddParameter("columns", _clsRLink.GetListAsRString(_clsRDotNetDataFrame.ColumnNames.ToList))
         Return _clsRLink.RunInternalScriptGetValue(clsRFunction.ToScript()).AsLogical(0)
     End Function
 
@@ -289,8 +293,8 @@ Public Class clsDataFramePage
         End If
         _lstColumns.Clear()
 
-        For i = 0 To _clsDataFrame.ColumnNames.ToList.Count - 1
-            columnHeader = GetColumnDispayDetails(_clsDataFrame.ColumnNames.ToList(i), vecColumnDataTypes(i))
+        For i = 0 To _clsRDotNetDataFrame.ColumnNames.ToList.Count - 1
+            columnHeader = GetColumnDispayDetails(_clsRDotNetDataFrame.ColumnNames.ToList(i), vecColumnDataTypes(i))
             If bApplyBackGroundColumnColours AndAlso vecColumnColours IsNot Nothing Then
                 columnHeader.clsBackGroundColour = GetColumnBackGroundColor(i, vecColumnColours(i).ToString())
             End If
@@ -320,7 +324,7 @@ Public Class clsDataFramePage
     Public Sub LoadNextRowPage()
         If CanLoadNextRowPage() Then
             _iRowStart += intRowIncrements
-            _clsDataFrame = GetDataFrameFromRCommand()
+            _clsRDotNetDataFrame = GetDataFrameFromRCommand()
         End If
     End Sub
 
@@ -338,7 +342,7 @@ Public Class clsDataFramePage
     Public Sub LoadPreviousRowPage()
         If CanLoadPreviousRowPage() Then
             _iRowStart -= intRowIncrements
-            _clsDataFrame = GetDataFrameFromRCommand()
+            _clsRDotNetDataFrame = GetDataFrameFromRCommand()
         End If
     End Sub
 
@@ -347,7 +351,7 @@ Public Class clsDataFramePage
     ''' </summary>
     Public Sub LoadLastRowPage()
         _iRowStart = (intRowIncrements * (GetNoOfRowPages() - 1)) + 1
-        _clsDataFrame = GetDataFrameFromRCommand()
+        _clsRDotNetDataFrame = GetDataFrameFromRCommand()
     End Sub
 
     ''' <summary>
@@ -355,7 +359,7 @@ Public Class clsDataFramePage
     ''' </summary>
     Public Sub LoadFirstRowPage()
         _iRowStart = 1
-        _clsDataFrame = GetDataFrameFromRCommand()
+        _clsRDotNetDataFrame = GetDataFrameFromRCommand()
     End Sub
 
     ''' <summary>
@@ -372,7 +376,7 @@ Public Class clsDataFramePage
     Public Sub LoadNextColumnPage()
         If CanLoadNextColumnPage() Then
             _iColumnStart += iColumnIncrements
-            _clsDataFrame = GetDataFrameFromRCommand()
+            _clsRDotNetDataFrame = GetDataFrameFromRCommand()
             SetHeaders()
         End If
     End Sub
@@ -391,7 +395,7 @@ Public Class clsDataFramePage
     Public Sub LoadPreviousColumnPage()
         If _iColumnStart - iColumnIncrements >= 0 Then
             _iColumnStart -= iColumnIncrements
-            _clsDataFrame = GetDataFrameFromRCommand()
+            _clsRDotNetDataFrame = GetDataFrameFromRCommand()
             SetHeaders()
         End If
     End Sub
@@ -401,7 +405,7 @@ Public Class clsDataFramePage
     ''' </summary>
     Public Sub LoadLastColumnPage()
         _iColumnStart = (iColumnIncrements * (GetNoOfColumnPages() - 1)) + 1
-        _clsDataFrame = GetDataFrameFromRCommand()
+        _clsRDotNetDataFrame = GetDataFrameFromRCommand()
         SetHeaders()
     End Sub
 
@@ -410,7 +414,7 @@ Public Class clsDataFramePage
     ''' </summary>
     Public Sub LoadFirstColumnPage()
         _iColumnStart = 1
-        _clsDataFrame = GetDataFrameFromRCommand()
+        _clsRDotNetDataFrame = GetDataFrameFromRCommand()
         SetHeaders()
     End Sub
 

--- a/instat/UserControls/DataGrid/Linux/ucrDataViewLinuxGrid.vb
+++ b/instat/UserControls/DataGrid/Linux/ucrDataViewLinuxGrid.vb
@@ -54,13 +54,13 @@ Public Class ucrDataViewLinuxGrid
             dataGrid.RowHeadersDefaultCellStyle.ForeColor = Color.DarkBlue
         End If
 
-        Dim strRowNames = dataFrame.strRowNames()
+        Dim strRowNames = dataFrame.DisplayedRowNames()
         dataGrid.Rows.Clear()
         For i = 0 To dataFrame.iDisplayedRowCount - 1
             dataGrid.Rows.Add()
             dataGrid.Rows(i).HeaderCell.Value = strRowNames(i)
             For j = 0 To dataGrid.ColumnCount - 1
-                dataGrid.Rows(i).Cells(j).Value = dataFrame.Data(i, j)
+                dataGrid.Rows(i).Cells(j).Value = dataFrame.DisplayedData(i, j)
             Next
         Next
     End Sub
@@ -99,8 +99,8 @@ Public Class ucrDataViewLinuxGrid
     Private Sub DataGridView_CellEndEdit(sender As Object, e As DataGridViewCellEventArgs)
         Dim dataGrid = GetDataGridFromSelectedTab()
         RaiseEvent IDataViewGrid_ReplaceValueInData(dataGrid.CurrentCell.Value.ToString(),
-                        GetCurrentDataFrameFocus().clsVisiblePage.lstColumns(dataGrid.CurrentCell.ColumnIndex).strName,
-                        GetCurrentDataFrameFocus().clsVisiblePage.RowNames()(dataGrid.CurrentCell.RowIndex))
+                        GetCurrentDataFrameFocus().clsVisibleDataFramePage.lstColumns(dataGrid.CurrentCell.ColumnIndex).strName,
+                        GetCurrentDataFrameFocus().clsVisibleDataFramePage.RowNames()(dataGrid.CurrentCell.RowIndex))
     End Sub
 
     'ToDo allow editing
@@ -138,7 +138,7 @@ Public Class ucrDataViewLinuxGrid
             End If
         Next
         For Each columnIndex In selectedColumns
-            lstColumns.Add(GetCurrentDataFrameFocus().clsVisiblePage.lstColumns(columnIndex))
+            lstColumns.Add(GetCurrentDataFrameFocus().clsVisibleDataFramePage.lstColumns(columnIndex))
         Next
         Return lstColumns
     End Function

--- a/instat/UserControls/DataGrid/ReoGrid/ucrDataViewReoGrid.vb
+++ b/instat/UserControls/DataGrid/ReoGrid/ucrDataViewReoGrid.vb
@@ -68,10 +68,10 @@ Public Class ucrDataViewReoGrid
             textColour = Color.DarkBlue
         End If
 
-        strRowNames = dataFrame.strRowNames()
+        strRowNames = dataFrame.DisplayedRowNames()
         For i = 0 To grdData.CurrentWorksheet.Rows - 1
             For j = 0 To grdData.CurrentWorksheet.Columns - 1
-                grdData.CurrentWorksheet(row:=i, col:=j) = dataFrame.Data(i, j)
+                grdData.CurrentWorksheet(row:=i, col:=j) = dataFrame.DisplayedData(i, j)
             Next
             grdData.CurrentWorksheet.RowHeaders.Item(i).Text = strRowNames(i)
             grdData.CurrentWorksheet.RowHeaders(i).TextColor = textColour
@@ -81,7 +81,7 @@ Public Class ucrDataViewReoGrid
     Public Function GetSelectedColumns() As List(Of clsColumnHeaderDisplay) Implements IDataViewGrid.GetSelectedColumns
         Dim lstColumns As New List(Of clsColumnHeaderDisplay)
         For i As Integer = grdData.CurrentWorksheet.SelectionRange.Col To grdData.CurrentWorksheet.SelectionRange.Col + grdData.CurrentWorksheet.SelectionRange.Cols - 1
-            lstColumns.Add(GetCurrentDataFrameFocus().clsVisiblePage.lstColumns(i))
+            lstColumns.Add(GetCurrentDataFrameFocus().clsVisibleDataFramePage.lstColumns(i))
         Next
         Return lstColumns
     End Function
@@ -138,8 +138,8 @@ Public Class ucrDataViewReoGrid
 
     Private Sub Worksheet_AfterCellEdit(sender As Object, e As CellAfterEditEventArgs)
         RaiseEvent ReplaceValueInData(e.NewData.ToString(),
-                           GetCurrentDataFrameFocus().clsVisiblePage.lstColumns(e.Cell.Column).strName,
-                           GetCurrentDataFrameFocus().clsVisiblePage.RowNames()(e.Cell.Row))
+                           GetCurrentDataFrameFocus().clsVisibleDataFramePage.lstColumns(e.Cell.Column).strName,
+                           GetCurrentDataFrameFocus().clsVisibleDataFramePage.RowNames()(e.Cell.Row))
         e.EndReason = unvell.ReoGrid.EndEditReason.Cancel
     End Sub
 
@@ -147,7 +147,7 @@ Public Class ucrDataViewReoGrid
     Private Sub Worksheet_BeforePaste(sender As Object, e As BeforeRangeOperationEventArgs)
         e.IsCancelled = True 'prevents pasted data from being added directly into the data view
         'validate columns
-        If e.Range.EndCol >= GetCurrentDataFrameFocus().clsVisiblePage.lstColumns.Count Then
+        If e.Range.EndCol >= GetCurrentDataFrameFocus().clsVisibleDataFramePage.lstColumns.Count Then
             'this happens when Ctrl + V is pressed and the data to be pasted has more columns
             'than columns between start and end column
             MsgBox("Columns copied are more than the current data frame columns.", MsgBoxStyle.Critical, "Excess Columns")

--- a/instat/ucrDataView.vb
+++ b/instat/ucrDataView.vb
@@ -94,14 +94,14 @@ Public Class ucrDataView
     End Sub
 
     Private Sub RefreshWorksheet(fillWorkSheet As clsWorksheetAdapter, dataFrame As clsDataFrame)
-        If Not dataFrame.clsVisiblePage.HasChanged Then
+        If Not dataFrame.clsVisibleDataFramePage.HasChanged Then
             Exit Sub
         End If
         _grid.CurrentWorksheet = fillWorkSheet
-        _grid.AddColumns(dataFrame.clsVisiblePage)
+        _grid.AddColumns(dataFrame.clsVisibleDataFramePage)
         _grid.AddRowData(dataFrame)
         _grid.UpdateWorksheetStyle(fillWorkSheet)
-        dataFrame.clsVisiblePage.HasChanged = False
+        dataFrame.clsVisibleDataFramePage.HasChanged = False
         RefreshDisplayInformation()
     End Sub
 
@@ -110,13 +110,13 @@ Public Class ucrDataView
     End Sub
 
     Private Sub UpdateNavigationButtons()
-        lblColBack.Enabled = If(GetCurrentDataFrameFocus()?.clsVisiblePage?.CanLoadPreviousColumnPage(), False)
-        lblColNext.Enabled = If(GetCurrentDataFrameFocus()?.clsVisiblePage?.CanLoadNextColumnPage(), False)
+        lblColBack.Enabled = If(GetCurrentDataFrameFocus()?.clsVisibleDataFramePage?.CanLoadPreviousColumnPage(), False)
+        lblColNext.Enabled = If(GetCurrentDataFrameFocus()?.clsVisibleDataFramePage?.CanLoadNextColumnPage(), False)
         lblColFirst.Enabled = lblColBack.Enabled
         lblColLast.Enabled = lblColNext.Enabled
 
-        lblRowBack.Enabled = If(GetCurrentDataFrameFocus()?.clsVisiblePage?.CanLoadPreviousRowPage(), False)
-        lblRowNext.Enabled = If(GetCurrentDataFrameFocus()?.clsVisiblePage?.CanLoadNextRowPage(), False)
+        lblRowBack.Enabled = If(GetCurrentDataFrameFocus()?.clsVisibleDataFramePage?.CanLoadPreviousRowPage(), False)
+        lblRowNext.Enabled = If(GetCurrentDataFrameFocus()?.clsVisibleDataFramePage?.CanLoadNextRowPage(), False)
         lblRowFirst.Enabled = lblRowBack.Enabled
         lblRowLast.Enabled = lblRowNext.Enabled
     End Sub
@@ -282,10 +282,10 @@ Public Class ucrDataView
     End Sub
 
     Private Sub SetDisplayLabels()
-        Dim strRowLabel As String = GetCurrentDataFrameFocus().clsVisiblePage.intStartRow & " to " &
-                             GetCurrentDataFrameFocus().clsVisiblePage.intEndRow & " of "
-        Dim strColLabel As String = GetCurrentDataFrameFocus().clsVisiblePage.intStartColumn & " to " &
-                              GetCurrentDataFrameFocus().clsVisiblePage.intEndColumn & " of "
+        Dim strRowLabel As String = GetCurrentDataFrameFocus().clsVisibleDataFramePage.intStartRow & " to " &
+                             GetCurrentDataFrameFocus().clsVisibleDataFramePage.intEndRow & " of "
+        Dim strColLabel As String = GetCurrentDataFrameFocus().clsVisibleDataFramePage.intStartColumn & " to " &
+                              GetCurrentDataFrameFocus().clsVisibleDataFramePage.intEndColumn & " of "
 
         If GetCurrentDataFrameFocus().clsFilterOrColumnSelection.bFilterApplied Then
             lblRowDisplay.Text = "Rows " & strRowLabel & GetCurrentDataFrameFocus().clsFilterOrColumnSelection.iFilteredRowCount &
@@ -295,7 +295,7 @@ Public Class ucrDataView
         End If
 
         If GetCurrentDataFrameFocus().clsFilterOrColumnSelection.bColumnSelectionApplied Then
-            lblColDisplay.Text = "Columns " & strColLabel & GetCurrentDataFrameFocus().clsVisiblePage.intEndColumn &
+            lblColDisplay.Text = "Columns " & strColLabel & GetCurrentDataFrameFocus().clsVisibleDataFramePage.intEndColumn &
                                 " (" & GetCurrentDataFrameFocus().iTotalColumnCount & ")" & " | Selection: " & GetCurrentDataFrameFocus().clsFilterOrColumnSelection.strSelectionName
         Else
             lblColDisplay.Text = "Showing columns " & strColLabel & GetCurrentDataFrameFocus().iTotalColumnCount
@@ -774,42 +774,42 @@ Public Class ucrDataView
     End Sub
 
     Private Sub lblRowFirst_Click(sender As Object, e As EventArgs) Handles lblRowFirst.Click
-        GetCurrentDataFrameFocus().clsVisiblePage.LoadFirstRowPage()
+        GetCurrentDataFrameFocus().clsVisibleDataFramePage.LoadFirstRowPage()
         RefreshWorksheet(_grid.CurrentWorksheet, GetCurrentDataFrameFocus())
     End Sub
 
     Private Sub lblRowBack_Click(sender As Object, e As EventArgs) Handles lblRowBack.Click
-        GetCurrentDataFrameFocus().clsVisiblePage.LoadPreviousRowPage()
+        GetCurrentDataFrameFocus().clsVisibleDataFramePage.LoadPreviousRowPage()
         RefreshWorksheet(_grid.CurrentWorksheet, GetCurrentDataFrameFocus())
     End Sub
 
     Private Sub lblRowNext_Click(sender As Object, e As EventArgs) Handles lblRowNext.Click
-        GetCurrentDataFrameFocus().clsVisiblePage.LoadNextRowPage()
+        GetCurrentDataFrameFocus().clsVisibleDataFramePage.LoadNextRowPage()
         RefreshWorksheet(_grid.CurrentWorksheet, GetCurrentDataFrameFocus())
     End Sub
 
     Private Sub lblRowLast_Click(sender As Object, e As EventArgs) Handles lblRowLast.Click
-        GetCurrentDataFrameFocus().clsVisiblePage.LoadLastRowPage()
+        GetCurrentDataFrameFocus().clsVisibleDataFramePage.LoadLastRowPage()
         RefreshWorksheet(_grid.CurrentWorksheet, GetCurrentDataFrameFocus())
     End Sub
 
     Private Sub lblColFirst_Click(sender As Object, e As EventArgs) Handles lblColFirst.Click
-        GetCurrentDataFrameFocus().clsVisiblePage.LoadFirstColumnPage()
+        GetCurrentDataFrameFocus().clsVisibleDataFramePage.LoadFirstColumnPage()
         RefreshWorksheet(_grid.CurrentWorksheet, GetCurrentDataFrameFocus())
     End Sub
 
     Private Sub lblColBack_Click(sender As Object, e As EventArgs) Handles lblColBack.Click
-        GetCurrentDataFrameFocus().clsVisiblePage.LoadPreviousColumnPage()
+        GetCurrentDataFrameFocus().clsVisibleDataFramePage.LoadPreviousColumnPage()
         RefreshWorksheet(_grid.CurrentWorksheet, GetCurrentDataFrameFocus())
     End Sub
 
     Private Sub lblColNext_Click(sender As Object, e As EventArgs) Handles lblColNext.Click
-        GetCurrentDataFrameFocus().clsVisiblePage.LoadNextColumnPage()
+        GetCurrentDataFrameFocus().clsVisibleDataFramePage.LoadNextColumnPage()
         RefreshWorksheet(_grid.CurrentWorksheet, GetCurrentDataFrameFocus())
     End Sub
 
     Private Sub lblColLast_Click(sender As Object, e As EventArgs) Handles lblColLast.Click
-        GetCurrentDataFrameFocus().clsVisiblePage.LoadLastColumnPage()
+        GetCurrentDataFrameFocus().clsVisibleDataFramePage.LoadLastColumnPage()
         RefreshWorksheet(_grid.CurrentWorksheet, GetCurrentDataFrameFocus())
     End Sub
 


### PR DESCRIPTION
Fixes #7374

@africanmathsinitiative/developers this is ready for review.

This PR is meant to prevent R-Instat from breaking if there is a problem with retrieving data frame form R. This prevention was already there in the old version of R-Instat.
Changes include;
1. Refactoring code
2. Adding a warning that was there in the old version. 

![error old](https://user-images.githubusercontent.com/21179007/163674691-cf06f561-e0ed-4d5b-aef3-b35769690436.PNG)

To test it, you can  use the data file in the issue. 
