### PR TITLE
Implemented new output system in Describe >One variable >Frequencies dialog

### DIFF
--- a/instat/dlgOneWayFrequencies.Designer.vb
+++ b/instat/dlgOneWayFrequencies.Designer.vb
@@ -42,35 +42,34 @@ Partial Class dlgOneWayFrequencies
         Me.rdoDescending = New System.Windows.Forms.RadioButton()
         Me.rdoAscending = New System.Windows.Forms.RadioButton()
         Me.rdoNone = New System.Windows.Forms.RadioButton()
-        Me.ucrPnlSort = New instat.UcrPanel()
         Me.cmdOptions = New System.Windows.Forms.Button()
         Me.lblSelectedVariable = New System.Windows.Forms.Label()
         Me.rdoGraph = New System.Windows.Forms.RadioButton()
         Me.rdoTable = New System.Windows.Forms.RadioButton()
         Me.rdoBoth = New System.Windows.Forms.RadioButton()
         Me.grpOutput = New System.Windows.Forms.GroupBox()
-        Me.rdoAsHtml = New System.Windows.Forms.RadioButton()
-        Me.rdoAsText = New System.Windows.Forms.RadioButton()
-        Me.ucrPnlOutput = New instat.UcrPanel()
+        Me.rdoAsTable = New System.Windows.Forms.RadioButton()
+        Me.rdoAsDataFrame = New System.Windows.Forms.RadioButton()
         Me.rdoStemAndLeaf = New System.Windows.Forms.RadioButton()
+        Me.ucrNudWidth = New instat.ucrNud()
         Me.ucrReceiverStemAndLeaf = New instat.ucrReceiverSingle()
         Me.ucrNudScale = New instat.ucrNud()
-        Me.ucrSaveDataFrame = New instat.ucrSave()
         Me.ucrNudMinFreq = New instat.ucrNud()
+        Me.ucrPnlOutput = New instat.UcrPanel()
         Me.ucrSaveGraph = New instat.ucrSave()
         Me.ucrNudGroups = New instat.ucrNud()
         Me.ucrPnlFrequencies = New instat.UcrPanel()
-        Me.ucrChkGroupData = New instat.ucrCheck()
         Me.ucrReceiverWeights = New instat.ucrReceiverSingle()
-        Me.ucrChkWeights = New instat.ucrCheck()
+        Me.ucrPnlSort = New instat.UcrPanel()
         Me.ucrBase = New instat.ucrButtons()
         Me.ucrSelectorOneWayFreq = New instat.ucrSelectorByDataFrameAddRemove()
         Me.ucrChkFlip = New instat.ucrCheck()
-        Me.ucrChkMinFrq = New instat.ucrCheck()
         Me.ucrChkScale = New instat.ucrCheck()
         Me.ucrReceiverOneWayFreq = New instat.ucrReceiverMultiple()
+        Me.ucrChkMinFrq = New instat.ucrCheck()
+        Me.ucrChkWeights = New instat.ucrCheck()
         Me.ucrChkWidth = New instat.ucrCheck()
-        Me.ucrNudWidth = New instat.ucrNud()
+        Me.ucrChkGroupData = New instat.ucrCheck()
         Me.grpSort.SuspendLayout()
         Me.grpOutput.SuspendLayout()
         Me.SuspendLayout()
@@ -120,14 +119,6 @@ Partial Class dlgOneWayFrequencies
         Me.rdoNone.TabStop = True
         Me.rdoNone.Text = "None"
         Me.rdoNone.UseVisualStyleBackColor = True
-        '
-        'ucrPnlSort
-        '
-        Me.ucrPnlSort.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrPnlSort.Location = New System.Drawing.Point(3, 14)
-        Me.ucrPnlSort.Name = "ucrPnlSort"
-        Me.ucrPnlSort.Size = New System.Drawing.Size(158, 69)
-        Me.ucrPnlSort.TabIndex = 0
         '
         'cmdOptions
         '
@@ -184,6 +175,7 @@ Partial Class dlgOneWayFrequencies
         'rdoBoth
         '
         Me.rdoBoth.Appearance = System.Windows.Forms.Appearance.Button
+        Me.rdoBoth.Enabled = False
         Me.rdoBoth.FlatAppearance.BorderColor = System.Drawing.SystemColors.ActiveCaption
         Me.rdoBoth.FlatAppearance.BorderSize = 2
         Me.rdoBoth.FlatAppearance.CheckedBackColor = System.Drawing.SystemColors.ActiveCaption
@@ -199,8 +191,8 @@ Partial Class dlgOneWayFrequencies
         '
         'grpOutput
         '
-        Me.grpOutput.Controls.Add(Me.rdoAsHtml)
-        Me.grpOutput.Controls.Add(Me.rdoAsText)
+        Me.grpOutput.Controls.Add(Me.rdoAsTable)
+        Me.grpOutput.Controls.Add(Me.rdoAsDataFrame)
         Me.grpOutput.Controls.Add(Me.ucrPnlOutput)
         Me.grpOutput.Location = New System.Drawing.Point(258, 275)
         Me.grpOutput.Name = "grpOutput"
@@ -209,35 +201,27 @@ Partial Class dlgOneWayFrequencies
         Me.grpOutput.TabStop = False
         Me.grpOutput.Text = "Output "
         '
-        'rdoAsHtml
+        'rdoAsTable
         '
-        Me.rdoAsHtml.AutoSize = True
-        Me.rdoAsHtml.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.rdoAsHtml.Location = New System.Drawing.Point(6, 43)
-        Me.rdoAsHtml.Name = "rdoAsHtml"
-        Me.rdoAsHtml.Size = New System.Drawing.Size(102, 17)
-        Me.rdoAsHtml.TabIndex = 2
-        Me.rdoAsHtml.Text = "HTML (Browser)"
-        Me.rdoAsHtml.UseVisualStyleBackColor = True
+        Me.rdoAsTable.AutoSize = True
+        Me.rdoAsTable.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.rdoAsTable.Location = New System.Drawing.Point(6, 20)
+        Me.rdoAsTable.Name = "rdoAsTable"
+        Me.rdoAsTable.Size = New System.Drawing.Size(67, 17)
+        Me.rdoAsTable.TabIndex = 2
+        Me.rdoAsTable.Text = "As Table"
+        Me.rdoAsTable.UseVisualStyleBackColor = True
         '
