### PR TITLE
Ensured that Column Metadata window opens with the default selected dataset in the Data View

### DIFF
--- a/instat/frmMain.vb
+++ b/instat/frmMain.vb
@@ -1505,6 +1505,10 @@ Public Class frmMain
         ucrColumnMeta.SetCurrentDataFrame(iIndex)
     End Sub
 
+    Public Sub UpCurrentColumnMetaDataFrame(strDataName As String)
+        ucrColumnMeta.SetCurrentDataFrame(strDataName)
+    End Sub
+
     Private Sub CummulativeDistributionToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles mnuDescribeSpecificCummulativeDistribution.Click
         dlgCumulativeDistribution.ShowDialog()
     End Sub

--- a/instat/frmMain.vb
+++ b/instat/frmMain.vb
@@ -1505,10 +1505,6 @@ Public Class frmMain
         ucrColumnMeta.SetCurrentDataFrame(iIndex)
     End Sub
 
-    Public Sub UpCurrentColumnMetaDataFrame(strDataName As String)
-        ucrColumnMeta.SetCurrentDataFrame(strDataName)
-    End Sub
-
     Private Sub CummulativeDistributionToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles mnuDescribeSpecificCummulativeDistribution.Click
         dlgCumulativeDistribution.ShowDialog()
     End Sub

--- a/instat/ucrDataView.vb
+++ b/instat/ucrDataView.vb
@@ -230,7 +230,7 @@ Public Class ucrDataView
     End Sub
 
     Public Sub CurrentWorksheetChanged()
-        frmMain.UpCurrentColumnMetaDataFrame(_grid.CurrentWorksheet.Name)
+        frmMain.ucrColumnMeta.SetCurrentDataFrame(_grid.CurrentWorksheet.Name)
         RefreshDisplayInformation()
     End Sub
 

--- a/instat/ucrDataView.vb
+++ b/instat/ucrDataView.vb
@@ -230,6 +230,7 @@ Public Class ucrDataView
     End Sub
 
     Public Sub CurrentWorksheetChanged()
+        frmMain.UpCurrentColumnMetaDataFrame(_grid.CurrentWorksheet.Name)
         RefreshDisplayInformation()
     End Sub
 


### PR DESCRIPTION
Fixes #7477 
@rdstern I have made the improvement to the column meta data to change to the current data frame when the current data frame has changed from data view. Please have a look. Thanks
@africanmathsinitiative/developers this is ready for review.
@derekagorhom please have a look.