### PR TITLE
In Data Frame Metadata grid, displays filtered columns and row in red

### DIFF
--- a/instat/Model/DataFrame/clsDataBook.vb
+++ b/instat/Model/DataFrame/clsDataBook.vb
@@ -138,9 +138,9 @@ Public Class clsDataBook
         Dim lstOfCurrentRDataFrameNames As List(Of String) = GetDataFrameNamesFromR()
 
         'add any data frames from this data book before removing them if not the R Instat object
-        For Each clsDatafram In _lstDataFrames
-            If Not _lstAllDataFrames.Contains(clsDatafram) Then
-                _lstAllDataFrames.Add(clsDatafram)
+        For Each clsDataframe In _lstDataFrames
+            If Not _lstAllDataFrames.Contains(clsDataframe) Then
+                _lstAllDataFrames.Add(clsDataframe)
             End If
         Next
 

--- a/instat/Model/DataFrame/clsDataBook.vb
+++ b/instat/Model/DataFrame/clsDataBook.vb
@@ -22,7 +22,7 @@ Imports RDotNet
 Public Class clsDataBook
     Private _RLink As RLink
     Private _lstDataFrames As List(Of clsDataFrame)
-    Private _lstAllDataFrames As List(Of clsDataFrame)
+    Private _lstAllDataFrames As New List(Of clsDataFrame)
     Private _clsDataFrameMetaData As clsDataFrameMetaData
 
     ''' <summary>
@@ -136,7 +136,11 @@ Public Class clsDataBook
         'get the recent list of data frame names from R Instant
         Dim lstOfCurrentRDataFrameNames As List(Of String) = GetDataFrameNamesFromR()
 
-        _lstAllDataFrames = _lstDataFrames
+        'add any data frames from this data book before removing them if not the R Instat object
+        For Each clsDatafram In _lstDataFrames
+            _lstAllDataFrames.Add(clsDatafram)
+        Next
+
         'remove any data frames from this data book that are not in the R Instat object
         _lstDataFrames.RemoveAll(Function(x) Not lstOfCurrentRDataFrameNames.Contains(x.strName))
 

--- a/instat/Model/DataFrame/clsDataBook.vb
+++ b/instat/Model/DataFrame/clsDataBook.vb
@@ -117,6 +117,7 @@ Public Class clsDataBook
         'and refresh the data frame metadata from R
         If Not _RLink.bInstatObjectExists Then
             _lstDataFrames.Clear()
+            _lstAllDataFrames.Clear()
             _clsDataFrameMetaData = New clsDataFrameMetaData(_RLink)
             Exit Sub
         End If
@@ -138,7 +139,9 @@ Public Class clsDataBook
 
         'add any data frames from this data book before removing them if not the R Instat object
         For Each clsDatafram In _lstDataFrames
-            _lstAllDataFrames.Add(clsDatafram)
+            If Not _lstAllDataFrames.Contains(clsDatafram) Then
+                _lstAllDataFrames.Add(clsDatafram)
+            End If
         Next
 
         'remove any data frames from this data book that are not in the R Instat object

--- a/instat/Model/DataFrame/clsDataBook.vb
+++ b/instat/Model/DataFrame/clsDataBook.vb
@@ -22,6 +22,7 @@ Imports RDotNet
 Public Class clsDataBook
     Private _RLink As RLink
     Private _lstDataFrames As List(Of clsDataFrame)
+    Private _lstAllDataFrames As List(Of clsDataFrame)
     Private _clsDataFrameMetaData As clsDataFrameMetaData
 
     ''' <summary>
@@ -95,6 +96,10 @@ Public Class clsDataBook
         Return _lstDataFrames.Where(Function(x) x.strName = strName).FirstOrDefault
     End Function
 
