### PR TITLE
Improved reordering of data frame tabs in Data View

### DIFF
--- a/instat/Interface/IGrid.vb
+++ b/instat/Interface/IGrid.vb
@@ -44,7 +44,7 @@ Public Interface IGrid
 
     Sub UpdateAllWorksheetStyles()
 
-    Sub ReOrderWorksheets(strDataframe As String, iCount As Integer)
+    Sub ReOrderWorksheets()
 
     Sub UpdateWorksheetStyle(worksheet As clsWorksheetAdapter)
 End Interface

--- a/instat/Interface/IGrid.vb
+++ b/instat/Interface/IGrid.vb
@@ -44,7 +44,5 @@ Public Interface IGrid
 
     Sub UpdateAllWorksheetStyles()
 
-    Sub ReorderSheets(strSheet As String, iNewPosition As Integer)
-
     Sub UpdateWorksheetStyle(worksheet As clsWorksheetAdapter)
 End Interface

--- a/instat/Interface/IGrid.vb
+++ b/instat/Interface/IGrid.vb
@@ -44,5 +44,7 @@ Public Interface IGrid
 
     Sub UpdateAllWorksheetStyles()
 
+    Sub ReorderSheets(strSheet As String, iNewPosition As Integer)
+
     Sub UpdateWorksheetStyle(worksheet As clsWorksheetAdapter)
 End Interface

--- a/instat/Interface/IGrid.vb
+++ b/instat/Interface/IGrid.vb
@@ -44,5 +44,7 @@ Public Interface IGrid
 
     Sub UpdateAllWorksheetStyles()
 
+    Sub ReOrderWorksheets(strDataframe As String, iCount As Integer)
+
     Sub UpdateWorksheetStyle(worksheet As clsWorksheetAdapter)
 End Interface

--- a/instat/Model/DataFrame/clsDataBook.vb
+++ b/instat/Model/DataFrame/clsDataBook.vb
@@ -152,6 +152,9 @@ Public Class clsDataBook
                 _lstDataFrames.Remove(dataFrame)
             End If
         Next
+        If lstOfCurrentRDataFrameNames.Count = _lstDataFrames.Count Then
+            _lstDataFrames.OrderBy(Function(x) lstOfCurrentRDataFrameNames.IndexOf(x.strName))
+        End If
     End Sub
 
 

--- a/instat/Model/DataFrame/clsDataBook.vb
+++ b/instat/Model/DataFrame/clsDataBook.vb
@@ -153,7 +153,7 @@ Public Class clsDataBook
             End If
         Next
         If lstOfCurrentRDataFrameNames.Count = _lstDataFrames.Count Then
-            _lstDataFrames.OrderBy(Function(x) lstOfCurrentRDataFrameNames.IndexOf(x.strName))
+            _lstDataFrames = _lstDataFrames.OrderBy(Function(x) lstOfCurrentRDataFrameNames.IndexOf(x.strName)).ToList()
         End If
     End Sub
 

--- a/instat/UserControls/DataGrid/Linux/ucrLinuxGrid.vb
+++ b/instat/UserControls/DataGrid/Linux/ucrLinuxGrid.vb
@@ -82,7 +82,7 @@ Public MustInherit Class ucrLinuxGrid
         Return New clsWorksheetAdapter(tab)
     End Function
 
-    Private Sub ReOrderWorksheets(strDataframe As String, iCount As Integer) Implements IGrid.ReOrderWorksheets
+    Private Sub ReOrderWorksheets() Implements IGrid.ReOrderWorksheets
 
     End Sub
 

--- a/instat/UserControls/DataGrid/Linux/ucrLinuxGrid.vb
+++ b/instat/UserControls/DataGrid/Linux/ucrLinuxGrid.vb
@@ -82,6 +82,10 @@ Public MustInherit Class ucrLinuxGrid
         Return New clsWorksheetAdapter(tab)
     End Function
 
+    Private Sub ReOrderWorksheets(strDataframe As String, iCount As Integer) Implements IGrid.ReOrderWorksheets
+
+    End Sub
+
     Public Sub CopyRange() Implements IGrid.CopyRange
         Dim dataGrid = GetDataGridFromSelectedTab()
         dataGrid.ClipboardCopyMode = DataGridViewClipboardCopyMode.EnableWithoutHeaderText

--- a/instat/UserControls/DataGrid/Linux/ucrLinuxGrid.vb
+++ b/instat/UserControls/DataGrid/Linux/ucrLinuxGrid.vb
@@ -195,6 +195,10 @@ Public MustInherit Class ucrLinuxGrid
         Next
     End Sub
 
