### PR TITLE
In the Script window, improved the usability of brackets and quotes

### DIFF
--- a/instat/ucrScript.Designer.vb
+++ b/instat/ucrScript.Designer.vb
@@ -40,15 +40,21 @@ Partial Class ucrScript
     Private Sub InitializeComponent()
         Me.components = New System.ComponentModel.Container()
         Me.mnuContextScript = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.mnuUndo = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuRedo = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ToolStripSeparator1 = New System.Windows.Forms.ToolStripSeparator()
         Me.mnuCut = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuCopy = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuPaste = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuSelectAll = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuClearContents = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ToolStripSeparator2 = New System.Windows.Forms.ToolStripSeparator()
         Me.mnuRunCurrentLineSelection = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuRunAllText = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ToolStripSeparator3 = New System.Windows.Forms.ToolStripSeparator()
         Me.mnuOpenScriptasFile = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuLoadScriptFromFile = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuSaveScript = New System.Windows.Forms.ToolStripMenuItem()
-        Me.mnuClearContents = New System.Windows.Forms.ToolStripMenuItem()
         Me.ToolStripSeparator4 = New System.Windows.Forms.ToolStripSeparator()
         Me.mnuHelp = New System.Windows.Forms.ToolStripMenuItem()
         Me.lblHeaderScript = New System.Windows.Forms.Label()
@@ -60,12 +66,6 @@ Partial Class ucrScript
         Me.cmdRunAll = New System.Windows.Forms.Button()
         Me.cmdRunLineSelection = New System.Windows.Forms.Button()
         Me.tooltiptScriptWindow = New System.Windows.Forms.ToolTip(Me.components)
-        Me.ToolStripSeparator2 = New System.Windows.Forms.ToolStripSeparator()
-        Me.ToolStripSeparator3 = New System.Windows.Forms.ToolStripSeparator()
-        Me.mnuSelectAll = New System.Windows.Forms.ToolStripMenuItem()
-        Me.mnuUndo = New System.Windows.Forms.ToolStripMenuItem()
-        Me.mnuRedo = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ToolStripSeparator1 = New System.Windows.Forms.ToolStripSeparator()
         Me.mnuContextScript.SuspendLayout()
         Me.tlpTableContainer.SuspendLayout()
         Me.Panel2.SuspendLayout()
@@ -76,7 +76,26 @@ Partial Class ucrScript
         Me.mnuContextScript.ImageScalingSize = New System.Drawing.Size(24, 24)
         Me.mnuContextScript.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuUndo, Me.mnuRedo, Me.ToolStripSeparator1, Me.mnuCut, Me.mnuCopy, Me.mnuPaste, Me.mnuSelectAll, Me.mnuClearContents, Me.ToolStripSeparator2, Me.mnuRunCurrentLineSelection, Me.mnuRunAllText, Me.ToolStripSeparator3, Me.mnuOpenScriptasFile, Me.mnuLoadScriptFromFile, Me.mnuSaveScript, Me.ToolStripSeparator4, Me.mnuHelp})
         Me.mnuContextScript.Name = "mnuContextLogFile"
-        Me.mnuContextScript.Size = New System.Drawing.Size(274, 336)
+        Me.mnuContextScript.Size = New System.Drawing.Size(274, 314)
+        '
+        'mnuUndo
+        '
+        Me.mnuUndo.Name = "mnuUndo"
+        Me.mnuUndo.ShortcutKeys = CType((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.Z), System.Windows.Forms.Keys)
+        Me.mnuUndo.Size = New System.Drawing.Size(273, 22)
+        Me.mnuUndo.Text = "Undo"
+        '
+        'mnuRedo
+        '
+        Me.mnuRedo.Name = "mnuRedo"
+        Me.mnuRedo.ShortcutKeys = CType((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.Y), System.Windows.Forms.Keys)
+        Me.mnuRedo.Size = New System.Drawing.Size(273, 22)
+        Me.mnuRedo.Text = "Redo"
+        '
+        'ToolStripSeparator1
+        '
+        Me.ToolStripSeparator1.Name = "ToolStripSeparator1"
+        Me.ToolStripSeparator1.Size = New System.Drawing.Size(270, 6)
         '
         'mnuCut
         '
@@ -99,6 +118,25 @@ Partial Class ucrScript
         Me.mnuPaste.Size = New System.Drawing.Size(273, 22)
         Me.mnuPaste.Text = "Paste"
         '
