### PR TITLE
Added more distributions to General Fit Model dialog

### DIFF
--- a/instat/clsRegressionDefaults.vb
+++ b/instat/clsRegressionDefaults.vb
@@ -28,11 +28,11 @@ Public Class clsRegressionDefaults
     Public Shared ReadOnly Property clsDefaultGLmNBFunction As RFunction
         Get
 
-            Dim clsRModelFunction As New RFunction
+            Dim clsNegativeBinomialFunction As New RFunction
 
-            clsRModelFunction.SetRCommand("glm.nb")
-            clsRModelFunction.SetPackageName("MASS")
-            Return clsRModelFunction
+            clsNegativeBinomialFunction.SetRCommand("glm.nb")
+            clsNegativeBinomialFunction.SetPackageName("MASS")
+            Return clsNegativeBinomialFunction
         End Get
     End Property
 
@@ -44,6 +44,17 @@ Public Class clsRegressionDefaults
             clsRModelFunction.SetRCommand("polr")
             clsRModelFunction.SetPackageName("MASS")
             Return clsRModelFunction
+        End Get
+    End Property
+
+    Public Shared ReadOnly Property clsDefaultGLmMultinomFunction As RFunction
+        Get
+
+            Dim clsMultinomFunction As New RFunction
+
+            clsMultinomFunction.SetRCommand("multinom")
+            clsMultinomFunction.SetPackageName("nnet")
+            Return clsMultinomFunction
         End Get
     End Property
     Public Shared ReadOnly Property clsDefaultGlmFunction As RFunction
@@ -112,6 +123,14 @@ Public Class clsRegressionDefaults
         End Get
     End Property
 
+    Public Shared ReadOnly Property clsDefaultAnovaIIFunction As RFunction
+        Get
+            Dim clsDefaultRaovFunction As New RFunction
+            clsDefaultRaovFunction.SetPackageName("car")
+            clsDefaultRaovFunction.SetRCommand("Anova")
+            Return clsDefaultRaovFunction
+        End Get
+    End Property
     Public Shared ReadOnly Property clsDefaultFormulaFunction As RFunction
         Get
             Dim clsDefaultRModelsFunction As New RFunction

--- a/instat/clsRegressionDefaults.vb
+++ b/instat/clsRegressionDefaults.vb
@@ -35,6 +35,17 @@ Public Class clsRegressionDefaults
             Return clsRModelFunction
         End Get
     End Property
+
+    Public Shared ReadOnly Property clsDefaultGLmPolrFunction As RFunction
+        Get
+
+            Dim clsRModelFunction As New RFunction
+
+            clsRModelFunction.SetRCommand("polr")
+            clsRModelFunction.SetPackageName("MASS")
+            Return clsRModelFunction
+        End Get
+    End Property
     Public Shared ReadOnly Property clsDefaultGlmFunction As RFunction
         Get
 

--- a/instat/clsRegressionDefaults.vb
+++ b/instat/clsRegressionDefaults.vb
@@ -131,6 +131,7 @@ Public Class clsRegressionDefaults
             Return clsDefaultRaovFunction
         End Get
     End Property
+
     Public Shared ReadOnly Property clsDefaultFormulaFunction As RFunction
         Get
             Dim clsDefaultRModelsFunction As New RFunction

--- a/instat/clsRegressionDefaults.vb
+++ b/instat/clsRegressionDefaults.vb
@@ -25,6 +25,16 @@ Public Class clsRegressionDefaults
         End Get
     End Property
 
+    Public Shared ReadOnly Property clsDefaultGLmNBFunction As RFunction
+        Get
+
+            Dim clsRModelFunction As New RFunction
+
+            clsRModelFunction.SetRCommand("glm.nb")
+            clsRModelFunction.SetPackageName("MASS")
+            Return clsRModelFunction
+        End Get
+    End Property
     Public Shared ReadOnly Property clsDefaultGlmFunction As RFunction
         Get
 

--- a/instat/dlgFitModel.vb
+++ b/instat/dlgFitModel.vb
@@ -27,7 +27,7 @@ Public Class dlgFitModel
 
     Public clsRestpvalFunction, clsFamilyFunction, clsRCIFunction, clsRConvert, clsAutoPlot, clsVisReg As New RFunction
     Public bResetModelOptions As Boolean = False
