### PR TITLE
 In Import dialog, read a JSON file with equal lengths of lists

### DIFF
--- a/instat/dlgImportDataset.vb
+++ b/instat/dlgImportDataset.vb
@@ -7,7 +7,7 @@ Public Class dlgImportDataset
 
     Private clsImportTextFileFormats, clsImportCSVFileFormats, clsImportRDS, clsReadRDS, clsImportExcel, clsImport, clsImportfromJSON As New RFunction
     Private clsGetExcelSheetNames As New RFunction
-    Private clsJsonDataFunction As New RFunction
+    Private clsJsonDataFrameFunction As New RFunction
     Private clsRangeOperator As New ROperator
     ''' <summary>   
     ''' Ensures that any file paths containing special characters (e.g. accents) are 
@@ -297,7 +297,7 @@ Public Class dlgImportDataset
         clsImport = New RFunction
         clsReadRDS = New RFunction
         clsImportfromJSON = New RFunction
-        clsJsonDataFunction = New RFunction
+        clsJsonDataFrameFunction = New RFunction
         clsGetExcelSheetNames = New RFunction
         clsRangeOperator = New ROperator
         clsEnc2Native = New RFunction
@@ -335,6 +335,9 @@ Public Class dlgImportDataset
 
         clsImportfromJSON.SetPackageName("jsonlite")
         clsImportfromJSON.SetRCommand("fromJSON")
+
+        clsJsonDataFrameFunction.SetRCommand("as.data.frame")
+        clsJsonDataFrameFunction.AddParameter("x", clsRFunctionParameter:=clsImportfromJSON, iPosition:=0)
 
         'This R command ensures that any file paths containing special characters (e.g. accents) 
         'are correctly encoded
@@ -482,7 +485,7 @@ Public Class dlgImportDataset
         ucrSaveFile.AddAdditionalRCode(clsImportMultipleFiles, iAdditionalPairNo:=5)
         ucrSaveFile.AddAdditionalRCode(clsImportMultipleTextFiles, iAdditionalPairNo:=6)
         ucrSaveFile.AddAdditionalRCode(clsPipeOperator, iAdditionalPairNo:=7)
-        ucrSaveFile.AddAdditionalRCode(clsJsonDataFunction, iAdditionalPairNo:=8)
+        ucrSaveFile.AddAdditionalRCode(clsJsonDataFrameFunction, iAdditionalPairNo:=8)
         ucrSaveFile.SetRCode(clsImport, bReset)
 
         'todo. commented temporarily until we are able to add an OR condition for the panel
@@ -680,7 +683,7 @@ Public Class dlgImportDataset
                 ExcelSheetsPreviewVisible(True)
                 FillExcelSheets()
             ElseIf IsJSONFileFormat() Then
-                ucrBase.clsRsyntax.SetBaseRFunction(clsJsonDataFunction)
+                ucrBase.clsRsyntax.SetBaseRFunction(clsJsonDataFrameFunction)
             Else
                 ucrBase.clsRsyntax.SetBaseRFunction(clsImport)
             End If

--- a/instat/dlgImportDataset.vb
+++ b/instat/dlgImportDataset.vb
@@ -5,8 +5,9 @@ Imports instat.Translations
 
 Public Class dlgImportDataset
 
-    Private clsImportTextFileFormats, clsImportCSVFileFormats, clsImportRDS, clsReadRDS, clsImportExcel, clsImport As New RFunction
+    Private clsImportTextFileFormats, clsImportCSVFileFormats, clsImportRDS, clsReadRDS, clsImportExcel, clsImport, clsImportfromJSON As New RFunction
     Private clsGetExcelSheetNames As New RFunction
+    Private clsJsonDataFunction As New RFunction
     Private clsRangeOperator As New ROperator
     ''' <summary>   
     ''' Ensures that any file paths containing special characters (e.g. accents) are 
@@ -295,6 +296,8 @@ Public Class dlgImportDataset
         clsImportExcel = New RFunction
         clsImport = New RFunction
         clsReadRDS = New RFunction
+        clsImportfromJSON = New RFunction
+        clsJsonDataFunction = New RFunction
         clsGetExcelSheetNames = New RFunction
         clsRangeOperator = New ROperator
         clsEnc2Native = New RFunction
