### PR TITLE
Changed the defaults of Correlation dialog to be '2/3 Variables' or 'Multivariate' depending on menu option used to open dialog

### DIFF
--- a/instat/frmMain.vb
+++ b/instat/frmMain.vb
@@ -1060,6 +1060,7 @@ Public Class frmMain
     End Sub
 
     Private Sub mnuDescribeMultivariateCorrelations_Click(sender As Object, e As EventArgs) Handles mnuDescribeMultivariateCorrelations.Click
+        dlgCorrelation.SetMultipleSequenceAsDefaultOption()
         dlgCorrelation.ShowDialog()
     End Sub
 
@@ -1285,6 +1286,7 @@ Public Class frmMain
     End Sub
 
     Private Sub mnuClimaticSCFSupportCorrelations_Click(sender As Object, e As EventArgs) Handles mnuClimaticSCFSupportCorrelations.Click
+        dlgCorrelation.SetMultipleSequenceAsDefaultOption()
         dlgCorrelation.ShowDialog()
     End Sub
 
@@ -2205,6 +2207,7 @@ Public Class frmMain
     End Sub
 
     Private Sub mnuClimaticCompareCorrelations_Click(sender As Object, e As EventArgs) Handles mnuClimaticCompareCorrelations.Click
+        dlgCorrelation.SetMultipleSequenceAsDefaultOption()
         dlgCorrelation.ShowDialog()
     End Sub
 
@@ -2423,6 +2426,8 @@ Public Class frmMain
     End Sub
 
     Private Sub mnuDescribeTwoThreeVariablesCorrelations_Click(sender As Object, e As EventArgs) Handles mnuDescribeTwoThreeVariablesCorrelations.Click
+        dlgCorrelation.mnuCurrent = mnuDescribeTwoThreeVariablesCorrelations
+        dlgCorrelation.SetTwoVariableSequenceAsDefaultOption()
         dlgCorrelation.ShowDialog()
     End Sub
 


### PR DESCRIPTION
Fixes #7452 
It replaces PR #7457  due to conflicting files
@rdstern @N-thony @lloyddewit this PR makes default to be Multiple variables in Multivariate sub-menu and Two Variables in 2/3 variables sub-menu
I have also updated the database for the labels changed 

![image](https://user-images.githubusercontent.com/89011415/172595290-39a3a491-f5cd-4af4-befa-1d93d57d7eb9.png)
