### PR TITLE
Ensured that Y-axis settings are persistent when closing/re-opening PICSA Rainfall dialog

### DIFF
--- a/instat/dlgPICSARainfall.vb
+++ b/instat/dlgPICSARainfall.vb
@@ -80,6 +80,8 @@ Public Class dlgPICSARainfall
     Private strLowerTercileName As String = ".lower_ter_y"
     Private strUpperTercileName As String = ".upper_ter_y"
 
+    Private clsDummyFunction As New RFunction
+
     Private clsAsDateYLimit As New RFunction
     Private clsGeomHlineMean As New RFunction
     Private clsGeomHlineMedian As New RFunction
@@ -220,6 +222,7 @@ Public Class dlgPICSARainfall
         clsBaseOperator = New ROperator
         clsGroupByFunction = New RFunction
         clsMutateFunction = New RFunction
+        clsDummyFunction = New RFunction
 
         clsRggplotFunction = New RFunction
         clsGeomLine = New RFunction
@@ -291,6 +294,9 @@ Public Class dlgPICSARainfall
         clsScaleFillViridisFunction = GgplotDefaults.clsScaleFillViridisFunction
         clsScaleColourViridisFunction = GgplotDefaults.clsScaleColorViridisFunction
         clsAnnotateFunction = GgplotDefaults.clsAnnotateFunction
+
+        clsDummyFunction.AddParameter("upper_limit", "FALSE", iPosition:=0)
+        clsDummyFunction.AddParameter("lower_limit", "FALSE", iPosition:=1)
 
         clsYScalecontinuousFunction.AddParameter("limits", clsRFunctionParameter:=clsCLimitsYContinuous, iPosition:=3)
         clsCLimitsYContinuous.SetRCommand("c")
@@ -796,7 +802,7 @@ Public Class dlgPICSARainfall
     'add more functions 
     Private Sub cmdPICSAOptions_Click(sender As Object, e As EventArgs) Handles cmdPICSAOptions.Click
         sdgPICSARainfallGraph.SetRCode(clsNewOperator:=ucrBase.clsRsyntax.clsBaseOperator, clsNewPipeOperator:=clsPipeOperator, clsNewStatRegEquation:=clsStatRegEquationFunction, clsNewStatsCorFunction:=clsStatsCorFunction,
-                                       dctNewThemeFunctions:=dctThemeFunctions, clsNewLabsFunction:=clsLabsFunction, clsNewThemeFunction:=clsThemeFunction,
+                                       dctNewThemeFunctions:=dctThemeFunctions, clsNewLabsFunction:=clsLabsFunction, clsNewThemeFunction:=clsThemeFunction, clsNewDummyFunction:=clsDummyFunction,
                                        clsNewXScaleContinuousFunction:=clsXScalecontinuousFunction, clsNewYScaleContinuousFunction:=clsYScalecontinuousFunction,
                                        clsNewGeomhlineMean:=clsGeomHlineMean, clsNewGeomhlineMedian:=clsGeomHlineMedian, clsNewGeomhlineLowerTercile:=clsGeomHlineLowerTercile,
                                        clsNewGeomhlineUpperTercile:=clsGeomHlineUpperTercile, clsNewXLabsFunction:=clsXLabsFunction, clsNewYLabsFunction:=clsYLabsFunction,

--- a/instat/dlgPICSARainfall.vb
+++ b/instat/dlgPICSARainfall.vb
@@ -882,7 +882,6 @@ Public Class dlgPICSARainfall
     Private Sub YAxisDataTypeCheck()
         If Not ucrVariablesAsFactorForPicsa.IsEmpty Then
             clsGeomLine.AddParameter("group", 0)
-            'clsBaseOperator.RemoveParameterByName("scale_y_continuous")
         Else
             clsGeomLine.RemoveParameterByName("group")
         End If

--- a/instat/dlgPICSARainfall.vb
+++ b/instat/dlgPICSARainfall.vb
@@ -882,7 +882,7 @@ Public Class dlgPICSARainfall
     Private Sub YAxisDataTypeCheck()
         If Not ucrVariablesAsFactorForPicsa.IsEmpty Then
             clsGeomLine.AddParameter("group", 0)
-            clsBaseOperator.RemoveParameterByName("scale_y_continuous")
+            'clsBaseOperator.RemoveParameterByName("scale_y_continuous")
         Else
             clsGeomLine.RemoveParameterByName("group")
         End If

--- a/instat/sdgPICSARainfallGraph.vb
+++ b/instat/sdgPICSARainfallGraph.vb
@@ -53,6 +53,7 @@ Public Class sdgPICSARainfallGraph
     Private clsYElementTitle As New RFunction
     Private clsXElementLabels As New RFunction
     Private clsYElementLabels As New RFunction
+    Private clsDummyFunction As New RFunction
     Private clsElementPanelGridMajor, clsElementPanelGridMinor As New RFunction
     'Private clsPnlBackgroundElementRect As New RFunction
     Private clsPanelBackgroundElementRect As New RFunction
@@ -225,8 +226,8 @@ Public Class sdgPICSARainfallGraph
         ucrPnlYAxisType.AddToLinkedControls(ucrInputYSpecifyUpperLimitDateMonth, {rdoYDate}, bNewLinkedHideIfParameterMissing:=True)
 
         ucrChkYSpecifyLowerLimit.SetText("Specify Lower Limit")
-        ucrChkYSpecifyLowerLimit.AddParameterValuesCondition(True, "lowerlimit", "NA", False)
-        ucrChkYSpecifyLowerLimit.AddParameterValuesCondition(False, "lowerlimit", "NA", True)
+        ucrChkYSpecifyLowerLimit.SetParameter(New RParameter("lower_limit", iNewPosition:=0))
+        ucrChkYSpecifyLowerLimit.SetValuesCheckedAndUnchecked("TRUE", "FALSE")
         ucrChkYSpecifyLowerLimit.AddToLinkedControls(ucrInputYSpecifyLowerLimitNumeric, {True}, bNewLinkedHideIfParameterMissing:=True)
 
         ucrInputYSpecifyLowerLimitNumeric.SetParameter(New RParameter("lowerlimit", 0))
@@ -235,8 +236,8 @@ Public Class sdgPICSARainfallGraph
         ucrInputYSpecifyLowerLimitNumeric.AddQuotesIfUnrecognised = False
 
         ucrChkYSpecifyUpperLimit.SetText("Specify Upper Limit")
-        ucrChkYSpecifyUpperLimit.AddParameterValuesCondition(True, "upperlimit", "NA", False)
-        ucrChkYSpecifyUpperLimit.AddParameterValuesCondition(False, "upperlimit", "NA", True)
+        ucrChkYSpecifyUpperLimit.SetParameter(New RParameter("upper_limit", iNewPosition:=1))
+        ucrChkYSpecifyUpperLimit.SetValuesCheckedAndUnchecked("TRUE", "FALSE")
         ucrChkYSpecifyUpperLimit.AddToLinkedControls(ucrInputYSpecifyUpperLimitNumeric, {True}, bNewLinkedHideIfParameterMissing:=True)
 
         ucrInputYSpecifyUpperLimitNumeric.SetParameter(New RParameter("upperlimit", 1))
@@ -662,7 +663,8 @@ Public Class sdgPICSARainfallGraph
                         Optional clsNewLowerTercileFunction As RFunction = Nothing, Optional clsNewStatRegEquation As RFunction = Nothing, Optional clsNewStatsCorFunction As RFunction = Nothing,
                         Optional clsNewUpperTercileFunction As RFunction = Nothing, Optional clsNewAsDateMeanY As RFunction = Nothing, Optional clsNewAsDateMedianY As RFunction = Nothing,
                         Optional clsNewAsDateLowerTercileY As RFunction = Nothing, Optional clsNewAsDateUpperTercileY As RFunction = Nothing, Optional clsNewFormatMeanY As RFunction = Nothing,
-                        Optional clsNewFormatMedianY As RFunction = Nothing, Optional clsNewFormatLowerTercileY As RFunction = Nothing, Optional clsNewFormatUpperTercileY As RFunction = Nothing, Optional bReset As Boolean = False)
+                        Optional clsNewFormatMedianY As RFunction = Nothing, Optional clsNewFormatLowerTercileY As RFunction = Nothing,
+                        Optional clsNewFormatUpperTercileY As RFunction = Nothing, Optional clsNewDummyFunction As RFunction = Nothing, Optional bReset As Boolean = False)
         Dim clsCLimitsY As RFunction
 
         bRCodeSet = False
