### PR TITLE
Ensured output for Two Way Frequencies dialog is correct

### DIFF
--- a/instat/dlgTwoWayFrequencies.vb
+++ b/instat/dlgTwoWayFrequencies.vb
@@ -141,7 +141,6 @@ Public Class dlgTwoWayFrequencies
         ucrPnlFreqDisplay.AddToLinkedControls(ucrChkCell, {rdoTable, rdoBoth}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
         ucrPnlFreqDisplay.AddToLinkedControls(ucrChkColumn, {rdoTable, rdoBoth}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
         ucrPnlFreqDisplay.AddToLinkedControls(ucrPnlFreqType, {rdoGraph, rdoBoth}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:=rdoCount)
-        'ucrPnlFreqDisplay.AddToLinkedControls(ucrSaveGraph, {rdoGraph, rdoBoth}, bNewLinkedHideIfParameterMissing:=True)
         ucrPnlFreqDisplay.AddToLinkedControls(ucrChkFacetGrid, {rdoGraph, rdoBoth}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:="TRUE")
         ucrPnlFreqType.SetLinkedDisplayControl(grpFreqTypeGraph)
 

--- a/instat/dlgTwoWayFrequencies.vb
+++ b/instat/dlgTwoWayFrequencies.vb
@@ -141,16 +141,13 @@ Public Class dlgTwoWayFrequencies
         ucrPnlFreqDisplay.AddToLinkedControls(ucrChkCell, {rdoTable, rdoBoth}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
         ucrPnlFreqDisplay.AddToLinkedControls(ucrChkColumn, {rdoTable, rdoBoth}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
         ucrPnlFreqDisplay.AddToLinkedControls(ucrPnlFreqType, {rdoGraph, rdoBoth}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:=rdoCount)
-        ucrPnlFreqDisplay.AddToLinkedControls(ucrSaveGraph, {rdoGraph, rdoBoth}, bNewLinkedHideIfParameterMissing:=True)
+        'ucrPnlFreqDisplay.AddToLinkedControls(ucrSaveGraph, {rdoGraph, rdoBoth}, bNewLinkedHideIfParameterMissing:=True)
         ucrPnlFreqDisplay.AddToLinkedControls(ucrChkFacetGrid, {rdoGraph, rdoBoth}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:="TRUE")
         ucrPnlFreqType.SetLinkedDisplayControl(grpFreqTypeGraph)
 
         ucrSaveGraph.SetPrefix("two_way_freq")
-        ucrSaveGraph.SetSaveTypeAsGraph()
         ucrSaveGraph.SetDataFrameSelector(ucrSelectorTwoWayFrequencies.ucrAvailableDataFrames)
-        ucrSaveGraph.SetCheckBoxText("Save Graph")
         ucrSaveGraph.SetIsComboBox()
-        ucrSaveGraph.SetAssignToIfUncheckedValue("last_graph")
         ucrChkColumn.SetLinkedDisplayControl(grpFreqTypeTable)
     End Sub
 
@@ -172,13 +169,11 @@ Public Class dlgTwoWayFrequencies
         clsSjTab.AddParameter("fun", Chr(34) & "xtab" & Chr(34))
         clsSjTab.AddParameter("title", Chr(34) & "" & Chr(34))
         clsSjTab.AddParameter("string.total", Chr(34) & "Total" & Chr(34))
-
-        clsSjTab.SetAssignToOutputObject("last_table",
-                                         RObjectTypeLabel.Table,
-                                         RObjectFormat.Html,
-                                         ucrSelectorTwoWayFrequencies.strCurrentDataFrame,
-                                         "last_table")
-
+        clsSjTab.SetAssignToOutputObject(strRObjectToAssignTo:="last_table",
+                                               strRObjectTypeLabelToAssignTo:=RObjectTypeLabel.Table,
+                                               strRObjectFormatToAssignTo:=RObjectFormat.Html,
+                                               strRDataFrameNameToAddObjectTo:=ucrSelectorTwoWayFrequencies.strCurrentDataFrame,
+                                               strObjectName:="last_table")
 
         'Defining Plot functions and default functions
         clsSjPlot.SetPackageName("sjPlot")
@@ -188,11 +183,11 @@ Public Class dlgTwoWayFrequencies
         clsSjPlot.AddParameter("show.n", "TRUE")
         clsSjPlot.AddParameter("title", Chr(34) & "" & Chr(34))
         clsSjPlot.AddParameter("facet.grid", "TRUE")
-        clsSjPlot.SetAssignToOutputObject("last_graph",
-                                          RObjectTypeLabel.Graph,
-                                          RObjectFormat.Image,
-                                          ucrSelectorTwoWayFrequencies.strCurrentDataFrame,
-                                          "last_graph")
+        clsSjPlot.SetAssignToOutputObject(strRObjectToAssignTo:="last_graph",
+                                               strRObjectTypeLabelToAssignTo:=RObjectTypeLabel.Graph,
+                                               strRObjectFormatToAssignTo:=RObjectFormat.Image,
+                                               strRDataFrameNameToAddObjectTo:=ucrSelectorTwoWayFrequencies.strCurrentDataFrame,
+                                               strObjectName:="last_graph")
 
         ucrBase.clsRsyntax.SetBaseRFunction(clsSjTab)
         bResetSubdialog = True
@@ -206,6 +201,9 @@ Public Class dlgTwoWayFrequencies
         clsTempParamOne = New RParameter("x", 1)
         clsTempParamOne.bIncludeArgumentName = False
         ucrReceiverRowFactor.AddAdditionalCodeParameterPair(clsSjPlot, clsTempParamOne, iAdditionalPairNo:=1)
+
+        ucrSaveGraph.AddAdditionalRCode(clsSjTab, iAdditionalPairNo:=1)
+        ucrSaveGraph.AddAdditionalRCode(clsSjPlot, iAdditionalPairNo:=2)
 
         clsTempParamTwo = New RParameter("grp", 2)
         clsTempParamTwo.bIncludeArgumentName = False
@@ -380,12 +378,14 @@ Public Class dlgTwoWayFrequencies
     Private Sub SetBaseFunction()
         If rdoTable.Checked OrElse rdoBoth.Checked Then
             ucrBase.clsRsyntax.SetBaseRFunction(clsSjTab)
-            'ucrBase.clsRsyntax.bHTMLOutput = True
-            ucrBase.clsRsyntax.iCallType = 2
+            ucrSaveGraph.SetSaveType(RObjectTypeLabel.Table, strRObjectFormat:=RObjectFormat.Html)
+            ucrSaveGraph.SetAssignToIfUncheckedValue("last_table")
+            ucrSaveGraph.SetCheckBoxText("Save Table")
         ElseIf rdoGraph.Checked Then
             ucrBase.clsRsyntax.SetBaseRFunction(clsSjPlot)
-            ' ucrBase.clsRsyntax.bHTMLOutput = False
-            ucrBase.clsRsyntax.iCallType = 3
+            ucrSaveGraph.SetSaveType(RObjectTypeLabel.Graph, strRObjectFormat:=RObjectFormat.Image)
+            ucrSaveGraph.SetAssignToIfUncheckedValue("last_graph")
+            ucrSaveGraph.SetCheckBoxText("Save Graph")
         End If
     End Sub
 

--- a/instat/dlgTwoWayFrequencies.vb
+++ b/instat/dlgTwoWayFrequencies.vb
@@ -247,7 +247,7 @@ Public Class dlgTwoWayFrequencies
     End Sub
 
     Private Sub TestOkEnabled()
-        If Not ucrReceiverColumnFactor.IsEmpty() AndAlso Not ucrReceiverRowFactor.IsEmpty() AndAlso ucrSaveGraph.IsComplete Then
+        If Not ucrReceiverColumnFactor.IsEmpty() AndAlso ucrSaveGraph.IsComplete AndAlso Not ucrReceiverRowFactor.IsEmpty() AndAlso ucrSaveGraph.IsComplete Then
             If Not ucrChkWeights.Checked Then
                 ucrBase.OKEnabled(True)
             Else


### PR DESCRIPTION
fixes partly #8104 

@lloyddewit , @Patowhiz this PR is ready for review

I added the save control for the `table option` of this dialogue and implemented the `new output system` for both the `graph and table options` of this dialogue. 