-        'rdoAsText
+        'rdoAsDataFrame
         '
-        Me.rdoAsText.AutoSize = True
-        Me.rdoAsText.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.rdoAsText.Location = New System.Drawing.Point(6, 20)
-        Me.rdoAsText.Name = "rdoAsText"
-        Me.rdoAsText.Size = New System.Drawing.Size(129, 17)
-        Me.rdoAsText.TabIndex = 1
-        Me.rdoAsText.Text = "Text (Output Window)"
-        Me.rdoAsText.UseVisualStyleBackColor = True
-        '
-        'ucrPnlOutput
-        '
-        Me.ucrPnlOutput.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrPnlOutput.Location = New System.Drawing.Point(3, 16)
-        Me.ucrPnlOutput.Name = "ucrPnlOutput"
-        Me.ucrPnlOutput.Size = New System.Drawing.Size(150, 53)
-        Me.ucrPnlOutput.TabIndex = 0
+        Me.rdoAsDataFrame.AutoSize = True
+        Me.rdoAsDataFrame.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.rdoAsDataFrame.Location = New System.Drawing.Point(6, 46)
+        Me.rdoAsDataFrame.Name = "rdoAsDataFrame"
+        Me.rdoAsDataFrame.Size = New System.Drawing.Size(92, 17)
+        Me.rdoAsDataFrame.TabIndex = 1
+        Me.rdoAsDataFrame.Text = "As DataFrame"
+        Me.rdoAsDataFrame.UseVisualStyleBackColor = True
         '
         'rdoStemAndLeaf
         '
@@ -254,6 +238,19 @@ Partial Class dlgOneWayFrequencies
         Me.rdoStemAndLeaf.Text = "Stem and Leaf"
         Me.rdoStemAndLeaf.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
         Me.rdoStemAndLeaf.UseVisualStyleBackColor = True
+        '
+        'ucrNudWidth
+        '
+        Me.ucrNudWidth.AutoSize = True
+        Me.ucrNudWidth.DecimalPlaces = New Decimal(New Integer() {0, 0, 0, 0})
+        Me.ucrNudWidth.Increment = New Decimal(New Integer() {1, 0, 0, 0})
+        Me.ucrNudWidth.Location = New System.Drawing.Point(142, 260)
+        Me.ucrNudWidth.Maximum = New Decimal(New Integer() {100, 0, 0, 0})
+        Me.ucrNudWidth.Minimum = New Decimal(New Integer() {0, 0, 0, 0})
+        Me.ucrNudWidth.Name = "ucrNudWidth"
+        Me.ucrNudWidth.Size = New System.Drawing.Size(50, 20)
+        Me.ucrNudWidth.TabIndex = 16
+        Me.ucrNudWidth.Value = New Decimal(New Integer() {0, 0, 0, 0})
         '
         'ucrReceiverStemAndLeaf
         '
@@ -281,15 +278,6 @@ Partial Class dlgOneWayFrequencies
         Me.ucrNudScale.TabIndex = 13
         Me.ucrNudScale.Value = New Decimal(New Integer() {0, 0, 0, 0})
         '
-        'ucrSaveDataFrame
-        '
-        Me.ucrSaveDataFrame.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrSaveDataFrame.Location = New System.Drawing.Point(10, 376)
-        Me.ucrSaveDataFrame.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
-        Me.ucrSaveDataFrame.Name = "ucrSaveDataFrame"
-        Me.ucrSaveDataFrame.Size = New System.Drawing.Size(304, 24)
-        Me.ucrSaveDataFrame.TabIndex = 23
-        '
         'ucrNudMinFreq
         '
         Me.ucrNudMinFreq.AutoSize = True
@@ -303,10 +291,18 @@ Partial Class dlgOneWayFrequencies
         Me.ucrNudMinFreq.TabIndex = 21
         Me.ucrNudMinFreq.Value = New Decimal(New Integer() {0, 0, 0, 0})
         '
+        'ucrPnlOutput
+        '
+        Me.ucrPnlOutput.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrPnlOutput.Location = New System.Drawing.Point(3, 16)
+        Me.ucrPnlOutput.Name = "ucrPnlOutput"
+        Me.ucrPnlOutput.Size = New System.Drawing.Size(150, 53)
+        Me.ucrPnlOutput.TabIndex = 0
+        '
         'ucrSaveGraph
         '
         Me.ucrSaveGraph.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrSaveGraph.Location = New System.Drawing.Point(10, 352)
+        Me.ucrSaveGraph.Location = New System.Drawing.Point(10, 368)
         Me.ucrSaveGraph.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
         Me.ucrSaveGraph.Name = "ucrSaveGraph"
         Me.ucrSaveGraph.Size = New System.Drawing.Size(304, 24)
@@ -333,15 +329,6 @@ Partial Class dlgOneWayFrequencies
         Me.ucrPnlFrequencies.Size = New System.Drawing.Size(410, 35)
         Me.ucrPnlFrequencies.TabIndex = 0
         '
-        'ucrChkGroupData
-        '
-        Me.ucrChkGroupData.AutoSize = True
-        Me.ucrChkGroupData.Checked = False
-        Me.ucrChkGroupData.Location = New System.Drawing.Point(10, 280)
-        Me.ucrChkGroupData.Name = "ucrChkGroupData"
-        Me.ucrChkGroupData.Size = New System.Drawing.Size(145, 23)
-        Me.ucrChkGroupData.TabIndex = 17
-        '
         'ucrReceiverWeights
         '
         Me.ucrReceiverWeights.AutoSize = True
@@ -355,20 +342,19 @@ Partial Class dlgOneWayFrequencies
         Me.ucrReceiverWeights.TabIndex = 15
         Me.ucrReceiverWeights.ucrSelector = Nothing
         '