@@ -674,6 +676,8 @@ Public Class sdgPICSARainfallGraph
 
         'themes function
         clsThemeFunction = clsNewThemeFunction
+
+        clsDummyFunction = clsNewDummyFunction
 
         clsMutateFunction = clsNewMutateFunction
         clsMeanFunction = clsNewMeanFunction
@@ -849,9 +853,9 @@ Public Class sdgPICSARainfallGraph
         Else
             clsCLimitsY = clsCLimitsYContinuous
         End If
-        ucrChkYSpecifyLowerLimit.SetRCode(clsCLimitsY, bReset, bCloneIfNeeded:=True)
+        ucrChkYSpecifyLowerLimit.SetRCode(clsDummyFunction, bReset, bCloneIfNeeded:=True)
         ucrInputYSpecifyLowerLimitNumeric.SetRCode(clsCLimitsYContinuous, bReset, bCloneIfNeeded:=True)
-        ucrChkYSpecifyUpperLimit.SetRCode(clsCLimitsY, bReset, bCloneIfNeeded:=True)
+        ucrChkYSpecifyUpperLimit.SetRCode(clsDummyFunction, bReset, bCloneIfNeeded:=True)
         ucrInputYSpecifyUpperLimitNumeric.SetRCode(clsCLimitsYContinuous, bReset, bCloneIfNeeded:=True)
 
         ucrChkSpecifyXAxisTickMarks.SetRCode(clsXScaleContinuousFunction, bReset, bCloneIfNeeded:=True)

--- a/instat/sdgPICSARainfallGraph.vb
+++ b/instat/sdgPICSARainfallGraph.vb
@@ -425,7 +425,6 @@ Public Class sdgPICSARainfallGraph
         ucrChkBorderLineType.AddToLinkedControls(ucrInputBorderLinetype, {True}, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:="Solid")
         UcrChkBorderSize.AddToLinkedControls(ucrNudBorderSize, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
 
-
         ' Line tab
         ' Mean Line
         ucrChkAddMean.SetText("Add Mean Line")


### PR DESCRIPTION
Fixes #7607 
@rdstern @N-thony @lloyddewit  this PR fixes the issue when you set Y-axis  at any point  then it doesn't unset itself when dialogue is used repeatedly