### PR TITLE
Ensured that the 'Try' message in the Calculator, and some other diogs, is correctly translated (e.g. to/from French)

### DIFF
--- a/instat/translations/en/r_instat_not_menus.json
+++ b/instat/translations/en/r_instat_not_menus.json
@@ -3688,5 +3688,14 @@
   "Display As DataFrame": "Display As DataFrame",
   "Data Frame Name": "Data Frame Name",
   "Rename With": "Rename With",
-  "Rename Columns": "Rename Columns"}
-
+  "Rename Columns": "Rename Columns",
+  "Command runs without error": "Command runs without error",
+  "Command runs ok": "Command runs ok",
+  "Problem detected running Command or no output to display.": "Problem detected running Command or no output to display.",
+  "Command produced an error. Modify input before running.": "Command produced an error. Modify input before running.",
+  "Model produced an error or no output to display.": "Model produced an error or no output to display.",
+  "Model runs without error": "Model runs without error",
+  "Model runs ok": "Model runs ok",
+  "Problem detected running Model or no output to display.": "Problem detected running Model or no output to display.",
+  "Model produced an error. Modify input before running.": "Model produced an error. Modify input before running."
+}

--- a/instat/ucrTry.vb
+++ b/instat/ucrTry.vb
@@ -151,21 +151,21 @@ Public Class ucrTry
                             ucrInputTryMessage.txtInput.BackColor = Color.White
                         Else
                             If bIsCommand Then
-                                ucrInputTryMessage.SetName(CommandModel & " runs without error")
+                                ucrInputTryMessage.SetName(Translations.GetTranslation(CommandModel & " runs without error"))
                                 ucrInputTryMessage.txtInput.BackColor = Color.LightGreen
                             ElseIf bIsModel Then
-                                ucrInputTryMessage.SetName(CommandModel & " runs ok")
+                                ucrInputTryMessage.SetName(Translations.GetTranslation(CommandModel & " runs ok"))
                                 ucrInputTryMessage.txtInput.BackColor = Color.LightGreen
                             End If
                         End If
                     Else
                         If bIsCommand Then
-                            ucrInputTryMessage.SetName(CommandModel & " produced an error or no output to display.")
+                            ucrInputTryMessage.SetName(Translations.GetTranslation(CommandModel & " produced an error or no output to display."))
                             ucrInputTryMessage.txtInput.BackColor = Color.LightCoral
                             strError = strErrorDetail
                             AddButtonInTryTextBox()
                         ElseIf bIsModel Then
-                            ucrInputTryMessage.SetName("Problem detected running " & CommandModel & " or no output to display.")
+                            ucrInputTryMessage.SetName(Translations.GetTranslation("Problem detected running " & CommandModel & " or no output to display."))
                             ucrInputTryMessage.txtInput.BackColor = Color.LightCoral
                             strError = strErrorDetail
                             AddButtonInTryTextBox()
@@ -174,7 +174,7 @@ Public Class ucrTry
                     End If
             End If
         Catch ex As Exception
-            ucrInputTryMessage.SetName(CommandModel & "produced an error. Modify input before running.")
+            ucrInputTryMessage.SetName(Translations.GetTranslation(CommandModel & " produced an error. Modify input before running."))
             strError = strErrorDetail
             ucrInputTryMessage.txtInput.BackColor = Color.LightCoral
             AddButtonInTryTextBox()


### PR DESCRIPTION
Fixes #7774.
Specifically, this fixes the part 'e' of issue #7774 (see screenshot below). The rest of this issue is covered by issue #3721, therefore it's OK for this PR to auttomatically close #7774 when this PR is merged.
This PR should also fix this issue for all other dialogs that use the `ucrTry` control.

@N-thony Please could you peer review? The database changes are shown below.
@rdstern Please could you test?

Thanks!

![image](https://user-images.githubusercontent.com/11226469/184597589-2d278ede-f517-43ab-bb75-8cf200b56e5f.png)

![image](https://user-images.githubusercontent.com/57253949/190411844-1304958f-6a89-4bd9-af47-bed4e6f1ee15.png)


