### PR TITLE
Adds a data book null check, in the data frame selector, to prevent design view error

### DIFF
--- a/instat/mdlCoreControl.vb
+++ b/instat/mdlCoreControl.vb
@@ -135,23 +135,4 @@ Module mdlCoreControl
             Return "c(" & String.Join(",", enumerable.ToArray()) & ")"
         End If
     End Function
-
-    'temporary code for visual studio design time
-
-    ''' <summary>
-    ''' Checks if current system process is in design mode.
-    ''' <para>To be used by developers to prevent visual studio from executing code during design mode. 
-    ''' Especially code that can be source of design errors.</para>
-    ''' </summary>
-    ''' <returns>True, if current process is in design mode. False otherwise.</returns>
-    Public Function IsInDesignMode() As Boolean
-        'temporary for developers to prevent visual studio from executing code during design mode
-        Dim process As System.Diagnostics.Process = System.Diagnostics.Process.GetCurrentProcess()
-        If process.ProcessName = "devenv" Then
-            process.Dispose()
-            Return True
-        End If
-        Return False
-    End Function
-
 End Module

--- a/instat/mdlCoreControl.vb
+++ b/instat/mdlCoreControl.vb
@@ -135,4 +135,5 @@ Module mdlCoreControl
             Return "c(" & String.Join(",", enumerable.ToArray()) & ")"
         End If
     End Function
+
 End Module

--- a/instat/mdlCoreControl.vb
+++ b/instat/mdlCoreControl.vb
@@ -136,4 +136,22 @@ Module mdlCoreControl
         End If
     End Function
 
+    'temporary code for visual studio design time
+
+    ''' <summary>
+    ''' Checks if current system process is in design mode.
+    ''' <para>To be used by developers to prevent visual studio from executing code during design mode. 
+    ''' Especially code that can be source of design errors.</para>
+    ''' </summary>
+    ''' <returns>True, if current process is in design mode. False otherwise.</returns>
+    Public Function IsInDesignMode() As Boolean
+        'temporary for developers to prevent visual studio from executing code during design mode
+        Dim process As System.Diagnostics.Process = System.Diagnostics.Process.GetCurrentProcess()
+        If process.ProcessName = "devenv" Then
+            process.Dispose()
+            Return True
+        End If
+        Return False
+    End Function
+
 End Module

--- a/instat/ucrDataFrame.vb
+++ b/instat/ucrDataFrame.vb
@@ -70,13 +70,9 @@ Public Class ucrDataFrame
             bFirstLoad = False
         End If
 
-        'this design mode check is necessary because of issue #7489
-        'todo. can be disabled [production mode
-        If Not mdlCoreControl.IsInDesignMode Then
-            'always load data frame names on load event because a data frame may have been deleted
-            'and the control needs to refresh the data frame names.
-            LoadDataFrameNamesAndFillComboBox()
-        End If
+        'always load data frame names on load event because a data frame may have been deleted
+        'and the control needs to refresh the data frame names.
+        LoadDataFrameNamesAndFillComboBox()
     End Sub
 
     Private Sub InitialiseControl()
@@ -116,7 +112,9 @@ Public Class ucrDataFrame
             'todo. GetLinkedToDataFrameNames should also be done through the data book
             'As of 22/04/022 the data book did not have this feature
             cboAvailableDataFrames.Items.AddRange(frmMain.clsRLink.GetLinkedToDataFrameNames(strPrimaryDataFrame, bIncludePrimaryDataFrameAsLinked).ToArray)
-        Else
+        ElseIf frmMain.DataBook IsNot Nothing Then
+            'Above check was added because of issue #4557.
+            'todo. Once the DataBook is moved to a global class, then it can be removed
             For Each dataFrame As clsDataFrame In frmMain.DataBook.DataFrames
                 cboAvailableDataFrames.Items.Add(dataFrame.strName)
             Next

--- a/instat/ucrDataFrame.vb
+++ b/instat/ucrDataFrame.vb
@@ -69,9 +69,14 @@ Public Class ucrDataFrame
             InitialiseControl()
             bFirstLoad = False
         End If
-        'always load data frame names on load event because a data frame may have been deleted
-        'and the control needs to refresh the data frame names.
-        LoadDataFrameNamesAndFillComboBox()
+
+        'this design mode check is necessary because of issue #7489
+        'todo. can be disabled [production mode
+        If Not mdlCoreControl.IsInDesignMode Then
+            'always load data frame names on load event because a data frame may have been deleted
+            'and the control needs to refresh the data frame names.
+            LoadDataFrameNamesAndFillComboBox()
+        End If
     End Sub
 
     Private Sub InitialiseControl()


### PR DESCRIPTION
Fixes #7489.
@africanmathsinitiative/developers @Wycklife this is ready for review.

@lloyddewit,

I'm not sure if we should generally allow committing changes like the one I've made `ucrDataFrame`. I did it here for @Wycklife to test, I can remove it if need be.

I think developers should be calling the `IsInDesignMode`  to make design changes then just remove or comment it out after that. 

I also understand there is no any significant performance difference in leaving such code. So I'm happy with any suggestion.

Thanks.  