+        'mnuSelectAll
+        '
+        Me.mnuSelectAll.Name = "mnuSelectAll"
+        Me.mnuSelectAll.ShortcutKeys = CType((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.A), System.Windows.Forms.Keys)
+        Me.mnuSelectAll.Size = New System.Drawing.Size(273, 22)
+        Me.mnuSelectAll.Text = "Select All"
+        '
+        'mnuClearContents
+        '
+        Me.mnuClearContents.Name = "mnuClearContents"
+        Me.mnuClearContents.ShortcutKeys = CType((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.L), System.Windows.Forms.Keys)
+        Me.mnuClearContents.Size = New System.Drawing.Size(273, 22)
+        Me.mnuClearContents.Text = "Clear All"
+        '
+        'ToolStripSeparator2
+        '
+        Me.ToolStripSeparator2.Name = "ToolStripSeparator2"
+        Me.ToolStripSeparator2.Size = New System.Drawing.Size(270, 6)
+        '
         'mnuRunCurrentLineSelection
         '
         Me.mnuRunCurrentLineSelection.Name = "mnuRunCurrentLineSelection"
@@ -112,6 +150,11 @@ Partial Class ucrScript
             Or System.Windows.Forms.Keys.R), System.Windows.Forms.Keys)
         Me.mnuRunAllText.Size = New System.Drawing.Size(273, 22)
         Me.mnuRunAllText.Text = "Run All Text"
+        '
+        'ToolStripSeparator3
+        '
+        Me.ToolStripSeparator3.Name = "ToolStripSeparator3"
+        Me.ToolStripSeparator3.Size = New System.Drawing.Size(270, 6)
         '
         'mnuOpenScriptasFile
         '
@@ -130,13 +173,6 @@ Partial Class ucrScript
         Me.mnuSaveScript.Name = "mnuSaveScript"
         Me.mnuSaveScript.Size = New System.Drawing.Size(273, 22)
         Me.mnuSaveScript.Text = "Save Script..."
-        '
-        'mnuClearContents
-        '
-        Me.mnuClearContents.Name = "mnuClearContents"
-        Me.mnuClearContents.ShortcutKeys = CType((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.L), System.Windows.Forms.Keys)
-        Me.mnuClearContents.Size = New System.Drawing.Size(273, 22)
-        Me.mnuClearContents.Text = "Clear All"
         '
         'ToolStripSeparator4
         '
@@ -243,42 +279,6 @@ Partial Class ucrScript
         Me.cmdRunLineSelection.Text = "Run"
         Me.tooltiptScriptWindow.SetToolTip(Me.cmdRunLineSelection, "Run the current line or selection." & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "(Ctrl + Enter)")
         Me.cmdRunLineSelection.UseVisualStyleBackColor = True
-        '
-        'ToolStripSeparator2
-        '
-        Me.ToolStripSeparator2.Name = "ToolStripSeparator2"
-        Me.ToolStripSeparator2.Size = New System.Drawing.Size(270, 6)
-        '
-        'ToolStripSeparator3
-        '
-        Me.ToolStripSeparator3.Name = "ToolStripSeparator3"
-        Me.ToolStripSeparator3.Size = New System.Drawing.Size(270, 6)
-        '
-        'mnuSelectAll
-        '
-        Me.mnuSelectAll.Name = "mnuSelectAll"
-        Me.mnuSelectAll.ShortcutKeys = CType((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.A), System.Windows.Forms.Keys)
-        Me.mnuSelectAll.Size = New System.Drawing.Size(273, 22)
-        Me.mnuSelectAll.Text = "Select All"
-        '
-        'mnuUndo
-        '
-        Me.mnuUndo.Name = "mnuUndo"
-        Me.mnuUndo.ShortcutKeys = CType((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.Z), System.Windows.Forms.Keys)
-        Me.mnuUndo.Size = New System.Drawing.Size(273, 22)
-        Me.mnuUndo.Text = "Undo"
-        '
-        'mnuRedo
-        '
-        Me.mnuRedo.Name = "mnuRedo"
-        Me.mnuRedo.ShortcutKeys = CType((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.Y), System.Windows.Forms.Keys)
-        Me.mnuRedo.Size = New System.Drawing.Size(273, 22)
-        Me.mnuRedo.Text = "Redo"
-        '
-        'ToolStripSeparator1
-        '
-        Me.ToolStripSeparator1.Name = "ToolStripSeparator1"
-        Me.ToolStripSeparator1.Size = New System.Drawing.Size(270, 6)
         '
         'ucrScript
         '

--- a/instat/ucrScript.resx
+++ b/instat/ucrScript.resx
@@ -123,7 +123,4 @@
   <metadata name="tooltiptScriptWindow.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>167, 17</value>
   </metadata>
-  <metadata name="tooltiptScriptWindow.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>167, 17</value>
-  </metadata>
 </root>