-        'ucrChkWeights
+        'ucrPnlSort
         '
-        Me.ucrChkWeights.AutoSize = True
-        Me.ucrChkWeights.Checked = False
-        Me.ucrChkWeights.Location = New System.Drawing.Point(10, 256)
-        Me.ucrChkWeights.Name = "ucrChkWeights"
-        Me.ucrChkWeights.Size = New System.Drawing.Size(145, 23)
-        Me.ucrChkWeights.TabIndex = 14
+        Me.ucrPnlSort.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrPnlSort.Location = New System.Drawing.Point(3, 14)
+        Me.ucrPnlSort.Name = "ucrPnlSort"
+        Me.ucrPnlSort.Size = New System.Drawing.Size(158, 69)
+        Me.ucrPnlSort.TabIndex = 0
         '
         'ucrBase
         '
         Me.ucrBase.AutoSize = True
         Me.ucrBase.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrBase.Location = New System.Drawing.Point(10, 410)
+        Me.ucrBase.Location = New System.Drawing.Point(10, 400)
         Me.ucrBase.Name = "ucrBase"
         Me.ucrBase.Size = New System.Drawing.Size(408, 52)
         Me.ucrBase.TabIndex = 24
@@ -394,15 +380,6 @@ Partial Class dlgOneWayFrequencies
         Me.ucrChkFlip.Size = New System.Drawing.Size(210, 23)
         Me.ucrChkFlip.TabIndex = 19
         '
-        'ucrChkMinFrq
-        '
-        Me.ucrChkMinFrq.AutoSize = True
-        Me.ucrChkMinFrq.Checked = False
-        Me.ucrChkMinFrq.Location = New System.Drawing.Point(10, 326)
-        Me.ucrChkMinFrq.Name = "ucrChkMinFrq"
-        Me.ucrChkMinFrq.Size = New System.Drawing.Size(210, 23)
-        Me.ucrChkMinFrq.TabIndex = 20
-        '
         'ucrChkScale
         '
         Me.ucrChkScale.AutoSize = True
@@ -425,6 +402,24 @@ Partial Class dlgOneWayFrequencies
         Me.ucrReceiverOneWayFreq.TabIndex = 8
         Me.ucrReceiverOneWayFreq.ucrSelector = Nothing
         '
+        'ucrChkMinFrq
+        '
+        Me.ucrChkMinFrq.AutoSize = True
+        Me.ucrChkMinFrq.Checked = False
+        Me.ucrChkMinFrq.Location = New System.Drawing.Point(10, 326)
+        Me.ucrChkMinFrq.Name = "ucrChkMinFrq"
+        Me.ucrChkMinFrq.Size = New System.Drawing.Size(210, 23)
+        Me.ucrChkMinFrq.TabIndex = 20
+        '
+        'ucrChkWeights
+        '
+        Me.ucrChkWeights.AutoSize = True
+        Me.ucrChkWeights.Checked = False
+        Me.ucrChkWeights.Location = New System.Drawing.Point(10, 256)
+        Me.ucrChkWeights.Name = "ucrChkWeights"
+        Me.ucrChkWeights.Size = New System.Drawing.Size(145, 23)
+        Me.ucrChkWeights.TabIndex = 14
+        '
         'ucrChkWidth
         '
         Me.ucrChkWidth.AutoSize = True
@@ -434,30 +429,25 @@ Partial Class dlgOneWayFrequencies
         Me.ucrChkWidth.Size = New System.Drawing.Size(126, 23)
         Me.ucrChkWidth.TabIndex = 15
         '
-        'ucrNudWidth
+        'ucrChkGroupData
         '
-        Me.ucrNudWidth.AutoSize = True
-        Me.ucrNudWidth.DecimalPlaces = New Decimal(New Integer() {0, 0, 0, 0})
-        Me.ucrNudWidth.Increment = New Decimal(New Integer() {1, 0, 0, 0})
-        Me.ucrNudWidth.Location = New System.Drawing.Point(142, 260)
-        Me.ucrNudWidth.Maximum = New Decimal(New Integer() {100, 0, 0, 0})
-        Me.ucrNudWidth.Minimum = New Decimal(New Integer() {0, 0, 0, 0})
-        Me.ucrNudWidth.Name = "ucrNudWidth"
-        Me.ucrNudWidth.Size = New System.Drawing.Size(50, 20)
-        Me.ucrNudWidth.TabIndex = 16
-        Me.ucrNudWidth.Value = New Decimal(New Integer() {0, 0, 0, 0})
+        Me.ucrChkGroupData.AutoSize = True
+        Me.ucrChkGroupData.Checked = False
+        Me.ucrChkGroupData.Location = New System.Drawing.Point(10, 280)
+        Me.ucrChkGroupData.Name = "ucrChkGroupData"
+        Me.ucrChkGroupData.Size = New System.Drawing.Size(145, 23)
+        Me.ucrChkGroupData.TabIndex = 17
         '
         'dlgOneWayFrequencies
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
         Me.AutoSize = True
-        Me.ClientSize = New System.Drawing.Size(435, 470)
+        Me.ClientSize = New System.Drawing.Size(435, 456)
         Me.Controls.Add(Me.ucrNudWidth)
         Me.Controls.Add(Me.ucrReceiverStemAndLeaf)
         Me.Controls.Add(Me.ucrNudScale)
         Me.Controls.Add(Me.rdoStemAndLeaf)
-        Me.Controls.Add(Me.ucrSaveDataFrame)
         Me.Controls.Add(Me.ucrNudMinFreq)
         Me.Controls.Add(Me.grpOutput)
         Me.Controls.Add(Me.ucrSaveGraph)
@@ -514,12 +504,11 @@ Partial Class dlgOneWayFrequencies
     Friend WithEvents ucrReceiverOneWayFreq As ucrReceiverMultiple
     Friend WithEvents ucrSaveGraph As ucrSave
     Friend WithEvents grpOutput As GroupBox