-    Public clsRSingleModelFunction, clsFormulaFunction, clsAnovaFunction, clsAnovaIIFunction, clsSummaryFunction, clsConfint As New RFunction
+    Public clsRSingleModelFunction, clsFormulaFunction, clsAnovaFunction, clsSummaryFunction, clsConfint As New RFunction
     Public clsGLM, clsLM, clsLMOrGLM, clsGLMNB, clsGLMPolr, clsGLMMultinom, clsAsNumeric As New RFunction
 
     'Saving Operators/Functions
@@ -101,7 +101,6 @@ Public Class dlgFitModel
         clsGLMMultinom = New RFunction
         clsConfint = New RFunction
         clsAnovaFunction = New RFunction
-        clsAnovaIIFunction = New RFunction
         clsVisReg = New RFunction
         clsFamilyFunction = New RFunction
 
@@ -165,10 +164,6 @@ Public Class dlgFitModel
         clsAnovaFunction = clsRegressionDefaults.clsDefaultAnovaFunction.Clone
         clsAnovaFunction.iCallType = 2
 
-        'ANOVAII
-        clsAnovaIIFunction = clsRegressionDefaults.clsDefaultAnovaIIFunction.Clone
-        clsAnovaIIFunction.iCallType = 2
-
         'FitModel
         clsVisReg.SetPackageName("visreg")
         clsVisReg.SetRCommand("visreg")
@@ -195,8 +190,7 @@ Public Class dlgFitModel
 
         ucrBase.clsRsyntax.ClearCodes()
         ucrBase.clsRsyntax.SetBaseRFunction(clsLM)
-        'ucrBase.clsRsyntax.AddToAfterCodes(clsAnovaFunction, 1)
-        'ucrBase.clsRsyntax.AddToAfterCodes(clsAnovaIIFunction, 1)
+        ucrBase.clsRsyntax.AddToAfterCodes(clsAnovaFunction, 1)
         ucrBase.clsRsyntax.AddToAfterCodes(clsSummaryFunction, 2)
 
         clsLMOrGLM = clsLM
@@ -366,8 +360,12 @@ Public Class dlgFitModel
                     ucrFamily.RecieverDatatype("numeric")
                 Else
                     clsFormulaOperator.AddParameter("x", strParameterValue:=ucrReceiverResponseVar.GetVariableNames(bWithQuotes:=False), iPosition:=0)
-                    'ucrFamily.RecieverDatatype(ucrSelectorByDataFrameAddRemoveForFitModel.ucrAvailableDataFrames.cboAvailableDataFrames.Text, ucrReceiverResponseVar.GetVariableNames(bWithQuotes:=False))
-                    ucrFamily.RecieverDatatype(ucrReceiverResponseVar.strCurrDataType)
+
+                    If strVariableType = "binary" Then
+                        ucrFamily.RecieverDatatype(ucrSelectorByDataFrameAddRemoveForFitModel.ucrAvailableDataFrames.cboAvailableDataFrames.Text, ucrReceiverResponseVar.GetVariableNames(bWithQuotes:=False))
+                    Else
+                        ucrFamily.RecieverDatatype(ucrReceiverResponseVar.strCurrDataType)
+                    End If
                 End If
                 sdgModelOptions.ucrDistributionChoice.RecieverDatatype(ucrFamily.strDataType)
             Else
@@ -419,7 +417,6 @@ Public Class dlgFitModel
             'Update display functions to contain correct model
             clsFormulaFunction.AddParameter("x", clsRFunctionParameter:=clsLMOrGLM)
             clsAnovaFunction.AddParameter("object", clsRFunctionParameter:=clsLMOrGLM, iPosition:=0)
-            clsAnovaIIFunction.AddParameter("mod", clsRFunctionParameter:=clsLMOrGLM, iPosition:=0)
             clsSummaryFunction.AddParameter("object", clsRFunctionParameter:=clsLMOrGLM, iPosition:=0)
             clsConfint.AddParameter("object", clsRFunctionParameter:=clsLMOrGLM, iPosition:=0)
             clsVisReg.AddParameter("fit", clsRFunctionParameter:=clsLMOrGLM, iPosition:=0)
@@ -438,7 +435,6 @@ Public Class dlgFitModel
 
     Public Sub ucrFamily_cboDistributionsIndexChanged() Handles ucrFamily.DistributionsIndexChanged
         ChooseRFunction()
