### PR TITLE
Fixed minor bug in Prepare>Data Frame>Rename Columns dialog

### DIFF
--- a/instat/dlgName.vb
+++ b/instat/dlgName.vb
@@ -231,7 +231,7 @@ Public Class dlgName
                             OrElse Boolean.TryParse(strValue, parsedValue) _
                             OrElse strValue.ToLower.Equals("t") OrElse strValue.ToLower.Equals("f") _
                             OrElse IsNumeric(strValue) Then
-                        MsgBox("The column name must not be a numeric or contain space or french accent or be a boolean e.g TRUE, FALSE, T, F.")
+                        MsgBox("The column name must not be a numeric or French accent or be a boolean e.g TRUE, FALSE, T, F.")
                         bCurrentCell = False
                         Exit For
                     End If

--- a/instat/dlgName.vb
+++ b/instat/dlgName.vb
@@ -240,7 +240,6 @@ Public Class dlgName
             Case 2
                 bCurrentCell = True
         End Select
-        End Select
         TestOKEnabled()
     End Sub
 

--- a/instat/dlgName.vb
+++ b/instat/dlgName.vb
@@ -301,18 +301,6 @@ Public Class dlgName
         Return bFind
     End Function
 
-    Private Function CheckNames(strNewData As String, iColIndex As Integer) As Boolean
-        Dim bCheck As Boolean
-        Dim parsedValue As Boolean
-        If (containsFrench(strNewData) OrElse strNewData.Equals("") OrElse Boolean.TryParse(strNewData, parsedValue) _
-             OrElse strNewData.Equals("t") OrElse strNewData.Equals("T") OrElse strNewData.Equals("f") OrElse strNewData.Equals("F") OrElse IsNumeric(strNewData)) AndAlso iColIndex = 1 Then
-            bCheck = False
-        Else
-            bCheck = True
-        End If
-        Return bCheck
-    End Function
-
     Private Sub RenameColumns(strNewData As String, iRowIndex As Integer, iColIndex As Integer)
         GetVariables(strNewData, iRowIndex + 1, iColIndex)
         TestOKEnabled()

--- a/instat/dlgName.vb
+++ b/instat/dlgName.vb
@@ -137,7 +137,7 @@ Public Class dlgName
         ucrSelectVariables.Reset()
         dctRowsNewNameChanged.Clear()
         dctRowsNewLabelChanged.Clear()
-
+        bCurrentCell = False
         clsNewColNameDataframeFunction.SetRCommand("data.frame")
 
         clsNewLabelDataframeFunction.SetRCommand("data.frame")
@@ -220,18 +220,24 @@ Public Class dlgName
         Return strValue
     End Function
 
+    Private Sub CheckChange(dctName As Dictionary(Of Integer, String), iCol As Integer)
+        For Each value In dctName.Values
+            If Not CheckNames(value, iCol) Then
+                MsgBox("The column name must not be a numeric or contains space or french accent or be a boolean e.g TRUE, FALSE, T, F.")
+                bCurrentCell = False
+                Exit For
+            Else
+                bCurrentCell = True
+            End If
+        Next
+    End Sub
+
     Private Sub ValidateNamesFromDictionary(iColIndex As Integer)
         'TODO this need to be implemented in the appropriare ucrControl
         If iColIndex = 1 Then
-            For Each value In dctRowsNewNameChanged.Values
-                If Not CheckNames(value, iColIndex) Then
-                    MsgBox("The column name must not be a numeric or contains space or french accent or be a boolean e.g TRUE, FALSE, T, F.")
-                    bCurrentCell = False
-                    Exit For
-                Else
-                    bCurrentCell = True
-                End If
-            Next
+            CheckChange(dctRowsNewNameChanged, iColIndex)
+        ElseIf iColIndex = 2 Then
+            CheckChange(dctRowsNewLabelChanged, iColIndex)
         End If
         TestOKEnabled()
     End Sub

--- a/instat/dlgName.vb
+++ b/instat/dlgName.vb
@@ -220,25 +220,26 @@ Public Class dlgName
         Return strValue
     End Function
 
-    Private Sub CheckChange(dctName As Dictionary(Of Integer, String), iCol As Integer)
-        For Each value In dctName.Values
-            If Not CheckNames(value, iCol) Then
-                MsgBox("The column name must not be a numeric or contains space or french accent or be a boolean e.g TRUE, FALSE, T, F.")
-                bCurrentCell = False
-                Exit For
-            Else
-                bCurrentCell = True
-            End If
-        Next
-    End Sub
-
     Private Sub ValidateNamesFromDictionary(iColIndex As Integer)
-        'TODO this need to be implemented in the appropriare ucrControl
-        If iColIndex = 1 Then
-            CheckChange(dctRowsNewNameChanged, iColIndex)
-        ElseIf iColIndex = 2 Then
-            CheckChange(dctRowsNewLabelChanged, iColIndex)
-        End If
+        'TODO this needs to be implemented in the appropriate ucrControl
+        Select Case iColIndex
+            Case 1
+                For Each strValue In dctRowsNewNameChanged.Values
+                    Dim parsedValue As Boolean
+                    If String.IsNullOrEmpty(strValue) _
+                            OrElse containsFrench(strValue) _
+                            OrElse Boolean.TryParse(strValue, parsedValue) _
+                            OrElse strValue.ToLower.Equals("t") OrElse strValue.ToLower.Equals("f") _
+                            OrElse IsNumeric(strValue) Then
+                        MsgBox("The column name must not be a numeric or contain space or french accent or be a boolean e.g TRUE, FALSE, T, F.")
+                        bCurrentCell = False
+                        Exit For
+                    End If
+                    bCurrentCell = True
+                Next
+            Case 2
+                bCurrentCell = True
+        End Select
         TestOKEnabled()
     End Sub
 


### PR DESCRIPTION
fixes #7422 , minor bug in Prepare>DataFrame>Rename Column Dialogue 

Enabling the `ok button` for the multiple option 

@africanmathsinitiative/developers  this PR is ready for review