### PR TITLE
Removed build warnings

### DIFF
--- a/instat/frmOutputWindow.vb
+++ b/instat/frmOutputWindow.vb
@@ -80,8 +80,8 @@ Public Class frmOutputWindow
 
     Private Sub CopyImageRTB_Click(sender As Object, e As EventArgs) Handles CopyImageRTB.Click
         'Copies the first selected image into the clipboard.
-        Dim prphTemp As System.Windows.Documents.Paragraph
-        Dim conImage As System.Windows.Documents.InlineUIContainer
+        'Dim prphTemp As System.Windows.Documents.Paragraph
+        'Dim conImage As System.Windows.Documents.InlineUIContainer
         'For Each block As System.Windows.Documents.Block In ucrRichTextBox.rtbOutput.Document.Blocks
         'If TypeOf (block) Is System.Windows.Documents.Paragraph Then
         'prphTemp = block

--- a/instat/ucrSelectorByDataFrameAddRemove.Designer.vb
+++ b/instat/ucrSelectorByDataFrameAddRemove.Designer.vb
@@ -44,7 +44,7 @@ Partial Class ucrSelectorByDataFrameAddRemove
         Me.contextMenuStripAdd = New System.Windows.Forms.ContextMenuStrip(Me.components)
         Me.toolStripAddSelected = New System.Windows.Forms.ToolStripMenuItem()
         Me.toolStripAddAll = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ToolStripSeparator1 = New System.Windows.Forms.ToolStripSeparator()
+        Me.ToolStripSeparatorContext = New System.Windows.Forms.ToolStripSeparator()
         Me.toolStripHelp = New System.Windows.Forms.ToolStripMenuItem()
         Me.contextMenuStripAdd.SuspendLayout()
         Me.SuspendLayout()
@@ -82,7 +82,7 @@ Partial Class ucrSelectorByDataFrameAddRemove
         '
         'contextMenuStripAdd
         '
-        Me.contextMenuStripAdd.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.toolStripAddSelected, Me.toolStripAddAll, Me.ToolStripSeparator1, Me.toolStripHelp})
+        Me.contextMenuStripAdd.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.toolStripAddSelected, Me.toolStripAddAll, Me.ToolStripSeparatorContext, Me.toolStripHelp})
         Me.contextMenuStripAdd.Name = "SelectionMenuStrip"
         Me.contextMenuStripAdd.Size = New System.Drawing.Size(181, 98)
         '
@@ -99,10 +99,10 @@ Partial Class ucrSelectorByDataFrameAddRemove
         Me.toolStripAddAll.Size = New System.Drawing.Size(180, 22)
         Me.toolStripAddAll.Text = "Add All"
         '
-        'ToolStripSeparator1
+        'ToolStripSeparatorContext
         '
-        Me.ToolStripSeparator1.Name = "ToolStripSeparator1"
-        Me.ToolStripSeparator1.Size = New System.Drawing.Size(177, 6)
+        Me.ToolStripSeparatorContext.Name = "ToolStripSeparatorContext"
+        Me.ToolStripSeparatorContext.Size = New System.Drawing.Size(177, 6)
         '
         'toolStripHelp
         '
@@ -132,6 +132,6 @@ Partial Class ucrSelectorByDataFrameAddRemove
     Friend WithEvents contextMenuStripAdd As ContextMenuStrip
     Friend WithEvents toolStripAddSelected As ToolStripMenuItem
     Friend WithEvents toolStripAddAll As ToolStripMenuItem
-    Friend WithEvents ToolStripSeparator1 As ToolStripSeparator
+    Friend WithEvents ToolStripSeparatorContext As ToolStripSeparator
     Friend WithEvents toolStripHelp As ToolStripMenuItem
 End Class


### PR DESCRIPTION
R-Instat displayed the following build warnings:
```
Rebuild started...
1>------ Rebuild All started: Project: instat, Configuration: Debug Any CPU ------
1>C:\Users\steph\source\repos\lloyddewit\R-Instat\instat\ucrSelectorByDataFrameAddRemove.Designer.vb(135,23): warning BC40004: WithEvents variable 'ToolStripSeparator1' conflicts with WithEvents variable 'ToolStripSeparator1' in the base class 'ucrSelector' and should be declared 'Shadows'.
1>C:\Users\steph\source\repos\lloyddewit\R-Instat\instat\frmOutputWindow.vb(83,13): warning BC42024: Unused local variable: 'prphTemp'.
1>C:\Users\steph\source\repos\lloyddewit\R-Instat\instat\frmOutputWindow.vb(84,13): warning BC42024: Unused local variable: 'conImage'.
1>  instat -> C:\Users\steph\source\repos\lloyddewit\R-Instat\instat\bin\Debug\instat.exe
========== Rebuild All: 1 succeeded, 0 failed, 0 skipped ==========
```
This PR removes these build warnings.

@N-thony 
The only significant change is to `ucrSelectorByDataFrameAddRemove`. 

![image](https://user-images.githubusercontent.com/57253949/184530755-eec6b3d8-d1fb-4990-bbdf-3565812ee42c.png)

I renamed the separator on the pull down menu.

![image](https://user-images.githubusercontent.com/57253949/184530770-9352a9eb-6726-49f0-94ad-d67a0a6e7b55.png)

Please could you review and approve?
Thanks!