### PR TITLE
Ensure that parameters can be edited in Random Samples dialog

### DIFF
--- a/instat/ucrDistributionsWithParameters.vb
+++ b/instat/ucrDistributionsWithParameters.vb
@@ -117,7 +117,7 @@ Public Class ucrDistributionsWithParameters
                 ucrInputParameter1.IsReadOnly = False
             End If
         End If
-            OnControlValueChanged()
+        OnControlValueChanged()
     End Sub
 
     Private Sub ucrInputParameter2_ContentsChanged() Handles ucrInputParameter2.ContentsChanged

--- a/instat/ucrDistributionsWithParameters.vb
+++ b/instat/ucrDistributionsWithParameters.vb
@@ -110,9 +110,14 @@ Public Class ucrDistributionsWithParameters
     Private Sub ucrInputParameter1_ControlValueChanged() Handles ucrInputParameter1.ControlValueChanged
         If lstCurrArguments IsNot Nothing AndAlso lstCurrArguments.Count > 0 Then
             AddParameter(lstCurrArguments(0), ucrInputParameter1.GetText)
-            CheckParametersFilled()
+            If clsCurrDistribution.strNameTag = "Discrete_Empirical" Then
+                ucrInputParameter1.IsReadOnly = True
+                CheckParametersFilled()
+            Else
+                ucrInputParameter1.IsReadOnly = False
+            End If
         End If
-        OnControlValueChanged()
+            OnControlValueChanged()
     End Sub
 
     Private Sub ucrInputParameter2_ContentsChanged() Handles ucrInputParameter2.ContentsChanged
@@ -120,10 +125,8 @@ Public Class ucrDistributionsWithParameters
             If clsCurrDistribution.strNameTag = "Discrete_Empirical" Then
                 AddParameter(lstCurrArguments(1), "c(" & ucrInputParameter2.GetText & ")")
                 ucrInputParameter1.SetName("1:" & ucrInputParameter2.GetText.Split(",").Length)
-                ucrInputParameter1.IsReadOnly = True
             Else
                 AddParameter(lstCurrArguments(1), ucrInputParameter2.GetText)
-                ucrInputParameter1.IsReadOnly = False
             End If
             CheckParametersFilled()
         End If


### PR DESCRIPTION
Fixes #7406 
@rdstern this PR makes ucrInputParameter1 to be editable for some distributions.