-    Friend WithEvents rdoAsHtml As RadioButton
-    Friend WithEvents rdoAsText As RadioButton
+    Friend WithEvents rdoAsTable As RadioButton
+    Friend WithEvents rdoAsDataFrame As RadioButton
     Friend WithEvents ucrPnlOutput As UcrPanel
     Friend WithEvents ucrNudMinFreq As ucrNud
     Friend WithEvents ucrChkMinFrq As ucrCheck
-    Friend WithEvents ucrSaveDataFrame As ucrSave
     Private WithEvents rdoStemAndLeaf As RadioButton
     Friend WithEvents ucrNudScale As ucrNud
     Friend WithEvents ucrChkScale As ucrCheck

--- a/instat/dlgOneWayFrequencies.vb
+++ b/instat/dlgOneWayFrequencies.vb
@@ -104,14 +104,9 @@ Public Class dlgOneWayFrequencies
         ucrPnlFrequencies.AddToLinkedControls({ucrPnlSort, ucrChkWeights, ucrChkGroupData, ucrReceiverOneWayFreq}, {rdoTable, rdoGraph, rdoBoth}, bNewLinkedHideIfParameterMissing:=True, bNewLinkedAddRemoveParameter:=True)
         ucrPnlFrequencies.AddToLinkedControls({ucrReceiverStemAndLeaf, ucrChkScale, ucrChkWidth}, {rdoStemAndLeaf}, bNewLinkedHideIfParameterMissing:=True, bNewLinkedAddRemoveParameter:=True)
         ucrPnlFrequencies.AddToLinkedControls(ucrPnlOutput, {rdoBoth, rdoTable}, bNewLinkedHideIfParameterMissing:=True)
-        'ucrPnlOutput.AddToLinkedControls(ucrSaveGraph, {rdoAsDataFrame}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
-        'ucrPnlOutput.AddToLinkedControls(ucrSaveGraph, {rdoAsTable}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
         ucrPnlOutput.SetLinkedDisplayControl(grpOutput)
         ucrPnlSort.SetLinkedDisplayControl(grpSort)
         ucrReceiverOneWayFreq.SetLinkedDisplayControl(cmdOptions)
-
-        'ucrPnlFrequencies.AddToLinkedControls(ucrSaveGraph, {rdoTable, rdoBoth}, bNewLinkedHideIfParameterMissing:=True, bNewLinkedAddRemoveParameter:=True)
-
 
         ucrNudGroups.SetParameter(New RParameter("auto.grp", 9))
         ucrNudGroups.SetMinMax(2, 100)
@@ -158,12 +153,7 @@ Public Class dlgOneWayFrequencies
         ucrNudWidth.SetMinMax(20)
         ucrNudWidth.Increment = 1
 
-        'ucrSaveGraph.SetPrefix("one_way_freq")
-        'ucrSaveGraph.SetSaveTypeAsGraph()
         ucrSaveGraph.SetDataFrameSelector(ucrSelectorOneWayFreq.ucrAvailableDataFrames)
-        'ucrSaveGraph.SetCheckBoxText("Save Graph")
-        'ucrSaveGraph.SetIsComboBox()
-        'ucrSaveGraph.SetAssignToIfUncheckedValue("last_graph")
     End Sub
 
     Private Sub SetDefaults()
@@ -183,7 +173,6 @@ Public Class dlgOneWayFrequencies
         clsDummyFunction.AddParameter("checked", "as.table", iPosition:=1)
 
         clsAsDataFrame.SetRCommand("as.data.frame")
-        clsAsDataFrame.AddParameter("x", clsRFunctionParameter:=clsSjMiscFrq, iPosition:=0)
 
         clsPlotGrid.SetPackageName("sjPlot")
         clsPlotGrid.SetRCommand("plot_grid")
@@ -194,13 +183,11 @@ Public Class dlgOneWayFrequencies
 
         clsSjMiscFrq.SetPackageName("sjmisc")
         clsSjMiscFrq.SetRCommand("frq")
-        'clsSjMiscFrq.AddParameter("out", Chr(34) & "txt" & Chr(34), iPosition:=7)
 
         clsSjPlot.SetPackageName("sjPlot")
         clsSjPlot.SetRCommand("plot_frq")
         clsSjPlot.AddParameter("geom.size", 0.5, iPosition:=14)
         clsSjPlot.SetAssignTo("one_way_plot")
-        'clsPlotGrid.SetAssignTo("last_graph", strTempDataframe:=ucrSelectorOneWayFreq.ucrAvailableDataFrames.cboAvailableDataFrames.Text, strTempGraph:="last_graph")
 
         clsAsGGplot.SetPackageName("ggplotify")
         clsAsGGplot.SetRCommand("as.ggplot")
@@ -226,18 +213,15 @@ Public Class dlgOneWayFrequencies
         ucrNudGroups.AddAdditionalCodeParameterPair(clsSjPlot, New RParameter("auto.group", 9), iAdditionalPairNo:=1)
         ucrChkGroupData.AddAdditionalCodeParameterPair(clsSjPlot, New RParameter("auto.group", 9), iAdditionalPairNo:=1)
         ucrReceiverOneWayFreq.AddAdditionalCodeParameterPair(clsSjPlot, New RParameter("data", 0), iAdditionalPairNo:=1)
-        ucrSaveGraph.AddAdditionalRCode(clsSjMiscFrq)
         ucrSaveGraph.AddAdditionalRCode(clsAsDataFrame)
 
         ucrReceiverWeights.SetRCode(clsSjMiscFrq, bReset)
         ucrReceiverOneWayFreq.SetRCode(clsSjMiscFrq, bReset)
-        ucrPnlFrequencies.SetRCode(clsDummyFunction, bReset)
 
         ucrNudScale.SetRCode(clsStemAndLeafFunction, bReset)
         ucrNudWidth.SetRCode(clsStemAndLeafFunction, bReset)
         ucrChkScale.SetRCode(clsStemAndLeafFunction, bReset)
         ucrChkWidth.SetRCode(clsStemAndLeafFunction, bReset)