--- a/instat/ucrScript.vb
+++ b/instat/ucrScript.vb
@@ -102,54 +102,62 @@ Public Class ucrScript
     End Sub
 
     Private Function IsCharBlank(charNew As Char) As Boolean
-        Return String.IsNullOrWhiteSpace(charNew.ToString()) OrElse charNew = vbLf OrElse charNew = vbCr
+        Return charNew = Chr(0) OrElse String.IsNullOrWhiteSpace(charNew.ToString()) OrElse charNew = vbLf OrElse charNew = vbCr
     End Function
 
+    Private Function IsCharQuote(charNew As Char) As Boolean
+        Return charNew = """" OrElse charNew = "'"
+    End Function
+
+    '''--------------------------------------------------------------------------------------------
+    ''' <summary>
+    '''     If <paramref name="charNew"/> is a bracket/quote, then inserts a closing bracket/quote. <para>
+    '''     This sub is based on a C# function from
+    '''     https://github.com/jacobslusser/ScintillaNET/wiki/Character-Autocompletion. </para><para>
+    '''     It avoids inserting matching quotes in situations such as "don't". 
+    '''     It also ensures that the caret does not remain in the center upon multiple quote insertions.</para><para>
+    '''     For example ("|" is cursor position; '=&gt;' is output):</para><list type="bullet"><item>
+    '''         insert ' =&gt; '|' </item><item>
+    '''         insert ' again =&gt; ''| </item></list>
+    '''     Visual Studio and RStudio have the same behaviour.
+    ''' </summary>
+    ''' <param name="charNew">  The character typed by the user. </param>
+    '''--------------------------------------------------------------------------------------------
     Private Sub InsertMatchedChars(charNew As Char)
         Dim iCaretPos As Integer = txtScript.CurrentPosition
         Dim bIsDocStart As Boolean = iCaretPos = 1
         Dim bIsDocEnd As Boolean = iCaretPos = txtScript.Text.Length
 
-        Dim charPrev As Char = If(bIsDocStart, Nothing, ChrW(txtScript.GetCharAt(iCaretPos - 2)))
-        Dim charNext As Char = If(bIsDocEnd, Nothing, ChrW(txtScript.GetCharAt(iCaretPos)))
-
-        Dim bIsCharPrevBlank As Boolean = bIsDocStart OrElse IsCharBlank(charPrev)
-        Dim bIsCharNextBlank As Boolean = bIsDocEnd OrElse IsCharBlank(charNext)
+        Dim charPrev As Char = If(bIsDocStart, Chr(0), ChrW(txtScript.GetCharAt(iCaretPos - 2)))
+        Dim charNext As Char = If(bIsDocEnd, Chr(0), ChrW(txtScript.GetCharAt(iCaretPos)))
 
         Dim dctBrackets As New Dictionary(Of Char, Char) From {{"(", ")"}, {"{", "}"}, {"[", "]"}}
-        Dim cClosingBracket As Char
-        Dim bIsEnclosed As Boolean = If(dctBrackets.TryGetValue(charPrev, cClosingBracket), charNext = cClosingBracket, False)
 
-        Dim bIsSpaceEnclosed As Boolean = (charPrev = "(" AndAlso bIsCharNextBlank) OrElse (bIsCharPrevBlank AndAlso charNext = ")") OrElse
-                          (charPrev = "{" AndAlso bIsCharNextBlank) OrElse (bIsCharPrevBlank AndAlso charNext = "}") OrElse
-                          (charPrev = "[" AndAlso bIsCharNextBlank) OrElse (bIsCharPrevBlank AndAlso charNext = "]")
+        'If user entered an open bracket character
+        If dctBrackets.ContainsKey(charNew) Then
+            If IsCharQuote(charNext) Then
+                Exit Sub
+            End If
+            'insert close bracket character
+            txtScript.InsertText(iCaretPos, dctBrackets(charNew))
+        ElseIf IsCharQuote(charNew) Then ' else if user entered quote
+            'if user enters multiple quotes, then ensure that the caret does not remain in the center
+            If charPrev = charNew AndAlso charNext = charNew Then
+                txtScript.DeleteRange(iCaretPos, 1)
+                txtScript.GotoPosition(iCaretPos)
+                Exit Sub
+            End If
 
-        Dim bIsCharOrString As Boolean = (bIsCharPrevBlank AndAlso bIsCharNextBlank) OrElse bIsEnclosed OrElse bIsSpaceEnclosed
-
-        Dim bIsNextCharOrString As Boolean = charNext = """" OrElse charNext = "'"
-
-        If (charNew = "(" OrElse charNew = "{" OrElse charNew = "[") _
-                        AndAlso bIsNextCharOrString Then
-            Exit Sub
+            'in certain situations add a closing quote after the caret
+            Dim charClosingBracket As Char
+            Dim bIsEnclosedByBrackets As Boolean = dctBrackets.TryGetValue(charPrev, charClosingBracket) AndAlso charNext = charClosingBracket
+            Dim bIsEnclosedBySpaces As Boolean = IsCharBlank(charPrev) AndAlso IsCharBlank(charNext)
+            Dim bIsEnclosedByBracketAndSpace As Boolean = (dctBrackets.ContainsKey(charPrev) AndAlso IsCharBlank(charNext)) _
+                                                   OrElse (dctBrackets.ContainsValue(charNext) AndAlso IsCharBlank(charPrev))
+            If bIsEnclosedByBrackets OrElse bIsEnclosedBySpaces OrElse bIsEnclosedByBracketAndSpace Then
+                txtScript.InsertText(iCaretPos, charNew)
+            End If
         End If
