### PR TITLE
Minor improvements to the Contrasts dialog.

### DIFF
--- a/instat/dlgContrasts.vb
+++ b/instat/dlgContrasts.vb
@@ -219,7 +219,7 @@ Public Class dlgContrasts
             vecColums = expContrasts.AsNumericMatrix()
             For j = 0 To vecColums.ColumnCount - 1
                 For i = 0 To vecColums.RowCount - 1
-                    grdCurrSheet.Item(row:=i, col:=j) = vecColums(i, j)
+                    grdCurrSheet.Item(row:=i, col:=j) = vecColums(i, j).ToString("0.###")
                 Next
             Next
         End If


### PR DESCRIPTION
This fixes (partially) #7392 
@rdstern, I limited the precision to 3 decimal places. I still used the survey data and set the contrast to polynomials, then the user-defined grid gives the available contrasts with a maximum of 3 decimal places.