@@ -329,6 +332,9 @@ Public Class dlgImportDataset
 
         clsReadRDS.SetRCommand("readRDS")
         clsReadRDS.SetAssignTo("new_RDS")
+
+        clsImportfromJSON.SetPackageName("jsonlite")
+        clsImportfromJSON.SetRCommand("fromJSON")
 
         'This R command ensures that any file paths containing special characters (e.g. accents) 
         'are correctly encoded
@@ -465,6 +471,7 @@ Public Class dlgImportDataset
         ucrInputFilePath.AddAdditionalCodeParameterPair(clsImportExcelMulti, New RParameter("file", 0), iAdditionalPairNo:=6)
         ucrInputFilePath.AddAdditionalCodeParameterPair(clsGetFilesList, New RParameter("path", 0), iAdditionalPairNo:=7)
         ucrInputFilePath.AddAdditionalCodeParameterPair(clsFileNamesWithExt, New RParameter("path", 0), iAdditionalPairNo:=8)
+        ucrInputFilePath.AddAdditionalCodeParameterPair(clsImportfromJSON, New RParameter("txt", 0), iAdditionalPairNo:=9)
         ucrInputFilePath.SetRCode(clsImport, bReset)
 
         'Save control
@@ -475,6 +482,7 @@ Public Class dlgImportDataset
         ucrSaveFile.AddAdditionalRCode(clsImportMultipleFiles, iAdditionalPairNo:=5)
         ucrSaveFile.AddAdditionalRCode(clsImportMultipleTextFiles, iAdditionalPairNo:=6)
         ucrSaveFile.AddAdditionalRCode(clsPipeOperator, iAdditionalPairNo:=7)
+        ucrSaveFile.AddAdditionalRCode(clsJsonDataFunction, iAdditionalPairNo:=8)
         ucrSaveFile.SetRCode(clsImport, bReset)
 
         'todo. commented temporarily until we are able to add an OR condition for the panel
@@ -671,6 +679,8 @@ Public Class dlgImportDataset
                 ucrBase.clsRsyntax.SetBaseRFunction(If(clbSheets.CheckedItems.Count > 1, clsImportExcelMulti, clsImportExcel))
                 ExcelSheetsPreviewVisible(True)
                 FillExcelSheets()
+            ElseIf IsJSONFileFormat() Then
+                ucrBase.clsRsyntax.SetBaseRFunction(clsJsonDataFunction)
             Else
                 ucrBase.clsRsyntax.SetBaseRFunction(clsImport)
             End If
@@ -772,7 +782,7 @@ Public Class dlgImportDataset
         bCanImport = False
 
         'grid preview is only supported for a few file formats. It is also not supported for folders
-        If bImportFromFolder OrElse Not (IsTextFileFormat() OrElse IsCSVFileFormat() OrElse IsExcelFileFormat()) Then
+        If bImportFromFolder OrElse Not (IsTextFileFormat() OrElse IsCSVFileFormat() OrElse IsExcelFileFormat() OrElse IsJSONFileFormat()) Then
             lblNoPreview.Show()
             bCanImport = True 'assume its true if preview is not supported for the file
             Exit Sub
@@ -782,6 +792,8 @@ Public Class dlgImportDataset
         If IsTextFileFormat() Then
             strRowMaxParamName = If(rdoSeparatortext.Checked, "nrows", "n_max")
         ElseIf IsCSVFileFormat() Then
+            strRowMaxParamName = "nrows"
+        ElseIf IsJSONFileFormat() Then
             strRowMaxParamName = "nrows"
         ElseIf IsExcelFileFormat() Then
             If dctSelectedExcelSheets.Count = 0 Then
@@ -1196,6 +1208,10 @@ Public Class dlgImportDataset
 
     Private Function IsExcelFileFormat() As Boolean
         Return {".xlsx", ".xls"}.Contains(strFileExtension)
+    End Function
+
+    Private Function IsJSONFileFormat() As Boolean
+        Return {".json"}.Contains(strFileExtension)
     End Function
 
     Private Sub RemoveMissingValues()


### PR DESCRIPTION
This Fixes #7714 
@rdstern, This is in progress.
So far the code can import a JSON file with equal lengths of lists. Am working towards being able to import JSON files with unequal lengths of lists.
I tried importing a simple txt file and the current options managed to import it to R-Instat, though I haven't tried with a bigger txt file!