-        ucrPnlOutput.SetRCode(clsDummyFunction, bReset)
         ucrChkWeights.SetRCode(clsSjMiscFrq, bReset)
         ucrPnlSort.SetRCode(clsSjMiscFrq, bReset)
         ucrChkFlip.SetRCode(clsSjPlot, bReset)
@@ -247,8 +231,8 @@ Public Class dlgOneWayFrequencies
         ucrNudMinFreq.SetRCode(clsSjMiscFrq, bReset)
         ucrChkMinFrq.SetRCode(clsSjMiscFrq, bReset)
         ucrReceiverStemAndLeaf.SetRCode(clsStemAndLeafFunction, bReset)
-
-        'ucrSaveGraph.SetRCode(clsAsDataFrame, bReset)
+        ucrPnlFrequencies.SetRCode(clsDummyFunction, bReset)
+        ucrPnlOutput.SetRCode(clsDummyFunction, bReset)
     End Sub
 
     Private Sub SetDefaultColumn()
@@ -316,32 +300,22 @@ Public Class dlgOneWayFrequencies
     End Sub
 
     Private Sub SetBaseFunction()
-        ucrBase.clsRsyntax.GetBeforeCodes().Clear()
         ucrReceiverOneWayFreq.SetMeAsReceiver()
         If rdoGraph.Checked Then
             ucrBase.clsRsyntax.SetBaseRFunction(clsAsGGplot)
-            'ucrBase.clsRsyntax.iCallType = 3
             clsDummyFunction.AddParameter("check", "graph", iPosition:=0)
-            'Else
-            'If rdoBoth.Checked Then
-            '    ucrBase.clsRsyntax.AddToBeforeCodes(If(ucrSaveGraph.ucrChkSave.Checked AndAlso ucrSaveGraph.IsComplete, clsAsDataFrame, clsSjMiscFrq))
-            '    ucrBase.clsRsyntax.SetBaseRFunction(clsAsGGplot)
-            '    ' ucrBase.clsRsyntax.iCallType = 3
-            '    clsDummyFunction.AddParameter("check", "both", iPosition:=0)
-
         ElseIf rdoTable.Checked Then
             clsDummyFunction.AddParameter("check", "table", iPosition:=0)
             If rdoAsTable.Checked Then
                 ucrBase.clsRsyntax.SetBaseRFunction(clsSjMiscFrq)
             Else
+                clsAsDataFrame.AddParameter("x", clsRFunctionParameter:=clsSjMiscFrq, iPosition:=0)
                 ucrBase.clsRsyntax.SetBaseRFunction(clsAsDataFrame)
             End If
-            clsDummyFunction.AddParameter("check", "table", iPosition:=0)
         Else
             ucrReceiverStemAndLeaf.SetMeAsReceiver()
-                ucrBase.clsRsyntax.SetBaseRFunction(clsStemAndLeafFunction)
-                clsDummyFunction.AddParameter("check", "stem", iPosition:=0)
-
+            ucrBase.clsRsyntax.SetBaseRFunction(clsStemAndLeafFunction)
+            clsDummyFunction.AddParameter("check", "stem", iPosition:=0)
         End If
 
     End Sub
@@ -365,7 +339,6 @@ Public Class dlgOneWayFrequencies
     Private Sub ChangeOutputObject()
         If rdoTable.Checked Then
             If rdoAsTable.Checked Then
-
                 ucrSaveGraph.SetSaveType(strRObjectType:=RObjectTypeLabel.Table, strRObjectFormat:=RObjectFormat.Text)
                 ucrSaveGraph.SetCheckBoxText("Save Table")
                 ucrSaveGraph.SetPrefix("freq_table")
@@ -377,8 +350,8 @@ Public Class dlgOneWayFrequencies
                                                       strRDataFrameNameToAddObjectTo:=ucrSelectorOneWayFreq.strCurrentDataFrame,
                                                       strObjectName:="last_table")
             Else
+                clsSjMiscFrq.RemoveAssignTo()
 
-                'clsSjMiscFrq.RemoveAssignTo()
                 ucrSaveGraph.SetPrefix("one_way_freq")
                 ucrSaveGraph.SetSaveTypeAsDataFrame()
                 ucrSaveGraph.SetCheckBoxText("Save Dataframe")
@@ -386,16 +359,11 @@ Public Class dlgOneWayFrequencies
                 ucrSaveGraph.SetAssignToIfUncheckedValue("one_way_freq")
             End If
         ElseIf rdoGraph.Checked Then
-
             ucrSaveGraph.SetSaveType(strRObjectType:=RObjectTypeLabel.Graph, strRObjectFormat:=RObjectFormat.Image)
             ucrSaveGraph.SetCheckBoxText("Save Graph")
             ucrSaveGraph.SetPrefix("freq_graph")
             ucrSaveGraph.SetIsComboBox()
             ucrSaveGraph.SetAssignToIfUncheckedValue("last_graph")
         End If
-    End Sub
-
-    Private Sub ucrPnlOutput_ControlValueChanged(ucrChangedControl As ucrCore)
-
     End Sub
 End Class

--- a/instat/dlgOneWayFrequencies.vb
+++ b/instat/dlgOneWayFrequencies.vb
@@ -92,26 +92,26 @@ Public Class dlgOneWayFrequencies
         ucrPnlFrequencies.AddParameterValuesCondition(rdoBoth, "check", "both")
         'TODO. the both options can be added here when we are able to have panels conditions across multiple functions
 
-        ucrPnlOutput.SetParameter(New RParameter("out", 7))
-        ucrPnlOutput.AddRadioButton(rdoAsText, Chr(34) & "txt" & Chr(34))
-        ucrPnlOutput.AddRadioButton(rdoAsHtml, Chr(34) & "viewer" & Chr(34))
+        'ucrPnlOutput.SetParameter(New RParameter("out", 7))
+        ucrPnlOutput.AddRadioButton(rdoAsTable)
+        ucrPnlOutput.AddRadioButton(rdoAsDataFrame)
+
+        ucrPnlOutput.AddParameterValuesCondition(rdoAsTable, "checked", "as.table")
+        ucrPnlOutput.AddParameterValuesCondition(rdoAsDataFrame, "checked", "as.dataframe")
 
         ucrPnlFrequencies.AddToLinkedControls(ucrChkFlip, {rdoGraph, rdoBoth}, bNewLinkedHideIfParameterMissing:=True, bNewLinkedAddRemoveParameter:=True)
