### PR TITLE
In Column Metadata grid, display columns selected in DataView in red

### DIFF
--- a/instat/UserControls/DataGrid/ReoGrid/ucrColumnMetadataReoGrid.vb
+++ b/instat/UserControls/DataGrid/ReoGrid/ucrColumnMetadataReoGrid.vb
@@ -46,6 +46,18 @@ Public Class ucrColumnMetadataReoGrid
             Next
             grdData.CurrentWorksheet.RowHeaders.Item(i).Text = columnMetaData.strRowName(i)
         Next
+
+        Dim clsDataFrame As clsDataFrame = _clsDataBook.GetDataFrame(grdData.CurrentWorksheet.Name)
+        If clsDataFrame.clsFilterOrColumnSelection.bColumnSelectionApplied Then
+            For i = 0 To clsDataFrame.clsVisibleDataFramePage.lstColumns.Count - 1
+                For j = 0 To grdData.CurrentWorksheet.Rows - 1
+                    Dim strRowValue As String = grdData.CurrentWorksheet(row:=j, col:=0)
+                    If strRowValue = clsDataFrame.clsVisibleDataFramePage.lstColumns(i).strName Then
+                        grdData.CurrentWorksheet.Cells(row:=j, col:=0).Style.TextColor = Color.Red
+                    End If
+                Next
+            Next
+        End If
     End Sub
 
     Public Function GetSelectedColumns() As List(Of String) Implements IColumnMetaDataGrid.GetSelectedColumns

--- a/instat/ucrColumnMetadata.vb
+++ b/instat/ucrColumnMetadata.vb
@@ -55,9 +55,9 @@ Public Class ucrColumnMetadata
         End If
 
         _grid.CurrentWorksheet = fillWorksheet
+        _grid.UpdateWorksheetStyle(fillWorksheet)
         _grid.AddColumns(dataFrame.clsColumnMetaData)
         _grid.AddRowData(dataFrame.clsColumnMetaData)
-        _grid.UpdateWorksheetStyle(fillWorksheet)
         dataFrame.clsColumnMetaData.HasChanged = False
     End Sub
 


### PR DESCRIPTION
Fixes (partially) #7643 
@lloyddewit this PR replaces PR #7918
@rdstern please have a look. 
This set the color to red of the selected columns in the Column Metadata grid
![image](https://user-images.githubusercontent.com/68591383/196174126-e07c6fe6-5f7f-4e15-90ef-8b80d636a46e.png)