-        ChooseAnovaFunction()
         ResponseVariableType()
         clsFamilyFunction.RemoveParameterByName("link")
     End Sub
@@ -450,27 +446,14 @@ Public Class dlgFitModel
     Private Sub ucrReceiverExpressionFitModel_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverExpressionFitModel.ControlValueChanged
         ChooseRFunction()
         ResponseConvert()
-        ChooseAnovaFunction()
     End Sub
 
     Private Sub ucrReceiverResponseVar_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverResponseVar.ControlValueChanged
         ChooseRFunction()
         ResponseConvert()
         ResponseVariableType()
-        ChooseAnovaFunction()
     End Sub
-    Public Sub ChooseAnovaFunction()
-        If bRCodeSet Then
-            If ucrReceiverResponseVar.strCurrDataType = ("factor") Then
-                ' ucrBase.clsRsyntax.SetBaseRFunction(clsAnovaIIFunction)
-                ucrBase.clsRsyntax.AddToAfterCodes(clsAnovaIIFunction, 1)
 
-            Else
-                'ucrBase.clsRsyntax.SetBaseRFunction(clsAnovaFunction)
-                ucrBase.clsRsyntax.AddToAfterCodes(clsAnovaFunction, 1)
-            End If
-        End If
-    End Sub
     Private Sub ucrConvertToVariate_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrChkConvertToVariate.ControlValueChanged
         ResponseConvert()
         ResponseVariableType()
@@ -484,7 +467,6 @@ Public Class dlgFitModel
     Private Sub ucrSelectorByDataFrameAddRemoveForFitModel_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrSelectorByDataFrameAddRemoveForFitModel.ControlValueChanged
         ChooseRFunction()
         GraphAssignTo()
-        ChooseAnovaFunction()
     End Sub
 
     Public Sub ResponseVariableType()

--- a/instat/dlgFitModel.vb
+++ b/instat/dlgFitModel.vb
@@ -353,7 +353,8 @@ Public Class dlgFitModel
                     ucrFamily.RecieverDatatype("numeric")
                 Else
                     clsFormulaOperator.AddParameter("x", strParameterValue:=ucrReceiverResponseVar.GetVariableNames(bWithQuotes:=False), iPosition:=0)
-                    ucrFamily.RecieverDatatype(ucrSelectorByDataFrameAddRemoveForFitModel.ucrAvailableDataFrames.cboAvailableDataFrames.Text, ucrReceiverResponseVar.GetVariableNames(bWithQuotes:=False))
+                    'ucrFamily.RecieverDatatype(ucrSelectorByDataFrameAddRemoveForFitModel.ucrAvailableDataFrames.cboAvailableDataFrames.Text, ucrReceiverResponseVar.GetVariableNames(bWithQuotes:=False))
+                    ucrFamily.RecieverDatatype(ucrReceiverResponseVar.strCurrDataType)
                 End If
                 sdgModelOptions.ucrDistributionChoice.RecieverDatatype(ucrFamily.strDataType)
             Else
@@ -459,12 +460,14 @@ Public Class dlgFitModel
                 ElseIf strVariableType.Contains("integer") Then
                     strVariableType = "integer"
                 ElseIf strVariableType.Contains("two level numeric") OrElse strVariableType.Contains("two level factor") Then
-                        strVariableType = "binary"
+                    strVariableType = "binary"
                 ElseIf strVariableType.Contains("numeric") Then
                     strVariableType = "numeric"
                 ElseIf strVariableType.Contains("logical") Then
                     strVariableType = "logical"
                 ElseIf strVariableType.Contains("factor") Then
+                    strVariableType = "factor"
+                ElseIf strVariableType.Contains("ordered,factor") Then
                     strVariableType = "factor"
                 Else
                     strVariableType = "unsuitable type"

--- a/instat/dlgFitModel.vb
+++ b/instat/dlgFitModel.vb
@@ -27,7 +27,7 @@ Public Class dlgFitModel
 
     Public clsRestpvalFunction, clsFamilyFunction, clsRCIFunction, clsRConvert, clsAutoPlot, clsVisReg As New RFunction
     Public bResetModelOptions As Boolean = False