-        ucrPnlFrequencies.AddToLinkedControls(ucrSaveGraph, {rdoGraph, rdoBoth}, bNewLinkedHideIfParameterMissing:=True, bNewLinkedAddRemoveParameter:=True)
+        ucrPnlFrequencies.AddToLinkedControls(ucrSaveGraph, {rdoGraph, rdoTable, rdoBoth}, bNewLinkedHideIfParameterMissing:=True, bNewLinkedAddRemoveParameter:=True)
         ucrPnlFrequencies.AddToLinkedControls({ucrPnlSort, ucrChkWeights, ucrChkGroupData, ucrReceiverOneWayFreq}, {rdoTable, rdoGraph, rdoBoth}, bNewLinkedHideIfParameterMissing:=True, bNewLinkedAddRemoveParameter:=True)
         ucrPnlFrequencies.AddToLinkedControls({ucrReceiverStemAndLeaf, ucrChkScale, ucrChkWidth}, {rdoStemAndLeaf}, bNewLinkedHideIfParameterMissing:=True, bNewLinkedAddRemoveParameter:=True)
         ucrPnlFrequencies.AddToLinkedControls(ucrPnlOutput, {rdoBoth, rdoTable}, bNewLinkedHideIfParameterMissing:=True)
+        'ucrPnlOutput.AddToLinkedControls(ucrSaveGraph, {rdoAsDataFrame}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
+        'ucrPnlOutput.AddToLinkedControls(ucrSaveGraph, {rdoAsTable}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
         ucrPnlOutput.SetLinkedDisplayControl(grpOutput)
         ucrPnlSort.SetLinkedDisplayControl(grpSort)
         ucrReceiverOneWayFreq.SetLinkedDisplayControl(cmdOptions)
 
-        ucrPnlFrequencies.AddToLinkedControls(ucrSaveDataFrame, {rdoTable, rdoBoth}, bNewLinkedHideIfParameterMissing:=True, bNewLinkedAddRemoveParameter:=True)
-        ucrSaveDataFrame.SetPrefix("one_way_freq_table")
-        ucrSaveDataFrame.SetSaveTypeAsDataFrame()
-        ucrSaveDataFrame.SetDataFrameSelector(ucrSelectorOneWayFreq.ucrAvailableDataFrames)
-        ucrSaveDataFrame.SetCheckBoxText("Save Table")
-        ucrSaveDataFrame.SetIsComboBox()
-        ucrSaveDataFrame.SetAssignToIfUncheckedValue("last_table")
+        'ucrPnlFrequencies.AddToLinkedControls(ucrSaveGraph, {rdoTable, rdoBoth}, bNewLinkedHideIfParameterMissing:=True, bNewLinkedAddRemoveParameter:=True)
+
 
         ucrNudGroups.SetParameter(New RParameter("auto.grp", 9))
         ucrNudGroups.SetMinMax(2, 100)
@@ -133,7 +133,6 @@ Public Class dlgOneWayFrequencies
         ucrNudMinFreq.SetParameter(New RParameter("min.frq", 10))
         ucrNudMinFreq.SetMinMax(iNewMin:=0)
         ucrNudMinFreq.SetRDefault(0)
-
 
         ucrChkFlip.SetParameter(New RParameter("coord.flip", 10))
         ucrChkFlip.SetText("Flip Coordinates")
@@ -159,12 +158,12 @@ Public Class dlgOneWayFrequencies
         ucrNudWidth.SetMinMax(20)
         ucrNudWidth.Increment = 1
 
-        ucrSaveGraph.SetPrefix("one_way_freq")
-        ucrSaveGraph.SetSaveTypeAsGraph()
+        'ucrSaveGraph.SetPrefix("one_way_freq")
+        'ucrSaveGraph.SetSaveTypeAsGraph()
         ucrSaveGraph.SetDataFrameSelector(ucrSelectorOneWayFreq.ucrAvailableDataFrames)
-        ucrSaveGraph.SetCheckBoxText("Save Graph")
-        ucrSaveGraph.SetIsComboBox()
-        ucrSaveGraph.SetAssignToIfUncheckedValue("last_graph")
+        'ucrSaveGraph.SetCheckBoxText("Save Graph")
+        'ucrSaveGraph.SetIsComboBox()
+        'ucrSaveGraph.SetAssignToIfUncheckedValue("last_graph")
     End Sub
 
     Private Sub SetDefaults()
@@ -179,9 +178,9 @@ Public Class dlgOneWayFrequencies
         ucrSelectorOneWayFreq.Reset()
         ucrReceiverOneWayFreq.SetMeAsReceiver()
         ucrSaveGraph.Reset()
-        ucrSaveDataFrame.Reset()
 
         clsDummyFunction.AddParameter("check", "table", iPosition:=0)
+        clsDummyFunction.AddParameter("checked", "as.table", iPosition:=1)
 
         clsAsDataFrame.SetRCommand("as.data.frame")
         clsAsDataFrame.AddParameter("x", clsRFunctionParameter:=clsSjMiscFrq, iPosition:=0)
@@ -195,17 +194,22 @@ Public Class dlgOneWayFrequencies
 
         clsSjMiscFrq.SetPackageName("sjmisc")
         clsSjMiscFrq.SetRCommand("frq")
-        clsSjMiscFrq.AddParameter("out", Chr(34) & "txt" & Chr(34), iPosition:=7)
+        'clsSjMiscFrq.AddParameter("out", Chr(34) & "txt" & Chr(34), iPosition:=7)
 
         clsSjPlot.SetPackageName("sjPlot")
         clsSjPlot.SetRCommand("plot_frq")
         clsSjPlot.AddParameter("geom.size", 0.5, iPosition:=14)
         clsSjPlot.SetAssignTo("one_way_plot")
