### PR TITLE
Made PICSA Graphs sub-dialogs' titles consistent with PICSA Graphs dialogs

### DIFF
--- a/instat/sdgPICSARainfallGraph.vb
+++ b/instat/sdgPICSARainfallGraph.vb
@@ -1384,10 +1384,13 @@ Public Class sdgPICSARainfallGraph
 
         Select Case dlgPICSARainfall.enumPICSAMode
             Case dlgPICSARainfall.PICSAMode.Temperature
+                Me.Text = "PICSA Temperature Graphs"
                 tbPICSA.TabPages.Add(tbPageSlope)
             Case dlgPICSARainfall.PICSAMode.Rainfall
+                Me.Text = "PICSA Rainfall Graphs"
                 tbPICSA.TabPages.Add(tbPageLines)
             Case dlgPICSARainfall.PICSAMode.General
+                Me.Text = "PICSA General Graphs"
                 tbPICSA.TabPages.Add(tbPageLines)
                 tbPICSA.TabPages.Add(tbPageSlope)
         End Select


### PR DESCRIPTION
Fixes (partially) #7668 
@N-thony @rdstern @lloyddewit this PR makes PICSA graphs sub-dialog titles be consistent with the PICSA graphs dialogs
@lloyddewit, please could change the id_text in the database for `sdgPICSARainfallGraph` to `ReplaceWithDynamicTranslation` before they test it . It's causing merge conflicts from my end if I do it.