-    Public clsRSingleModelFunction, clsFormulaFunction, clsAnovaFunction, clsSummaryFunction, clsConfint As New RFunction
+    Public clsRSingleModelFunction, clsFormulaFunction, clsAnovaFunction, clsAnovaIIFunction, clsSummaryFunction, clsConfint As New RFunction
     Public clsGLM, clsLM, clsLMOrGLM, clsGLMNB, clsGLMPolr, clsGLMMultinom, clsAsNumeric As New RFunction
 
     'Saving Operators/Functions
@@ -101,6 +101,7 @@ Public Class dlgFitModel
         clsGLMMultinom = New RFunction
         clsConfint = New RFunction
         clsAnovaFunction = New RFunction
+        clsAnovaIIFunction = New RFunction
         clsVisReg = New RFunction
         clsFamilyFunction = New RFunction
 
@@ -164,6 +165,9 @@ Public Class dlgFitModel
         clsAnovaFunction = clsRegressionDefaults.clsDefaultAnovaFunction.Clone
         clsAnovaFunction.iCallType = 2
 
+        'ANOVAII
+        clsAnovaIIFunction = clsRegressionDefaults.clsDefaultAnovaIIFunction.Clone
+        clsAnovaIIFunction.iCallType = 2
 
         'FitModel
         clsVisReg.SetPackageName("visreg")
@@ -191,7 +195,8 @@ Public Class dlgFitModel
 
         ucrBase.clsRsyntax.ClearCodes()
         ucrBase.clsRsyntax.SetBaseRFunction(clsLM)
-        ucrBase.clsRsyntax.AddToAfterCodes(clsAnovaFunction, 1)
+        'ucrBase.clsRsyntax.AddToAfterCodes(clsAnovaFunction, 1)
+        'ucrBase.clsRsyntax.AddToAfterCodes(clsAnovaIIFunction, 1)
         ucrBase.clsRsyntax.AddToAfterCodes(clsSummaryFunction, 2)
 
         clsLMOrGLM = clsLM
@@ -414,7 +419,7 @@ Public Class dlgFitModel
             'Update display functions to contain correct model
             clsFormulaFunction.AddParameter("x", clsRFunctionParameter:=clsLMOrGLM)
             clsAnovaFunction.AddParameter("object", clsRFunctionParameter:=clsLMOrGLM, iPosition:=0)
-            'clsAnovaIIFunction.AddParameter("mod", clsRFunctionParameter:=clsLMOrGLM, iPosition:=0)
+            clsAnovaIIFunction.AddParameter("mod", clsRFunctionParameter:=clsLMOrGLM, iPosition:=0)
             clsSummaryFunction.AddParameter("object", clsRFunctionParameter:=clsLMOrGLM, iPosition:=0)
             clsConfint.AddParameter("object", clsRFunctionParameter:=clsLMOrGLM, iPosition:=0)
             clsVisReg.AddParameter("fit", clsRFunctionParameter:=clsLMOrGLM, iPosition:=0)
@@ -433,6 +438,7 @@ Public Class dlgFitModel
 
     Public Sub ucrFamily_cboDistributionsIndexChanged() Handles ucrFamily.DistributionsIndexChanged
         ChooseRFunction()
+        ChooseAnovaFunction()
         ResponseVariableType()
         clsFamilyFunction.RemoveParameterByName("link")
     End Sub
@@ -444,14 +450,27 @@ Public Class dlgFitModel
     Private Sub ucrReceiverExpressionFitModel_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverExpressionFitModel.ControlValueChanged
         ChooseRFunction()
         ResponseConvert()
+        ChooseAnovaFunction()
     End Sub
 
     Private Sub ucrReceiverResponseVar_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverResponseVar.ControlValueChanged
         ChooseRFunction()
         ResponseConvert()
         ResponseVariableType()
+        ChooseAnovaFunction()
     End Sub
+    Public Sub ChooseAnovaFunction()
+        If bRCodeSet Then
+            If ucrReceiverResponseVar.strCurrDataType = ("factor") Then
+                ' ucrBase.clsRsyntax.SetBaseRFunction(clsAnovaIIFunction)
+                ucrBase.clsRsyntax.AddToAfterCodes(clsAnovaIIFunction, 1)
 
+            Else
+                'ucrBase.clsRsyntax.SetBaseRFunction(clsAnovaFunction)
+                ucrBase.clsRsyntax.AddToAfterCodes(clsAnovaFunction, 1)
+            End If
+        End If
+    End Sub
     Private Sub ucrConvertToVariate_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrChkConvertToVariate.ControlValueChanged
         ResponseConvert()
         ResponseVariableType()
