### PR TITLE
Improvement of the code quality of receiver logic that checks that when a dialog is reopened, only columns that still exist are shown in the list of selected columns

### DIFF
--- a/instat/ucrReceiver.vb
+++ b/instat/ucrReceiver.vb
@@ -130,7 +130,7 @@ Public Class ucrReceiver
 
     End Sub
 
-    'This refers to the selector list of column
+    'This refers to the selector list of columns
     Public Overridable Sub RemoveAnyVariablesNotInList()
 
     End Sub

--- a/instat/ucrReceiver.vb
+++ b/instat/ucrReceiver.vb
@@ -130,7 +130,7 @@ Public Class ucrReceiver
 
     End Sub
 
-    Public Overridable Sub RemoveAnyVariablesNotInList(lstViewItem As ListView)
+    Public Overridable Sub RemoveAnyVariablesNotInList()
 
     End Sub
 

--- a/instat/ucrReceiver.vb
+++ b/instat/ucrReceiver.vb
@@ -130,6 +130,7 @@ Public Class ucrReceiver
 
     End Sub
 
+    'This refers to the selector list of column
     Public Overridable Sub RemoveAnyVariablesNotInList()
 
     End Sub

--- a/instat/ucrReceiverMultiple.vb
+++ b/instat/ucrReceiverMultiple.vb
@@ -312,10 +312,9 @@ Public Class ucrReceiverMultiple
     ''' Removes any variable in the multiple receiver
     ''' that is not in the list of variables of the selector
     ''' </summary>
-    ''' <param name="lstViewItem"></param>
-    Public Overrides Sub RemoveAnyVariablesNotInList(lstViewItem As ListView)
+    Public Overrides Sub RemoveAnyVariablesNotInList()
         For Each strVar In GetVariableNamesAsList()
-            If lstViewItem.FindItemWithText(strVar) Is Nothing Then
+            If Selector.lstAvailableVariable.FindItemWithText(strVar) Is Nothing Then
                 Remove({strVar})
             End If
         Next
@@ -381,7 +380,7 @@ Public Class ucrReceiverMultiple
         kvpItems(0) = New KeyValuePair(Of String, String)(strDataFrame, strItem)
         AddMultiple(kvpItems)
 
-        RemoveAnyVariablesNotInList(Selector.lstAvailableVariable) 'needed due to the Autofill option
+        RemoveAnyVariablesNotInList() 'needed due to the Autofill option
 
         lstSelectedVariables.Enabled = Not bFixreceiver
     End Sub

--- a/instat/ucrSelector.vb
+++ b/instat/ucrSelector.vb
@@ -148,7 +148,7 @@ Public Class ucrSelector
 
         'todo, for columns, the list view should be field with variables from the .Net metadata object
         frmMain.clsRLink.FillListView(lstAvailableVariable, strType:=strCurrentType, lstIncludedDataTypes:=lstCombinedMetadataLists(0), lstExcludedDataTypes:=lstCombinedMetadataLists(1), strHeading:=CurrentReceiver.strSelectorHeading, strDataFrameName:=strCurrentDataFrame, strExcludedItems:=arrStrExclud, strDatabaseQuery:=CurrentReceiver.strDatabaseQuery, strNcFilePath:=CurrentReceiver.strNcFilePath)
-        CurrentReceiver.RemoveAnyVariablesNotInList()
+        CurrentReceiver.RemoveAnyVariablesNotInList() 'this needed for the multiple receiver(s) where the autofill is not applied
         EnableDataOptions(strCurrentType)
 
     End Sub

--- a/instat/ucrSelector.vb
+++ b/instat/ucrSelector.vb
@@ -148,7 +148,7 @@ Public Class ucrSelector
 
         'todo, for columns, the list view should be field with variables from the .Net metadata object
         frmMain.clsRLink.FillListView(lstAvailableVariable, strType:=strCurrentType, lstIncludedDataTypes:=lstCombinedMetadataLists(0), lstExcludedDataTypes:=lstCombinedMetadataLists(1), strHeading:=CurrentReceiver.strSelectorHeading, strDataFrameName:=strCurrentDataFrame, strExcludedItems:=arrStrExclud, strDatabaseQuery:=CurrentReceiver.strDatabaseQuery, strNcFilePath:=CurrentReceiver.strNcFilePath)
-        CurrentReceiver.RemoveAnyVariablesNotInList(lstAvailableVariable)
+        CurrentReceiver.RemoveAnyVariablesNotInList()
         EnableDataOptions(strCurrentType)
 
     End Sub


### PR DESCRIPTION
Fixes #8073
@lloyddewit @Patowhiz I have the changes suggested in PR #7581. Please take a look. Thanks