+    Private Sub ReorderSheets(strSheet As String, iNewPosition As Integer) Implements IGrid.ReorderSheets
+
+    End Sub
+
     Public Sub UpdateWorksheetStyle(dataGrid As DataGridView)
         If frmMain.clsInstatOptions IsNot Nothing Then
             Dim newFont As New Font(frmMain.clsInstatOptions.fntEditor.FontFamily, frmMain.clsInstatOptions.fntEditor.Size,

--- a/instat/UserControls/DataGrid/Linux/ucrLinuxGrid.vb
+++ b/instat/UserControls/DataGrid/Linux/ucrLinuxGrid.vb
@@ -83,30 +83,25 @@ Public MustInherit Class ucrLinuxGrid
     End Function
 
     Private Sub ReOrderWorksheets() Implements IGrid.ReOrderWorksheets
-        Dim iNewPosition As Integer
-        Dim bFound As Boolean = False
-        Dim iCount As Integer
-        Dim strName As String = ""
-        iCount = 0
+        'assuming the databook will always have all the data frames 
+        'and the grid may not have all the data frame worksheets equivalent
+        'and all data frames in the data book have changed their order positions 
+        'get data frames sheets in the grid based on the databook data frames position order
+        'and add it to the list.
+        Dim lstWorkSheetsFound As New List(Of TabPage)
         For Each clsDataframe In _clsDataBook.DataFrames
-            For i As Integer = 0 To tcTabs.TabPages.Count - 1
-                If tcTabs.TabPages(i).Text = clsDataframe.strName Then
-                    strName = clsDataframe.strName
-                    iNewPosition = iCount
-                    bFound = True
-                    Exit For
-                End If
-            Next
-            If bFound Then
-                Dim newtab = GetTabPage(strName)
-                If newtab IsNot Nothing AndAlso tcTabs.TabPages.Count > 1 Then
-                    tcTabs.TabPages.Remove(newtab)
-                    tcTabs.TabPages.Insert(iNewPosition, newtab)
-                    iCount += 1
-                    bFound = False
-                End If
+            Dim fillWorkSheet As TabPage = GetTabPage(clsDataframe.strName)
+            If fillWorkSheet IsNot Nothing Then
+                lstWorkSheetsFound.Add(fillWorkSheet)
             End If
         Next
+        If lstWorkSheetsFound.Count > 1 Then
+            'reorder the worksheets based on the filled list
+            For i As Integer = 0 To lstWorkSheetsFound.Count - 1
+                tcTabs.TabPages.Remove(lstWorkSheetsFound(i))
+                tcTabs.TabPages.Insert(i, lstWorkSheetsFound(i))
+            Next
+        End If
     End Sub
 
     Private Function GetTabPage(strName As String) As TabPage

--- a/instat/UserControls/DataGrid/Linux/ucrLinuxGrid.vb
+++ b/instat/UserControls/DataGrid/Linux/ucrLinuxGrid.vb
@@ -98,15 +98,27 @@ Public MustInherit Class ucrLinuxGrid
                 End If
             Next
             If bFound Then
-                Dim tab As New TabPage(strName)
-                'tcTabs.TabPages.Remove(tab)
-                tcTabs.TabPages.Add(tab)
-                tcTabs.TabPages.Insert(iNewPosition, tab)
-                iCount += 1
-                bFound = False
+                Dim newtab = GetTabPage(strName)
+                If newtab IsNot Nothing AndAlso tcTabs.TabPages.Count > 1 Then
+                    tcTabs.TabPages.Remove(newtab)
+                    tcTabs.TabPages.Insert(iNewPosition, newtab)
+                    iCount += 1
+                    bFound = False
+                End If
             End If
         Next
     End Sub
+
+    Private Function GetTabPage(strName As String) As TabPage
+        Dim tab As TabPage = Nothing
+        For i As Integer = 0 To tcTabs.TabPages.Count - 1
+            If tcTabs.TabPages(i).Text = strName Then
+                tab = tcTabs.TabPages(i)
+                Exit For
+            End If
+        Next
+        Return tab
+    End Function
 
     Public Sub CopyRange() Implements IGrid.CopyRange
         Dim dataGrid = GetDataGridFromSelectedTab()

--- a/instat/UserControls/DataGrid/Linux/ucrLinuxGrid.vb
+++ b/instat/UserControls/DataGrid/Linux/ucrLinuxGrid.vb
@@ -195,10 +195,6 @@ Public MustInherit Class ucrLinuxGrid
         Next
     End Sub
 
-    Private Sub ReorderSheets(strSheet As String, iNewPosition As Integer) Implements IGrid.ReorderSheets
-
-    End Sub
-
     Public Sub UpdateWorksheetStyle(dataGrid As DataGridView)
         If frmMain.clsInstatOptions IsNot Nothing Then
             Dim newFont As New Font(frmMain.clsInstatOptions.fntEditor.FontFamily, frmMain.clsInstatOptions.fntEditor.Size,

--- a/instat/UserControls/DataGrid/Linux/ucrLinuxGrid.vb
+++ b/instat/UserControls/DataGrid/Linux/ucrLinuxGrid.vb
@@ -83,7 +83,29 @@ Public MustInherit Class ucrLinuxGrid
     End Function
 
     Private Sub ReOrderWorksheets() Implements IGrid.ReOrderWorksheets
-
+        Dim iNewPosition As Integer
+        Dim bFound As Boolean = False
+        Dim iCount As Integer
+        Dim strName As String = ""
+        iCount = 0
+        For Each clsDataframe In _clsDataBook.DataFrames
+            For i As Integer = 0 To tcTabs.TabPages.Count - 1
+                If tcTabs.TabPages(i).Text = clsDataframe.strName Then
+                    strName = clsDataframe.strName
+                    iNewPosition = iCount
+                    bFound = True
+                    Exit For
+                End If
+            Next
+            If bFound Then
+                Dim tab As New TabPage(strName)
+                'tcTabs.TabPages.Remove(tab)
+                tcTabs.TabPages.Add(tab)
+                tcTabs.TabPages.Insert(iNewPosition, tab)
+                iCount += 1
+                bFound = False
+            End If
+        Next
     End Sub
 
     Public Sub CopyRange() Implements IGrid.CopyRange

--- a/instat/UserControls/DataGrid/ReoGrid/ucrReoGrid.vb
+++ b/instat/UserControls/DataGrid/ReoGrid/ucrReoGrid.vb
@@ -21,6 +21,7 @@ Public MustInherit Class ucrReoGrid
     Implements IGrid
 
     Protected _clsDataBook As clsDataBook
+    Private fillWorkSheet As Worksheet
 
     ''' <summary>
     ''' Gets current worksheet adapter
@@ -61,7 +62,7 @@ Public MustInherit Class ucrReoGrid
     End Property
 
     Public Function AddNewWorksheet(name As String) As clsWorksheetAdapter Implements IGrid.AddNewWorksheet
-        Dim fillWorkSheet = grdData.CreateWorksheet(name)
+        fillWorkSheet = grdData.CreateWorksheet(name)
         grdData.AddWorksheet(fillWorkSheet)
         fillWorkSheet.SelectionForwardDirection = unvell.ReoGrid.SelectionForwardDirection.Down
         fillWorkSheet.SetSettings(unvell.ReoGrid.WorksheetSettings.Edit_DragSelectionToMoveCells, False)
@@ -70,6 +71,20 @@ Public MustInherit Class ucrReoGrid
         AttachEventsToWorksheet(fillWorkSheet)
         Return New clsWorksheetAdapter(fillWorkSheet)
     End Function
+
+    Private Sub ReOrderWorksheets(strDataframe As String, iCount As Integer) Implements IGrid.ReOrderWorksheets
+        Dim iNewPosition As Integer
+        For Each tempWorkSheet In grdData.Worksheets
+            If tempWorkSheet.Name = strDataframe Then
+                iNewPosition = iCount
+                Exit For
+            End If
+        Next
+        If fillWorkSheet IsNot Nothing AndAlso iNewPosition < grdData.Worksheets.Count Then
+            grdData.MoveWorksheet(fillWorkSheet, iNewPosition)
+        End If
+        'grdData.Worksheets.OrderBy(Function(x) _clsDataBook.DataFrames.IndexOf())
+    End Sub
 
     Public Sub CopyRange() Implements IGrid.CopyRange
         grdData.CurrentWorksheet.Copy()

--- a/instat/UserControls/DataGrid/ReoGrid/ucrReoGrid.vb
+++ b/instat/UserControls/DataGrid/ReoGrid/ucrReoGrid.vb
@@ -171,6 +171,7 @@ Public MustInherit Class ucrReoGrid
         End If
         If grdData.Worksheets.Count > 0 Then
             grdData.MoveWorksheet(fillWorkSheet, iNewPosition)
+            grdData.CurrentWorksheet = fillWorkSheet
         End If
     End Sub
 

--- a/instat/UserControls/DataGrid/ReoGrid/ucrReoGrid.vb
+++ b/instat/UserControls/DataGrid/ReoGrid/ucrReoGrid.vb
@@ -157,25 +157,6 @@ Public MustInherit Class ucrReoGrid
         Next
     End Sub
 
-    Private Sub ReorderSheets(strSheet As String, iNewPosition As Integer) Implements IGrid.ReorderSheets
-        Dim bFoundWorksheet As Boolean = False
-        Dim grdWorksheetToMove As Worksheet = Nothing
-        If strSheet <> "" Then
-            For Each tempWorkSheet In grdData.Worksheets
-                If tempWorkSheet.Name = strSheet Then
-                    bFoundWorksheet = True
-                    Exit For
-                End If
-            Next
-
-            If bFoundWorksheet AndAlso grdData.Worksheets.Count > 0 Then
-                grdWorksheetToMove = grdData.GetWorksheetByName(strSheet)
-                grdData.MoveWorksheet(grdWorksheetToMove, iNewPosition)
-                grdData.CurrentWorksheet = grdWorksheetToMove
-            End If
-        End If
-    End Sub
-
     Public Sub UpdateWorksheetStyle(worksheet As clsWorksheetAdapter) Implements IGrid.UpdateWorksheetStyle
         UpdateWorksheetStyle(grdData.Worksheets.Where(Function(x) x.Name = worksheet.Name).FirstOrDefault)
     End Sub

--- a/instat/UserControls/DataGrid/ReoGrid/ucrReoGrid.vb
+++ b/instat/UserControls/DataGrid/ReoGrid/ucrReoGrid.vb
@@ -157,6 +157,23 @@ Public MustInherit Class ucrReoGrid
         Next
     End Sub
 
+    Private Sub ReorderSheets(strSheet As String, iNewPosition As Integer) Implements IGrid.ReorderSheets
+        Dim bFoundWorksheet As Boolean = False
+        Dim fillWorkSheet As Worksheet = Nothing
+        For Each tempWorkSheet In grdData.Worksheets
+            If tempWorkSheet.Name = strSheet Then
+                bFoundWorksheet = True
+                Exit For
+            End If
+        Next
+        If bFoundWorksheet Then
+            fillWorkSheet = grdData.GetWorksheetByName(strSheet)
+        End If
+        If grdData.Worksheets.Count > 0 Then
+            grdData.MoveWorksheet(fillWorkSheet, iNewPosition)
+        End If
+    End Sub
+
     Public Sub UpdateWorksheetStyle(worksheet As clsWorksheetAdapter) Implements IGrid.UpdateWorksheetStyle
         UpdateWorksheetStyle(grdData.Worksheets.Where(Function(x) x.Name = worksheet.Name).FirstOrDefault)
     End Sub

--- a/instat/UserControls/DataGrid/ReoGrid/ucrReoGrid.vb
+++ b/instat/UserControls/DataGrid/ReoGrid/ucrReoGrid.vb
@@ -92,6 +92,7 @@ Public MustInherit Class ucrReoGrid
                     grdData.MoveWorksheet(fillWorkSheet, iNewPosition)
                     grdData.CurrentWorksheet = fillWorkSheet
                     iCount += 1
+                    bFound = False
                 End If
             End If
         Next

--- a/instat/UserControls/DataGrid/ReoGrid/ucrReoGrid.vb
+++ b/instat/UserControls/DataGrid/ReoGrid/ucrReoGrid.vb
@@ -21,7 +21,6 @@ Public MustInherit Class ucrReoGrid
     Implements IGrid
 
     Protected _clsDataBook As clsDataBook
-    Private fillWorkSheet As Worksheet
 
     ''' <summary>
     ''' Gets current worksheet adapter
@@ -62,7 +61,7 @@ Public MustInherit Class ucrReoGrid
     End Property
 
     Public Function AddNewWorksheet(name As String) As clsWorksheetAdapter Implements IGrid.AddNewWorksheet
-        fillWorkSheet = grdData.CreateWorksheet(name)
+        Dim fillWorkSheet = grdData.CreateWorksheet(name)
         grdData.AddWorksheet(fillWorkSheet)
         fillWorkSheet.SelectionForwardDirection = unvell.ReoGrid.SelectionForwardDirection.Down
         fillWorkSheet.SetSettings(unvell.ReoGrid.WorksheetSettings.Edit_DragSelectionToMoveCells, False)
@@ -72,18 +71,30 @@ Public MustInherit Class ucrReoGrid
         Return New clsWorksheetAdapter(fillWorkSheet)
     End Function
 
-    Private Sub ReOrderWorksheets(strDataframe As String, iCount As Integer) Implements IGrid.ReOrderWorksheets
+    Private Sub ReOrderWorksheets() Implements IGrid.ReOrderWorksheets
         Dim iNewPosition As Integer
-        For Each tempWorkSheet In grdData.Worksheets
-            If tempWorkSheet.Name = strDataframe Then
-                iNewPosition = iCount
-                Exit For
+        Dim strName As String = Nothing
+        Dim bFound As Boolean = False
+        Dim iCount As Integer
+        iCount = 0
+        For Each clsDataframe In _clsDataBook.DataFrames
+            For Each tempWorkSheet In grdData.Worksheets
+                If tempWorkSheet.Name = clsDataframe.strName Then
+                    strName = clsDataframe.strName
+                    iNewPosition = iCount
+                    bFound = True
+                    Exit For
+                End If
+            Next
+            If bFound Then
+                Dim fillWorkSheet = grdData.GetWorksheetByName(strName)
+                If fillWorkSheet IsNot Nothing AndAlso iNewPosition < grdData.Worksheets.Count Then
+                    grdData.MoveWorksheet(fillWorkSheet, iNewPosition)
+                    grdData.CurrentWorksheet = fillWorkSheet
+                    iCount += 1
+                End If
             End If
         Next
-        If fillWorkSheet IsNot Nothing AndAlso iNewPosition < grdData.Worksheets.Count Then
-            grdData.MoveWorksheet(fillWorkSheet, iNewPosition)
-        End If
-        'grdData.Worksheets.OrderBy(Function(x) _clsDataBook.DataFrames.IndexOf())
     End Sub
 
     Public Sub CopyRange() Implements IGrid.CopyRange

--- a/instat/UserControls/DataGrid/ReoGrid/ucrReoGrid.vb
+++ b/instat/UserControls/DataGrid/ReoGrid/ucrReoGrid.vb
@@ -159,19 +159,20 @@ Public MustInherit Class ucrReoGrid
 
     Private Sub ReorderSheets(strSheet As String, iNewPosition As Integer) Implements IGrid.ReorderSheets
         Dim bFoundWorksheet As Boolean = False
-        Dim fillWorkSheet As Worksheet = Nothing
-        For Each tempWorkSheet In grdData.Worksheets
-            If tempWorkSheet.Name = strSheet Then
-                bFoundWorksheet = True
-                Exit For
+        Dim grdWorksheetToMove As Worksheet = Nothing
+        If strSheet <> "" Then
+            For Each tempWorkSheet In grdData.Worksheets
+                If tempWorkSheet.Name = strSheet Then
+                    bFoundWorksheet = True
+                    Exit For
+                End If
+            Next
+
+            If bFoundWorksheet AndAlso grdData.Worksheets.Count > 0 Then
+                grdWorksheetToMove = grdData.GetWorksheetByName(strSheet)
+                grdData.MoveWorksheet(grdWorksheetToMove, iNewPosition)
+                grdData.CurrentWorksheet = grdWorksheetToMove
             End If
-        Next
-        If bFoundWorksheet Then
-            fillWorkSheet = grdData.GetWorksheetByName(strSheet)
-        End If
-        If grdData.Worksheets.Count > 0 Then
-            grdData.MoveWorksheet(fillWorkSheet, iNewPosition)
-            grdData.CurrentWorksheet = fillWorkSheet
         End If
     End Sub
 

--- a/instat/UserControls/DataGrid/ReoGrid/ucrReoGrid.vb
+++ b/instat/UserControls/DataGrid/ReoGrid/ucrReoGrid.vb
@@ -84,11 +84,13 @@ Public MustInherit Class ucrReoGrid
                 lstWorkSheetsFound.Add(fillWorkSheet)
             End If
         Next
-        'then reorder the worksheets based on the filled list
-        For i As Integer = 0 To lstWorkSheetsFound.Count - 1
-            grdData.MoveWorksheet(lstWorkSheetsFound(i), i)
-            grdData.CurrentWorksheet = lstWorkSheetsFound(i)
-        Next
+        If lstWorkSheetsFound.Count > 1 Then
+            'reorder the worksheets based on the filled list
+            For i As Integer = 0 To lstWorkSheetsFound.Count - 1
+                grdData.MoveWorksheet(lstWorkSheetsFound(i), i)
+                grdData.CurrentWorksheet = lstWorkSheetsFound(i)
+            Next
+        End If
     End Sub
 
     Public Sub CopyRange() Implements IGrid.CopyRange

--- a/instat/UserControls/DataGrid/ReoGrid/ucrReoGrid.vb
+++ b/instat/UserControls/DataGrid/ReoGrid/ucrReoGrid.vb
@@ -72,29 +72,22 @@ Public MustInherit Class ucrReoGrid
     End Function
 
     Private Sub ReOrderWorksheets() Implements IGrid.ReOrderWorksheets
-        Dim iNewPosition As Integer
-        Dim strName As String = Nothing
-        Dim bFound As Boolean = False
-        Dim iCount As Integer
-        iCount = 0
+        'assuming the databook will always have all the data frames 
+        'and the grid may not have all the data frame worksheets equivalent
+        'and all data frames in the data book have changed their order positions 
+        'get data frames sheets in the grid based on the databook data frames position order
+        'and add it to the list.
+        Dim lstWorkSheetsFound As New List(Of Worksheet)
         For Each clsDataframe In _clsDataBook.DataFrames
-            For Each tempWorkSheet In grdData.Worksheets
-                If tempWorkSheet.Name = clsDataframe.strName Then
-                    strName = clsDataframe.strName
-                    iNewPosition = iCount
-                    bFound = True
-                    Exit For
-                End If
-            Next
-            If bFound Then
-                Dim fillWorkSheet = grdData.GetWorksheetByName(strName)
-                If fillWorkSheet IsNot Nothing AndAlso iNewPosition < grdData.Worksheets.Count Then
-                    grdData.MoveWorksheet(fillWorkSheet, iNewPosition)
-                    grdData.CurrentWorksheet = fillWorkSheet
-                    iCount += 1
-                    bFound = False
-                End If
+            Dim fillWorkSheet As Worksheet = grdData.GetWorksheetByName(clsDataframe.strName)
+            If fillWorkSheet IsNot Nothing Then
+                lstWorkSheetsFound.Add(fillWorkSheet)
             End If
+        Next
+        'then reorder the worksheets based on the filled list
+        For i As Integer = 0 To lstWorkSheetsFound.Count - 1
+            grdData.MoveWorksheet(lstWorkSheetsFound(i), i)
+            grdData.CurrentWorksheet = lstWorkSheetsFound(i)
         Next
     End Sub
 

--- a/instat/dlgReorderDataFrame.Designer.vb
+++ b/instat/dlgReorderDataFrame.Designer.vb
@@ -46,7 +46,7 @@ Partial Class dlgReorderDataFrame
         'lblDataFrameToReorder
         '
         Me.lblDataFrameToReorder.AutoSize = True
-        Me.lblDataFrameToReorder.Location = New System.Drawing.Point(10, 13)
+        Me.lblDataFrameToReorder.Location = New System.Drawing.Point(175, 13)
         Me.lblDataFrameToReorder.Name = "lblDataFrameToReorder"
         Me.lblDataFrameToReorder.Size = New System.Drawing.Size(123, 13)
         Me.lblDataFrameToReorder.TabIndex = 0
@@ -56,14 +56,14 @@ Partial Class dlgReorderDataFrame
         '
         Me.ucrBase.AutoSize = True
         Me.ucrBase.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrBase.Location = New System.Drawing.Point(13, 210)
+        Me.ucrBase.Location = New System.Drawing.Point(5, 210)
         Me.ucrBase.Name = "ucrBase"
-        Me.ucrBase.Size = New System.Drawing.Size(405, 52)
+        Me.ucrBase.Size = New System.Drawing.Size(408, 52)
         Me.ucrBase.TabIndex = 2
         '
         'ucrDataFrameToReorder
         '
-        Me.ucrDataFrameToReorder.Location = New System.Drawing.Point(10, 29)
+        Me.ucrDataFrameToReorder.Location = New System.Drawing.Point(173, 29)
         Me.ucrDataFrameToReorder.Name = "ucrDataFrameToReorder"
         Me.ucrDataFrameToReorder.Size = New System.Drawing.Size(209, 175)
         Me.ucrDataFrameToReorder.TabIndex = 1
@@ -75,7 +75,7 @@ Partial Class dlgReorderDataFrame
         Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
         Me.AutoSize = True
-        Me.ClientSize = New System.Drawing.Size(422, 269)
+        Me.ClientSize = New System.Drawing.Size(415, 266)
         Me.Controls.Add(Me.lblDataFrameToReorder)
         Me.Controls.Add(Me.ucrBase)
         Me.Controls.Add(Me.ucrDataFrameToReorder)

--- a/instat/dlgReorderDataFrame.vb
+++ b/instat/dlgReorderDataFrame.vb
@@ -56,8 +56,6 @@ Public Class dlgReorderDataFrame
     Private Sub SetDefaults()
         clsReorderDataFrame = New RFunction
 
-        ucrDataFrameToReorder.Reset()
-
         clsReorderDataFrame.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$reorder_dataframes")
         ucrBase.clsRsyntax.SetBaseRFunction(clsReorderDataFrame)
     End Sub
@@ -67,11 +65,7 @@ Public Class dlgReorderDataFrame
     End Sub
 
     Private Sub TestOkEnabled()
-        If Not ucrDataFrameToReorder.IsEmpty Then
-            ucrBase.OKEnabled(True)
-        Else
-            ucrBase.OKEnabled(False)
-        End If
+        ucrBase.OKEnabled(Not ucrDataFrameToReorder.IsEmpty AndAlso ucrDataFrameToReorder.Count > 1)
     End Sub
 
     Private Sub ucrBase_ClickReset(sender As Object, e As EventArgs) Handles ucrBase.ClickReset

--- a/instat/dlgReorderDataFrame.vb
+++ b/instat/dlgReorderDataFrame.vb
@@ -89,10 +89,8 @@ Public Class dlgReorderDataFrame
             For i As Integer = 0 To ucrDataFrameToReorder.lstAvailableData.Items.Count - 1
                 Dim strName As String = ucrDataFrameToReorder.lstAvailableData.Items(i).Text
                 Dim iNewPosition As Integer = ucrDataFrameToReorder.lstAvailableData.Items(i).Index
-                frmMain.ucrDataViewer.ReorderSheets(strName, iNewPosition)
-                frmMain.ucrColumnMeta.ReorderSheets(strName, iNewPosition)
-                frmMain.ucrDataViewer.SetCurrentDataFrame(strName)
-                frmMain.ucrColumnMeta.SetCurrentDataFrame(strName)
+                frmMain.ReorderSheets(strName, iNewPosition)
+                frmMain.SetCurrentDataFrame(strName)
             Next
         End If
     End Sub

--- a/instat/dlgReorderDataFrame.vb
+++ b/instat/dlgReorderDataFrame.vb
@@ -91,6 +91,8 @@ Public Class dlgReorderDataFrame
                 Dim iNewPosition As Integer = ucrDataFrameToReorder.lstAvailableData.Items(i).Index
                 frmMain.ucrDataViewer.ReorderSheets(strName, iNewPosition)
                 frmMain.ucrColumnMeta.ReorderSheets(strName, iNewPosition)
+                frmMain.ucrDataViewer.SetCurrentDataFrame(strName)
+                frmMain.ucrColumnMeta.SetCurrentDataFrame(strName)
             Next
         End If
     End Sub

--- a/instat/dlgReorderDataFrame.vb
+++ b/instat/dlgReorderDataFrame.vb
@@ -83,4 +83,14 @@ Public Class dlgReorderDataFrame
     Private Sub Controls_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrDataFrameToReorder.ControlContentsChanged
         TestOkEnabled()
     End Sub
+
+    'Private Sub ucrBase_ClickOk(sender As Object, e As EventArgs) Handles ucrBase.ClickOk
+    '    If ucrDataFrameToReorder.lstAvailableData.Items.Count > 0 Then
+    '        For i As Integer = 0 To ucrDataFrameToReorder.lstAvailableData.Items.Count - 1
+    '            Dim strName As String = ucrDataFrameToReorder.lstAvailableData.Items(i).Text
+    '            Dim iNewPosition As Integer = ucrDataFrameToReorder.lstAvailableData.Items(i).Index
+    '            frmMain.ucrDataViewer.ReorderSheets(strName, iNewPosition)
+    '        Next
+    '    End If
+    'End Sub
 End Class

--- a/instat/dlgReorderDataFrame.vb
+++ b/instat/dlgReorderDataFrame.vb
@@ -77,14 +77,4 @@ Public Class dlgReorderDataFrame
     Private Sub Controls_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrDataFrameToReorder.ControlContentsChanged
         TestOkEnabled()
     End Sub
-
-    Private Sub ucrBase_ClickOk(sender As Object, e As EventArgs) Handles ucrBase.ClickOk
-        If ucrDataFrameToReorder.lstAvailableData.Items.Count > 0 Then
-            For i As Integer = 0 To ucrDataFrameToReorder.lstAvailableData.Items.Count - 1
-                Dim strName As String = ucrDataFrameToReorder.lstAvailableData.Items(i).Text
-                Dim iNewPosition As Integer = ucrDataFrameToReorder.lstAvailableData.Items(i).Index
-                frmMain.ReorderSheets(strName, iNewPosition)
-            Next
-        End If
-    End Sub
 End Class

--- a/instat/dlgReorderDataFrame.vb
+++ b/instat/dlgReorderDataFrame.vb
@@ -84,13 +84,14 @@ Public Class dlgReorderDataFrame
         TestOkEnabled()
     End Sub
 
-    'Private Sub ucrBase_ClickOk(sender As Object, e As EventArgs) Handles ucrBase.ClickOk
-    '    If ucrDataFrameToReorder.lstAvailableData.Items.Count > 0 Then
-    '        For i As Integer = 0 To ucrDataFrameToReorder.lstAvailableData.Items.Count - 1
-    '            Dim strName As String = ucrDataFrameToReorder.lstAvailableData.Items(i).Text
-    '            Dim iNewPosition As Integer = ucrDataFrameToReorder.lstAvailableData.Items(i).Index
-    '            frmMain.ucrDataViewer.ReorderSheets(strName, iNewPosition)
-    '        Next
-    '    End If
-    'End Sub
+    Private Sub ucrBase_ClickOk(sender As Object, e As EventArgs) Handles ucrBase.ClickOk
+        If ucrDataFrameToReorder.lstAvailableData.Items.Count > 0 Then
+            For i As Integer = 0 To ucrDataFrameToReorder.lstAvailableData.Items.Count - 1
+                Dim strName As String = ucrDataFrameToReorder.lstAvailableData.Items(i).Text
+                Dim iNewPosition As Integer = ucrDataFrameToReorder.lstAvailableData.Items(i).Index
+                frmMain.ucrDataViewer.ReorderSheets(strName, iNewPosition)
+                frmMain.ucrColumnMeta.ReorderSheets(strName, iNewPosition)
+            Next
+        End If
+    End Sub
 End Class

--- a/instat/dlgReorderDataFrame.vb
+++ b/instat/dlgReorderDataFrame.vb
@@ -50,7 +50,7 @@ Public Class dlgReorderDataFrame
         ucrBase.iHelpTopicID = 62
 
         ucrDataFrameToReorder.SetParameter(New RParameter("data_frames_order", 0))
-        ucrDataFrameToReorder.setDataType("data frame")
+        ucrDataFrameToReorder.setDataType("dataframe")
     End Sub
 
     Private Sub SetDefaults()

--- a/instat/dlgReorderDataFrame.vb
+++ b/instat/dlgReorderDataFrame.vb
@@ -84,7 +84,6 @@ Public Class dlgReorderDataFrame
                 Dim strName As String = ucrDataFrameToReorder.lstAvailableData.Items(i).Text
                 Dim iNewPosition As Integer = ucrDataFrameToReorder.lstAvailableData.Items(i).Index
                 frmMain.ReorderSheets(strName, iNewPosition)
-                frmMain.SetCurrentDataFrame(strName)
             Next
         End If
     End Sub

--- a/instat/frmMain.vb
+++ b/instat/frmMain.vb
@@ -1495,11 +1495,6 @@ Public Class frmMain
         Return 0
     End Function
 
-    Public Sub ReorderSheets(strSheet As String, iNewPosition As Integer)
-        ucrDataViewer.ReorderSheets(strSheet, iNewPosition)
-        ucrColumnMeta.ReorderSheets(strSheet, iNewPosition)
-    End Sub
-
     Public Sub SetCurrentDataFrame(strDataName As String)
         ucrDataViewer.SetCurrentDataFrame(strDataName)
         ucrColumnMeta.SetCurrentDataFrame(strDataName)

--- a/instat/frmMain.vb
+++ b/instat/frmMain.vb
@@ -1495,6 +1495,11 @@ Public Class frmMain
         Return 0
     End Function
 
+    Public Sub ReorderSheets(strSheet As String, iNewPosition As Integer)
+        ucrDataViewer.ReorderSheets(strSheet, iNewPosition)
+        ucrColumnMeta.ReorderSheets(strSheet, iNewPosition)
+    End Sub
+
     Public Sub SetCurrentDataFrame(strDataName As String)
         ucrDataViewer.SetCurrentDataFrame(strDataName)
         ucrColumnMeta.SetCurrentDataFrame(strDataName)

--- a/instat/static/InstatObject/R/instat_object_R6.R
+++ b/instat/static/InstatObject/R/instat_object_R6.R
@@ -125,7 +125,7 @@ DataBook$set("public", "replace_instat_object", function(new_instat_object) {
 )
 
 DataBook$set("public", "set_data_objects", function(new_data_objects) {
-  if(!is.list(new_data_objects) || (length(new_data_objects) > 0 && !all("data_object" %in% sapply(new_data_objects, class)))) {
+  if(!is.list(new_data_objects) || (length(new_data_objects) > 0 && !all("DataSheet" %in% sapply(new_data_objects, class)))) {
     stop("new_data_objects must be a list of data_objects")
   }
   else private$.data_sheets <- new_data_objects
@@ -1104,7 +1104,7 @@ DataBook$set("public", "add_metadata_field", function(data_name, property, new_v
 DataBook$set("public", "reorder_dataframes", function(data_frames_order) {
   if(length(data_frames_order) != length(names(private$.data_sheets))) stop("number data frames to order should be equal to number of dataframes in the object")
   if(!setequal(data_frames_order,names(private$.data_sheets))) stop("data_frames_order must be a permutation of the dataframe names.")
-  
+
   self$set_data_objects(private$.data_sheets[data_frames_order])
   self$data_objects_changed <- TRUE
 } 

--- a/instat/static/InstatObject/R/instat_object_R6.R
+++ b/instat/static/InstatObject/R/instat_object_R6.R
@@ -125,7 +125,8 @@ DataBook$set("public", "replace_instat_object", function(new_instat_object) {
 )
 
 DataBook$set("public", "set_data_objects", function(new_data_objects) {
-  if(!is.list(new_data_objects) || (length(new_data_objects) > 0 && !all("DataSheet" %in% sapply(new_data_objects, class)))) {
+  # new_data_objects could be of old class type 'data_object'
+  if(!is.list(new_data_objects) || (length(new_data_objects) > 0 && !any(c("DataSheet", "data_object") %in% sapply(new_data_objects, class)))) {
     stop("new_data_objects must be a list of data_objects")
   }
   else private$.data_sheets <- new_data_objects

--- a/instat/ucrColumnMetadata.Designer.vb
+++ b/instat/ucrColumnMetadata.Designer.vb
@@ -107,66 +107,65 @@ Partial Class ucrColumnMetadata
         Me.statusColumnMenu.ImageScalingSize = New System.Drawing.Size(20, 20)
         Me.statusColumnMenu.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.deleteDataFrame, Me.renameSheet, Me.mnuBottomAddComment, Me.hideSheet, Me.unhideSheet, Me.copySheet, Me.reorderSheet, Me.viewSheet, Me.ToolStripSeparator4, Me.mnuHelp2})
         Me.statusColumnMenu.Name = "statusColumnMenu"
-        Me.statusColumnMenu.Size = New System.Drawing.Size(163, 208)
+        Me.statusColumnMenu.Size = New System.Drawing.Size(181, 230)
         '
         'deleteDataFrame
         '
         Me.deleteDataFrame.Name = "deleteDataFrame"
-        Me.deleteDataFrame.Size = New System.Drawing.Size(162, 22)
+        Me.deleteDataFrame.Size = New System.Drawing.Size(180, 22)
         Me.deleteDataFrame.Text = "Delete..."
         '
         'renameSheet
         '
         Me.renameSheet.Name = "renameSheet"
-        Me.renameSheet.Size = New System.Drawing.Size(162, 22)
+        Me.renameSheet.Size = New System.Drawing.Size(180, 22)
         Me.renameSheet.Text = "Rename..."
         '
         'mnuBottomAddComment
         '
         Me.mnuBottomAddComment.Name = "mnuBottomAddComment"
-        Me.mnuBottomAddComment.Size = New System.Drawing.Size(162, 22)
+        Me.mnuBottomAddComment.Size = New System.Drawing.Size(180, 22)
         Me.mnuBottomAddComment.Text = "Add Comment..."
         '
         'hideSheet
         '
         Me.hideSheet.Name = "hideSheet"
-        Me.hideSheet.Size = New System.Drawing.Size(162, 22)
+        Me.hideSheet.Size = New System.Drawing.Size(180, 22)
         Me.hideSheet.Text = "Hide"
         '
         'unhideSheet
         '
         Me.unhideSheet.Name = "unhideSheet"
-        Me.unhideSheet.Size = New System.Drawing.Size(162, 22)
+        Me.unhideSheet.Size = New System.Drawing.Size(180, 22)
         Me.unhideSheet.Text = "Unhide..."
         '
         'copySheet
         '
         Me.copySheet.Name = "copySheet"
-        Me.copySheet.Size = New System.Drawing.Size(162, 22)
+        Me.copySheet.Size = New System.Drawing.Size(180, 22)
         Me.copySheet.Text = "Copy..."
         '
         'reorderSheet
         '
-        Me.reorderSheet.Enabled = False
         Me.reorderSheet.Name = "reorderSheet"
-        Me.reorderSheet.Size = New System.Drawing.Size(162, 22)
+        Me.reorderSheet.Size = New System.Drawing.Size(180, 22)
         Me.reorderSheet.Text = "Reorder..."
         '
         'viewSheet
         '
         Me.viewSheet.Name = "viewSheet"
-        Me.viewSheet.Size = New System.Drawing.Size(162, 22)
+        Me.viewSheet.Size = New System.Drawing.Size(180, 22)
         Me.viewSheet.Text = "View Data Frame"
         '
         'ToolStripSeparator4
         '
         Me.ToolStripSeparator4.Name = "ToolStripSeparator4"
-        Me.ToolStripSeparator4.Size = New System.Drawing.Size(159, 6)
+        Me.ToolStripSeparator4.Size = New System.Drawing.Size(177, 6)
         '
         'mnuHelp2
         '
         Me.mnuHelp2.Name = "mnuHelp2"
-        Me.mnuHelp2.Size = New System.Drawing.Size(162, 22)
+        Me.mnuHelp2.Size = New System.Drawing.Size(180, 22)
         Me.mnuHelp2.Text = "Help"
         '
         'propertiesContextMenuStrip
@@ -361,7 +360,7 @@ Partial Class ucrColumnMetadata
         Me.columnContextMenuStrip.ImageScalingSize = New System.Drawing.Size(24, 24)
         Me.columnContextMenuStrip.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuColumnRename, Me.mnuDuplicateColumn, Me.mnuReorderColumns, Me.mnuInsertColsBefore, Me.mnuInsertColsAfter, Me.mnuDeleteCol, Me.toolStripMenuItem2, Me.mnuConvertToFactor, Me.mnuCovertToOrderedFactors, Me.mnuConvertText, Me.mnuConvertToLogical, Me.mnuConvertVariate, Me.ToolStripSeparator2, Me.mnuLevelsLabels, Me.ToolStripSeparator1, Me.mnuSort, Me.mnuAddComment, Me.mnuColumnFilterRows, Me.mnuColumnContextSelectColumns, Me.mnuColumnContextRemoveCurrentColumnSelection, Me.mnuClearColumnFilter, Me.ToolStripSeparator3, Me.mnuHelp1})
         Me.columnContextMenuStrip.Name = "columnContextMenuStrip"
-        Me.columnContextMenuStrip.Size = New System.Drawing.Size(215, 468)
+        Me.columnContextMenuStrip.Size = New System.Drawing.Size(215, 446)
         '
         'ToolStripSeparator3
         '

--- a/instat/ucrColumnMetadata.vb
+++ b/instat/ucrColumnMetadata.vb
@@ -82,6 +82,10 @@ Public Class ucrColumnMetadata
         _grid.UpdateAllWorksheetStyles()
     End Sub
 
+    Public Sub ReorderSheets(strSheet As String, iNewPosition As Integer)
+        _grid.ReorderSheets(strSheet, iNewPosition)
+    End Sub
+
     Public Sub RefreshGridData()
         If _clsDataBook IsNot Nothing Then
             _grid.RemoveOldWorksheets()

--- a/instat/ucrColumnMetadata.vb
+++ b/instat/ucrColumnMetadata.vb
@@ -76,6 +76,7 @@ Public Class ucrColumnMetadata
         If firstAddedWorksheet IsNot Nothing Then
             _grid.CurrentWorksheet = firstAddedWorksheet
         End If
+        _grid.ReOrderWorksheets()
     End Sub
 
     Public Sub UpdateAllWorksheetStyles()

--- a/instat/ucrColumnMetadata.vb
+++ b/instat/ucrColumnMetadata.vb
@@ -82,10 +82,6 @@ Public Class ucrColumnMetadata
         _grid.UpdateAllWorksheetStyles()
     End Sub
 
-    Public Sub ReorderSheets(strSheet As String, iNewPosition As Integer)
-        _grid.ReorderSheets(strSheet, iNewPosition)
-    End Sub
-
     Public Sub RefreshGridData()
         If _clsDataBook IsNot Nothing Then
             _grid.RemoveOldWorksheets()

--- a/instat/ucrDataView.Designer.vb
+++ b/instat/ucrDataView.Designer.vb
@@ -446,7 +446,7 @@ Partial Class ucrDataView
         Me.rowContextMenuStrip.ImageScalingSize = New System.Drawing.Size(20, 20)
         Me.rowContextMenuStrip.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuInsertRowsBefore, Me.mnuInsertRowsAfter, Me.mnuDeleteRows, Me.ToolStripSeparator2, Me.mnuAddComment, Me.ToolStripSeparator4, Me.mnuFilter, Me.mnuRowContextColumnSelection, Me.mnuRowContextRemoveCurrentColumnSelection, Me.mnuRemoveCurrentFilter, Me.ToolStripSeparator10, Me.mnuHelp2})
         Me.rowContextMenuStrip.Name = "columnContextMenuStrip"
-        Me.rowContextMenuStrip.Size = New System.Drawing.Size(215, 242)
+        Me.rowContextMenuStrip.Size = New System.Drawing.Size(215, 220)
         '
         'mnuInsertRowsBefore
         '
@@ -524,66 +524,65 @@ Partial Class ucrDataView
         Me.statusColumnMenu.ImageScalingSize = New System.Drawing.Size(20, 20)
         Me.statusColumnMenu.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.deleteDataFrame, Me.renameSheet, Me.mnuBottomAddComment, Me.HideSheet, Me.unhideSheet, Me.CopySheet, Me.reorderSheet, Me.ViewSheet, Me.ToolStripSeparator11, Me.mnuHelp3})
         Me.statusColumnMenu.Name = "statusColumnMenu"
-        Me.statusColumnMenu.Size = New System.Drawing.Size(163, 208)
+        Me.statusColumnMenu.Size = New System.Drawing.Size(181, 230)
         '
         'deleteDataFrame
         '
         Me.deleteDataFrame.Name = "deleteDataFrame"
-        Me.deleteDataFrame.Size = New System.Drawing.Size(162, 22)
+        Me.deleteDataFrame.Size = New System.Drawing.Size(180, 22)
         Me.deleteDataFrame.Text = "Delete..."
         '
         'renameSheet
         '
         Me.renameSheet.Name = "renameSheet"
-        Me.renameSheet.Size = New System.Drawing.Size(162, 22)
+        Me.renameSheet.Size = New System.Drawing.Size(180, 22)
         Me.renameSheet.Text = "Rename..."
         '
         'mnuBottomAddComment
         '
         Me.mnuBottomAddComment.Name = "mnuBottomAddComment"
-        Me.mnuBottomAddComment.Size = New System.Drawing.Size(162, 22)
+        Me.mnuBottomAddComment.Size = New System.Drawing.Size(180, 22)
         Me.mnuBottomAddComment.Text = "Add Comment..."
         '
         'HideSheet
         '
         Me.HideSheet.Name = "HideSheet"
-        Me.HideSheet.Size = New System.Drawing.Size(162, 22)
+        Me.HideSheet.Size = New System.Drawing.Size(180, 22)
         Me.HideSheet.Text = "Hide"
         '
         'unhideSheet
         '
         Me.unhideSheet.Name = "unhideSheet"
-        Me.unhideSheet.Size = New System.Drawing.Size(162, 22)
+        Me.unhideSheet.Size = New System.Drawing.Size(180, 22)
         Me.unhideSheet.Text = "Unhide..."
         '
         'CopySheet
         '
         Me.CopySheet.Name = "CopySheet"
-        Me.CopySheet.Size = New System.Drawing.Size(162, 22)
+        Me.CopySheet.Size = New System.Drawing.Size(180, 22)
         Me.CopySheet.Text = "Copy..."
         '
         'reorderSheet
         '
-        Me.reorderSheet.Enabled = False
         Me.reorderSheet.Name = "reorderSheet"
-        Me.reorderSheet.Size = New System.Drawing.Size(162, 22)
+        Me.reorderSheet.Size = New System.Drawing.Size(180, 22)
         Me.reorderSheet.Text = "Reorder..."
         '
         'ViewSheet
         '
         Me.ViewSheet.Name = "ViewSheet"
-        Me.ViewSheet.Size = New System.Drawing.Size(162, 22)
+        Me.ViewSheet.Size = New System.Drawing.Size(180, 22)
         Me.ViewSheet.Text = "View Data Frame"
         '
         'ToolStripSeparator11
         '
         Me.ToolStripSeparator11.Name = "ToolStripSeparator11"
-        Me.ToolStripSeparator11.Size = New System.Drawing.Size(159, 6)
+        Me.ToolStripSeparator11.Size = New System.Drawing.Size(177, 6)
         '
         'mnuHelp3
         '
         Me.mnuHelp3.Name = "mnuHelp3"
-        Me.mnuHelp3.Size = New System.Drawing.Size(162, 22)
+        Me.mnuHelp3.Size = New System.Drawing.Size(180, 22)
         Me.mnuHelp3.Text = "Help"
         '
         'lblHeaderDataView

--- a/instat/ucrDataView.vb
+++ b/instat/ucrDataView.vb
@@ -100,6 +100,10 @@ Public Class ucrDataView
         RefreshDisplayInformation()
     End Sub
 
+    Public Sub ReorderSheets(strSheet As String, iNewPosition As Integer)
+        _grid.ReorderSheets(strSheet, iNewPosition)
+    End Sub
+
     Public Sub UpdateAllWorksheetStyles()
         _grid.UpdateAllWorksheetStyles()
     End Sub

--- a/instat/ucrDataView.vb
+++ b/instat/ucrDataView.vb
@@ -118,8 +118,6 @@ Public Class ucrDataView
 
     Private Sub AddAndUpdateWorksheets()
         Dim firstAddedWorksheet As clsWorksheetAdapter = Nothing
-        Dim iCount As Integer
-        iCount = 0
         For Each clsDataFrame In _clsDataBook.DataFrames
             Dim worksheet As clsWorksheetAdapter = _grid.GetWorksheet(clsDataFrame.strName)
             If worksheet Is Nothing Then
@@ -128,13 +126,12 @@ Public Class ucrDataView
                     firstAddedWorksheet = worksheet
                 End If
             End If
-            'iCount += 1
-            _grid.ReOrderWorksheets(clsDataFrame.strName, iCount)
             RefreshWorksheet(worksheet, clsDataFrame)
         Next
         If firstAddedWorksheet IsNot Nothing Then
             _grid.CurrentWorksheet = firstAddedWorksheet
         End If
+        _grid.ReOrderWorksheets()
     End Sub
 
     Public Sub RefreshGridData()

--- a/instat/ucrDataView.vb
+++ b/instat/ucrDataView.vb
@@ -100,10 +100,6 @@ Public Class ucrDataView
         RefreshDisplayInformation()
     End Sub
 
-    Public Sub ReorderSheets(strSheet As String, iNewPosition As Integer)
-        _grid.ReorderSheets(strSheet, iNewPosition)
-    End Sub
-
     Public Sub UpdateAllWorksheetStyles()
         _grid.UpdateAllWorksheetStyles()
     End Sub

--- a/instat/ucrDataView.vb
+++ b/instat/ucrDataView.vb
@@ -118,6 +118,8 @@ Public Class ucrDataView
 
     Private Sub AddAndUpdateWorksheets()
         Dim firstAddedWorksheet As clsWorksheetAdapter = Nothing
+        Dim iCount As Integer
+        iCount = 0
         For Each clsDataFrame In _clsDataBook.DataFrames
             Dim worksheet As clsWorksheetAdapter = _grid.GetWorksheet(clsDataFrame.strName)
             If worksheet Is Nothing Then
@@ -126,6 +128,8 @@ Public Class ucrDataView
                     firstAddedWorksheet = worksheet
                 End If
             End If
+            'iCount += 1
+            _grid.ReOrderWorksheets(clsDataFrame.strName, iCount)
             RefreshWorksheet(worksheet, clsDataFrame)
         Next
         If firstAddedWorksheet IsNot Nothing Then

--- a/instat/ucrDataView.vb
+++ b/instat/ucrDataView.vb
@@ -72,7 +72,7 @@ Public Class ucrDataView
             _grid = ucrReoGrid
         End If
         'Debug 
-        '_grid = ucrLinuxGrid
+        _grid = ucrLinuxGrid
 
         _grid.SetContextmenuStrips(columnContextMenuStrip, cellContextMenuStrip, rowContextMenuStrip, statusColumnMenu)
         AttachEventsToGrid()

--- a/instat/ucrDataView.vb
+++ b/instat/ucrDataView.vb
@@ -72,7 +72,7 @@ Public Class ucrDataView
             _grid = ucrReoGrid
         End If
         'Debug 
-        _grid = ucrLinuxGrid
+        '_grid = ucrLinuxGrid
 
         _grid.SetContextmenuStrips(columnContextMenuStrip, cellContextMenuStrip, rowContextMenuStrip, statusColumnMenu)
         AttachEventsToGrid()

--- a/instat/ucrReorder.vb
+++ b/instat/ucrReorder.vb
@@ -174,7 +174,7 @@ Public Class ucrReorder
                     If ucrReceiver IsNot Nothing AndAlso Not ucrReceiver.IsEmpty() AndAlso ucrReceiver.strCurrDataType.Contains("factor") Then
                         vecNames = frmMain.clsRLink.RunInternalScriptGetValue(frmMain.clsRLink.strInstatDataObject & "$get_column_factor_levels(data_name = " & Chr(34) & ucrReceiver.GetDataName() & Chr(34) & ", col_name = " & ucrReceiver.GetVariableNames() & ")").AsCharacter
                     End If
-                Case "data frame"
+                Case "dataframe"
                     vecNames = frmMain.clsRLink.RunInternalScriptGetValue(frmMain.clsRLink.strInstatDataObject & "$get_data_names()").AsCharacter
                 Case "metadata"
                     If ucrDataFrameList IsNot Nothing AndAlso ucrDataFrameList.cboAvailableDataFrames.Text <> "" Then

--- a/instat/ucrReorder.vb
+++ b/instat/ucrReorder.vb
@@ -45,7 +45,7 @@ Public Class ucrReorder
             Case "factor"
                 lstAvailableData.Columns.Add("Levels")
             Case "dataframe"
-                lstAvailableData.Columns.Add("Data Frame")
+                lstAvailableData.Columns.Add("Data Frames")
             Case "metadata"
                 lstAvailableData.Columns.Add("Metadata")
             Case "object"
@@ -235,6 +235,10 @@ Public Class ucrReorder
     Public Sub Reset()
         lstAvailableData.Items.Clear()
     End Sub
+
+    Public Function Count() As Integer
+        Return lstAvailableData.Items.Count
+    End Function
 
     Protected Overrides Sub SetControlValue()
         Dim lstCurrentVariables As String()

--- a/instat/ucrReorder.vb
+++ b/instat/ucrReorder.vb
@@ -44,7 +44,7 @@ Public Class ucrReorder
                 lstAvailableData.Columns.Add("Variables")
             Case "factor"
                 lstAvailableData.Columns.Add("Levels")
-            Case "data frame"
+            Case "dataframe"
                 lstAvailableData.Columns.Add("Data Frame")
             Case "metadata"
                 lstAvailableData.Columns.Add("Metadata")


### PR DESCRIPTION
Fixes (partially) #4557 
@shadrackkibet @lilyclements I checked the R code, then I found that on line 128, we were trying to check the obj class type as `data_object` i.e ` if(!is.list(new_data_objects) || (length(new_data_objects) > 0 && !all("data_object" %in% sapply(new_data_objects, class))))` to `if(!is.list(new_data_objects) || (length(new_data_objects) > 0 && !all("DataSheet" %in% sapply(new_data_objects, class))))`, please have a look, if everything is okay, I will then check the reodering in the front end.
