### PR TITLE
Allowing consistent order of columns in the calculate_summary R function.

### DIFF
--- a/instat/static/InstatObject/R/Backend_Components/summary_functions.R
+++ b/instat/static/InstatObject/R/Backend_Components/summary_functions.R
@@ -228,7 +228,9 @@ DataBook$set("public", "calculate_summary", function(data_name, columns_to_summa
   if(return_output) {
     dat <- out$data
     # relocate so that the value_factors are first still for consistency
-    out$data <- (out$data %>% dplyr::select(c(tidyselect::all_of(value_factors), tidyselect::all_of(manip_factors)), tidyselect::everything()))
+      if (percentage_type != "none"){
+        out$data <- (out$data %>% dplyr::select(c(tidyselect::all_of(value_factors), tidyselect::all_of(manip_factors)), tidyselect::everything()))
+      }
     if(percentage_type == "none" || perc_return_all) return(out$data)
     else {
       #This is a temp fix to only returning final percentage columns.

--- a/instat/static/InstatObject/R/Backend_Components/summary_functions.R
+++ b/instat/static/InstatObject/R/Backend_Components/summary_functions.R
@@ -227,6 +227,8 @@ DataBook$set("public", "calculate_summary", function(data_name, columns_to_summa
   out <- self$apply_instat_calculation(combined_calc_sum)
   if(return_output) {
     dat <- out$data
+    # relocate so that the value_factors are first still for consistency
+    out$data <- (out$data %>% dplyr::select(c(tidyselect::all_of(value_factors), tidyselect::all_of(manip_factors)), tidyselect::everything()))
     if(percentage_type == "none" || perc_return_all) return(out$data)
     else {
       #This is a temp fix to only returning final percentage columns.


### PR DESCRIPTION
Fixes bug in calculate_summary so that all the returned columns are in a consistent order regardless of if a percentage manipulation is performed or not.

@Ivanluv this should fix the issue you found.

Before, the order of columns would move if a percentage was available. This was inconsistent and creating a small issue in the `summary_calculations` R code.

```
# E.g., before, the following would give the column order as "variety" then "village"
# [1]
data_book$summary_table(data_name="survey",
                        summaries=c("summary_count"),
                        factors=c("variety", "village"))

# but this would give  "village" then "variety"
# [2]
data_book$summary_table(data_name="survey",
                        percentage_type="factors",
                        perc_total_factors="village",
                        summaries=c("summary_count"),
                        factors=c("variety", "village"))

# but now the code from [2] gives the order as "variety" then "village"
```

@Ivanluv this is ready. Should we merge straight into your branch, or should we merge it into the main first? (If your branch is not ready to merge, I suggest we do the latter in case of any other changes)