-        clsPlotGrid.SetAssignTo("last_graph", strTempDataframe:=ucrSelectorOneWayFreq.ucrAvailableDataFrames.cboAvailableDataFrames.Text, strTempGraph:="last_graph")
+        'clsPlotGrid.SetAssignTo("last_graph", strTempDataframe:=ucrSelectorOneWayFreq.ucrAvailableDataFrames.cboAvailableDataFrames.Text, strTempGraph:="last_graph")
 
         clsAsGGplot.SetPackageName("ggplotify")
         clsAsGGplot.SetRCommand("as.ggplot")
         clsAsGGplot.AddParameter("plot", clsRFunctionParameter:=clsPlotGrid, iPosition:=0)
+        clsAsGGplot.SetAssignToOutputObject(strRObjectToAssignTo:="last_graph",
+                                                  strRObjectTypeLabelToAssignTo:=RObjectTypeLabel.Graph,
+                                                  strRObjectFormatToAssignTo:=RObjectFormat.Image,
+                                                  strRDataFrameNameToAddObjectTo:=ucrSelectorOneWayFreq.strCurrentDataFrame,
+                                                  strObjectName:="last_graph")
 
         clsStemAndLeafFunction.SetRCommand("stem")
         clsStemAndLeafFunction.AddParameter("x", Chr(34) & "stem" & Chr(34), iPosition:=0)
@@ -215,13 +219,15 @@ Public Class dlgOneWayFrequencies
     End Sub
 
     Public Sub SetRCodeForControls(bReset As Boolean)
+
         ucrChkWeights.AddAdditionalCodeParameterPair(clsSjPlot, ucrReceiverWeights.GetParameter(), iAdditionalPairNo:=1)
         ucrReceiverWeights.AddAdditionalCodeParameterPair(clsSjPlot, ucrReceiverWeights.GetParameter(), iAdditionalPairNo:=1)
         ucrPnlSort.AddAdditionalCodeParameterPair(clsSjPlot, New RParameter("sort.frq", 3), iAdditionalPairNo:=1)
         ucrNudGroups.AddAdditionalCodeParameterPair(clsSjPlot, New RParameter("auto.group", 9), iAdditionalPairNo:=1)
         ucrChkGroupData.AddAdditionalCodeParameterPair(clsSjPlot, New RParameter("auto.group", 9), iAdditionalPairNo:=1)
         ucrReceiverOneWayFreq.AddAdditionalCodeParameterPair(clsSjPlot, New RParameter("data", 0), iAdditionalPairNo:=1)
-
+        ucrSaveGraph.AddAdditionalRCode(clsSjMiscFrq)
+        ucrSaveGraph.AddAdditionalRCode(clsAsDataFrame)
 
         ucrReceiverWeights.SetRCode(clsSjMiscFrq, bReset)
         ucrReceiverOneWayFreq.SetRCode(clsSjMiscFrq, bReset)
@@ -231,7 +237,7 @@ Public Class dlgOneWayFrequencies
         ucrNudWidth.SetRCode(clsStemAndLeafFunction, bReset)
         ucrChkScale.SetRCode(clsStemAndLeafFunction, bReset)
         ucrChkWidth.SetRCode(clsStemAndLeafFunction, bReset)
-        ucrPnlOutput.SetRCode(clsSjMiscFrq, bReset)
+        ucrPnlOutput.SetRCode(clsDummyFunction, bReset)
         ucrChkWeights.SetRCode(clsSjMiscFrq, bReset)
         ucrPnlSort.SetRCode(clsSjMiscFrq, bReset)
         ucrChkFlip.SetRCode(clsSjPlot, bReset)
@@ -242,8 +248,7 @@ Public Class dlgOneWayFrequencies
         ucrChkMinFrq.SetRCode(clsSjMiscFrq, bReset)
         ucrReceiverStemAndLeaf.SetRCode(clsStemAndLeafFunction, bReset)
 
-        ucrSaveDataFrame.SetRCode(clsAsDataFrame, bReset)
-
+        'ucrSaveGraph.SetRCode(clsAsDataFrame, bReset)
     End Sub
 
     Private Sub SetDefaultColumn()
@@ -267,7 +272,7 @@ Public Class dlgOneWayFrequencies
                 ucrBase.OKEnabled(False)
             End If
         Else
-            If Not ucrReceiverOneWayFreq.IsEmpty() AndAlso ((ucrChkGroupData.Checked AndAlso ucrNudGroups.GetText <> "") OrElse Not ucrChkGroupData.Checked) AndAlso ucrSaveGraph.IsComplete() AndAlso ucrSaveDataFrame.IsComplete() Then
+            If Not ucrReceiverOneWayFreq.IsEmpty() AndAlso ((ucrChkGroupData.Checked AndAlso ucrNudGroups.GetText <> "") OrElse Not ucrChkGroupData.Checked) AndAlso ucrSaveGraph.IsComplete() Then
                 If ucrChkWeights.Checked Then
                     If Not ucrReceiverWeights.IsEmpty Then
                         ucrBase.OKEnabled(True)
@@ -305,7 +310,8 @@ Public Class dlgOneWayFrequencies
         TestOkEnabled()
     End Sub
 
-    Private Sub ucrPnlFrequencies_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrPnlFrequencies.ControlValueChanged, ucrSaveDataFrame.ControlValueChanged
+    Private Sub ucrPnlFrequencies_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrPnlFrequencies.ControlValueChanged, ucrPnlOutput.ControlValueChanged
+        ChangeOutputObject()
         SetBaseFunction()
     End Sub
 
@@ -314,23 +320,28 @@ Public Class dlgOneWayFrequencies
         ucrReceiverOneWayFreq.SetMeAsReceiver()
         If rdoGraph.Checked Then
             ucrBase.clsRsyntax.SetBaseRFunction(clsAsGGplot)
-            ucrBase.clsRsyntax.iCallType = 3
+            'ucrBase.clsRsyntax.iCallType = 3
             clsDummyFunction.AddParameter("check", "graph", iPosition:=0)
