### PR TITLE
Ensured big numbers can be displayed in Data View grid

### DIFF
--- a/instat/static/InstatObject/R/stand_alone_functions.R
+++ b/instat/static/InstatObject/R/stand_alone_functions.R
@@ -27,11 +27,12 @@ convert_to_character_matrix <- function(data, format_decimal_places = TRUE, deci
         #  format(data[[i]], digits = decimal_places[i], scientific = is_scientific[i])
         temp_data <- c()
         for(val in data[[i]]){
-            if(nchar(val) > 9){
+            #if(nchar(val) > 9 && is_scientific[i]){
+            #   temp_data <- append(temp_data, format(val, digits = decimal_places[i], scientific = is_scientific[i]))
                temp_data <- append(temp_data, format(val, digits = decimal_places[i], scientific = is_scientific[i]))
-            }else{
-               temp_data <- append(temp_data, val)
-            }
+            #}else{
+            #   temp_data <- append(temp_data, val)
+            #}
         }
         out[, i] <- temp_data
       }

--- a/instat/static/InstatObject/R/stand_alone_functions.R
+++ b/instat/static/InstatObject/R/stand_alone_functions.R
@@ -23,8 +23,19 @@ convert_to_character_matrix <- function(data, format_decimal_places = TRUE, deci
         #which are recognised oddly by the R.Net
         out[, i] <- as.character(data[[i]])
       } else {
-        out[, i] <-
-          format(data[[i]], digits = decimal_places[i], scientific = is_scientific[i])
+        #out[, i] <-
+        #  format(data[[i]], digits = decimal_places[i], scientific = is_scientific[i])
+                #out[, i] <-
+        #  format(data[[i]], digits = decimal_places[i], scientific = is_scientific[i])
+        temp_data <- c()
+        for(val in data[[i]]){
+            if(nchar(val) > 9){
+               temp_data <- append(temp_data, format(val, digits = decimal_places[i], scientific = is_scientific[i]))
+            }else{
+               temp_data <- append(temp_data, val)
+            }
+        }
+        out[, i] <- temp_data
       }
       if (!is.null(na_display)) {
         out[is.na(data[[i]]), i] <- na_display

--- a/instat/static/InstatObject/R/stand_alone_functions.R
+++ b/instat/static/InstatObject/R/stand_alone_functions.R
@@ -25,8 +25,6 @@ convert_to_character_matrix <- function(data, format_decimal_places = TRUE, deci
       } else {
         #out[, i] <-
         #  format(data[[i]], digits = decimal_places[i], scientific = is_scientific[i])
-                #out[, i] <-
-        #  format(data[[i]], digits = decimal_places[i], scientific = is_scientific[i])
         temp_data <- c()
         for(val in data[[i]]){
             if(nchar(val) > 9){

--- a/instat/static/InstatObject/R/stand_alone_functions.R
+++ b/instat/static/InstatObject/R/stand_alone_functions.R
@@ -27,12 +27,11 @@ convert_to_character_matrix <- function(data, format_decimal_places = TRUE, deci
         #  format(data[[i]], digits = decimal_places[i], scientific = is_scientific[i])
         temp_data <- c()
         for(val in data[[i]]){
-            #if(nchar(val) > 9 && is_scientific[i]){
-            #   temp_data <- append(temp_data, format(val, digits = decimal_places[i], scientific = is_scientific[i]))
+            if(nchar(val) > 9 && is.na(is_scientific[i])){
                temp_data <- append(temp_data, format(val, digits = decimal_places[i], scientific = is_scientific[i]))
-            #}else{
-            #   temp_data <- append(temp_data, val)
-            #}
+            } else{
+              temp_data <- append(temp_data, format(val, digits = decimal_places[i], scientific = is_scientific[i]))
+            }
         }
         out[, i] <- temp_data
       }

--- a/instat/static/InstatObject/R/stand_alone_functions.R
+++ b/instat/static/InstatObject/R/stand_alone_functions.R
@@ -25,11 +25,7 @@ convert_to_character_matrix <- function(data, format_decimal_places = TRUE, deci
       } else {
         temp_data <- c()
         for(val in data[[i]]){
-            if(nchar(val) > 9 && is.na(is_scientific[i])){
-               temp_data <- append(temp_data, format(val, digits = decimal_places[i], scientific = is_scientific[i]))
-            } else{
-              temp_data <- append(temp_data, format(val, digits = decimal_places[i], scientific = is_scientific[i]))
-            }
+          temp_data <- append(temp_data, format(val, digits = decimal_places[i], scientific = is_scientific[i]))
         }
         out[, i] <- temp_data
       }

--- a/instat/static/InstatObject/R/stand_alone_functions.R
+++ b/instat/static/InstatObject/R/stand_alone_functions.R
@@ -23,8 +23,6 @@ convert_to_character_matrix <- function(data, format_decimal_places = TRUE, deci
         #which are recognised oddly by the R.Net
         out[, i] <- as.character(data[[i]])
       } else {
-        #out[, i] <-
-        #  format(data[[i]], digits = decimal_places[i], scientific = is_scientific[i])
         temp_data <- c()
         for(val in data[[i]]){
             if(nchar(val) > 9 && is.na(is_scientific[i])){

--- a/instat/ucrColumnMetadata.vb
+++ b/instat/ucrColumnMetadata.vb
@@ -181,7 +181,7 @@ Public Class ucrColumnMetadata
                 End If
                 strNewValue = newValue
             Else
-                MsgBox("Type TRUE/T to change to scientific display and FALSE/F back to numeric display and N or NA for a mixture", MsgBoxStyle.Information)
+                MsgBox("Type TRUE/T to change to scientific display and FALSE/F back to numeric display and NA/N for a mixture", MsgBoxStyle.Information)
                 Exit Sub
             End If
         Else

--- a/instat/ucrColumnMetadata.vb
+++ b/instat/ucrColumnMetadata.vb
@@ -172,13 +172,14 @@ Public Class ucrColumnMetadata
         ElseIf strColumnName = strLabelsScientific Then
             newValue = newValue.ToString.ToUpper
             If strBooleanValsAllowed.Contains(newValue) Then
-                If newValue(0) = "F" Then
-                    newValue = "FALSE"
-                ElseIf newValue(0) = "T" Then
-                    newValue = "TRUE"
-                ElseIf newValue(0) = "N" Then
-                    newValue = "NA"
-                End If
+                Select Case newValue(0)
+                    Case "F"
+                        newValue = "FALSE"
+                    Case "T"
+                        newValue = "TRUE"
+                    Case "N"
+                        newValue = "NA"
+                End Select
                 strNewValue = newValue
             Else
                 MsgBox("Type TRUE/T to change to scientific display and FALSE/F back to numeric display and NA/N for a mixture", MsgBoxStyle.Information)

--- a/instat/ucrColumnMetadata.vb
+++ b/instat/ucrColumnMetadata.vb
@@ -154,7 +154,7 @@ Public Class ucrColumnMetadata
         Dim strNameColumn As String
         Dim iTemp As Integer
         Dim strNewValue As String
-        Dim strBooleanValsAllowed As String() = {"T", "TR", "TRU", "TRUE", "F", "FA", "FAL", "FALS", "FALSE"}
+        Dim strBooleanValsAllowed As String() = {"T", "TR", "TRU", "TRUE", "F", "FA", "FAL", "FALS", "FALSE", "N", "NA"}
 
         strNameColumn = _grid.GetCellValue(iRow, strNameLabel)
         If strNameColumn = "" Then
@@ -174,12 +174,14 @@ Public Class ucrColumnMetadata
             If strBooleanValsAllowed.Contains(newValue) Then
                 If newValue(0) = "F" Then
                     newValue = "FALSE"
-                Else
+                ElseIf newValue(0) = "T" Then
                     newValue = "TRUE"
+                ElseIf newValue(0) = "N" Then
+                    newValue = "NA"
                 End If
                 strNewValue = newValue
             Else
-                MsgBox("Type TRUE/T to change to scientific display and FALSE/F back to numeric display", MsgBoxStyle.Information)
+                MsgBox("Type TRUE/T to change to scientific display and FALSE/F back to numeric display and N or NA for a mixture", MsgBoxStyle.Information)
                 Exit Sub
             End If
         Else


### PR DESCRIPTION
Fixes (partially) #7812 
@rdstern have a look of what we have now, when I use your example by creating a big number with `2^x1-1` in the corresponding issue I get this in the grid, with `Scientific = FALSE`
![image](https://user-images.githubusercontent.com/68591383/198229842-5c453303-ce00-4c43-807b-44eee5f569fa.png)

So, here when we set `Scientific = TRUE` we get the `e-notation` where the character are more than 9, you can see from row 30
![image](https://user-images.githubusercontent.com/68591383/198230148-e0858d5c-594a-4fd4-a998-11420b6a5646.png)
