### PR TITLE
Fixed bugs in PICSA Rainfall Dialogue 

### DIFF
--- a/instat/dlgPICSARainfall.Designer.vb
+++ b/instat/dlgPICSARainfall.Designer.vb
@@ -58,7 +58,6 @@ Partial Class dlgPICSARainfall
         Me.PlotOptionsToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.toolStripMenuItemLineOptions = New System.Windows.Forms.ToolStripMenuItem()
         Me.toolStripMenuItemPointOption = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ucrReceiverY = New instat.ucrReceiverSingle()
         Me.contextMenuStripOptions.SuspendLayout()
         Me.SuspendLayout()
         '
@@ -255,26 +254,12 @@ Partial Class dlgPICSARainfall
         Me.toolStripMenuItemPointOption.Size = New System.Drawing.Size(150, 22)
         Me.toolStripMenuItemPointOption.Text = "Point Options "
         '
-        'ucrReceiverY
-        '
-        Me.ucrReceiverY.AutoSize = True
-        Me.ucrReceiverY.frmParent = Me
-        Me.ucrReceiverY.Location = New System.Drawing.Point(248, 51)
-        Me.ucrReceiverY.Margin = New System.Windows.Forms.Padding(0)
-        Me.ucrReceiverY.Name = "ucrReceiverY"
-        Me.ucrReceiverY.Selector = Nothing
-        Me.ucrReceiverY.Size = New System.Drawing.Size(125, 26)
-        Me.ucrReceiverY.strNcFilePath = ""
-        Me.ucrReceiverY.TabIndex = 4
-        Me.ucrReceiverY.ucrSelector = Nothing
-        '
         'dlgPICSARainfall
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
         Me.AutoSize = True
         Me.ClientSize = New System.Drawing.Size(463, 420)
-        Me.Controls.Add(Me.ucrReceiverY)
         Me.Controls.Add(Me.ucrVariablesAsFactorForPicsa)
         Me.Controls.Add(Me.cmdOptions)
         Me.Controls.Add(Me.ucrInputStation)
@@ -321,5 +306,4 @@ Partial Class dlgPICSARainfall
     Friend WithEvents PlotOptionsToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents toolStripMenuItemLineOptions As ToolStripMenuItem
     Friend WithEvents toolStripMenuItemPointOption As ToolStripMenuItem
-    Friend WithEvents ucrReceiverY As ucrReceiverSingle
 End Class

--- a/instat/dlgPICSARainfall.vb
+++ b/instat/dlgPICSARainfall.vb
@@ -152,12 +152,6 @@ Public Class dlgPICSARainfall
         ucrReceiverX.SetIncludedDataTypes({"numeric", "factor"})
         ucrReceiverX.bAddParameterIfEmpty = True
 
-        ucrReceiverY.SetParameter(New RParameter("y", 2))
-        ucrReceiverY.Selector = ucrSelectorPICSARainfall
-        ucrReceiverY.bWithQuotes = False
-        ucrReceiverY.SetParameterIsString()
-        ucrReceiverY.SetIncludedDataTypes({"numeric"})
-
         ucrReceiverColourBy.SetParameter(New RParameter("colour", 2))
         ucrReceiverColourBy.Selector = ucrSelectorPICSARainfall
         ucrReceiverColourBy.SetIncludedDataTypes({"factor"})
@@ -188,7 +182,7 @@ Public Class dlgPICSARainfall
         ucrInputStation.SetItems({strFacetWrap, strFacetRow, strFacetCol, strNone})
         ucrInputStation.SetDropDownStyleAsNonEditable()
 
-        ucrReceiverY.SetLinkedDisplayControl(ucrVariablesAsFactorForPicsa)
+
 
         ucrSave.SetPrefix("picsa_rainfall_graph")
         ucrSave.SetIsComboBox()
@@ -309,7 +303,7 @@ Public Class dlgPICSARainfall
         ucrSelectorPICSARainfall.Reset()
         ucrSelectorPICSARainfall.SetGgplotFunction(clsBaseOperator)
         ucrSave.Reset()
-        ucrReceiverY.SetMeAsReceiver()
+        ucrVariablesAsFactorForPicsa.SetMeAsReceiver()
         bResetSubdialog = True
         bResetLineLayerSubdialog = True
 
@@ -623,11 +617,9 @@ Public Class dlgPICSARainfall
         ucrVariablesAsFactorForPicsa.AddAdditionalCodeParameterPair(clsMedianFunction, New RParameter("x", 0), iAdditionalPairNo:=3)
         ucrVariablesAsFactorForPicsa.AddAdditionalCodeParameterPair(clsLowerTercileFunction, New RParameter("x", 0), iAdditionalPairNo:=4)
         ucrVariablesAsFactorForPicsa.AddAdditionalCodeParameterPair(clsUpperTercileFunction, New RParameter("x", 0), iAdditionalPairNo:=5)
-        ucrReceiverY.AddAdditionalCodeParameterPair(clsRaesFunction, New RParameter("y", iNewPosition:=1), iAdditionalPairNo:=1)
 
 
         ucrSelectorPICSARainfall.SetRCode(clsPipeOperator, bReset)
-        ucrReceiverY.SetRCode(clsRaesFunction, bReset)
         ucrReceiverX.SetRCode(clsRaesFunction, bReset)
         ucrReceiverColourBy.SetRCode(clsRaesFunction, bReset)
         ucrSave.SetRCode(clsBaseOperator, bReset)
@@ -640,7 +632,7 @@ Public Class dlgPICSARainfall
     End Sub
 
     Private Sub TestOkEnabled()
-        If (ucrReceiverY.IsEmpty OrElse ucrReceiverX.IsEmpty) OrElse Not ucrSave.IsComplete Then
+        If (ucrVariablesAsFactorForPicsa.IsEmpty OrElse ucrReceiverX.IsEmpty) OrElse Not ucrSave.IsComplete Then
             ucrBase.OKEnabled(False)
         Else
             ucrBase.OKEnabled(True)


### PR DESCRIPTION
Fixes (partially) #7534
This PR fixes the bugs recently found on the PICSA rainfall graph dialogue. 
@N-thony @Vitalis95 can you test. 

There seems to be an issue with the dialogue. 

1. In the Single variable; when using either Line or Point Options the user has to automatically select the variable it wants to use as the Y variable. (I tried correcting that but it created more problems that solutions). 
to show proof: 
When using the dialogue without Line/Point options:
ghana <- data_book$get_data_frame(data_name="ghana")
last_graph <- ggplot2::ggplot(data=ghana,` mapping=ggplot2::aes(y=as.numeric(x=rainfall), x=month_abbr)) `+....

When using the Dialogue with Line/Point options:
ghana <- data_book$get_data_frame(data_name="ghana")
last_graph <- ggplot2::ggplot(data=ghana, `mapping=ggplot2::aes(y=rainfall, x=month_abbr))` +...

And finally when using the dialogue with the multiple variable: 
ghana <- data_book$get_data_frame(data_name="ghana", stack_data=TRUE, measure.vars=c("min_temperature","max_temperature"))
last_graph <- ggplot2::ggplot(data=ghana, `mapping=ggplot2::aes(y=as.numeric(x=value), colour=variable, x=month_abbr))` +....


 This PR does not fix issue #7534...but rather the bugs reported by Antoine and Vitalis