-
-        Select Case charNew
-            Case "("
-                txtScript.InsertText(iCaretPos, ")")
-            Case "{"
-                txtScript.InsertText(iCaretPos, "}")
-            Case "["
-                txtScript.InsertText(iCaretPos, "]")
-            Case """", "'"
-                If charPrev = charNew AndAlso charNext = charNew Then
-                    txtScript.DeleteRange(iCaretPos, 1)
-                    txtScript.GotoPosition(iCaretPos)
-                    Exit Sub
-                End If
-                If bIsCharOrString Then
-                    txtScript.InsertText(iCaretPos, charNew)
-                End If
-        End Select
     End Sub
 
     Private Sub RunLineSelection_Click(sender As Object, e As EventArgs) Handles mnuRunCurrentLineSelection.Click, cmdRunLineSelection.Click

--- a/instat/ucrScript.vb
+++ b/instat/ucrScript.vb
@@ -169,7 +169,8 @@ Public Class ucrScript
     ''' <summary>
     '''     If the caret is next to a bracket, then it highlights the paired open/close bracket. 
     '''     If it cannot find a paired bracket, then it displays the bracket next to the caret in 
-    '''     red (to indicate an error). <para>
+    '''     the specified error colour. For nested indented brackets, also shows a vertical 
+    '''     indentation line. <para>
     '''     This sub is based on a C# function from:
     '''     https://github.com/jacobslusser/ScintillaNET/wiki/Brace-Matching. </para>
     ''' </summary>
@@ -196,12 +197,15 @@ Public Class ucrScript
             Dim iBracketPos2 As Integer = txtScript.BraceMatch(iBracketPos1)
             If iBracketPos2 = Scintilla.InvalidPosition Then
                 txtScript.BraceBadLight(iBracketPos1)
+                txtScript.HighlightGuide = 0
             Else
                 txtScript.BraceHighlight(iBracketPos1, iBracketPos2)
+                txtScript.HighlightGuide = txtScript.GetColumn(iBracketPos1)
             End If
         Else
             'turn off brace matching
             txtScript.BraceHighlight(Scintilla.InvalidPosition, Scintilla.InvalidPosition)
+            txtScript.HighlightGuide = 0
         End If
     End Sub
 
@@ -339,6 +343,7 @@ Public Class ucrScript
         'txtScript.Styles(Style.Default).Font = frmMain.clsInstatOptions.fntEditor.Name
         'txtScript.Styles(Style.Default).Size = frmMain.clsInstatOptions.fntEditor.Size
 
+        txtScript.IndentationGuides = IndentView.LookBoth
         txtScript.StyleClearAll()
         txtScript.Styles(Style.R.Default).ForeColor = Color.Silver
         txtScript.Styles(Style.R.Comment).ForeColor = Color.Green


### PR DESCRIPTION
**Brackets**
If the user types an open bracket (e.g. `[`), then R-Instat automaticaly inserts a closing bracket.
Also, if the user moves the cursor, and the caret is then next to a bracket, then it highlights the paired open/close bracket. 
If it cannot find a paired bracket, then it displays the bracket next to the caret in red (to indicate an error).
For indented brackets, it shows a vertical line at different indentation levels:

![image](https://user-images.githubusercontent.com/57253949/193463517-13dbd3ea-bc70-4397-a49a-b5860dd32c06.png)


**Quotes**
If the user types a quote character (e.g. `"`), then R-Instat automaticaly inserts a closing quote character.
It avoids inserting closing quotes in situations such as `don't`. 
It also ensures that the caret does not remain in the center upon multiple quote insertions. For example ("|" is cursor position; '=&gt;' is output):
- insert ' => '|' 
- insert ' again => ''| 

Visual Studio and RStudio have the same behaviour.

@rdstern Please could you test?
@N-thony Please could you peer review?
Thanks!