### PR TITLE
Ensured that date-type variables return `NA` if `sum` is performed in a calculation

### DIFF
--- a/instat/static/InstatObject/R/Backend_Components/calculations.R
+++ b/instat/static/InstatObject/R/Backend_Components/calculations.R
@@ -499,7 +499,7 @@ DataBook$set("public", "apply_instat_calculation", function(calc, curr_data_list
           curr_data_list[[c_data_label]] <- curr_data_list[[c_data_label]] %>%
             dplyr::summarise_(.dots = setNames(list(NA), calc$result_name))
         }
-      } else if (any(stringr::str_detect("Date", col_data_type))){
+      } else if (any(stringr::str_detect("Date | POSIXct | POSIXt", col_data_type))){
         # put in here the ones that DO NOT work for date
         if (any(grepl("summary_sum", formula_fn_exp))){
           curr_data_list[[c_data_label]] <- curr_data_list[[c_data_label]] %>%


### PR DESCRIPTION
As @rdstern pointed out in #7465:

> I then tried with data-time variables. I used the mydata file from openair in the library. When you ask for sum there, (default with customised) it gives: ![image](https://user-images.githubusercontent.com/11226469/177487588-3229fd68-f41a-4d0b-8193-44d7cbacb617.png)

This PR fixes this problem.

@rdstern @africanmathsinitiative/developers this is ready to review