@@ -465,6 +484,7 @@ Public Class dlgFitModel
     Private Sub ucrSelectorByDataFrameAddRemoveForFitModel_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrSelectorByDataFrameAddRemoveForFitModel.ControlValueChanged
         ChooseRFunction()
         GraphAssignTo()
+        ChooseAnovaFunction()
     End Sub
 
     Public Sub ResponseVariableType()

--- a/instat/dlgFitModel.vb
+++ b/instat/dlgFitModel.vb
@@ -383,6 +383,7 @@ Public Class dlgFitModel
             End If
             UpdatePreview()
             TestOKEnabled()
+            ChooseAnovaFunction()
         End If
     End Sub
 

--- a/instat/dlgFitModel.vb
+++ b/instat/dlgFitModel.vb
@@ -28,7 +28,7 @@ Public Class dlgFitModel
     Public clsRestpvalFunction, clsFamilyFunction, clsRCIFunction, clsRConvert, clsAutoPlot, clsVisReg As New RFunction
     Public bResetModelOptions As Boolean = False
     Public clsRSingleModelFunction, clsFormulaFunction, clsAnovaFunction, clsSummaryFunction, clsConfint As New RFunction
-    Public clsGLM, clsLM, clsLMOrGLM, clsGLMNB, clsAsNumeric As New RFunction
+    Public clsGLM, clsLM, clsLMOrGLM, clsGLMNB, clsGLMPolr, clsAsNumeric As New RFunction
 
     'Saving Operators/Functions
     Private clsRstandardFunction, clsHatvaluesFunction, clsResidualFunction, clsFittedValuesFunction As New RFunction
@@ -97,6 +97,7 @@ Public Class dlgFitModel
         clsLM = New RFunction
         clsGLM = New RFunction
         clsGLMNB = New RFunction
+        clsGLMPolr = New RFunction
         clsConfint = New RFunction
         clsAnovaFunction = New RFunction
         clsVisReg = New RFunction
@@ -138,6 +139,10 @@ Public Class dlgFitModel
         clsGLMNB = clsRegressionDefaults.clsDefaultGLmNBFunction.Clone
         clsGLMNB.AddParameter("formula", clsROperatorParameter:=clsFormulaOperator, iPosition:=1)
         clsGLMNB.SetAssignTo("last_model", strTempDataframe:=ucrSelectorByDataFrameAddRemoveForFitModel.ucrAvailableDataFrames.cboAvailableDataFrames.Text, strTempModel:="last_model", bAssignToIsPrefix:=True)
+
+        clsGLMPolr = clsRegressionDefaults.clsDefaultGLmPolrFunction.Clone
+        clsGLMPolr.AddParameter("formula", clsROperatorParameter:=clsFormulaOperator, iPosition:=1)
+        clsGLMPolr.SetAssignTo("last_model", strTempDataframe:=ucrSelectorByDataFrameAddRemoveForFitModel.ucrAvailableDataFrames.cboAvailableDataFrames.Text, strTempModel:="last_model", bAssignToIsPrefix:=True)
 
 
         'Residual Plots
@@ -200,10 +205,13 @@ Public Class dlgFitModel
 
     Private Sub SetRCodeForControls(bReset As Boolean)
         bRCodeSet = False
+        ucrModelName.AddAdditionalRCode(clsGLMPolr, bReset)
         ucrModelName.AddAdditionalRCode(clsGLMNB, bReset)
         ucrModelName.AddAdditionalRCode(clsGLM, bReset)
         ucrSelectorByDataFrameAddRemoveForFitModel.AddAdditionalCodeParameterPair(clsGLM, ucrSelectorByDataFrameAddRemoveForFitModel.GetParameter(), 1)
         ucrSelectorByDataFrameAddRemoveForFitModel.AddAdditionalCodeParameterPair(clsGLMNB, ucrSelectorByDataFrameAddRemoveForFitModel.GetParameter(), 2)
+        ucrSelectorByDataFrameAddRemoveForFitModel.AddAdditionalCodeParameterPair(clsGLMPolr, ucrSelectorByDataFrameAddRemoveForFitModel.GetParameter(), 3)
+
 
         ucrChkConvertToVariate.SetRCode(clsFormulaOperator, bReset)
         ucrReceiverResponseVar.SetRCode(clsRConvert, bReset)
