### PR TITLE
Fixed memory leak

### DIFF
--- a/instat/NLog.config
+++ b/instat/NLog.config
@@ -34,7 +34,7 @@
 		  name="AllLogs"
 		  xsi:type="File"
 		  layout="${longdate} ${uppercase:${level}} ${message}|${exception}"
-		  fileName="${basedir}/logs/${shortdate}.log"		  
+		  fileName="${specialfolder:folder=ApplicationData}/RInstat/logs/${shortdate}.log"
 		  maxArchiveDays="5"
 		  archiveEvery="Day"
 		  archiveOldFileOnStartup="true"

--- a/instat/Translations.vb
+++ b/instat/Translations.vb
@@ -27,7 +27,7 @@ Public Class Translations
     '''
     ''' <param name="clsControl">    The WinForm control to translate. </param>
     '''--------------------------------------------------------------------------------------------
-    Public Shared Sub autoTranslate(clsControl As Control)
+    Public Shared Sub autoTranslate(ByRef clsControl As Control)
         If IsNothing(TryCast(clsControl, Form)) Then
             Exit Sub
         End If
@@ -44,7 +44,7 @@ Public Class Translations
     ''' <param name="tsCollection">     The WinForm menu items to translate. </param>
     ''' <param name="ctrParent">        The WinForm control that is the parent of the menu. </param>
     '''--------------------------------------------------------------------------------------------
-    Public Shared Sub translateMenu(tsCollection As ToolStripItemCollection, ctrParent As Control)
+    Public Shared Sub translateMenu(ByRef tsCollection As ToolStripItemCollection, ctrParent As Control)
         ' The 'WriteCsvFile' function call below should normally be commented out. 
         ' It only needs be uncommented and executed once, prior to each new release.
         'WriteCsvFile()
@@ -73,7 +73,7 @@ Public Class Translations
         HandleError(TranslateWinForm.clsTranslateWinForm.TranslateMenuItems(frmMain.ucrDataFrameMeta.Name, frmMain.ucrDataFrameMeta.rowRightClickMenu.Items, strDbPath, strLanguageCode))
         HandleError(TranslateWinForm.clsTranslateWinForm.TranslateMenuItems(frmMain.ucrLogWindow.Name, frmMain.ucrLogWindow.mnuContextLogFile.Items, strDbPath, strLanguageCode))
         HandleError(TranslateWinForm.clsTranslateWinForm.TranslateMenuItems(frmMain.ucrScriptWindow.Name, frmMain.ucrScriptWindow.mnuContextScript.Items, strDbPath, strLanguageCode))
-        HandleError(TranslateWinForm.clsTranslateWinForm.TranslateMenuItems(frmMain.ucrDataViewer.Name, frmMain.ucrDataViewer.rowContextMenu.Items, strDbPath, strLanguageCode))
+        HandleError(TranslateWinForm.clsTranslateWinForm.TranslateMenuItems(frmMain.ucrDataViewer.Name, frmMain.ucrDataViewer.RowContextMenu.Items, strDbPath, strLanguageCode))
         HandleError(TranslateWinForm.clsTranslateWinForm.TranslateMenuItems(frmMain.ucrDataViewer.Name, frmMain.ucrDataViewer.ColumnContextMenu.Items, strDbPath, strLanguageCode))
         HandleError(TranslateWinForm.clsTranslateWinForm.TranslateMenuItems(frmMain.ucrDataViewer.Name, frmMain.ucrDataViewer.CellContextMenu.Items, strDbPath, strLanguageCode))
         HandleError(TranslateWinForm.clsTranslateWinForm.TranslateMenuItems(frmMain.ucrDataViewer.Name, frmMain.ucrDataViewer.SheetTabContextMenu.Items, strDbPath, strLanguageCode))

--- a/instat/clsRLink.vb
+++ b/instat/clsRLink.vb
@@ -149,6 +149,8 @@ Public Class RLink
 
     Private clsOutputLogger As clsOutputLogger
 
+    Private Shared ReadOnly Logger As NLog.Logger = NLog.LogManager.GetCurrentClassLogger()
+
     ''' <summary>
     ''' Create method for clsRLink
     ''' Must pass in the output logger so the R link knows where to post outputs to
@@ -229,12 +231,12 @@ Public Class RLink
                 cpuArchitectureFolder = "x64"
             End If
             Dim rPath = Path.Combine(rHome, "bin", cpuArchitectureFolder)
-            Console.WriteLine("R Home: " & rHome)
-            Console.WriteLine("R Path: " & rPath)
+            Logger.Info("R Home: " & rHome)
+            Logger.Info("R Path: " & rPath)
 
             ' Use bundled R if included
             If Directory.Exists(rHome) And Directory.Exists(rPath) Then
-                Console.WriteLine("Using bundled R")
+                Logger.Info("Using bundled R")
                 REngine.SetEnvironmentVariables(rPath, rHome)
             Else
                 ' Use normal process for finding local R if bundled version not included

--- a/instat/frmMain.vb
+++ b/instat/frmMain.vb
@@ -77,7 +77,7 @@ Public Class frmMain
 
     Private strCurrLang As String
     Public Sub New()
-        Logger.Info("R-Instat started")
+        Logger.Info("R-Instat started version" + My.Application.Info.Version.ToString)
         ' This call is required by the designer.
         InitializeComponent()
 
@@ -2036,7 +2036,10 @@ Public Class frmMain
     End Sub
 
     Private Sub mnuPrepareCalculateCalculations_Click(sender As Object, e As EventArgs) Handles mnuPrepareCalculator.Click
+        'Trace logging for possible memory leak
+        Logger.Trace("Memory before dlgCalculator is shown :" + GC.GetTotalMemory(True).ToString)
         dlgCalculator.ShowDialog()
+        Logger.Trace("Memory after dlgCalculator is shown  :" + GC.GetTotalMemory(True).ToString)
     End Sub
 
     Private Sub mnuPrepareColumnFactorCountInFactor_Click(sender As Object, e As EventArgs) Handles mnuPrepareColumnFactorCountInFactor.Click


### PR DESCRIPTION
Updated logging to log memory usage when opening the calculator
Updated translations to pass controls ByRef

@rdstern Hopefully this fixes the memory issues. It wasn't specific to the calculator but a problem with all forms. I have added extra logging around the calculator so if the problem still exists we should be able to see what's happening. 

About the logging.
It's still early of what we are putting in the logs and we will keep adding to them. 
The logs are stored in "../AppData/Roaming/RInstat/logs". 
What we log is defined in NLog.config. Therefore we can change the logging levels after the install. By default, we log 'Debug' and above.
The memory usage is under 'Trace' so the log file will need to be updated if we get the issue again. Change 'minlevel="Debug"' to 'minlevel="Trace"' in the NLog.config file.