-        Else
-            If rdoBoth.Checked Then
-                ucrBase.clsRsyntax.AddToBeforeCodes(If(ucrSaveDataFrame.ucrChkSave.Checked AndAlso ucrSaveDataFrame.IsComplete, clsAsDataFrame, clsSjMiscFrq))
-                ucrBase.clsRsyntax.SetBaseRFunction(clsAsGGplot)
-                ucrBase.clsRsyntax.iCallType = 3
-                clsDummyFunction.AddParameter("check", "both", iPosition:=0)
-            ElseIf rdoTable.Checked Then
-                ucrBase.clsRsyntax.SetBaseRFunction(If(ucrSaveDataFrame.ucrChkSave.Checked AndAlso ucrSaveDataFrame.IsComplete, clsAsDataFrame, clsSjMiscFrq))
-                ucrBase.clsRsyntax.iCallType = 2
-                clsDummyFunction.AddParameter("check", "table", iPosition:=0)
+            'Else
+            'If rdoBoth.Checked Then
+            '    ucrBase.clsRsyntax.AddToBeforeCodes(If(ucrSaveGraph.ucrChkSave.Checked AndAlso ucrSaveGraph.IsComplete, clsAsDataFrame, clsSjMiscFrq))
+            '    ucrBase.clsRsyntax.SetBaseRFunction(clsAsGGplot)
+            '    ' ucrBase.clsRsyntax.iCallType = 3
+            '    clsDummyFunction.AddParameter("check", "both", iPosition:=0)
+
+        ElseIf rdoTable.Checked Then
+            clsDummyFunction.AddParameter("check", "table", iPosition:=0)
+            If rdoAsTable.Checked Then
+                ucrBase.clsRsyntax.SetBaseRFunction(clsSjMiscFrq)
             Else
-                ucrReceiverStemAndLeaf.SetMeAsReceiver()
+                ucrBase.clsRsyntax.SetBaseRFunction(clsAsDataFrame)
+            End If
+            clsDummyFunction.AddParameter("check", "table", iPosition:=0)
+        Else
+            ucrReceiverStemAndLeaf.SetMeAsReceiver()
                 ucrBase.clsRsyntax.SetBaseRFunction(clsStemAndLeafFunction)
                 clsDummyFunction.AddParameter("check", "stem", iPosition:=0)
-            End If
+
         End If
 
     End Sub
@@ -346,8 +357,45 @@ Public Class dlgOneWayFrequencies
 
     Private Sub Controls_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrReceiverWeights.ControlContentsChanged, ucrChkWeights.ControlContentsChanged,
         ucrNudGroups.ControlContentsChanged, ucrChkGroupData.ControlContentsChanged, ucrReceiverOneWayFreq.ControlContentsChanged, ucrSaveGraph.ControlContentsChanged,
-        ucrNudMinFreq.ControlValueChanged, ucrChkMinFrq.ControlValueChanged, ucrSaveDataFrame.ControlValueChanged, ucrReceiverStemAndLeaf.ControlContentsChanged,
-        ucrChkScale.ControlContentsChanged, ucrChkWidth.ControlContentsChanged
+        ucrNudMinFreq.ControlContentsChanged, ucrChkMinFrq.ControlContentsChanged, ucrReceiverStemAndLeaf.ControlContentsChanged,
+        ucrChkScale.ControlContentsChanged, ucrChkWidth.ControlContentsChanged, ucrPnlOutput.ControlContentsChanged
         TestOkEnabled()
+    End Sub
+
+    Private Sub ChangeOutputObject()
+        If rdoTable.Checked Then
+            If rdoAsTable.Checked Then
+
+                ucrSaveGraph.SetSaveType(strRObjectType:=RObjectTypeLabel.Table, strRObjectFormat:=RObjectFormat.Text)
+                ucrSaveGraph.SetCheckBoxText("Save Table")
+                ucrSaveGraph.SetPrefix("freq_table")
+                ucrSaveGraph.SetIsComboBox()
+                ucrSaveGraph.SetAssignToIfUncheckedValue("last_table")
+                clsSjMiscFrq.SetAssignToOutputObject(strRObjectToAssignTo:="last_table",
+                                                      strRObjectTypeLabelToAssignTo:=RObjectTypeLabel.Table,
+                                                      strRObjectFormatToAssignTo:=RObjectFormat.Text,
+                                                      strRDataFrameNameToAddObjectTo:=ucrSelectorOneWayFreq.strCurrentDataFrame,
+                                                      strObjectName:="last_table")
+            Else
+
+                'clsSjMiscFrq.RemoveAssignTo()
+                ucrSaveGraph.SetPrefix("one_way_freq")
+                ucrSaveGraph.SetSaveTypeAsDataFrame()
+                ucrSaveGraph.SetCheckBoxText("Save Dataframe")
+                ucrSaveGraph.SetIsComboBox()
+                ucrSaveGraph.SetAssignToIfUncheckedValue("one_way_freq")
+            End If
+        ElseIf rdoGraph.Checked Then
+
+            ucrSaveGraph.SetSaveType(strRObjectType:=RObjectTypeLabel.Graph, strRObjectFormat:=RObjectFormat.Image)
+            ucrSaveGraph.SetCheckBoxText("Save Graph")
+            ucrSaveGraph.SetPrefix("freq_graph")
+            ucrSaveGraph.SetIsComboBox()
+            ucrSaveGraph.SetAssignToIfUncheckedValue("last_graph")
+        End If
+    End Sub
+
+    Private Sub ucrPnlOutput_ControlValueChanged(ucrChangedControl As ucrCore)
+
     End Sub
 End Class


### PR DESCRIPTION
Fixes partially #8104 

@rdstern, @Patowhiz and @lloyddewit 
I have implemented the new output system in this dialog.
1. I have disabled the` Both option` since the new output system does not support producing two objects simultaneously. From the discussion with @Patowhiz, it's so easy for a user to go back and produce the other object when needed.
2. The dialog uses only one save control now.
3. The panel that initially controlled save as text(viewer) or HTML (browser) now controls save as a table and save as a data frame, for the `Table option`.