@@ -339,7 +347,7 @@ Public Class dlgFitModel
                     ucrChkConvertToVariate.Visible = False
                 End If
 
-            If ucrChkConvertToVariate.Checked Then
+                If ucrChkConvertToVariate.Checked Then
                     ' clsRConvert.AddParameter("x", ucrReceiverResponseVar.GetVariableNames(bWithQuotes:=False))
                     clsFormulaOperator.AddParameter("x", clsRFunctionParameter:=clsRConvert, iPosition:=0)
                     ucrFamily.RecieverDatatype("numeric")
@@ -377,6 +385,12 @@ Public Class dlgFitModel
 
             If (ucrFamily.clsCurrDistribution.strNameTag = "glm.negative_binomial") AndAlso (Not clsFamilyFunction.ContainsParameter("link") OrElse clsFamilyFunction.GetParameter("link").strArgumentValue = Chr(34) & "identity" & Chr(34)) Then
                 clsLMOrGLM = clsGLMNB
+            Else
+                clsLMOrGLM = clsGLM
+            End If
+
+            If (ucrFamily.clsCurrDistribution.strNameTag = "Ordered_Logistic") AndAlso (Not clsFamilyFunction.ContainsParameter("link") OrElse clsFamilyFunction.GetParameter("link").strArgumentValue = Chr(34) & "identity" & Chr(34)) Then
+                clsLMOrGLM = clsGLMPolr
             Else
                 clsLMOrGLM = clsGLM
             End If

--- a/instat/ucrDistributions.vb
+++ b/instat/ucrDistributions.vb
@@ -177,6 +177,10 @@ Public Class ucrDistributions
                                 If Dist.bTwoLevelFactor Then
                                     bUse = True
                                 End If
+                            Case "factor"
+                                If Dist.bFactor Then
+                                    bUse = True
+                                End If
                         End Select
                     End If
                 Case Else
@@ -229,6 +233,7 @@ Public Class ucrDistributions
         Dim clsEmpiricalDist As New Distribution
         Dim clsTriangularDist As New Distribution
         Dim clsGlmNegativeBinomial As New Distribution
+        Dim clsPolarDist As New Distribution
 
         ' Normal distribution
         clsNormalDist.strNameTag = "Normal"
@@ -532,6 +537,15 @@ Public Class ucrDistributions
         clsGlmNegativeBinomial.bNumeric = True
         clsGlmNegativeBinomial.bIsExact = True
         lstAllDistributions.Add(clsGlmNegativeBinomial)
+
+        'ordered factor
+        clsPolarDist.strNameTag = "Ordered_Logistic"
+        clsPolarDist.strPackagName = "MASS"
+        clsPolarDist.strRName = "polr"
+        clsPolarDist.bFactor = True
+        clsPolarDist.bIsContinuous = False
+        clsPolarDist.strGLMFunctionName = "polr"
+        lstAllDistributions.Add(clsPolarDist)
 
         'Gamma with Zeros distribution
         clsGammaWithZerosDist.strNameTag = "Gamma_With_Zeros"

--- a/instat/ucrDistributions.vb
+++ b/instat/ucrDistributions.vb
@@ -181,6 +181,10 @@ Public Class ucrDistributions
                                 If Dist.bFactor Then
                                     bUse = True
                                 End If
+                            Case "ordered,factor"
+                                If Dist.bFactor Then
+                                    bUse = True
+                                End If
                         End Select
                     End If
                 Case Else

--- a/instat/ucrDistributions.vb
+++ b/instat/ucrDistributions.vb
@@ -535,10 +535,10 @@ Public Class ucrDistributions
         lstAllDistributions.Add(clsGamma)
 
         'Negative Binomial distribution
-        clsGlmNegativeBinomialDist.strNameTag = "glm.negative_binomial"
+        clsGlmNegativeBinomialDist.strNameTag = "Negative_Binomial_GLM"
         clsGlmNegativeBinomialDist.strRName = "glm.nb"
         clsGlmNegativeBinomialDist.strPackagName = "MASS"
-        clsGlmNegativeBinomialDist.strGLMFunctionName = "GLMNB"
+        clsGlmNegativeBinomialDist.strGLMFunctionName = "glm.nb"
         clsGlmNegativeBinomialDist.bNumeric = True
         'clsGlmNegativeBinomialDist.bIsExact = True
         lstAllDistributions.Add(clsGlmNegativeBinomialDist)

