### PR TITLE
Fixed error message in Script window

### DIFF
--- a/instat/ucrScript.vb
+++ b/instat/ucrScript.vb
@@ -380,7 +380,7 @@ Public Class ucrScript
             txtScript.Paste()
             EnableDisableButtons()
         Else
-            MsgBox("You can only paste text data on the script window.", "Paste to Script Window")
+            MsgBox(Prompt:="You can only paste text data on the script window.", Title:="Paste to Script Window")
         End If
     End Sub
 

--- a/instat/ucrScript.vb
+++ b/instat/ucrScript.vb
@@ -380,7 +380,7 @@ Public Class ucrScript
             txtScript.Paste()
             EnableDisableButtons()
         Else
-            MsgBox(Prompt:="You can only paste text data on the script window.", Title:="Paste to Script Window")
+            MsgBox("You can only paste text data on the script window.", MsgBoxStyle.Exclamation, "Paste to Script Window")
         End If
     End Sub
 


### PR DESCRIPTION
Fixes #7931 

If I tried to paste an image (e.g. jpeg) into the script window, it would try to bring up the error message that this cannot be performed.
However, instead of bringing up the error message, it would crash.
This fixes that bug

@africanmathsinitiative/developers this is ready to review

