### PR TITLE
Made the change to the metadata to update the Data Frame Metadata grid

### DIFF
--- a/instat/static/InstatObject/R/data_object_R6.R
+++ b/instat/static/InstatObject/R/data_object_R6.R
@@ -2228,7 +2228,6 @@ DataSheet$set("public", "add_key", function(col_names, key_name) {
     self$append_to_variables_metadata(col_names, is_key_label, TRUE)
     if(length(private$keys) == 1) self$append_to_variables_metadata(setdiff(self$get_column_names(), col_names), is_key_label, FALSE)
     self$append_to_metadata(is_linkable, TRUE)
-    #self$append_to_metadata(next_default_item(key_label, names(self$get_metadata())), paste(col_names, collapse = ","))
     self$append_to_metadata(key_label, paste(private$keys[[key_name]], collapse = ","))
     cat(paste("Key name:", key_name),
         paste("Key columns:", paste(private$keys[[key_name]], collapse = ", ")),
@@ -2263,8 +2262,6 @@ DataSheet$set("public", "remove_key", function(key_name) {
   self$append_to_variables_metadata(private$keys[[key_name]], is_key_label, FALSE)
   private$keys[[key_name]] <- NULL
   self$append_to_metadata(key_label, NULL)
-  self$append_to_metadata(is_linkable, FALSE)
-  self$append_to_metadata(is_key_label, FALSE)
   cat("Key removed:", key_name)
 }
 )

--- a/instat/static/InstatObject/R/data_object_R6.R
+++ b/instat/static/InstatObject/R/data_object_R6.R
@@ -2259,7 +2259,11 @@ DataSheet$set("public", "get_keys", function(key_name) {
 
 DataSheet$set("public", "remove_key", function(key_name) {
   if(!key_name %in% names(private$keys)) stop(key_name, " not found.")
+  self$append_to_variables_metadata(private$keys[[key_name]], is_key_label, FALSE)
   private$keys[[key_name]] <- NULL
+  self$append_to_metadata(key_label, NULL)
+  self$append_to_metadata(is_linkable, FALSE)
+  self$append_to_metadata(is_key_label, FALSE)
   cat("Key removed:", key_name)
 }
 )

--- a/instat/static/InstatObject/R/data_object_R6.R
+++ b/instat/static/InstatObject/R/data_object_R6.R
@@ -2228,7 +2228,8 @@ DataSheet$set("public", "add_key", function(col_names, key_name) {
     self$append_to_variables_metadata(col_names, is_key_label, TRUE)
     if(length(private$keys) == 1) self$append_to_variables_metadata(setdiff(self$get_column_names(), col_names), is_key_label, FALSE)
     self$append_to_metadata(is_linkable, TRUE)
-    self$append_to_metadata(next_default_item(key_label, names(self$get_metadata())), paste(col_names, collapse = ","))
+    #self$append_to_metadata(next_default_item(key_label, names(self$get_metadata())), paste(col_names, collapse = ","))
+    self$append_to_metadata(key_label, paste(private$keys[[key_name]], collapse = ","))
     cat(paste("Key name:", key_name),
         paste("Key columns:", paste(private$keys[[key_name]], collapse = ", ")),
         sep = "\n")

--- a/instat/static/InstatObject/R/instat_object_R6.R
+++ b/instat/static/InstatObject/R/instat_object_R6.R
@@ -1020,7 +1020,7 @@ DataBook$set("public", "delete_dataframes", function(data_names, delete_graph_bo
 
 DataBook$set("public", "remove_link", function(link_name) {
   if(!link_name %in% names(private$.links)) stop(link_name, " not found.")
-  #private$.links[[link_name]] <- NULL
+  private$.links[[link_name]] <- NULL
   cat("Link removed:", link_name)
 }
 )

--- a/instat/static/InstatObject/R/instat_object_R6.R
+++ b/instat/static/InstatObject/R/instat_object_R6.R
@@ -1020,7 +1020,7 @@ DataBook$set("public", "delete_dataframes", function(data_names, delete_graph_bo
 
 DataBook$set("public", "remove_link", function(link_name) {
   if(!link_name %in% names(private$.links)) stop(link_name, " not found.")
-  private$.links[[link_name]] <- NULL
+  #private$.links[[link_name]] <- NULL
   cat("Link removed:", link_name)
 }
 )
@@ -1559,7 +1559,7 @@ DataBook$set("public", "get_key_names", function(data_name, include_overall = TR
 )
 
 DataBook$set("public", "remove_key", function(data_name, key_name) {
-  self$get_data_objects(data_name)$remove_key(key_name)
+  self$get_data_objects(data_name)$remove_key(key_name = key_name)
 }
 )
 


### PR DESCRIPTION
Fixes (partially) #7351 
@rdstern @lilyclements I have updated the metadata to be able to drop the key columns when there is no keys.
These changes concern items a) b) and c), please take a look. 