### PR TITLE
Removed signmedian.test R package

### DIFF
--- a/instat/static/InstatObject/R/install_packages.R
+++ b/instat/static/InstatObject/R/install_packages.R
@@ -47,7 +47,6 @@ pkgs <-
     "RMySQL",
     "DBI",
     "EnvStats",
-    "signmedian.test",
     "sjPlot",
     "sjmisc",
     "plotly",


### PR DESCRIPTION
fixes #7626

- Removed signmedian.test R package because it has been [removed ](https://cran.r-project.org/web/packages/signmedian.test/index.html)from CRAN and we do not use it anywhere.