### PR TITLE
Added missing strings in Scale/Distances dialog to the database

### DIFF
--- a/instat/dlgCluster.Designer.vb
+++ b/instat/dlgCluster.Designer.vb
@@ -194,7 +194,7 @@ Partial Class dlgCluster
         Me.ucrPnlSelectData.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.ucrPnlSelectData.Location = New System.Drawing.Point(255, 65)
         Me.ucrPnlSelectData.Name = "ucrPnlSelectData"
-        Me.ucrPnlSelectData.Size = New System.Drawing.Size(135, 48)
+        Me.ucrPnlSelectData.Size = New System.Drawing.Size(160, 48)
         Me.ucrPnlSelectData.TabIndex = 4
         '
         'ucrPnlPrepareData


### PR DESCRIPTION
@N-thony , @lloyddewit - I have added missing strings mentioned in  issue #7749   to the database.

![image](https://user-images.githubusercontent.com/89011415/202989827-21825ad1-3205-495e-a01e-2a432bdbec70.png)
