### PR TITLE
Bug fixed on Add (Merge) Columns when merging with different datasets length

### DIFF
--- a/instat/dlgMergeAdditionalData.vb
+++ b/instat/dlgMergeAdditionalData.vb
@@ -20,7 +20,7 @@ Imports RDotNet
 Public Class dlgMergeAdditionalData
     Private bFirstLoad As Boolean = True
     Private bReset As Boolean = True
-    Private clsInsertColumnFunction, clsGetColumnsFromData As New RFunction
+    Private clsInsertColumnFunction, clsGetColumnsFromData, clsImportDataFunction, clsListFunction As New RFunction
     Private lstJoinColumns As New List(Of String)
     Private clsLeftJoinFunction As New RFunction
     Private clsByListFunction As New RFunction
@@ -72,12 +72,19 @@ Public Class dlgMergeAdditionalData
         clsInsertColumnFunction = New RFunction
         clsGetColumnsFromData = New RFunction
         clsGetVariablesFunction = New RFunction
+        clsImportDataFunction = New RFunction
+        clsListFunction = New RFunction
 
         ucrToDataFrame.Reset()
         ucrFromDataFrame.Reset()
         ucrReceiverSecond.SetMeAsReceiver()
         ucrInputSaveDataFrame.SetName("merge")
         ucrInputCheckInput.Reset()
+
+        clsImportDataFunction.SetRCommand("data_book$import_data")
+        clsImportDataFunction.AddParameter("data_tables", clsRFunctionParameter:=clsListFunction)
+
+        clsListFunction.SetRCommand("list")
 
         clsGetVariablesFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_columns_from_data")
 
@@ -92,9 +99,8 @@ Public Class dlgMergeAdditionalData
 
         clsInsertColumnFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$add_columns_to_data")
 
-
         SetDataFrameAssign()
-        ucrBase.clsRsyntax.SetBaseRFunction(clsInsertColumnFunction)
+        ucrBase.clsRsyntax.SetBaseRFunction(clsImportDataFunction)
         bResetSubdialog = True
     End Sub
 
@@ -144,10 +150,10 @@ Public Class dlgMergeAdditionalData
                     cmdCheckUnique.Visible = False
                     SetInputCheckVisibility(False)
                 Else
+                    clsListFunction.ClearParameters()
                     clsLeftJoinFunction.SetAssignTo(ucrToDataFrame.cboAvailableDataFrames.Text)
-                    clsInsertColumnFunction.AddParameter("data_name", Chr(34) & ucrToDataFrame.cboAvailableDataFrames.Text & Chr(34), iPosition:=0)
-                    clsInsertColumnFunction.AddParameter("col_data", clsRFunctionParameter:=clsLeftJoinFunction, iPosition:=1)
-                    ucrBase.clsRsyntax.SetBaseRFunction(clsInsertColumnFunction)
+                    clsListFunction.AddParameter(ucrToDataFrame.cboAvailableDataFrames.Text, clsRFunctionParameter:=clsLeftJoinFunction, iPosition:=0)
+                    ucrBase.clsRsyntax.SetBaseRFunction(clsImportDataFunction)
                     ucrInputSaveDataFrame.Visible = False
                     cmdCheckUnique.Visible = True
                 End If

--- a/instat/dlgMergeAdditionalData.vb
+++ b/instat/dlgMergeAdditionalData.vb
@@ -45,7 +45,7 @@ Public Class dlgMergeAdditionalData
     End Sub
 
     Private Sub InitialiseDialog()
-        ucrToDataFrame.SetParameter(New RParameter("y", 1))
+        ucrToDataFrame.SetParameter(New RParameter("x", 0))
         ucrToDataFrame.SetParameterIsRFunction()
         ucrToDataFrame.SetLabelText("To Data Frame:")
 
@@ -90,7 +90,7 @@ Public Class dlgMergeAdditionalData
 
         clsLeftJoinFunction.SetPackageName("dplyr")
         clsLeftJoinFunction.SetRCommand("left_join")
-        clsLeftJoinFunction.AddParameter("x", clsRFunctionParameter:=clsGetColumnsFromData, iPosition:=0)
+        clsLeftJoinFunction.AddParameter("y", clsRFunctionParameter:=clsGetColumnsFromData, iPosition:=1)
 
         clsByListFunction.SetRCommand("c")
 

--- a/instat/dlgMergeAdditionalData.vb
+++ b/instat/dlgMergeAdditionalData.vb
@@ -20,7 +20,7 @@ Imports RDotNet
 Public Class dlgMergeAdditionalData
     Private bFirstLoad As Boolean = True
     Private bReset As Boolean = True
-    Private clsInsertColumnFunction, clsGetColumnsFromData, clsImportDataFunction, clsListFunction As New RFunction
+    Private clsInsertColumnFunction, clsGetColumnsFromData As New RFunction
     Private lstJoinColumns As New List(Of String)
     Private clsLeftJoinFunction As New RFunction
     Private clsByListFunction As New RFunction
@@ -72,19 +72,12 @@ Public Class dlgMergeAdditionalData
         clsInsertColumnFunction = New RFunction
         clsGetColumnsFromData = New RFunction
         clsGetVariablesFunction = New RFunction
-        clsImportDataFunction = New RFunction
-        clsListFunction = New RFunction
 
         ucrToDataFrame.Reset()
         ucrFromDataFrame.Reset()
         ucrReceiverSecond.SetMeAsReceiver()
         ucrInputSaveDataFrame.SetName("merge")
         ucrInputCheckInput.Reset()
-
-        clsImportDataFunction.SetRCommand("data_book$import_data")
-        clsImportDataFunction.AddParameter("data_tables", clsRFunctionParameter:=clsListFunction)
-
-        clsListFunction.SetRCommand("list")
 
         clsGetVariablesFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_columns_from_data")
 
@@ -100,7 +93,7 @@ Public Class dlgMergeAdditionalData
         clsInsertColumnFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$add_columns_to_data")
 
         SetDataFrameAssign()
-        ucrBase.clsRsyntax.SetBaseRFunction(clsImportDataFunction)
+        ucrBase.clsRsyntax.SetBaseRFunction(clsInsertColumnFunction)
         bResetSubdialog = True
     End Sub
 
@@ -150,10 +143,10 @@ Public Class dlgMergeAdditionalData
                     cmdCheckUnique.Visible = False
                     SetInputCheckVisibility(False)
                 Else
-                    clsListFunction.ClearParameters()
                     clsLeftJoinFunction.SetAssignTo(ucrToDataFrame.cboAvailableDataFrames.Text)
-                    clsListFunction.AddParameter(ucrToDataFrame.cboAvailableDataFrames.Text, clsRFunctionParameter:=clsLeftJoinFunction, iPosition:=0)
-                    ucrBase.clsRsyntax.SetBaseRFunction(clsImportDataFunction)
+                    clsInsertColumnFunction.AddParameter("data_name", Chr(34) & ucrToDataFrame.cboAvailableDataFrames.Text & Chr(34), iPosition:=0)
+                    clsInsertColumnFunction.AddParameter("col_data", clsRFunctionParameter:=clsLeftJoinFunction, iPosition:=1)
+                    ucrBase.clsRsyntax.SetBaseRFunction(clsInsertColumnFunction)
                     ucrInputSaveDataFrame.Visible = False
                     cmdCheckUnique.Visible = True
                 End If


### PR DESCRIPTION
Fixes #7382
@africanmathsinitiative/developers this is ready for review.
@rdstern I have fixed the bug as described in the corresponding issue, this problem is fixed by swapping the `x` and `y` parameters values in the `left_join function`. Please take a look. Thanks.