### PR TITLE
Ensured that R script with unclosed brackets treated as incomplete R statement

### DIFF
--- a/instat/clsRLink.vb
+++ b/instat/clsRLink.vb
@@ -359,13 +359,18 @@ Public Class RLink
             '    then assume command is not complete
             Dim cLastChar As Char = strTrimmedLine.Last
             Dim strLast3Chars As String = ""
+            Dim iNumOpenRound As Integer = strScriptCmd.Where(Function(c) c = "("c).Count
+            Dim iNumClosedRound As Integer = strScriptCmd.Where(Function(c) c = ")"c).Count
             Dim iNumOpenCurlies As Integer = strScriptCmd.Where(Function(c) c = "{"c).Count
             Dim iNumClosedCurlies As Integer = strScriptCmd.Where(Function(c) c = "}"c).Count
             Dim iNumDoubleQuotes As Integer = strScriptCmd.Where(Function(c) c = """"c).Count
             If strTrimmedLine.Length >= 3 Then
                 strLast3Chars = strTrimmedLine.Substring(strTrimmedLine.Length - 3)
             End If
-            If cLastChar = "+" OrElse cLastChar = "," OrElse strLast3Chars = "%>%" OrElse iNumOpenCurlies <> iNumClosedCurlies OrElse iNumDoubleQuotes Mod 2 Then
+            If cLastChar = "+" OrElse cLastChar = "," OrElse strLast3Chars = "%>%" _
+                    OrElse iNumOpenRound <> iNumClosedRound _
+                    OrElse iNumOpenCurlies <> iNumClosedCurlies _
+                    OrElse iNumDoubleQuotes Mod 2 Then
                 Continue For
             End If
 


### PR DESCRIPTION
Fixes #7609 

In the script window, R statements can be split across multiple lines for readability. When R-Instat parses the script, it parses line by line, and only executes the text when it judges that the R statement is complete.
It uses a set of heuristics to judge if the statement is complete (e.g. unclosed quotes, line ends in ',' etc.). This PR adds a check to ensure there that all open brackets have been closed. See issue #7609 for an example.

Note: The set of heuristics is quite simple but should cover most real-world examples. The RScript library parsing is much more sophisticated. However, it doesn't currently have a public function to check if the R script represents an incomplete R statement.
I suggest to stay with the simpler heuristics for now. If we find that we continue to expand the heuristics, then we should consider updating RScript and using this library instead (see issue #6744).