--- a/instat/ucrDistributions.vb
+++ b/instat/ucrDistributions.vb
@@ -228,6 +228,7 @@ Public Class ucrDistributions
         Dim clsNoDist As New Distribution
         Dim clsEmpiricalDist As New Distribution
         Dim clsTriangularDist As New Distribution
+        Dim clsGlmNegativeBinomial As New Distribution
 
         ' Normal distribution
         clsNormalDist.strNameTag = "Normal"
@@ -522,6 +523,15 @@ Public Class ucrDistributions
         clsGamma.bNumeric = True
         clsGamma.bIsContinuous = True
         lstAllDistributions.Add(clsGamma)
+
+        'Negative Binomial distribution
+        clsGlmNegativeBinomial.strNameTag = "glm.negative_binomial"
+        clsGlmNegativeBinomial.strRName = "glm.nb"
+        clsGlmNegativeBinomial.strPackagName = "MASS"
+        clsGlmNegativeBinomial.strGLMFunctionName = "glm.nb"
+        clsGlmNegativeBinomial.bNumeric = True
+        clsGlmNegativeBinomial.bIsExact = True
+        lstAllDistributions.Add(clsGlmNegativeBinomial)
 
         'Gamma with Zeros distribution
         clsGammaWithZerosDist.strNameTag = "Gamma_With_Zeros"

--- a/instat/ucrDistributions.vb
+++ b/instat/ucrDistributions.vb
@@ -236,8 +236,9 @@ Public Class ucrDistributions
         Dim clsNoDist As New Distribution
         Dim clsEmpiricalDist As New Distribution
         Dim clsTriangularDist As New Distribution
-        Dim clsGlmNegativeBinomial As New Distribution
+        Dim clsGlmNegativeBinomialDist As New Distribution
         Dim clsPolarDist As New Distribution
+        Dim clsMultinomDist As New Distribution
 
         ' Normal distribution
         clsNormalDist.strNameTag = "Normal"
@@ -534,13 +535,13 @@ Public Class ucrDistributions
         lstAllDistributions.Add(clsGamma)
 
         'Negative Binomial distribution
-        clsGlmNegativeBinomial.strNameTag = "glm.negative_binomial"
-        clsGlmNegativeBinomial.strRName = "glm.nb"
-        clsGlmNegativeBinomial.strPackagName = "MASS"
-        clsGlmNegativeBinomial.strGLMFunctionName = "glm.nb"
-        clsGlmNegativeBinomial.bNumeric = True
-        clsGlmNegativeBinomial.bIsExact = True
-        lstAllDistributions.Add(clsGlmNegativeBinomial)
+        clsGlmNegativeBinomialDist.strNameTag = "glm.negative_binomial"
+        clsGlmNegativeBinomialDist.strRName = "glm.nb"
+        clsGlmNegativeBinomialDist.strPackagName = "MASS"
+        clsGlmNegativeBinomialDist.strGLMFunctionName = "GLMNB"
+        clsGlmNegativeBinomialDist.bNumeric = True
+        'clsGlmNegativeBinomialDist.bIsExact = True
+        lstAllDistributions.Add(clsGlmNegativeBinomialDist)
 
         'ordered factor
         clsPolarDist.strNameTag = "Ordered_Logistic"
@@ -550,6 +551,14 @@ Public Class ucrDistributions
         clsPolarDist.bIsContinuous = False
         clsPolarDist.strGLMFunctionName = "polr"
         lstAllDistributions.Add(clsPolarDist)
+
+        'multinomial distribution
+        clsMultinomDist.strNameTag = "Multinomial"
+        clsMultinomDist.strPackagName = "nnet"
+        clsMultinomDist.strGLMFunctionName = "multinom"
+        clsMultinomDist.strRName = "multinom"
+        clsMultinomDist.bFactor = True
+        lstAllDistributions.Add(clsMultinomDist)
 
         'Gamma with Zeros distribution
         clsGammaWithZerosDist.strNameTag = "Gamma_With_Zeros"


### PR DESCRIPTION
Fixes #6345  

@rdstern @lilyclements @N-thony , we have added (@Tula1 and I) `glm.nb`, `polr`  distributions from `MASS` package and `multinom` from `nnet` package.
For the factor response variables, the dialog runs `car::Anova`  to the saved model (type-II analysis-of-variance tables for model objects)