+    Public Function GetAllDataFrame(strName As String) As clsDataFrame
+        Return _lstAllDataFrames.Where(Function(x) x.strName = strName).FirstOrDefault
+    End Function
+
     ''' <summary>
     ''' Gets the Column Metadata for the dataframe name given
     ''' </summary>
@@ -131,6 +136,7 @@ Public Class clsDataBook
         'get the recent list of data frame names from R Instant
         Dim lstOfCurrentRDataFrameNames As List(Of String) = GetDataFrameNamesFromR()
 
+        _lstAllDataFrames = _lstDataFrames
         'remove any data frames from this data book that are not in the R Instat object
         _lstDataFrames.RemoveAll(Function(x) Not lstOfCurrentRDataFrameNames.Contains(x.strName))
 

--- a/instat/UserControls/DataGrid/ReoGrid/ucrDataframeMetadataReoGrid.vb
+++ b/instat/UserControls/DataGrid/ReoGrid/ucrDataframeMetadataReoGrid.vb
@@ -42,14 +42,14 @@ Public Class ucrDataframeMetadataReoGrid
         For i = 0 To _clsDataBook.clsDataFrameMetaData.RowCount - 1
             For j = 0 To grdData.CurrentWorksheet.Columns - 1
                 grdData.CurrentWorksheet(row:=i, col:=j) = _clsDataBook.clsDataFrameMetaData.Data(i, j)
-                Dim clsFirstColumnSelection As clsDataFrameFilterOrColumnSelection =
-                        _clsDataBook.GetAllDataFrame(_clsDataBook.clsDataFrameMetaData.Data(i, 0)).clsFilterOrColumnSelection
-                Dim strColumnHeaderText As String = grdData.CurrentWorksheet.ColumnHeaders(j).Text
-
-                grdData.CurrentWorksheet(row:=i, col:=j) = _clsDataBook.clsDataFrameMetaData.Data(i, j)
-                If clsFirstColumnSelection.bFilterApplied AndAlso strColumnHeaderText = "Rows" _
-                        OrElse (clsFirstColumnSelection.bColumnSelectionApplied AndAlso strColumnHeaderText = "Columns") Then
-                    grdData.CurrentWorksheet.Cells(row:=i, col:=j).Style.TextColor = Color.Red
+                Dim clsDataFrame As clsDataFrame = _clsDataBook.GetAllDataFrame(_clsDataBook.clsDataFrameMetaData.Data(i, 0))
+                If clsDataFrame IsNot Nothing Then
+                    Dim strColumnHeaderText As String = grdData.CurrentWorksheet.ColumnHeaders(j).Text
+                    grdData.CurrentWorksheet(row:=i, col:=j) = _clsDataBook.clsDataFrameMetaData.Data(i, j)
+                    If clsDataFrame.clsFilterOrColumnSelection.bFilterApplied AndAlso strColumnHeaderText = "Rows" _
+                            OrElse (clsDataFrame.clsFilterOrColumnSelection.bColumnSelectionApplied AndAlso strColumnHeaderText = "Columns") Then
+                        grdData.CurrentWorksheet.Cells(row:=i, col:=j).Style.TextColor = Color.Red
+                    End If
                 End If
             Next
             grdData.CurrentWorksheet.RowHeaders.Item(i).Text = _clsDataBook.clsDataFrameMetaData.RowName(i)

--- a/instat/UserControls/DataGrid/ReoGrid/ucrDataframeMetadataReoGrid.vb
+++ b/instat/UserControls/DataGrid/ReoGrid/ucrDataframeMetadataReoGrid.vb
@@ -42,6 +42,11 @@ Public Class ucrDataframeMetadataReoGrid
         For i = 0 To _clsDataBook.clsDataFrameMetaData.RowCount - 1
             For j = 0 To grdData.CurrentWorksheet.Columns - 1
                 grdData.CurrentWorksheet(row:=i, col:=j) = _clsDataBook.clsDataFrameMetaData.Data(i, j)
+                If _clsDataBook.GetDataFrame(_clsDataBook.clsDataFrameMetaData.Data(i, 0)).clsFilterOrColumnSelection.bFilterApplied AndAlso grdData.CurrentWorksheet.ColumnHeaders(j).Text = "Rows" Then
+                    grdData.CurrentWorksheet.Cells(row:=i, col:=j).Style.TextColor = Color.Red
+                ElseIf _clsDataBook.GetDataFrame(_clsDataBook.clsDataFrameMetaData.Data(i, 0)).clsFilterOrColumnSelection.bColumnSelectionApplied AndAlso grdData.CurrentWorksheet.ColumnHeaders(j).Text = "Columns" Then
+                    grdData.CurrentWorksheet.Cells(row:=i, col:=j).Style.TextColor = Color.Red
+                End If
             Next
             grdData.CurrentWorksheet.RowHeaders.Item(i).Text = _clsDataBook.clsDataFrameMetaData.RowName(i)
         Next

--- a/instat/UserControls/DataGrid/ReoGrid/ucrDataframeMetadataReoGrid.vb
+++ b/instat/UserControls/DataGrid/ReoGrid/ucrDataframeMetadataReoGrid.vb
@@ -42,9 +42,11 @@ Public Class ucrDataframeMetadataReoGrid
         For i = 0 To _clsDataBook.clsDataFrameMetaData.RowCount - 1
             For j = 0 To grdData.CurrentWorksheet.Columns - 1
                 grdData.CurrentWorksheet(row:=i, col:=j) = _clsDataBook.clsDataFrameMetaData.Data(i, j)
-                If _clsDataBook.GetDataFrame(_clsDataBook.clsDataFrameMetaData.Data(i, 0)).clsFilterOrColumnSelection.bFilterApplied AndAlso grdData.CurrentWorksheet.ColumnHeaders(j).Text = "Rows" Then
+                If _clsDataBook.GetDataFrame(_clsDataBook.clsDataFrameMetaData.Data(i, 0)).clsFilterOrColumnSelection.bFilterApplied _
+                    AndAlso grdData.CurrentWorksheet.ColumnHeaders(j).Text = "Rows" Then
                     grdData.CurrentWorksheet.Cells(row:=i, col:=j).Style.TextColor = Color.Red
-                ElseIf _clsDataBook.GetDataFrame(_clsDataBook.clsDataFrameMetaData.Data(i, 0)).clsFilterOrColumnSelection.bColumnSelectionApplied AndAlso grdData.CurrentWorksheet.ColumnHeaders(j).Text = "Columns" Then
+                ElseIf _clsDataBook.GetDataFrame(_clsDataBook.clsDataFrameMetaData.Data(i, 0)).clsFilterOrColumnSelection.bColumnSelectionApplied _
+                    AndAlso grdData.CurrentWorksheet.ColumnHeaders(j).Text = "Columns" Then
                     grdData.CurrentWorksheet.Cells(row:=i, col:=j).Style.TextColor = Color.Red
                 End If
             Next

--- a/instat/UserControls/DataGrid/ReoGrid/ucrDataframeMetadataReoGrid.vb
+++ b/instat/UserControls/DataGrid/ReoGrid/ucrDataframeMetadataReoGrid.vb
@@ -42,11 +42,13 @@ Public Class ucrDataframeMetadataReoGrid
         For i = 0 To _clsDataBook.clsDataFrameMetaData.RowCount - 1
             For j = 0 To grdData.CurrentWorksheet.Columns - 1
                 grdData.CurrentWorksheet(row:=i, col:=j) = _clsDataBook.clsDataFrameMetaData.Data(i, j)
-                If _clsDataBook.GetDataFrame(_clsDataBook.clsDataFrameMetaData.Data(i, 0)).clsFilterOrColumnSelection.bFilterApplied _
-                    AndAlso grdData.CurrentWorksheet.ColumnHeaders(j).Text = "Rows" Then
-                    grdData.CurrentWorksheet.Cells(row:=i, col:=j).Style.TextColor = Color.Red
-                ElseIf _clsDataBook.GetDataFrame(_clsDataBook.clsDataFrameMetaData.Data(i, 0)).clsFilterOrColumnSelection.bColumnSelectionApplied _
-                    AndAlso grdData.CurrentWorksheet.ColumnHeaders(j).Text = "Columns" Then
+                Dim clsFirstColumnSelection As clsDataFrameFilterOrColumnSelection =
+                        _clsDataBook.GetDataFrame(_clsDataBook.clsDataFrameMetaData.Data(i, 0)).clsFilterOrColumnSelection
+                Dim strColumnHeaderText As String = grdData.CurrentWorksheet.ColumnHeaders(j).Text
+
+                grdData.CurrentWorksheet(row:=i, col:=j) = _clsDataBook.clsDataFrameMetaData.Data(i, j)
+                If clsFirstColumnSelection.bFilterApplied AndAlso strColumnHeaderText = "Rows" _
+                        OrElse (clsFirstColumnSelection.bColumnSelectionApplied AndAlso strColumnHeaderText = "Columns") Then
                     grdData.CurrentWorksheet.Cells(row:=i, col:=j).Style.TextColor = Color.Red
                 End If
             Next

--- a/instat/UserControls/DataGrid/ReoGrid/ucrDataframeMetadataReoGrid.vb
+++ b/instat/UserControls/DataGrid/ReoGrid/ucrDataframeMetadataReoGrid.vb
@@ -43,7 +43,7 @@ Public Class ucrDataframeMetadataReoGrid
             For j = 0 To grdData.CurrentWorksheet.Columns - 1
                 grdData.CurrentWorksheet(row:=i, col:=j) = _clsDataBook.clsDataFrameMetaData.Data(i, j)
                 Dim clsFirstColumnSelection As clsDataFrameFilterOrColumnSelection =
-                        _clsDataBook.GetDataFrame(_clsDataBook.clsDataFrameMetaData.Data(i, 0)).clsFilterOrColumnSelection
+                        _clsDataBook.GetAllDataFrame(_clsDataBook.clsDataFrameMetaData.Data(i, 0)).clsFilterOrColumnSelection
                 Dim strColumnHeaderText As String = grdData.CurrentWorksheet.ColumnHeaders(j).Text
 
                 grdData.CurrentWorksheet(row:=i, col:=j) = _clsDataBook.clsDataFrameMetaData.Data(i, j)

--- a/instat/static/InstatObject/R/data_object_R6.R
+++ b/instat/static/InstatObject/R/data_object_R6.R
@@ -551,7 +551,7 @@ DataSheet$set("public", "clear_variables_metadata", function() {
 )
 
 DataSheet$set("public", "get_metadata", function(label, include_calculated = TRUE, excluded_not_for_display = TRUE) {
-  curr_data <- self$get_data_frame(use_current_filter = FALSE)
+  curr_data <- self$get_data_frame(use_current_filter = TRUE)
   if(missing(label)) {
     if(include_calculated) {
       #Must be private$data because assigning attribute to data field

--- a/instat/static/InstatObject/R/data_object_R6.R
+++ b/instat/static/InstatObject/R/data_object_R6.R
@@ -551,11 +551,12 @@ DataSheet$set("public", "clear_variables_metadata", function() {
 )
 
 DataSheet$set("public", "get_metadata", function(label, include_calculated = TRUE, excluded_not_for_display = TRUE) {
-  curr_data <- self$get_data_frame(use_current_filter = TRUE)
+  curr_data <- self$get_data_frame(use_current_filter = FALSE)
+  n_row <- self$get_data_frame_length(use_current_filter = TRUE) #this is to avoid an eventual bug if we consider using curr_data <- self$get_data_frame(use_current_filter = TRUE)
   if(missing(label)) {
     if(include_calculated) {
       #Must be private$data because assigning attribute to data field
-      attr(curr_data, row_count_label) <- nrow(curr_data)
+      attr(curr_data, row_count_label) <- n_row
       attr(curr_data, column_count_label) <- ncol(curr_data)
     }
     if(excluded_not_for_display) {
@@ -567,7 +568,7 @@ DataSheet$set("public", "get_metadata", function(label, include_calculated = TRU
   }
   else {
     if(label %in% names(attributes(curr_data))) return(attributes(curr_data)[[label]])
-    else if(label == row_count_label) return(nrow(curr_data))
+    else if(label == row_count_label) return(n_row)
     else if(label == column_count_label) return(ncol(curr_data))
     else return("")
   }

--- a/instat/ucrDataFrameMetadata.vb
+++ b/instat/ucrDataFrameMetadata.vb
@@ -82,9 +82,9 @@ Public Class ucrDataFrameMetadata
         If _clsDataBook Is Nothing Or _clsDataBook.DataFrames.Count = 0 Then
             Exit Sub
         End If
+        _grid.UpdateAllWorksheetStyles()
         _grid.AddColumns()
         _grid.AddRowData()
-        _grid.UpdateAllWorksheetStyles()
     End Sub
 
     Public Sub RefreshGridData()


### PR DESCRIPTION
Fixes (partially) #7339
@rdstern this fixes item 4) in the corresponding issue, please have a look. Thanks.
it changes the colors of `Columns` and `Rows` of the datasets where the filter is applied
![image](https://user-images.githubusercontent.com/68591383/193573299-3eef51dc-fd2e-4145-b1f4-0e7b478d4975.png)

Perhaps we can move `Rows` after/before `Columns`?

