### PR TITLE
Display R package help in output window rather than in browser

### DIFF
--- a/instat/UserControls/Webview/Windows/ucrWebViewer.vb
+++ b/instat/UserControls/Webview/Windows/ucrWebViewer.vb
@@ -47,7 +47,7 @@ Public Class ucrWebViewer
         'that should be the first step
         Dim strUrl As String = strFileName
         If bReplace Then
-            bReplace = "file:///" + strFileName.Replace("\", "/")
+            strUrl = "file:///" + strFileName.Replace("\", "/")
         End If
         _browser.LoadUrl(strUrl)
         _browser.Dock = DockStyle.Fill

--- a/instat/UserControls/Webview/Windows/ucrWebViewer.vb
+++ b/instat/UserControls/Webview/Windows/ucrWebViewer.vb
@@ -35,7 +35,7 @@ Public Class ucrWebViewer
         Me.Controls.Add(_browser)
     End Sub
 
-    Public Sub LoadHtmlFile(strFileName As String)
+    Public Sub LoadHtmlFile(strFileName As String, Optional bReplace As Boolean = True)
         If _browser Is Nothing Then
             Return
         End If
@@ -45,8 +45,10 @@ Public Class ucrWebViewer
         'it's not yet clear how we can implement a custom schema at this point,
         'not unless we specify R-Instat temp output folder in the R commands.
         'that should be the first step
-
-        Dim strUrl As String = "file:///" + strFileName.Replace("\", "/")
+        Dim strUrl As String = strFileName
+        If bReplace Then
+            bReplace = "file:///" + strFileName.Replace("\", "/")
+        End If
         _browser.LoadUrl(strUrl)
         _browser.Dock = DockStyle.Fill
     End Sub

--- a/instat/UserControls/frmMaximiseOutput.vb
+++ b/instat/UserControls/frmMaximiseOutput.vb
@@ -27,7 +27,7 @@ Public Class frmMaximiseOutput
     'todo. to be used by the output page to remember paths selected by user when saving outputs
     Public _strFileDestinationDirectory As String = ""
 
-    Public Overloads Sub Show(strFileName As String)
+    Public Overloads Sub Show(strFileName As String, Optional bReplace As Boolean = True)
         Me._strDisplayedFileName = strFileName
         Dim strFileExtension As String = Path.GetExtension(_strDisplayedFileName).ToLower
         Me.panelControl.Controls.Clear()
@@ -51,7 +51,7 @@ Public Class frmMaximiseOutput
                 If RuntimeInformation.IsOSPlatform(OSPlatform.Windows) AndAlso CefRuntimeWrapper.IsCefInitilised Then
                     _strFileFilter = "html (*.html)|*.html"
                     Dim ucrWebView As New ucrWebViewer
-                    ucrWebView.LoadHtmlFile(_strDisplayedFileName)
+                    ucrWebView.LoadHtmlFile(strFileName:=_strDisplayedFileName, bReplace:=bReplace)
                     Me.panelControl.Controls.Add(ucrWebView)
                     ucrWebView.Dock = DockStyle.Fill
                 Else

--- a/instat/clsFileUrlUtilities.vb
+++ b/instat/clsFileUrlUtilities.vb
@@ -1,0 +1,63 @@
+﻿' R- Instat
+' Copyright (C) 2015-2017
+'
+' This program is free software: you can redistribute it and/or modify
+' it under the terms of the GNU General Public License as published by
+' the Free Software Foundation, either version 3 of the License, or
+' (at your option) any later version.
+'
+' This program is distributed in the hope that it will be useful,
+' but WITHOUT ANY WARRANTY; without even the implied warranty of
+' MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+' GNU General Public License for more details.
+'
+' You should have received a copy of the GNU General Public License 
+' along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Imports System.IO
+Imports RDotNet
+Public Class clsFileUrlUtilities
+
+    ''' <summary>
+    ''' Returns the URL of the package HTML file.
+    ''' </summary>
+    ''' <param name="strPackageName"> The package name. </param>
+    ''' <param name="strTopic"> The package topic. </param>
+    ''' <param name="bVignette"> Check if we need to return the URL of the package vignette file. </param>
+    ''' <returns></returns>
+    Public Shared Function GetHelpFileURL(strPackageName As String, Optional strTopic As String = "", Optional bVignette As Boolean = False) As String
+        Dim clsGetPortFunction As New RFunction
+
+        clsGetPortFunction.SetPackageName("tools")
+        clsGetPortFunction.SetRCommand("startDynamicHelp")
+        clsGetPortFunction.AddParameter("start", "NA", iPosition:=0)
+
+        Dim expPortTemp As SymbolicExpression
+        expPortTemp = frmMain.clsRLink.RunInternalScriptGetValue(clsGetPortFunction.ToScript(), bSeparateThread:=False)
+        Dim strPort As String = ""
+        If expPortTemp IsNot Nothing AndAlso expPortTemp.Type <> Internals.SymbolicExpressionType.Null Then
+            strPort = expPortTemp.AsInteger(0)
+        End If
+
+        Dim strFilePath As String = Path.Combine("library", strPackageName, "html", "00Index.html")
+        If strTopic <> "" Then
+            strFilePath = Path.Combine("library", strPackageName, "html", String.Concat(strTopic, ".html"))
+        End If
+
+        Dim strLocalHost As String = "127.0.0.1:"
+        Dim strURL As String = Path.Combine(String.Concat("http://", strLocalHost), strPort, strFilePath)
+
+        If bVignette Then
+            Dim clsGetVignetteFunction As New RFunction
+
+            clsGetVignetteFunction.SetRCommand("get_vignette")
+            clsGetVignetteFunction.AddParameter("package", Chr(34) & strPackageName & Chr(34), iPosition:=0)
+            strURL = frmMain.clsRLink.RunInternalScriptGetValue(clsGetVignetteFunction.ToScript(), bSeparateThread:=False).AsCharacter(0)
+        End If
+
+        If strURL <> "" Then
+            strURL = strURL.Replace("\", "/")
+        End If
+        Return strURL
+    End Function
+End Class

--- a/instat/dlgFromLibrary.vb
+++ b/instat/dlgFromLibrary.vb
@@ -230,21 +230,14 @@ Public Class dlgFromLibrary
     End Function
 
     Private Sub cmdHelp_Click(sender As Object, e As EventArgs) Handles cmdHelp.Click
-        Dim clsGetPortOperator As New ROperator
-        Dim clsStartDynamicServerFunction As New RFunction
+        Dim clsGetPortFunction As New RFunction
 
-        clsGetPortOperator.SetOperation(":::")
-        clsGetPortOperator.AddParameter("left", "tools", iPosition:=0)
-        clsGetPortOperator.AddParameter("right", "httpdPort()", iPosition:=1)
-        clsGetPortOperator.bSpaceAroundOperation = False
-
-        clsStartDynamicServerFunction.SetPackageName("tools")
-        clsStartDynamicServerFunction.SetRCommand("startDynamicHelp")
-        clsStartDynamicServerFunction.AddParameter("start", "NA", iPosition:=0)
-        frmMain.clsRLink.RunScript(clsStartDynamicServerFunction.ToScript(), iCallType:=5, bSeparateThread:=False, bSilent:=False)
+        clsGetPortFunction.SetPackageName("tools")
+        clsGetPortFunction.SetRCommand("startDynamicHelp")
+        clsGetPortFunction.AddParameter("start", "NA", iPosition:=0)
 
         Dim expPortTemp As SymbolicExpression
-        expPortTemp = frmMain.clsRLink.RunInternalScriptGetValue(clsGetPortOperator.ToScript())
+        expPortTemp = frmMain.clsRLink.RunInternalScriptGetValue(clsGetPortFunction.ToScript(), bSeparateThread:=False)
         Dim strPort As String = ""
         If expPortTemp IsNot Nothing AndAlso expPortTemp.Type <> Internals.SymbolicExpressionType.Null Then
             strPort = expPortTemp.AsInteger(0)

--- a/instat/dlgFromLibrary.vb
+++ b/instat/dlgFromLibrary.vb
@@ -16,7 +16,6 @@
 
 Imports instat.Translations
 Imports RDotNet
-Imports System.IO
 
 Public Class dlgFromLibrary
     Private strLibraryTemp As String = "dfLibrary"
@@ -229,47 +228,11 @@ Public Class dlgFromLibrary
         End If
     End Function
 
-    Public Function GetFileURL(strPackageName As String, Optional strTopic As String = "", Optional bVignette As Boolean = False) As String
-        Dim clsGetPortFunction As New RFunction
-
-        clsGetPortFunction.SetPackageName("tools")
-        clsGetPortFunction.SetRCommand("startDynamicHelp")
-        clsGetPortFunction.AddParameter("start", "NA", iPosition:=0)
-
-        Dim expPortTemp As SymbolicExpression
-        expPortTemp = frmMain.clsRLink.RunInternalScriptGetValue(clsGetPortFunction.ToScript(), bSeparateThread:=False)
-        Dim strPort As String = ""
-        If expPortTemp IsNot Nothing AndAlso expPortTemp.Type <> Internals.SymbolicExpressionType.Null Then
-            strPort = expPortTemp.AsInteger(0)
-        End If
-
-        Dim strFilePath As String = Path.Combine("library", strPackageName, "html", "00Index.html")
-        If strTopic <> "" Then
-            strFilePath = Path.Combine("library", strPackageName, "html", String.Concat(strTopic, ".html"))
-        End If
-
-        Dim strLocalHost As String = "127.0.0.1:"
-        Dim strURL As String = Path.Combine(String.Concat("http://", strLocalHost), strPort, strFilePath)
-
-        If bVignette Then
-            Dim clsGetVignetteFunction As New RFunction
-
-            clsGetVignetteFunction.SetRCommand("get_vignette")
-            clsGetVignetteFunction.AddParameter("package", Chr(34) & strPackageName & Chr(34), iPosition:=0)
-            strURL = frmMain.clsRLink.RunInternalScriptGetValue(clsGetVignetteFunction.ToScript(), bSeparateThread:=False).AsCharacter(0)
-        End If
-
-        If strURL <> "" Then
-            strURL = strURL.Replace("\", "/")
-        End If
-        Return strURL
-    End Function
-
     Private Sub cmdHelp_Click(sender As Object, e As EventArgs) Handles cmdHelp.Click
         Dim strPackageName As String = ucrInputPackages.cboInput.SelectedItem
         Dim strTopic As String = lstCollection.SelectedItems(0).Text
         If strPackageName <> "" AndAlso strTopic <> "" Then
-            frmMaximiseOutput.Show(strFileName:=GetFileURL(strPackageName:=strPackageName, strTopic:=strTopic), bReplace:=False)
+            frmMaximiseOutput.Show(strFileName:=clsFileUrlUtilities.GetHelpFileURL(strPackageName:=strPackageName, strTopic:=strTopic), bReplace:=False)
         End If
     End Sub
 

--- a/instat/dlgFromLibrary.vb
+++ b/instat/dlgFromLibrary.vb
@@ -229,7 +229,7 @@ Public Class dlgFromLibrary
         End If
     End Function
 
-    Private Sub cmdHelp_Click(sender As Object, e As EventArgs) Handles cmdHelp.Click
+    Public Function GetFileURL(strPackageName As String, Optional strTopic As String = "", Optional bVignette As Boolean = False) As String
         Dim clsGetPortFunction As New RFunction
 
         clsGetPortFunction.SetPackageName("tools")
@@ -243,15 +243,33 @@ Public Class dlgFromLibrary
             strPort = expPortTemp.AsInteger(0)
         End If
 
-        Dim strPackageName As String = ucrInputPackages.cboInput.SelectedItem
-        Dim strTopic As String = lstCollection.SelectedItems(0).Text
-        Dim strFilePath As String = Path.Combine("library", strPackageName, "html", String.Concat(strTopic, ".html"))
+        Dim strFilePath As String = Path.Combine("library", strPackageName, "html", "00Index.html")
+        If strTopic <> "" Then
+            strFilePath = Path.Combine("library", strPackageName, "html", String.Concat(strTopic, ".html"))
+        End If
+
         Dim strLocalHost As String = "127.0.0.1:"
-        Dim strURL As String
-        strURL = Path.Combine(String.Concat("http://", strLocalHost), strPort, strFilePath)
+        Dim strURL As String = Path.Combine(String.Concat("http://", strLocalHost), strPort, strFilePath)
+
+        If bVignette Then
+            Dim clsGetVignetteFunction As New RFunction
+
+            clsGetVignetteFunction.SetRCommand("get_vignette")
+            clsGetVignetteFunction.AddParameter("package", Chr(34) & strPackageName & Chr(34), iPosition:=0)
+            strURL = frmMain.clsRLink.RunInternalScriptGetValue(clsGetVignetteFunction.ToScript(), bSeparateThread:=False).AsCharacter(0)
+        End If
+
         If strURL <> "" Then
             strURL = strURL.Replace("\", "/")
-            frmMaximiseOutput.Show(strFileName:=strURL, bReplace:=False)
+        End If
+        Return strURL
+    End Function
+
+    Private Sub cmdHelp_Click(sender As Object, e As EventArgs) Handles cmdHelp.Click
+        Dim strPackageName As String = ucrInputPackages.cboInput.SelectedItem
+        Dim strTopic As String = lstCollection.SelectedItems(0).Text
+        If strPackageName <> "" AndAlso strTopic <> "" Then
+            frmMaximiseOutput.Show(strFileName:=GetFileURL(strPackageName:=strPackageName, strTopic:=strTopic), bReplace:=False)
         End If
     End Sub
 

--- a/instat/dlgFromLibrary.vb
+++ b/instat/dlgFromLibrary.vb
@@ -16,6 +16,7 @@
 
 Imports instat.Translations
 Imports RDotNet
+Imports System.IO
 
 Public Class dlgFromLibrary
     Private strLibraryTemp As String = "dfLibrary"
@@ -229,13 +230,36 @@ Public Class dlgFromLibrary
     End Function
 
     Private Sub cmdHelp_Click(sender As Object, e As EventArgs) Handles cmdHelp.Click
-        Dim clsHelp As New RFunction
-        clsHelp.SetPackageName("utils")
-        clsHelp.SetRCommand("help")
-        clsHelp.AddParameter("topic", Chr(34) & lstCollection.SelectedItems(0).Text & Chr(34))
-        clsHelp.AddParameter("package", Chr(34) & ucrInputPackages.cboInput.SelectedItem & Chr(34))
-        clsHelp.AddParameter("help_type", Chr(34) & "html" & Chr(34))
-        frmMain.clsRLink.RunScript(clsHelp.ToScript, strComment:="Opening help page for" & " " & lstCollection.SelectedItems(0).Text & " " & "dataset. Generated from dialog Open Dataset from Library", iCallType:=2, bSeparateThread:=False, bUpdateGrids:=False)
+        Dim clsGetPortOperator As New ROperator
+        Dim clsStartDynamicServerFunction As New RFunction
+
+        clsGetPortOperator.SetOperation(":::")
+        clsGetPortOperator.AddParameter("left", "tools", iPosition:=0)
+        clsGetPortOperator.AddParameter("right", "httpdPort()", iPosition:=1)
+        clsGetPortOperator.bSpaceAroundOperation = False
+
+        clsStartDynamicServerFunction.SetPackageName("tools")
+        clsStartDynamicServerFunction.SetRCommand("startDynamicHelp")
+        clsStartDynamicServerFunction.AddParameter("start", "NA", iPosition:=0)
+        frmMain.clsRLink.RunScript(clsStartDynamicServerFunction.ToScript(), iCallType:=5, bSeparateThread:=False, bSilent:=False)
+
+        Dim expPortTemp As SymbolicExpression
+        expPortTemp = frmMain.clsRLink.RunInternalScriptGetValue(clsGetPortOperator.ToScript())
+        Dim strPort As String = ""
+        If expPortTemp IsNot Nothing AndAlso expPortTemp.Type <> Internals.SymbolicExpressionType.Null Then
+            strPort = expPortTemp.AsInteger(0)
+        End If
+
+        Dim strPackageName As String = ucrInputPackages.cboInput.SelectedItem
+        Dim strTopic As String = lstCollection.SelectedItems(0).Text
+        Dim strFilePath As String = Path.Combine("library", strPackageName, "html", String.Concat(strTopic, ".html"))
+        Dim strLocalHost As String = "127.0.0.1:"
+        Dim strURL As String
+        strURL = Path.Combine(String.Concat("http://", strLocalHost), strPort, strFilePath)
+        If strURL <> "" Then
+            strURL = strURL.Replace("\", "/")
+            frmMaximiseOutput.Show(strFileName:=strURL, bReplace:=False)
+        End If
     End Sub
 
     Private Sub ucrNewDataFrameName_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrNewDataFrameName.ControlContentsChanged

--- a/instat/dlgHelpVignettes.vb
+++ b/instat/dlgHelpVignettes.vb
@@ -65,7 +65,7 @@ Public Class dlgHelpVignettes
         End If
 
         If strAvailablePackages IsNot Nothing Then
-            ucrInputComboPackage.SetParameter(New RParameter("package", 0))
+            'ucrInputComboPackage.SetParameter(New RParameter("package", 0))
             ucrInputComboPackage.SetItems(strAvailablePackages)
             ucrInputComboPackage.SetDropDownStyleAsNonEditable()
         End If
@@ -96,8 +96,6 @@ Public Class dlgHelpVignettes
     End Sub
 
     Private Sub SetRCodeForControls(bReset As Boolean)
-        ucrChkFunction.SetRCode(clsStartDynamicServerFunction, bReset)
-        ucrInputComboPackage.SetRCode(clsVignettesFunction, bReset)
         ucrPnlHelpVignettes.SetRCode(ucrBase.clsRsyntax.clsBaseFunction, bReset)
     End Sub
 

--- a/instat/dlgHelpVignettes.vb
+++ b/instat/dlgHelpVignettes.vb
@@ -65,7 +65,6 @@ Public Class dlgHelpVignettes
         End If
 
         If strAvailablePackages IsNot Nothing Then
-            'ucrInputComboPackage.SetParameter(New RParameter("package", 0))
             ucrInputComboPackage.SetItems(strAvailablePackages)
             ucrInputComboPackage.SetDropDownStyleAsNonEditable()
         End If
@@ -102,8 +101,10 @@ Public Class dlgHelpVignettes
     Private Sub ucrPnlHelpVignettes_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrPnlHelpVignettes.ControlValueChanged
         If rdoHelp.Checked Then
             ucrBase.clsRsyntax.SetBaseRFunction(clsStartDynamicServerFunction)
+            ucrBase.clsRsyntax.iCallType = 5
         Else
             ucrBase.clsRsyntax.SetBaseRFunction(clsVignettesFunction)
+            ucrBase.clsRsyntax.iCallType = 2
         End If
     End Sub
 
@@ -140,5 +141,9 @@ Public Class dlgHelpVignettes
         If rdoHelp.Checked Then
             OpenHelpFile()
         End If
+    End Sub
+
+    Private Sub ucrInputComboPackage_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrInputComboPackage.ControlValueChanged
+        clsVignettesFunction.AddParameter("package", Chr(34) & ucrInputComboPackage.GetText() & Chr(34), iPosition:=0)
     End Sub
 End Class

--- a/instat/dlgHelpVignettes.vb
+++ b/instat/dlgHelpVignettes.vb
@@ -89,7 +89,7 @@ Public Class dlgHelpVignettes
         Dim strPackageName As String = ucrInputComboPackage.cboInput.SelectedItem
         Dim strTopic As String = ucrInputFunctionName.GetText
         If strPackageName <> "" Then
-            Dim strURL = dlgFromLibrary.GetFileURL(strPackageName:=strPackageName, strTopic:=strTopic,
+            Dim strURL = clsFileUrlUtilities.GetHelpFileURL(strPackageName:=strPackageName, strTopic:=strTopic,
                                                           bVignette:=rdoVignettes.Checked)
             frmMaximiseOutput.Show(strFileName:=strURL, bReplace:=False)
         End If

--- a/instat/dlgHelpVignettes.vb
+++ b/instat/dlgHelpVignettes.vb
@@ -22,8 +22,9 @@ Public Class dlgHelpVignettes
     Private bFirstload As Boolean = True
     Private bReset As Boolean = True
     Private strAvailablePackages() As String
-    Private clsVignettesFunction, clsStartDynamicServerFunction As New RFunction
-    Private clsGetPortOperator As New ROperator
+    Private clsGetVignetteFunction As New RFunction
+    Private clsGetPortFunction As New RFunction
+    Private clsDummyFunction As New RFunction
     Private Sub dlgHelpVignettes_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         If bFirstload Then
             InitialiseDialog()
@@ -47,8 +48,8 @@ Public Class dlgHelpVignettes
 
         ucrInputFunctionName.AddQuotesIfUnrecognised = True
 
-        ucrPnlHelpVignettes.AddFunctionNamesCondition(rdoHelp, "startDynamicHelp")
-        ucrPnlHelpVignettes.AddFunctionNamesCondition(rdoVignettes, "browseVignettes")
+        ucrPnlHelpVignettes.AddParameterValuesCondition(rdoHelp, "type", "help")
+        ucrPnlHelpVignettes.AddParameterValuesCondition(rdoVignettes, "type", "browseVignettes")
 
         ucrPnlHelpVignettes.AddToLinkedControls(ucrChkFunction, {rdoHelp}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedDisabledIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:=False)
         ucrChkFunction.AddToLinkedControls(ucrInputFunctionName, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedDisabledIfParameterMissing:=True)
@@ -68,49 +69,31 @@ Public Class dlgHelpVignettes
             ucrInputComboPackage.SetItems(strAvailablePackages)
             ucrInputComboPackage.SetDropDownStyleAsNonEditable()
         End If
-
     End Sub
 
     Private Sub SetDefaults()
-        clsGetPortOperator = New ROperator
-        clsStartDynamicServerFunction = New RFunction
-        clsVignettesFunction = New RFunction
+        clsGetPortFunction = New RFunction
+        clsGetVignetteFunction = New RFunction
+        clsDummyFunction = New RFunction
 
-        clsVignettesFunction.SetPackageName("utils")
-        clsVignettesFunction.SetRCommand("browseVignettes")
+        clsGetVignetteFunction.SetRCommand("get_vignette")
 
         ucrInputComboPackage.cboInput.SelectedItem = "datasets"
 
-        clsGetPortOperator.SetOperation(":::")
-        clsGetPortOperator.AddParameter("left", "tools", iPosition:=0)
-        clsGetPortOperator.AddParameter("right", "httpdPort()", iPosition:=1)
-        clsGetPortOperator.bSpaceAroundOperation = False
+        clsDummyFunction.AddParameter("type", "help", iPosition:=0)
 
-        clsStartDynamicServerFunction.SetPackageName("tools")
-        clsStartDynamicServerFunction.SetRCommand("startDynamicHelp")
-        clsStartDynamicServerFunction.AddParameter("start", "NA", iPosition:=0)
-
-        ucrBase.clsRsyntax.SetBaseRFunction(clsStartDynamicServerFunction)
-        ucrBase.clsRsyntax.bSeparateThread = False
+        clsGetPortFunction.SetPackageName("tools")
+        clsGetPortFunction.SetRCommand("startDynamicHelp")
+        clsGetPortFunction.AddParameter("start", "NA", iPosition:=0)
     End Sub
 
     Private Sub SetRCodeForControls(bReset As Boolean)
-        ucrPnlHelpVignettes.SetRCode(ucrBase.clsRsyntax.clsBaseFunction, bReset)
-    End Sub
-
-    Private Sub ucrPnlHelpVignettes_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrPnlHelpVignettes.ControlValueChanged
-        If rdoHelp.Checked Then
-            ucrBase.clsRsyntax.SetBaseRFunction(clsStartDynamicServerFunction)
-            ucrBase.clsRsyntax.iCallType = 5
-        Else
-            ucrBase.clsRsyntax.SetBaseRFunction(clsVignettesFunction)
-            ucrBase.clsRsyntax.iCallType = 2
-        End If
+        ucrPnlHelpVignettes.SetRCode(clsDummyFunction, bReset)
     End Sub
 
     Private Sub OpenHelpFile()
         Dim expPortTemp As SymbolicExpression
-        expPortTemp = frmMain.clsRLink.RunInternalScriptGetValue(clsGetPortOperator.ToScript())
+        expPortTemp = frmMain.clsRLink.RunInternalScriptGetValue(clsGetPortFunction.ToScript(), bSeparateThread:=False)
         Dim strPort As String = ""
         If expPortTemp IsNot Nothing AndAlso expPortTemp.Type <> Internals.SymbolicExpressionType.Null Then
             strPort = expPortTemp.AsInteger(0)
@@ -126,6 +109,11 @@ Public Class dlgHelpVignettes
         Dim strLocalHost As String = "127.0.0.1:"
         Dim strURL As String
         strURL = Path.Combine(String.Concat("http://", strLocalHost), strPort, strFilePath)
+
+        If rdoVignettes.Checked Then
+            strURL = frmMain.clsRLink.RunInternalScriptGetValue(clsGetVignetteFunction.ToScript(), bSeparateThread:=False).AsCharacter(0)
+        End If
+
         If strURL <> "" Then
             strURL = strURL.Replace("\", "/")
             frmMaximiseOutput.Show(strFileName:=strURL, bReplace:=False)
@@ -138,12 +126,18 @@ Public Class dlgHelpVignettes
     End Sub
 
     Private Sub ucrBase_ClickOk(sender As Object, e As EventArgs) Handles ucrBase.ClickOk
-        If rdoHelp.Checked Then
-            OpenHelpFile()
-        End If
+        OpenHelpFile()
     End Sub
 
     Private Sub ucrInputComboPackage_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrInputComboPackage.ControlValueChanged
-        clsVignettesFunction.AddParameter("package", Chr(34) & ucrInputComboPackage.GetText() & Chr(34), iPosition:=0)
+        clsGetVignetteFunction.AddParameter("package", Chr(34) & ucrInputComboPackage.GetText & Chr(34), iPosition:=0)
+    End Sub
+
+    Private Sub ucrPnlHelpVignettes_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrPnlHelpVignettes.ControlValueChanged
+        If rdoHelp.Checked Then
+            clsDummyFunction.AddParameter("type", "help", iPosition:=0)
+        Else
+            clsDummyFunction.AddParameter("type", "browseVignettes", iPosition:=0)
+        End If
     End Sub
 End Class

--- a/instat/dlgHypothesisTestsCalculator.Designer.vb
+++ b/instat/dlgHypothesisTestsCalculator.Designer.vb
@@ -168,10 +168,9 @@ Partial Class dlgHypothesisTestsCalculator
         '
         Me.lblTest.AutoSize = True
         Me.lblTest.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblTest.Location = New System.Drawing.Point(9, 29)
-        Me.lblTest.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
+        Me.lblTest.Location = New System.Drawing.Point(14, 44)
         Me.lblTest.Name = "lblTest"
-        Me.lblTest.Size = New System.Drawing.Size(31, 13)
+        Me.lblTest.Size = New System.Drawing.Size(44, 20)
         Me.lblTest.TabIndex = 0
         Me.lblTest.Tag = "Test"
         Me.lblTest.Text = "Test:"
@@ -187,21 +186,21 @@ Partial Class dlgHypothesisTestsCalculator
         Me.grpMainKeyboard.Controls.Add(Me.cmdAlt)
         Me.grpMainKeyboard.Controls.Add(Me.cmdSquiggle)
         Me.grpMainKeyboard.Controls.Add(Me.cmdSquareBrackets)
-        Me.grpMainKeyboard.Location = New System.Drawing.Point(408, 288)
-        Me.grpMainKeyboard.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.grpMainKeyboard.Location = New System.Drawing.Point(612, 432)
+        Me.grpMainKeyboard.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.grpMainKeyboard.Name = "grpMainKeyboard"
-        Me.grpMainKeyboard.Padding = New System.Windows.Forms.Padding(2, 3, 2, 3)
-        Me.grpMainKeyboard.Size = New System.Drawing.Size(188, 100)
+        Me.grpMainKeyboard.Padding = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.grpMainKeyboard.Size = New System.Drawing.Size(282, 150)
         Me.grpMainKeyboard.TabIndex = 12
         Me.grpMainKeyboard.TabStop = False
         '
         'cmdZero
         '
         Me.cmdZero.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdZero.Location = New System.Drawing.Point(140, 66)
-        Me.cmdZero.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdZero.Location = New System.Drawing.Point(210, 99)
+        Me.cmdZero.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdZero.Name = "cmdZero"
-        Me.cmdZero.Size = New System.Drawing.Size(45, 30)
+        Me.cmdZero.Size = New System.Drawing.Size(68, 45)
         Me.cmdZero.TabIndex = 153
         Me.cmdZero.Text = "I()"
         Me.cmdZero.UseVisualStyleBackColor = True
@@ -209,10 +208,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdPlus
         '
         Me.cmdPlus.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdPlus.Location = New System.Drawing.Point(140, 8)
-        Me.cmdPlus.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdPlus.Location = New System.Drawing.Point(210, 12)
+        Me.cmdPlus.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdPlus.Name = "cmdPlus"
-        Me.cmdPlus.Size = New System.Drawing.Size(45, 30)
+        Me.cmdPlus.Size = New System.Drawing.Size(68, 45)
         Me.cmdPlus.TabIndex = 151
         Me.cmdPlus.Text = "+"
         Me.cmdPlus.UseVisualStyleBackColor = True
@@ -220,10 +219,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdComma
         '
         Me.cmdComma.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdComma.Location = New System.Drawing.Point(71, 8)
-        Me.cmdComma.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdComma.Location = New System.Drawing.Point(106, 12)
+        Me.cmdComma.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdComma.Name = "cmdComma"
-        Me.cmdComma.Size = New System.Drawing.Size(70, 30)
+        Me.cmdComma.Size = New System.Drawing.Size(105, 45)
         Me.cmdComma.TabIndex = 152
         Me.cmdComma.Tag = ""
         Me.cmdComma.Text = ","
@@ -232,10 +231,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdDelete
         '
         Me.cmdDelete.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdDelete.Location = New System.Drawing.Point(140, 37)
-        Me.cmdDelete.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdDelete.Location = New System.Drawing.Point(210, 56)
+        Me.cmdDelete.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdDelete.Name = "cmdDelete"
-        Me.cmdDelete.Size = New System.Drawing.Size(45, 30)
+        Me.cmdDelete.Size = New System.Drawing.Size(68, 45)
         Me.cmdDelete.TabIndex = 149
         Me.cmdDelete.Text = "Del"
         Me.cmdDelete.UseVisualStyleBackColor = True
@@ -244,10 +243,10 @@ Partial Class dlgHypothesisTestsCalculator
         '
         Me.cmdConf.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!)
         Me.cmdConf.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdConf.Location = New System.Drawing.Point(2, 66)
-        Me.cmdConf.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdConf.Location = New System.Drawing.Point(3, 99)
+        Me.cmdConf.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdConf.Name = "cmdConf"
-        Me.cmdConf.Size = New System.Drawing.Size(70, 30)
+        Me.cmdConf.Size = New System.Drawing.Size(105, 45)
         Me.cmdConf.TabIndex = 147
         Me.cmdConf.Tag = "Del"
         Me.cmdConf.Text = "Conf=0.95"
@@ -256,10 +255,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdBrackets
         '
         Me.cmdBrackets.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdBrackets.Location = New System.Drawing.Point(71, 37)
-        Me.cmdBrackets.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdBrackets.Location = New System.Drawing.Point(106, 56)
+        Me.cmdBrackets.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdBrackets.Name = "cmdBrackets"
-        Me.cmdBrackets.Size = New System.Drawing.Size(70, 30)
+        Me.cmdBrackets.Size = New System.Drawing.Size(105, 45)
         Me.cmdBrackets.TabIndex = 145
         Me.cmdBrackets.Text = "( )"
         Me.cmdBrackets.UseVisualStyleBackColor = True
@@ -268,10 +267,10 @@ Partial Class dlgHypothesisTestsCalculator
         '
         Me.cmdAlt.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!)
         Me.cmdAlt.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdAlt.Location = New System.Drawing.Point(71, 66)
-        Me.cmdAlt.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdAlt.Location = New System.Drawing.Point(106, 99)
+        Me.cmdAlt.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdAlt.Name = "cmdAlt"
-        Me.cmdAlt.Size = New System.Drawing.Size(70, 30)
+        Me.cmdAlt.Size = New System.Drawing.Size(105, 45)
         Me.cmdAlt.TabIndex = 143
         Me.cmdAlt.Text = "Alt=""two"""
         Me.cmdAlt.UseVisualStyleBackColor = True
@@ -279,10 +278,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdSquiggle
         '
         Me.cmdSquiggle.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdSquiggle.Location = New System.Drawing.Point(2, 8)
-        Me.cmdSquiggle.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdSquiggle.Location = New System.Drawing.Point(3, 12)
+        Me.cmdSquiggle.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdSquiggle.Name = "cmdSquiggle"
-        Me.cmdSquiggle.Size = New System.Drawing.Size(70, 30)
+        Me.cmdSquiggle.Size = New System.Drawing.Size(105, 45)
         Me.cmdSquiggle.TabIndex = 149
         Me.cmdSquiggle.Text = "~"
         Me.cmdSquiggle.UseVisualStyleBackColor = True
@@ -290,10 +289,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdSquareBrackets
         '
         Me.cmdSquareBrackets.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdSquareBrackets.Location = New System.Drawing.Point(2, 37)
-        Me.cmdSquareBrackets.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdSquareBrackets.Location = New System.Drawing.Point(3, 56)
+        Me.cmdSquareBrackets.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdSquareBrackets.Name = "cmdSquareBrackets"
-        Me.cmdSquareBrackets.Size = New System.Drawing.Size(70, 30)
+        Me.cmdSquareBrackets.Size = New System.Drawing.Size(105, 45)
         Me.cmdSquareBrackets.TabIndex = 142
         Me.cmdSquareBrackets.Text = "[ ]"
         Me.cmdSquareBrackets.UseVisualStyleBackColor = True
@@ -302,10 +301,10 @@ Partial Class dlgHypothesisTestsCalculator
         '
         Me.cmdClear.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!)
         Me.cmdClear.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdClear.Location = New System.Drawing.Point(440, 261)
-        Me.cmdClear.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdClear.Location = New System.Drawing.Point(660, 392)
+        Me.cmdClear.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdClear.Name = "cmdClear"
-        Me.cmdClear.Size = New System.Drawing.Size(75, 23)
+        Me.cmdClear.Size = New System.Drawing.Size(112, 34)
         Me.cmdClear.TabIndex = 10
         Me.cmdClear.Text = "Clear"
         Me.cmdClear.UseVisualStyleBackColor = True
@@ -328,11 +327,11 @@ Partial Class dlgHypothesisTestsCalculator
         Me.grpStats1.Controls.Add(Me.cmdBinom)
         Me.grpStats1.Controls.Add(Me.cmdBartlett)
         Me.grpStats1.Controls.Add(Me.cmdfisher)
-        Me.grpStats1.Location = New System.Drawing.Point(241, 79)
-        Me.grpStats1.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.grpStats1.Location = New System.Drawing.Point(362, 118)
+        Me.grpStats1.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.grpStats1.Name = "grpStats1"
-        Me.grpStats1.Padding = New System.Windows.Forms.Padding(2, 3, 2, 3)
-        Me.grpStats1.Size = New System.Drawing.Size(355, 141)
+        Me.grpStats1.Padding = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.grpStats1.Size = New System.Drawing.Size(532, 212)
         Me.grpStats1.TabIndex = 6
         Me.grpStats1.TabStop = False
         Me.grpStats1.Text = "Stats1"
@@ -340,10 +339,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdT
         '
         Me.cmdT.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdT.Location = New System.Drawing.Point(90, 107)
-        Me.cmdT.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdT.Location = New System.Drawing.Point(135, 160)
+        Me.cmdT.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdT.Name = "cmdT"
-        Me.cmdT.Size = New System.Drawing.Size(86, 30)
+        Me.cmdT.Size = New System.Drawing.Size(129, 45)
         Me.cmdT.TabIndex = 167
         Me.cmdT.Text = "t"
         Me.cmdT.UseVisualStyleBackColor = True
@@ -351,10 +350,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdProp
         '
         Me.cmdProp.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdProp.Location = New System.Drawing.Point(262, 76)
-        Me.cmdProp.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdProp.Location = New System.Drawing.Point(393, 114)
+        Me.cmdProp.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdProp.Name = "cmdProp"
-        Me.cmdProp.Size = New System.Drawing.Size(86, 30)
+        Me.cmdProp.Size = New System.Drawing.Size(129, 45)
         Me.cmdProp.TabIndex = 165
         Me.cmdProp.Text = "prop"
         Me.cmdProp.UseVisualStyleBackColor = True
@@ -362,10 +361,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdPoisson
         '
         Me.cmdPoisson.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdPoisson.Location = New System.Drawing.Point(176, 76)
-        Me.cmdPoisson.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdPoisson.Location = New System.Drawing.Point(264, 114)
+        Me.cmdPoisson.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdPoisson.Name = "cmdPoisson"
-        Me.cmdPoisson.Size = New System.Drawing.Size(86, 30)
+        Me.cmdPoisson.Size = New System.Drawing.Size(129, 45)
         Me.cmdPoisson.TabIndex = 164
         Me.cmdPoisson.Text = "poisson"
         Me.cmdPoisson.UseVisualStyleBackColor = True
@@ -373,10 +372,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdVar
         '
         Me.cmdVar.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdVar.Location = New System.Drawing.Point(176, 107)
-        Me.cmdVar.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdVar.Location = New System.Drawing.Point(264, 160)
+        Me.cmdVar.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdVar.Name = "cmdVar"
-        Me.cmdVar.Size = New System.Drawing.Size(86, 30)
+        Me.cmdVar.Size = New System.Drawing.Size(129, 45)
         Me.cmdVar.TabIndex = 162
         Me.cmdVar.Text = "var"
         Me.cmdVar.UseVisualStyleBackColor = True
@@ -384,10 +383,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdShapiro
         '
         Me.cmdShapiro.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdShapiro.Location = New System.Drawing.Point(4, 107)
-        Me.cmdShapiro.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdShapiro.Location = New System.Drawing.Point(6, 160)
+        Me.cmdShapiro.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdShapiro.Name = "cmdShapiro"
-        Me.cmdShapiro.Size = New System.Drawing.Size(86, 30)
+        Me.cmdShapiro.Size = New System.Drawing.Size(129, 45)
         Me.cmdShapiro.TabIndex = 161
         Me.cmdShapiro.Text = "shapiro"
         Me.cmdShapiro.UseVisualStyleBackColor = True
@@ -396,10 +395,10 @@ Partial Class dlgHypothesisTestsCalculator
         '
         Me.cmdWilcox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!)
         Me.cmdWilcox.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdWilcox.Location = New System.Drawing.Point(262, 107)
-        Me.cmdWilcox.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdWilcox.Location = New System.Drawing.Point(393, 160)
+        Me.cmdWilcox.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdWilcox.Name = "cmdWilcox"
-        Me.cmdWilcox.Size = New System.Drawing.Size(86, 30)
+        Me.cmdWilcox.Size = New System.Drawing.Size(129, 45)
         Me.cmdWilcox.TabIndex = 163
         Me.cmdWilcox.Tag = "Del"
         Me.cmdWilcox.Text = "wilcox"
@@ -408,10 +407,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdKruskal
         '
         Me.cmdKruskal.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdKruskal.Location = New System.Drawing.Point(262, 45)
-        Me.cmdKruskal.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdKruskal.Location = New System.Drawing.Point(393, 68)
+        Me.cmdKruskal.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdKruskal.Name = "cmdKruskal"
-        Me.cmdKruskal.Size = New System.Drawing.Size(86, 30)
+        Me.cmdKruskal.Size = New System.Drawing.Size(129, 45)
         Me.cmdKruskal.TabIndex = 155
         Me.cmdKruskal.Text = " kruskal"
         Me.cmdKruskal.UseVisualStyleBackColor = True
@@ -419,10 +418,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdChisq
         '
         Me.cmdChisq.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdChisq.Location = New System.Drawing.Point(262, 14)
-        Me.cmdChisq.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdChisq.Location = New System.Drawing.Point(393, 21)
+        Me.cmdChisq.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdChisq.Name = "cmdChisq"
-        Me.cmdChisq.Size = New System.Drawing.Size(86, 30)
+        Me.cmdChisq.Size = New System.Drawing.Size(129, 45)
         Me.cmdChisq.TabIndex = 154
         Me.cmdChisq.Text = "chisq"
         Me.cmdChisq.UseVisualStyleBackColor = True
@@ -430,10 +429,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdbox
         '
         Me.cmdbox.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdbox.Location = New System.Drawing.Point(176, 14)
-        Me.cmdbox.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdbox.Location = New System.Drawing.Point(264, 21)
+        Me.cmdbox.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdbox.Name = "cmdbox"
-        Me.cmdbox.Size = New System.Drawing.Size(86, 30)
+        Me.cmdbox.Size = New System.Drawing.Size(129, 45)
         Me.cmdbox.TabIndex = 153
         Me.cmdbox.Text = " box"
         Me.cmdbox.UseVisualStyleBackColor = True
@@ -441,10 +440,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdKs
         '
         Me.cmdKs.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdKs.Location = New System.Drawing.Point(4, 76)
-        Me.cmdKs.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdKs.Location = New System.Drawing.Point(6, 114)
+        Me.cmdKs.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdKs.Name = "cmdKs"
-        Me.cmdKs.Size = New System.Drawing.Size(86, 30)
+        Me.cmdKs.Size = New System.Drawing.Size(129, 45)
         Me.cmdKs.TabIndex = 151
         Me.cmdKs.Text = "ks"
         Me.cmdKs.UseVisualStyleBackColor = True
@@ -452,10 +451,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdFriedman
         '
         Me.cmdFriedman.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdFriedman.Location = New System.Drawing.Point(176, 45)
-        Me.cmdFriedman.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdFriedman.Location = New System.Drawing.Point(264, 68)
+        Me.cmdFriedman.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdFriedman.Name = "cmdFriedman"
-        Me.cmdFriedman.Size = New System.Drawing.Size(86, 30)
+        Me.cmdFriedman.Size = New System.Drawing.Size(129, 45)
         Me.cmdFriedman.TabIndex = 150
         Me.cmdFriedman.Text = "friedman"
         Me.cmdFriedman.UseVisualStyleBackColor = True
@@ -463,10 +462,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdOneway
         '
         Me.cmdOneway.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdOneway.Location = New System.Drawing.Point(90, 76)
-        Me.cmdOneway.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdOneway.Location = New System.Drawing.Point(135, 114)
+        Me.cmdOneway.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdOneway.Name = "cmdOneway"
-        Me.cmdOneway.Size = New System.Drawing.Size(86, 30)
+        Me.cmdOneway.Size = New System.Drawing.Size(129, 45)
         Me.cmdOneway.TabIndex = 148
         Me.cmdOneway.Text = "oneway"
         Me.cmdOneway.UseVisualStyleBackColor = True
@@ -474,10 +473,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdCor
         '
         Me.cmdCor.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdCor.Location = New System.Drawing.Point(4, 45)
-        Me.cmdCor.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdCor.Location = New System.Drawing.Point(6, 68)
+        Me.cmdCor.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdCor.Name = "cmdCor"
-        Me.cmdCor.Size = New System.Drawing.Size(86, 30)
+        Me.cmdCor.Size = New System.Drawing.Size(129, 45)
         Me.cmdCor.TabIndex = 158
         Me.cmdCor.Text = "cor"
         Me.cmdCor.UseVisualStyleBackColor = True
@@ -485,10 +484,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdBinom
         '
         Me.cmdBinom.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdBinom.Location = New System.Drawing.Point(90, 14)
-        Me.cmdBinom.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdBinom.Location = New System.Drawing.Point(135, 21)
+        Me.cmdBinom.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdBinom.Name = "cmdBinom"
-        Me.cmdBinom.Size = New System.Drawing.Size(86, 30)
+        Me.cmdBinom.Size = New System.Drawing.Size(129, 45)
         Me.cmdBinom.TabIndex = 126
         Me.cmdBinom.Text = " binom"
         Me.cmdBinom.UseVisualStyleBackColor = True
@@ -496,10 +495,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdBartlett
         '
         Me.cmdBartlett.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdBartlett.Location = New System.Drawing.Point(4, 14)
-        Me.cmdBartlett.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdBartlett.Location = New System.Drawing.Point(6, 21)
+        Me.cmdBartlett.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdBartlett.Name = "cmdBartlett"
-        Me.cmdBartlett.Size = New System.Drawing.Size(86, 30)
+        Me.cmdBartlett.Size = New System.Drawing.Size(129, 45)
         Me.cmdBartlett.TabIndex = 124
         Me.cmdBartlett.Text = "bartlett"
         Me.cmdBartlett.UseVisualStyleBackColor = True
@@ -507,10 +506,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdfisher
         '
         Me.cmdfisher.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdfisher.Location = New System.Drawing.Point(90, 45)
-        Me.cmdfisher.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdfisher.Location = New System.Drawing.Point(135, 68)
+        Me.cmdfisher.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdfisher.Name = "cmdfisher"
-        Me.cmdfisher.Size = New System.Drawing.Size(86, 30)
+        Me.cmdfisher.Size = New System.Drawing.Size(129, 45)
         Me.cmdfisher.TabIndex = 121
         Me.cmdfisher.Text = " fisher"
         Me.cmdfisher.UseVisualStyleBackColor = True
@@ -519,10 +518,10 @@ Partial Class dlgHypothesisTestsCalculator
         '
         Me.cmdClearStats2.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!)
         Me.cmdClearStats2.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdClearStats2.Location = New System.Drawing.Point(262, 107)
-        Me.cmdClearStats2.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdClearStats2.Location = New System.Drawing.Point(393, 160)
+        Me.cmdClearStats2.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdClearStats2.Name = "cmdClearStats2"
-        Me.cmdClearStats2.Size = New System.Drawing.Size(86, 30)
+        Me.cmdClearStats2.Size = New System.Drawing.Size(129, 45)
         Me.cmdClearStats2.TabIndex = 168
         Me.cmdClearStats2.Text = "Clear"
         Me.cmdClearStats2.UseVisualStyleBackColor = True
@@ -530,10 +529,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdPropTrend
         '
         Me.cmdPropTrend.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdPropTrend.Location = New System.Drawing.Point(4, 107)
-        Me.cmdPropTrend.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdPropTrend.Location = New System.Drawing.Point(6, 160)
+        Me.cmdPropTrend.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdPropTrend.Name = "cmdPropTrend"
-        Me.cmdPropTrend.Size = New System.Drawing.Size(86, 30)
+        Me.cmdPropTrend.Size = New System.Drawing.Size(129, 45)
         Me.cmdPropTrend.TabIndex = 160
         Me.cmdPropTrend.Text = "prop.trend"
         Me.cmdPropTrend.UseVisualStyleBackColor = True
@@ -541,10 +540,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdPowerProp
         '
         Me.cmdPowerProp.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdPowerProp.Location = New System.Drawing.Point(176, 76)
-        Me.cmdPowerProp.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdPowerProp.Location = New System.Drawing.Point(264, 114)
+        Me.cmdPowerProp.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdPowerProp.Name = "cmdPowerProp"
-        Me.cmdPowerProp.Size = New System.Drawing.Size(86, 30)
+        Me.cmdPowerProp.Size = New System.Drawing.Size(129, 45)
         Me.cmdPowerProp.TabIndex = 159
         Me.cmdPowerProp.Text = "power.prop"
         Me.cmdPowerProp.UseVisualStyleBackColor = True
@@ -552,10 +551,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdPowerT
         '
         Me.cmdPowerT.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdPowerT.Location = New System.Drawing.Point(262, 76)
-        Me.cmdPowerT.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdPowerT.Location = New System.Drawing.Point(393, 114)
+        Me.cmdPowerT.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdPowerT.Name = "cmdPowerT"
-        Me.cmdPowerT.Size = New System.Drawing.Size(86, 30)
+        Me.cmdPowerT.Size = New System.Drawing.Size(129, 45)
         Me.cmdPowerT.TabIndex = 157
         Me.cmdPowerT.Text = "power.t"
         Me.cmdPowerT.UseVisualStyleBackColor = True
@@ -564,10 +563,10 @@ Partial Class dlgHypothesisTestsCalculator
         '
         Me.cmdPaiwiseWilcox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!)
         Me.cmdPaiwiseWilcox.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdPaiwiseWilcox.Location = New System.Drawing.Point(262, 45)
-        Me.cmdPaiwiseWilcox.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdPaiwiseWilcox.Location = New System.Drawing.Point(393, 68)
+        Me.cmdPaiwiseWilcox.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdPaiwiseWilcox.Name = "cmdPaiwiseWilcox"
-        Me.cmdPaiwiseWilcox.Size = New System.Drawing.Size(86, 30)
+        Me.cmdPaiwiseWilcox.Size = New System.Drawing.Size(129, 45)
         Me.cmdPaiwiseWilcox.TabIndex = 156
         Me.cmdPaiwiseWilcox.Tag = "Del"
         Me.cmdPaiwiseWilcox.Text = "pairwise.wilcox"
@@ -576,10 +575,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdMood
         '
         Me.cmdMood.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdMood.Location = New System.Drawing.Point(90, 45)
-        Me.cmdMood.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdMood.Location = New System.Drawing.Point(135, 68)
+        Me.cmdMood.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdMood.Name = "cmdMood"
-        Me.cmdMood.Size = New System.Drawing.Size(86, 30)
+        Me.cmdMood.Size = New System.Drawing.Size(129, 45)
         Me.cmdMood.TabIndex = 147
         Me.cmdMood.Text = "mood"
         Me.cmdMood.UseVisualStyleBackColor = True
@@ -587,10 +586,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdPowerAnova
         '
         Me.cmdPowerAnova.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdPowerAnova.Location = New System.Drawing.Point(90, 76)
-        Me.cmdPowerAnova.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdPowerAnova.Location = New System.Drawing.Point(135, 114)
+        Me.cmdPowerAnova.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdPowerAnova.Name = "cmdPowerAnova"
-        Me.cmdPowerAnova.Size = New System.Drawing.Size(86, 30)
+        Me.cmdPowerAnova.Size = New System.Drawing.Size(129, 45)
         Me.cmdPowerAnova.TabIndex = 146
         Me.cmdPowerAnova.Text = "power.anova"
         Me.cmdPowerAnova.UseVisualStyleBackColor = True
@@ -598,10 +597,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdMcnemar
         '
         Me.cmdMcnemar.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdMcnemar.Location = New System.Drawing.Point(4, 45)
-        Me.cmdMcnemar.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdMcnemar.Location = New System.Drawing.Point(6, 68)
+        Me.cmdMcnemar.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdMcnemar.Name = "cmdMcnemar"
-        Me.cmdMcnemar.Size = New System.Drawing.Size(86, 30)
+        Me.cmdMcnemar.Size = New System.Drawing.Size(129, 45)
         Me.cmdMcnemar.TabIndex = 145
         Me.cmdMcnemar.Text = "mcnemar"
         Me.cmdMcnemar.UseVisualStyleBackColor = True
@@ -610,10 +609,10 @@ Partial Class dlgHypothesisTestsCalculator
         '
         Me.cmdPairwiseProp.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!)
         Me.cmdPairwiseProp.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdPairwiseProp.Location = New System.Drawing.Point(176, 45)
-        Me.cmdPairwiseProp.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdPairwiseProp.Location = New System.Drawing.Point(264, 68)
+        Me.cmdPairwiseProp.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdPairwiseProp.Name = "cmdPairwiseProp"
-        Me.cmdPairwiseProp.Size = New System.Drawing.Size(86, 30)
+        Me.cmdPairwiseProp.Size = New System.Drawing.Size(129, 45)
         Me.cmdPairwiseProp.TabIndex = 132
         Me.cmdPairwiseProp.Tag = "Del"
         Me.cmdPairwiseProp.Text = "pairwise.Prop"
@@ -622,10 +621,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdfligner
         '
         Me.cmdfligner.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdfligner.Location = New System.Drawing.Point(90, 14)
-        Me.cmdfligner.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdfligner.Location = New System.Drawing.Point(135, 21)
+        Me.cmdfligner.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdfligner.Name = "cmdfligner"
-        Me.cmdfligner.Size = New System.Drawing.Size(86, 30)
+        Me.cmdfligner.Size = New System.Drawing.Size(129, 45)
         Me.cmdfligner.TabIndex = 129
         Me.cmdfligner.Text = "fligner"
         Me.cmdfligner.UseVisualStyleBackColor = True
@@ -634,10 +633,10 @@ Partial Class dlgHypothesisTestsCalculator
         '
         Me.cmdPairwiset.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
         Me.cmdPairwiset.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdPairwiset.Location = New System.Drawing.Point(4, 76)
-        Me.cmdPairwiset.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdPairwiset.Location = New System.Drawing.Point(6, 114)
+        Me.cmdPairwiset.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdPairwiset.Name = "cmdPairwiset"
-        Me.cmdPairwiset.Size = New System.Drawing.Size(86, 30)
+        Me.cmdPairwiset.Size = New System.Drawing.Size(129, 45)
         Me.cmdPairwiset.TabIndex = 144
         Me.cmdPairwiset.Text = "pairwise.t"
         Me.cmdPairwiset.UseVisualStyleBackColor = True
@@ -645,10 +644,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdMauchly
         '
         Me.cmdMauchly.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdMauchly.Location = New System.Drawing.Point(262, 14)
-        Me.cmdMauchly.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdMauchly.Location = New System.Drawing.Point(393, 21)
+        Me.cmdMauchly.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdMauchly.Name = "cmdMauchly"
-        Me.cmdMauchly.Size = New System.Drawing.Size(86, 30)
+        Me.cmdMauchly.Size = New System.Drawing.Size(129, 45)
         Me.cmdMauchly.TabIndex = 117
         Me.cmdMauchly.Text = "mauchly"
         Me.cmdMauchly.UseVisualStyleBackColor = True
@@ -656,19 +655,20 @@ Partial Class dlgHypothesisTestsCalculator
         'lblRpackage
         '
         Me.lblRpackage.AutoSize = True
-        Me.lblRpackage.Location = New System.Drawing.Point(241, 55)
+        Me.lblRpackage.Location = New System.Drawing.Point(362, 82)
+        Me.lblRpackage.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblRpackage.Name = "lblRpackage"
-        Me.lblRpackage.Size = New System.Drawing.Size(63, 13)
+        Me.lblRpackage.Size = New System.Drawing.Size(90, 20)
         Me.lblRpackage.TabIndex = 4
         Me.lblRpackage.Text = "R package:"
         '
         'cmdAnsari
         '
         Me.cmdAnsari.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdAnsari.Location = New System.Drawing.Point(4, 14)
-        Me.cmdAnsari.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdAnsari.Location = New System.Drawing.Point(6, 21)
+        Me.cmdAnsari.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdAnsari.Name = "cmdAnsari"
-        Me.cmdAnsari.Size = New System.Drawing.Size(86, 30)
+        Me.cmdAnsari.Size = New System.Drawing.Size(129, 45)
         Me.cmdAnsari.TabIndex = 169
         Me.cmdAnsari.Text = "ansari"
         Me.cmdAnsari.UseVisualStyleBackColor = True
@@ -676,10 +676,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdMantelhaen
         '
         Me.cmdMantelhaen.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdMantelhaen.Location = New System.Drawing.Point(176, 14)
-        Me.cmdMantelhaen.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdMantelhaen.Location = New System.Drawing.Point(264, 21)
+        Me.cmdMantelhaen.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdMantelhaen.Name = "cmdMantelhaen"
-        Me.cmdMantelhaen.Size = New System.Drawing.Size(86, 30)
+        Me.cmdMantelhaen.Size = New System.Drawing.Size(129, 45)
         Me.cmdMantelhaen.TabIndex = 170
         Me.cmdMantelhaen.Text = "mantelhaen"
         Me.cmdMantelhaen.UseVisualStyleBackColor = True
@@ -687,10 +687,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdQuade
         '
         Me.cmdQuade.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdQuade.Location = New System.Drawing.Point(176, 107)
-        Me.cmdQuade.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdQuade.Location = New System.Drawing.Point(264, 160)
+        Me.cmdQuade.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdQuade.Name = "cmdQuade"
-        Me.cmdQuade.Size = New System.Drawing.Size(86, 30)
+        Me.cmdQuade.Size = New System.Drawing.Size(129, 45)
         Me.cmdQuade.TabIndex = 171
         Me.cmdQuade.Text = "quade"
         Me.cmdQuade.UseVisualStyleBackColor = True
@@ -698,10 +698,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdPP
         '
         Me.cmdPP.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdPP.Location = New System.Drawing.Point(90, 107)
-        Me.cmdPP.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdPP.Location = New System.Drawing.Point(135, 160)
+        Me.cmdPP.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdPP.Name = "cmdPP"
-        Me.cmdPP.Size = New System.Drawing.Size(86, 30)
+        Me.cmdPP.Size = New System.Drawing.Size(129, 45)
         Me.cmdPP.TabIndex = 172
         Me.cmdPP.Text = "PP"
         Me.cmdPP.UseVisualStyleBackColor = True
@@ -724,9 +724,11 @@ Partial Class dlgHypothesisTestsCalculator
         Me.grpStats2.Controls.Add(Me.cmdPaiwiseWilcox)
         Me.grpStats2.Controls.Add(Me.cmdPowerT)
         Me.grpStats2.Controls.Add(Me.cmdPowerProp)
-        Me.grpStats2.Location = New System.Drawing.Point(241, 79)
+        Me.grpStats2.Location = New System.Drawing.Point(362, 118)
+        Me.grpStats2.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
         Me.grpStats2.Name = "grpStats2"
-        Me.grpStats2.Size = New System.Drawing.Size(355, 141)
+        Me.grpStats2.Padding = New System.Windows.Forms.Padding(4, 4, 4, 4)
+        Me.grpStats2.Size = New System.Drawing.Size(532, 212)
         Me.grpStats2.TabIndex = 14
         Me.grpStats2.TabStop = False
         Me.grpStats2.Text = "Stats2"
@@ -736,41 +738,36 @@ Partial Class dlgHypothesisTestsCalculator
         Me.grpVerification.Controls.Add(Me.cmdCont)
         Me.grpVerification.Controls.Add(Me.cmdCat)
         Me.grpVerification.Controls.Add(Me.cmdBinary)
-        Me.grpVerification.Location = New System.Drawing.Point(241, 79)
-        Me.grpVerification.Margin = New System.Windows.Forms.Padding(2)
+        Me.grpVerification.Location = New System.Drawing.Point(362, 118)
         Me.grpVerification.Name = "grpVerification"
-        Me.grpVerification.Padding = New System.Windows.Forms.Padding(2)
-        Me.grpVerification.Size = New System.Drawing.Size(355, 49)
+        Me.grpVerification.Size = New System.Drawing.Size(532, 74)
         Me.grpVerification.TabIndex = 18
         Me.grpVerification.TabStop = False
         Me.grpVerification.Text = "Verification"
         '
         'cmdCont
         '
-        Me.cmdCont.Location = New System.Drawing.Point(176, 14)
-        Me.cmdCont.Margin = New System.Windows.Forms.Padding(2)
+        Me.cmdCont.Location = New System.Drawing.Point(264, 21)
         Me.cmdCont.Name = "cmdCont"
-        Me.cmdCont.Size = New System.Drawing.Size(86, 30)
+        Me.cmdCont.Size = New System.Drawing.Size(129, 45)
         Me.cmdCont.TabIndex = 21
         Me.cmdCont.Text = "cont"
         Me.cmdCont.UseVisualStyleBackColor = True
         '
         'cmdCat
         '
-        Me.cmdCat.Location = New System.Drawing.Point(90, 14)
-        Me.cmdCat.Margin = New System.Windows.Forms.Padding(2)
+        Me.cmdCat.Location = New System.Drawing.Point(135, 21)
         Me.cmdCat.Name = "cmdCat"
-        Me.cmdCat.Size = New System.Drawing.Size(86, 30)
+        Me.cmdCat.Size = New System.Drawing.Size(129, 45)
         Me.cmdCat.TabIndex = 20
         Me.cmdCat.Text = "cat"
         Me.cmdCat.UseVisualStyleBackColor = True
         '
         'cmdBinary
         '
-        Me.cmdBinary.Location = New System.Drawing.Point(4, 14)
-        Me.cmdBinary.Margin = New System.Windows.Forms.Padding(2)
+        Me.cmdBinary.Location = New System.Drawing.Point(6, 21)
         Me.cmdBinary.Name = "cmdBinary"
-        Me.cmdBinary.Size = New System.Drawing.Size(86, 30)
+        Me.cmdBinary.Size = New System.Drawing.Size(129, 45)
         Me.cmdBinary.TabIndex = 19
         Me.cmdBinary.Text = "binary"
         Me.cmdBinary.UseVisualStyleBackColor = True
@@ -791,9 +788,11 @@ Partial Class dlgHypothesisTestsCalculator
         Me.grpAgricolae.Controls.Add(Me.cmdLSD)
         Me.grpAgricolae.Controls.Add(Me.cmdDuncan)
         Me.grpAgricolae.Controls.Add(Me.cmdBIB)
-        Me.grpAgricolae.Location = New System.Drawing.Point(241, 79)
+        Me.grpAgricolae.Location = New System.Drawing.Point(362, 118)
+        Me.grpAgricolae.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
         Me.grpAgricolae.Name = "grpAgricolae"
-        Me.grpAgricolae.Size = New System.Drawing.Size(355, 141)
+        Me.grpAgricolae.Padding = New System.Windows.Forms.Padding(4, 4, 4, 4)
+        Me.grpAgricolae.Size = New System.Drawing.Size(532, 212)
         Me.grpAgricolae.TabIndex = 15
         Me.grpAgricolae.TabStop = False
         Me.grpAgricolae.Text = "Agricolae"
@@ -801,10 +800,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdPBIB
         '
         Me.cmdPBIB.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdPBIB.Location = New System.Drawing.Point(4, 76)
-        Me.cmdPBIB.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdPBIB.Location = New System.Drawing.Point(6, 114)
+        Me.cmdPBIB.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdPBIB.Name = "cmdPBIB"
-        Me.cmdPBIB.Size = New System.Drawing.Size(86, 30)
+        Me.cmdPBIB.Size = New System.Drawing.Size(129, 45)
         Me.cmdPBIB.TabIndex = 186
         Me.cmdPBIB.Text = "PBIB"
         Me.cmdPBIB.UseVisualStyleBackColor = True
@@ -812,10 +811,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdAgriKruskal
         '
         Me.cmdAgriKruskal.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdAgriKruskal.Location = New System.Drawing.Point(4, 45)
-        Me.cmdAgriKruskal.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdAgriKruskal.Location = New System.Drawing.Point(6, 68)
+        Me.cmdAgriKruskal.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdAgriKruskal.Name = "cmdAgriKruskal"
-        Me.cmdAgriKruskal.Size = New System.Drawing.Size(86, 30)
+        Me.cmdAgriKruskal.Size = New System.Drawing.Size(129, 45)
         Me.cmdAgriKruskal.TabIndex = 185
         Me.cmdAgriKruskal.Text = "kruskal"
         Me.cmdAgriKruskal.UseVisualStyleBackColor = True
@@ -823,10 +822,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdScheffe
         '
         Me.cmdScheffe.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdScheffe.Location = New System.Drawing.Point(176, 76)
-        Me.cmdScheffe.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdScheffe.Location = New System.Drawing.Point(264, 114)
+        Me.cmdScheffe.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdScheffe.Name = "cmdScheffe"
-        Me.cmdScheffe.Size = New System.Drawing.Size(86, 30)
+        Me.cmdScheffe.Size = New System.Drawing.Size(129, 45)
         Me.cmdScheffe.TabIndex = 184
         Me.cmdScheffe.Text = "scheffe"
         Me.cmdScheffe.UseVisualStyleBackColor = True
@@ -834,10 +833,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdDurbin
         '
         Me.cmdDurbin.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdDurbin.Location = New System.Drawing.Point(175, 14)
-        Me.cmdDurbin.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdDurbin.Location = New System.Drawing.Point(262, 21)
+        Me.cmdDurbin.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdDurbin.Name = "cmdDurbin"
-        Me.cmdDurbin.Size = New System.Drawing.Size(86, 30)
+        Me.cmdDurbin.Size = New System.Drawing.Size(129, 45)
         Me.cmdDurbin.TabIndex = 183
         Me.cmdDurbin.Text = "durbin"
         Me.cmdDurbin.UseVisualStyleBackColor = True
@@ -845,10 +844,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdAgriFriedman
         '
         Me.cmdAgriFriedman.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdAgriFriedman.Location = New System.Drawing.Point(261, 14)
-        Me.cmdAgriFriedman.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdAgriFriedman.Location = New System.Drawing.Point(392, 21)
+        Me.cmdAgriFriedman.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdAgriFriedman.Name = "cmdAgriFriedman"
-        Me.cmdAgriFriedman.Size = New System.Drawing.Size(86, 30)
+        Me.cmdAgriFriedman.Size = New System.Drawing.Size(129, 45)
         Me.cmdAgriFriedman.TabIndex = 182
         Me.cmdAgriFriedman.Text = "friedman"
         Me.cmdAgriFriedman.UseVisualStyleBackColor = True
@@ -856,10 +855,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdSNK
         '
         Me.cmdSNK.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdSNK.Location = New System.Drawing.Point(4, 107)
-        Me.cmdSNK.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdSNK.Location = New System.Drawing.Point(6, 160)
+        Me.cmdSNK.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdSNK.Name = "cmdSNK"
-        Me.cmdSNK.Size = New System.Drawing.Size(86, 30)
+        Me.cmdSNK.Size = New System.Drawing.Size(129, 45)
         Me.cmdSNK.TabIndex = 181
         Me.cmdSNK.Text = "SNK"
         Me.cmdSNK.UseVisualStyleBackColor = True
@@ -867,10 +866,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdWaerden
         '
         Me.cmdWaerden.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdWaerden.Location = New System.Drawing.Point(90, 107)
-        Me.cmdWaerden.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdWaerden.Location = New System.Drawing.Point(135, 160)
+        Me.cmdWaerden.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdWaerden.Name = "cmdWaerden"
-        Me.cmdWaerden.Size = New System.Drawing.Size(86, 30)
+        Me.cmdWaerden.Size = New System.Drawing.Size(129, 45)
         Me.cmdWaerden.TabIndex = 180
         Me.cmdWaerden.Text = "waerden"
         Me.cmdWaerden.UseVisualStyleBackColor = True
@@ -878,10 +877,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdAgriWaller
         '
         Me.cmdAgriWaller.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdAgriWaller.Location = New System.Drawing.Point(176, 107)
-        Me.cmdAgriWaller.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdAgriWaller.Location = New System.Drawing.Point(264, 160)
+        Me.cmdAgriWaller.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdAgriWaller.Name = "cmdAgriWaller"
-        Me.cmdAgriWaller.Size = New System.Drawing.Size(86, 30)
+        Me.cmdAgriWaller.Size = New System.Drawing.Size(129, 45)
         Me.cmdAgriWaller.TabIndex = 179
         Me.cmdAgriWaller.Text = "waller "
         Me.cmdAgriWaller.UseVisualStyleBackColor = True
@@ -889,10 +888,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdAgriNonAdditivity
         '
         Me.cmdAgriNonAdditivity.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdAgriNonAdditivity.Location = New System.Drawing.Point(262, 45)
-        Me.cmdAgriNonAdditivity.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdAgriNonAdditivity.Location = New System.Drawing.Point(393, 68)
+        Me.cmdAgriNonAdditivity.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdAgriNonAdditivity.Name = "cmdAgriNonAdditivity"
-        Me.cmdAgriNonAdditivity.Size = New System.Drawing.Size(86, 30)
+        Me.cmdAgriNonAdditivity.Size = New System.Drawing.Size(129, 45)
         Me.cmdAgriNonAdditivity.TabIndex = 178
         Me.cmdAgriNonAdditivity.Text = "nonadditivity "
         Me.cmdAgriNonAdditivity.UseVisualStyleBackColor = True
@@ -900,10 +899,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdMedian
         '
         Me.cmdMedian.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdMedian.Location = New System.Drawing.Point(176, 45)
-        Me.cmdMedian.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdMedian.Location = New System.Drawing.Point(264, 68)
+        Me.cmdMedian.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdMedian.Name = "cmdMedian"
-        Me.cmdMedian.Size = New System.Drawing.Size(86, 30)
+        Me.cmdMedian.Size = New System.Drawing.Size(129, 45)
         Me.cmdMedian.TabIndex = 177
         Me.cmdMedian.Text = "median"
         Me.cmdMedian.UseVisualStyleBackColor = True
@@ -911,10 +910,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdREGW
         '
         Me.cmdREGW.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdREGW.Location = New System.Drawing.Point(90, 76)
-        Me.cmdREGW.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdREGW.Location = New System.Drawing.Point(135, 114)
+        Me.cmdREGW.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdREGW.Name = "cmdREGW"
-        Me.cmdREGW.Size = New System.Drawing.Size(86, 30)
+        Me.cmdREGW.Size = New System.Drawing.Size(129, 45)
         Me.cmdREGW.TabIndex = 176
         Me.cmdREGW.Text = "REGW"
         Me.cmdREGW.UseVisualStyleBackColor = True
@@ -922,10 +921,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdLSD
         '
         Me.cmdLSD.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdLSD.Location = New System.Drawing.Point(90, 45)
-        Me.cmdLSD.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdLSD.Location = New System.Drawing.Point(135, 68)
+        Me.cmdLSD.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdLSD.Name = "cmdLSD"
-        Me.cmdLSD.Size = New System.Drawing.Size(86, 30)
+        Me.cmdLSD.Size = New System.Drawing.Size(129, 45)
         Me.cmdLSD.TabIndex = 175
         Me.cmdLSD.Text = "LSD"
         Me.cmdLSD.UseVisualStyleBackColor = True
@@ -933,10 +932,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdDuncan
         '
         Me.cmdDuncan.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdDuncan.Location = New System.Drawing.Point(90, 14)
-        Me.cmdDuncan.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdDuncan.Location = New System.Drawing.Point(135, 21)
+        Me.cmdDuncan.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdDuncan.Name = "cmdDuncan"
-        Me.cmdDuncan.Size = New System.Drawing.Size(86, 30)
+        Me.cmdDuncan.Size = New System.Drawing.Size(129, 45)
         Me.cmdDuncan.TabIndex = 174
         Me.cmdDuncan.Text = "duncan"
         Me.cmdDuncan.UseVisualStyleBackColor = True
@@ -944,10 +943,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdBIB
         '
         Me.cmdBIB.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdBIB.Location = New System.Drawing.Point(4, 14)
-        Me.cmdBIB.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdBIB.Location = New System.Drawing.Point(6, 21)
+        Me.cmdBIB.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdBIB.Name = "cmdBIB"
-        Me.cmdBIB.Size = New System.Drawing.Size(86, 30)
+        Me.cmdBIB.Size = New System.Drawing.Size(129, 45)
         Me.cmdBIB.TabIndex = 173
         Me.cmdBIB.Text = "BIB"
         Me.cmdBIB.UseVisualStyleBackColor = True
@@ -955,11 +954,12 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdHelp
         '
         Me.cmdHelp.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdHelp.Location = New System.Drawing.Point(521, 261)
+        Me.cmdHelp.Location = New System.Drawing.Point(782, 392)
+        Me.cmdHelp.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
         Me.cmdHelp.Name = "cmdHelp"
-        Me.cmdHelp.Size = New System.Drawing.Size(75, 23)
+        Me.cmdHelp.Size = New System.Drawing.Size(112, 34)
         Me.cmdHelp.TabIndex = 11
-        Me.cmdHelp.Text = "Help"
+        Me.cmdHelp.Text = "R Help"
         Me.cmdHelp.UseVisualStyleBackColor = True
         '
         'grpCoin
@@ -969,11 +969,9 @@ Partial Class dlgHypothesisTestsCalculator
         Me.grpCoin.Controls.Add(Me.grpSymmetry)
         Me.grpCoin.Controls.Add(Me.grpCorrelation)
         Me.grpCoin.Controls.Add(Me.grpLocation)
-        Me.grpCoin.Location = New System.Drawing.Point(241, 79)
-        Me.grpCoin.Margin = New System.Windows.Forms.Padding(2)
+        Me.grpCoin.Location = New System.Drawing.Point(362, 118)
         Me.grpCoin.Name = "grpCoin"
-        Me.grpCoin.Padding = New System.Windows.Forms.Padding(2)
-        Me.grpCoin.Size = New System.Drawing.Size(383, 175)
+        Me.grpCoin.Size = New System.Drawing.Size(574, 262)
         Me.grpCoin.TabIndex = 22
         Me.grpCoin.TabStop = False
         Me.grpCoin.Text = "Coin"
@@ -987,71 +985,63 @@ Partial Class dlgHypothesisTestsCalculator
         Me.grpScale.Controls.Add(Me.cmdMood1)
         Me.grpScale.Controls.Add(Me.cmdKlotz)
         Me.grpScale.Controls.Add(Me.cmdTaha)
-        Me.grpScale.Location = New System.Drawing.Point(257, 11)
-        Me.grpScale.Margin = New System.Windows.Forms.Padding(2)
+        Me.grpScale.Location = New System.Drawing.Point(386, 16)
         Me.grpScale.Name = "grpScale"
-        Me.grpScale.Padding = New System.Windows.Forms.Padding(2)
-        Me.grpScale.Size = New System.Drawing.Size(124, 88)
+        Me.grpScale.Size = New System.Drawing.Size(186, 132)
         Me.grpScale.TabIndex = 4
         Me.grpScale.TabStop = False
         Me.grpScale.Text = "Scale"
         '
         'cmdConover
         '
-        Me.cmdConover.Location = New System.Drawing.Point(61, 58)
-        Me.cmdConover.Margin = New System.Windows.Forms.Padding(2)
+        Me.cmdConover.Location = New System.Drawing.Point(92, 87)
         Me.cmdConover.Name = "cmdConover"
-        Me.cmdConover.Size = New System.Drawing.Size(60, 24)
+        Me.cmdConover.Size = New System.Drawing.Size(90, 36)
         Me.cmdConover.TabIndex = 6
         Me.cmdConover.Text = "conover"
         Me.cmdConover.UseVisualStyleBackColor = True
         '
         'cmdFligner1
         '
-        Me.cmdFligner1.Location = New System.Drawing.Point(2, 58)
-        Me.cmdFligner1.Margin = New System.Windows.Forms.Padding(2)
+        Me.cmdFligner1.Location = New System.Drawing.Point(3, 87)
         Me.cmdFligner1.Name = "cmdFligner1"
-        Me.cmdFligner1.Size = New System.Drawing.Size(60, 24)
+        Me.cmdFligner1.Size = New System.Drawing.Size(90, 36)
         Me.cmdFligner1.TabIndex = 5
         Me.cmdFligner1.Text = "fligner"
         Me.cmdFligner1.UseVisualStyleBackColor = True
         '
         'cmdAnsari1
         '
-        Me.cmdAnsari1.Location = New System.Drawing.Point(61, 35)
-        Me.cmdAnsari1.Margin = New System.Windows.Forms.Padding(2)
+        Me.cmdAnsari1.Location = New System.Drawing.Point(92, 52)
         Me.cmdAnsari1.Name = "cmdAnsari1"
-        Me.cmdAnsari1.Size = New System.Drawing.Size(60, 24)
+        Me.cmdAnsari1.Size = New System.Drawing.Size(90, 36)
         Me.cmdAnsari1.TabIndex = 4
         Me.cmdAnsari1.Text = "ansari"
         Me.cmdAnsari1.UseVisualStyleBackColor = True
         '
         'cmdMood1
         '
-        Me.cmdMood1.Location = New System.Drawing.Point(2, 35)
-        Me.cmdMood1.Margin = New System.Windows.Forms.Padding(2)
+        Me.cmdMood1.Location = New System.Drawing.Point(3, 52)
         Me.cmdMood1.Name = "cmdMood1"
-        Me.cmdMood1.Size = New System.Drawing.Size(60, 24)
+        Me.cmdMood1.Size = New System.Drawing.Size(90, 36)
         Me.cmdMood1.TabIndex = 3
         Me.cmdMood1.Text = "mood"
         Me.cmdMood1.UseVisualStyleBackColor = True
         '
         'cmdKlotz
         '
-        Me.cmdKlotz.Location = New System.Drawing.Point(61, 12)
-        Me.cmdKlotz.Margin = New System.Windows.Forms.Padding(2)
+        Me.cmdKlotz.Location = New System.Drawing.Point(92, 18)
         Me.cmdKlotz.Name = "cmdKlotz"
-        Me.cmdKlotz.Size = New System.Drawing.Size(60, 24)
+        Me.cmdKlotz.Size = New System.Drawing.Size(90, 36)
         Me.cmdKlotz.TabIndex = 2
         Me.cmdKlotz.Text = "klotz"
         Me.cmdKlotz.UseVisualStyleBackColor = True
         '
         'cmdTaha
         '
-        Me.cmdTaha.Location = New System.Drawing.Point(2, 12)
-        Me.cmdTaha.Margin = New System.Windows.Forms.Padding(2)
+        Me.cmdTaha.Location = New System.Drawing.Point(3, 18)
         Me.cmdTaha.Name = "cmdTaha"
-        Me.cmdTaha.Size = New System.Drawing.Size(60, 24)
+        Me.cmdTaha.Size = New System.Drawing.Size(90, 36)
         Me.cmdTaha.TabIndex = 1
         Me.cmdTaha.Text = "taha"
         Me.cmdTaha.UseVisualStyleBackColor = True
@@ -1062,41 +1052,36 @@ Partial Class dlgHypothesisTestsCalculator
         Me.grpContigency.Controls.Add(Me.cmdLbl)
         Me.grpContigency.Controls.Add(Me.cmdCmh)
         Me.grpContigency.Controls.Add(Me.cmdChisq1)
-        Me.grpContigency.Location = New System.Drawing.Point(138, 101)
-        Me.grpContigency.Margin = New System.Windows.Forms.Padding(2)
+        Me.grpContigency.Location = New System.Drawing.Point(207, 152)
         Me.grpContigency.Name = "grpContigency"
-        Me.grpContigency.Padding = New System.Windows.Forms.Padding(2)
-        Me.grpContigency.Size = New System.Drawing.Size(185, 50)
+        Me.grpContigency.Size = New System.Drawing.Size(278, 75)
         Me.grpContigency.TabIndex = 3
         Me.grpContigency.TabStop = False
         Me.grpContigency.Text = "Contingency"
         '
         'cmdLbl
         '
-        Me.cmdLbl.Location = New System.Drawing.Point(120, 16)
-        Me.cmdLbl.Margin = New System.Windows.Forms.Padding(2)
+        Me.cmdLbl.Location = New System.Drawing.Point(180, 24)
         Me.cmdLbl.Name = "cmdLbl"
-        Me.cmdLbl.Size = New System.Drawing.Size(60, 24)
+        Me.cmdLbl.Size = New System.Drawing.Size(90, 36)
         Me.cmdLbl.TabIndex = 3
         Me.cmdLbl.Text = "lbl"
         Me.cmdLbl.UseVisualStyleBackColor = True
         '
         'cmdCmh
         '
-        Me.cmdCmh.Location = New System.Drawing.Point(61, 16)
-        Me.cmdCmh.Margin = New System.Windows.Forms.Padding(2)
+        Me.cmdCmh.Location = New System.Drawing.Point(92, 24)
         Me.cmdCmh.Name = "cmdCmh"
-        Me.cmdCmh.Size = New System.Drawing.Size(60, 24)
+        Me.cmdCmh.Size = New System.Drawing.Size(90, 36)
         Me.cmdCmh.TabIndex = 2
         Me.cmdCmh.Text = "cmh"
         Me.cmdCmh.UseVisualStyleBackColor = True
         '
         'cmdChisq1
         '
-        Me.cmdChisq1.Location = New System.Drawing.Point(2, 16)
-        Me.cmdChisq1.Margin = New System.Windows.Forms.Padding(2)
+        Me.cmdChisq1.Location = New System.Drawing.Point(3, 24)
         Me.cmdChisq1.Name = "cmdChisq1"
-        Me.cmdChisq1.Size = New System.Drawing.Size(60, 24)
+        Me.cmdChisq1.Size = New System.Drawing.Size(90, 36)
         Me.cmdChisq1.TabIndex = 1
         Me.cmdChisq1.Text = "chisq"
         Me.cmdChisq1.UseVisualStyleBackColor = True
@@ -1107,51 +1092,45 @@ Partial Class dlgHypothesisTestsCalculator
         Me.grpSymmetry.Controls.Add(Me.cmdFriedman1)
         Me.grpSymmetry.Controls.Add(Me.cmdWilcoxsign)
         Me.grpSymmetry.Controls.Add(Me.cmdSign)
-        Me.grpSymmetry.Location = New System.Drawing.Point(128, 11)
-        Me.grpSymmetry.Margin = New System.Windows.Forms.Padding(2)
+        Me.grpSymmetry.Location = New System.Drawing.Point(192, 16)
         Me.grpSymmetry.Name = "grpSymmetry"
-        Me.grpSymmetry.Padding = New System.Windows.Forms.Padding(2)
-        Me.grpSymmetry.Size = New System.Drawing.Size(127, 88)
+        Me.grpSymmetry.Size = New System.Drawing.Size(190, 132)
         Me.grpSymmetry.TabIndex = 2
         Me.grpSymmetry.TabStop = False
         Me.grpSymmetry.Text = "Symmetry"
         '
         'cmdQuade1
         '
-        Me.cmdQuade1.Location = New System.Drawing.Point(60, 38)
-        Me.cmdQuade1.Margin = New System.Windows.Forms.Padding(2)
+        Me.cmdQuade1.Location = New System.Drawing.Point(90, 57)
         Me.cmdQuade1.Name = "cmdQuade1"
-        Me.cmdQuade1.Size = New System.Drawing.Size(65, 24)
+        Me.cmdQuade1.Size = New System.Drawing.Size(98, 36)
         Me.cmdQuade1.TabIndex = 4
         Me.cmdQuade1.Text = "quade"
         Me.cmdQuade1.UseVisualStyleBackColor = True
         '
         'cmdFriedman1
         '
-        Me.cmdFriedman1.Location = New System.Drawing.Point(1, 38)
-        Me.cmdFriedman1.Margin = New System.Windows.Forms.Padding(2)
+        Me.cmdFriedman1.Location = New System.Drawing.Point(2, 57)
         Me.cmdFriedman1.Name = "cmdFriedman1"
-        Me.cmdFriedman1.Size = New System.Drawing.Size(60, 24)
+        Me.cmdFriedman1.Size = New System.Drawing.Size(90, 36)
         Me.cmdFriedman1.TabIndex = 3
         Me.cmdFriedman1.Text = "friedman"
         Me.cmdFriedman1.UseVisualStyleBackColor = True
         '
         'cmdWilcoxsign
         '
-        Me.cmdWilcoxsign.Location = New System.Drawing.Point(60, 15)
-        Me.cmdWilcoxsign.Margin = New System.Windows.Forms.Padding(2)
+        Me.cmdWilcoxsign.Location = New System.Drawing.Point(90, 22)
         Me.cmdWilcoxsign.Name = "cmdWilcoxsign"
-        Me.cmdWilcoxsign.Size = New System.Drawing.Size(65, 24)
+        Me.cmdWilcoxsign.Size = New System.Drawing.Size(98, 36)
         Me.cmdWilcoxsign.TabIndex = 2
         Me.cmdWilcoxsign.Text = "wilcoxsign"
         Me.cmdWilcoxsign.UseVisualStyleBackColor = True
         '
         'cmdSign
         '
-        Me.cmdSign.Location = New System.Drawing.Point(1, 15)
-        Me.cmdSign.Margin = New System.Windows.Forms.Padding(2)
+        Me.cmdSign.Location = New System.Drawing.Point(2, 22)
         Me.cmdSign.Name = "cmdSign"
-        Me.cmdSign.Size = New System.Drawing.Size(60, 24)
+        Me.cmdSign.Size = New System.Drawing.Size(90, 36)
         Me.cmdSign.TabIndex = 1
         Me.cmdSign.Text = "sign"
         Me.cmdSign.UseVisualStyleBackColor = True
@@ -1163,51 +1142,45 @@ Partial Class dlgHypothesisTestsCalculator
         Me.grpCorrelation.Controls.Add(Me.cmdQuadrant)
         Me.grpCorrelation.Controls.Add(Me.cmdFisyat)
         Me.grpCorrelation.Controls.Add(Me.cmdSpearman)
-        Me.grpCorrelation.Location = New System.Drawing.Point(2, 101)
-        Me.grpCorrelation.Margin = New System.Windows.Forms.Padding(2)
+        Me.grpCorrelation.Location = New System.Drawing.Point(3, 152)
         Me.grpCorrelation.Name = "grpCorrelation"
-        Me.grpCorrelation.Padding = New System.Windows.Forms.Padding(2)
-        Me.grpCorrelation.Size = New System.Drawing.Size(133, 71)
+        Me.grpCorrelation.Size = New System.Drawing.Size(200, 106)
         Me.grpCorrelation.TabIndex = 1
         Me.grpCorrelation.TabStop = False
         Me.grpCorrelation.Text = "Correlation"
         '
         'cmdKoziol
         '
-        Me.cmdKoziol.Location = New System.Drawing.Point(67, 37)
-        Me.cmdKoziol.Margin = New System.Windows.Forms.Padding(2)
+        Me.cmdKoziol.Location = New System.Drawing.Point(100, 56)
         Me.cmdKoziol.Name = "cmdKoziol"
-        Me.cmdKoziol.Size = New System.Drawing.Size(60, 24)
+        Me.cmdKoziol.Size = New System.Drawing.Size(90, 36)
         Me.cmdKoziol.TabIndex = 4
         Me.cmdKoziol.Text = "koziol"
         Me.cmdKoziol.UseVisualStyleBackColor = True
         '
         'cmdQuadrant
         '
-        Me.cmdQuadrant.Location = New System.Drawing.Point(1, 37)
-        Me.cmdQuadrant.Margin = New System.Windows.Forms.Padding(2)
+        Me.cmdQuadrant.Location = New System.Drawing.Point(2, 56)
         Me.cmdQuadrant.Name = "cmdQuadrant"
-        Me.cmdQuadrant.Size = New System.Drawing.Size(67, 24)
+        Me.cmdQuadrant.Size = New System.Drawing.Size(100, 36)
         Me.cmdQuadrant.TabIndex = 3
         Me.cmdQuadrant.Text = "quadrant"
         Me.cmdQuadrant.UseVisualStyleBackColor = True
         '
         'cmdFisyat
         '
-        Me.cmdFisyat.Location = New System.Drawing.Point(67, 14)
-        Me.cmdFisyat.Margin = New System.Windows.Forms.Padding(2)
+        Me.cmdFisyat.Location = New System.Drawing.Point(100, 21)
         Me.cmdFisyat.Name = "cmdFisyat"
-        Me.cmdFisyat.Size = New System.Drawing.Size(60, 24)
+        Me.cmdFisyat.Size = New System.Drawing.Size(90, 36)
         Me.cmdFisyat.TabIndex = 2
         Me.cmdFisyat.Text = "fisyat"
         Me.cmdFisyat.UseVisualStyleBackColor = True
         '
         'cmdSpearman
         '
-        Me.cmdSpearman.Location = New System.Drawing.Point(1, 14)
-        Me.cmdSpearman.Margin = New System.Windows.Forms.Padding(2)
+        Me.cmdSpearman.Location = New System.Drawing.Point(2, 21)
         Me.cmdSpearman.Name = "cmdSpearman"
-        Me.cmdSpearman.Size = New System.Drawing.Size(67, 24)
+        Me.cmdSpearman.Size = New System.Drawing.Size(100, 36)
         Me.cmdSpearman.TabIndex = 1
         Me.cmdSpearman.Text = "spearman"
         Me.cmdSpearman.UseVisualStyleBackColor = True
@@ -1220,21 +1193,18 @@ Partial Class dlgHypothesisTestsCalculator
         Me.grpLocation.Controls.Add(Me.cmdKruskal1)
         Me.grpLocation.Controls.Add(Me.cmdWilcox1)
         Me.grpLocation.Controls.Add(Me.cmdOneway1)
-        Me.grpLocation.Location = New System.Drawing.Point(2, 11)
-        Me.grpLocation.Margin = New System.Windows.Forms.Padding(2)
+        Me.grpLocation.Location = New System.Drawing.Point(3, 16)
         Me.grpLocation.Name = "grpLocation"
-        Me.grpLocation.Padding = New System.Windows.Forms.Padding(2)
-        Me.grpLocation.Size = New System.Drawing.Size(124, 88)
+        Me.grpLocation.Size = New System.Drawing.Size(186, 132)
         Me.grpLocation.TabIndex = 0
         Me.grpLocation.TabStop = False
         Me.grpLocation.Text = "Location"
         '
         'cmdSavage
         '
-        Me.cmdSavage.Location = New System.Drawing.Point(60, 60)
-        Me.cmdSavage.Margin = New System.Windows.Forms.Padding(2)
+        Me.cmdSavage.Location = New System.Drawing.Point(90, 90)
         Me.cmdSavage.Name = "cmdSavage"
-        Me.cmdSavage.Size = New System.Drawing.Size(60, 24)
+        Me.cmdSavage.Size = New System.Drawing.Size(90, 36)
         Me.cmdSavage.TabIndex = 5
         Me.cmdSavage.Text = "savage"
         Me.cmdSavage.UseVisualStyleBackColor = True
@@ -1242,10 +1212,9 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdMedian1
         '
         Me.cmdMedian1.AccessibleDescription = ""
-        Me.cmdMedian1.Location = New System.Drawing.Point(1, 60)
-        Me.cmdMedian1.Margin = New System.Windows.Forms.Padding(2)
+        Me.cmdMedian1.Location = New System.Drawing.Point(2, 90)
         Me.cmdMedian1.Name = "cmdMedian1"
-        Me.cmdMedian1.Size = New System.Drawing.Size(60, 24)
+        Me.cmdMedian1.Size = New System.Drawing.Size(90, 36)
         Me.cmdMedian1.TabIndex = 4
         Me.cmdMedian1.Text = "median"
         Me.cmdMedian1.UseVisualStyleBackColor = True
@@ -1253,10 +1222,9 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdNormal
         '
         Me.cmdNormal.AccessibleDescription = ""
-        Me.cmdNormal.Location = New System.Drawing.Point(60, 37)
-        Me.cmdNormal.Margin = New System.Windows.Forms.Padding(2)
+        Me.cmdNormal.Location = New System.Drawing.Point(90, 56)
         Me.cmdNormal.Name = "cmdNormal"
-        Me.cmdNormal.Size = New System.Drawing.Size(60, 24)
+        Me.cmdNormal.Size = New System.Drawing.Size(90, 36)
         Me.cmdNormal.TabIndex = 3
         Me.cmdNormal.Text = "normal"
         Me.cmdNormal.UseVisualStyleBackColor = True
@@ -1264,10 +1232,9 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdKruskal1
         '
         Me.cmdKruskal1.AccessibleDescription = ""
-        Me.cmdKruskal1.Location = New System.Drawing.Point(1, 37)
-        Me.cmdKruskal1.Margin = New System.Windows.Forms.Padding(2)
+        Me.cmdKruskal1.Location = New System.Drawing.Point(2, 56)
         Me.cmdKruskal1.Name = "cmdKruskal1"
-        Me.cmdKruskal1.Size = New System.Drawing.Size(60, 24)
+        Me.cmdKruskal1.Size = New System.Drawing.Size(90, 36)
         Me.cmdKruskal1.TabIndex = 2
         Me.cmdKruskal1.Text = "kruskal"
         Me.cmdKruskal1.UseVisualStyleBackColor = True
@@ -1275,10 +1242,9 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdWilcox1
         '
         Me.cmdWilcox1.AccessibleDescription = "cmdWilcox"
-        Me.cmdWilcox1.Location = New System.Drawing.Point(60, 14)
-        Me.cmdWilcox1.Margin = New System.Windows.Forms.Padding(2)
+        Me.cmdWilcox1.Location = New System.Drawing.Point(90, 21)
         Me.cmdWilcox1.Name = "cmdWilcox1"
-        Me.cmdWilcox1.Size = New System.Drawing.Size(60, 24)
+        Me.cmdWilcox1.Size = New System.Drawing.Size(90, 36)
         Me.cmdWilcox1.TabIndex = 1
         Me.cmdWilcox1.Text = "wilcox"
         Me.cmdWilcox1.UseVisualStyleBackColor = True
@@ -1287,10 +1253,9 @@ Partial Class dlgHypothesisTestsCalculator
         '
         Me.cmdOneway1.AccessibleDescription = ""
         Me.cmdOneway1.AccessibleName = ""
-        Me.cmdOneway1.Location = New System.Drawing.Point(1, 14)
-        Me.cmdOneway1.Margin = New System.Windows.Forms.Padding(2)
+        Me.cmdOneway1.Location = New System.Drawing.Point(2, 21)
         Me.cmdOneway1.Name = "cmdOneway1"
-        Me.cmdOneway1.Size = New System.Drawing.Size(60, 24)
+        Me.cmdOneway1.Size = New System.Drawing.Size(90, 36)
         Me.cmdOneway1.TabIndex = 0
         Me.cmdOneway1.Text = "oneway"
         Me.cmdOneway1.UseVisualStyleBackColor = True
@@ -1315,171 +1280,191 @@ Partial Class dlgHypothesisTestsCalculator
         Me.grpTrend.Controls.Add(Me.cmdBu)
         Me.grpTrend.Controls.Add(Me.cmdBr)
         Me.grpTrend.Controls.Add(Me.cmdBartels)
-        Me.grpTrend.Location = New System.Drawing.Point(241, 79)
+        Me.grpTrend.Location = New System.Drawing.Point(362, 118)
+        Me.grpTrend.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
         Me.grpTrend.Name = "grpTrend"
-        Me.grpTrend.Size = New System.Drawing.Size(355, 175)
+        Me.grpTrend.Padding = New System.Windows.Forms.Padding(4, 4, 4, 4)
+        Me.grpTrend.Size = New System.Drawing.Size(532, 262)
         Me.grpTrend.TabIndex = 23
         Me.grpTrend.TabStop = False
         Me.grpTrend.Text = "Trend"
         '
         'cmdWm
         '
-        Me.cmdWm.Location = New System.Drawing.Point(4, 138)
+        Me.cmdWm.Location = New System.Drawing.Point(6, 207)
+        Me.cmdWm.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
         Me.cmdWm.Name = "cmdWm"
-        Me.cmdWm.Size = New System.Drawing.Size(86, 30)
+        Me.cmdWm.Size = New System.Drawing.Size(129, 45)
         Me.cmdWm.TabIndex = 17
         Me.cmdWm.Text = "wm"
         Me.cmdWm.UseVisualStyleBackColor = True
         '
         'cmdWw
         '
-        Me.cmdWw.Location = New System.Drawing.Point(90, 138)
+        Me.cmdWw.Location = New System.Drawing.Point(135, 207)
+        Me.cmdWw.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
         Me.cmdWw.Name = "cmdWw"
-        Me.cmdWw.Size = New System.Drawing.Size(86, 30)
+        Me.cmdWw.Size = New System.Drawing.Size(129, 45)
         Me.cmdWw.TabIndex = 16
         Me.cmdWw.Text = "ww "
         Me.cmdWw.UseVisualStyleBackColor = True
         '
         'cmdSnh
         '
-        Me.cmdSnh.Location = New System.Drawing.Point(262, 107)
+        Me.cmdSnh.Location = New System.Drawing.Point(393, 160)
+        Me.cmdSnh.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
         Me.cmdSnh.Name = "cmdSnh"
-        Me.cmdSnh.Size = New System.Drawing.Size(86, 30)
+        Me.cmdSnh.Size = New System.Drawing.Size(129, 45)
         Me.cmdSnh.TabIndex = 15
         Me.cmdSnh.Text = "snh "
         Me.cmdSnh.UseVisualStyleBackColor = True
         '
         'cmdSmk
         '
-        Me.cmdSmk.Location = New System.Drawing.Point(176, 107)
+        Me.cmdSmk.Location = New System.Drawing.Point(264, 160)
+        Me.cmdSmk.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
         Me.cmdSmk.Name = "cmdSmk"
-        Me.cmdSmk.Size = New System.Drawing.Size(86, 30)
+        Me.cmdSmk.Size = New System.Drawing.Size(129, 45)
         Me.cmdSmk.TabIndex = 14
         Me.cmdSmk.Text = "smk "
         Me.cmdSmk.UseVisualStyleBackColor = True
         '
         'cmdSens
         '
-        Me.cmdSens.Location = New System.Drawing.Point(90, 107)
+        Me.cmdSens.Location = New System.Drawing.Point(135, 160)
+        Me.cmdSens.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
         Me.cmdSens.Name = "cmdSens"
-        Me.cmdSens.Size = New System.Drawing.Size(86, 30)
+        Me.cmdSens.Size = New System.Drawing.Size(129, 45)
         Me.cmdSens.TabIndex = 13
         Me.cmdSens.Text = "sens "
         Me.cmdSens.UseVisualStyleBackColor = True
         '
         'cmdSsens
         '
-        Me.cmdSsens.Location = New System.Drawing.Point(4, 107)
+        Me.cmdSsens.Location = New System.Drawing.Point(6, 160)
+        Me.cmdSsens.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
         Me.cmdSsens.Name = "cmdSsens"
-        Me.cmdSsens.Size = New System.Drawing.Size(86, 30)
+        Me.cmdSsens.Size = New System.Drawing.Size(129, 45)
         Me.cmdSsens.TabIndex = 12
         Me.cmdSsens.Text = "ssens "
         Me.cmdSsens.UseVisualStyleBackColor = True
         '
         'cmdRrod
         '
-        Me.cmdRrod.Location = New System.Drawing.Point(262, 76)
+        Me.cmdRrod.Location = New System.Drawing.Point(393, 114)
+        Me.cmdRrod.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
         Me.cmdRrod.Name = "cmdRrod"
-        Me.cmdRrod.Size = New System.Drawing.Size(86, 30)
+        Me.cmdRrod.Size = New System.Drawing.Size(129, 45)
         Me.cmdRrod.TabIndex = 11
         Me.cmdRrod.Text = "rrod "
         Me.cmdRrod.UseVisualStyleBackColor = True
         '
         'cmdPettitt
         '
-        Me.cmdPettitt.Location = New System.Drawing.Point(176, 76)
+        Me.cmdPettitt.Location = New System.Drawing.Point(264, 114)
+        Me.cmdPettitt.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
         Me.cmdPettitt.Name = "cmdPettitt"
-        Me.cmdPettitt.Size = New System.Drawing.Size(86, 30)
+        Me.cmdPettitt.Size = New System.Drawing.Size(129, 45)
         Me.cmdPettitt.TabIndex = 10
         Me.cmdPettitt.Text = "pettitt "
         Me.cmdPettitt.UseVisualStyleBackColor = True
         '
         'cmdPmk
         '
-        Me.cmdPmk.Location = New System.Drawing.Point(90, 76)
+        Me.cmdPmk.Location = New System.Drawing.Point(135, 114)
+        Me.cmdPmk.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
         Me.cmdPmk.Name = "cmdPmk"
-        Me.cmdPmk.Size = New System.Drawing.Size(86, 30)
+        Me.cmdPmk.Size = New System.Drawing.Size(129, 45)
         Me.cmdPmk.TabIndex = 9
         Me.cmdPmk.Text = "pmk "
         Me.cmdPmk.UseVisualStyleBackColor = True
         '
         'cmdPcor
         '
-        Me.cmdPcor.Location = New System.Drawing.Point(4, 76)
+        Me.cmdPcor.Location = New System.Drawing.Point(6, 114)
+        Me.cmdPcor.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
         Me.cmdPcor.Name = "cmdPcor"
-        Me.cmdPcor.Size = New System.Drawing.Size(86, 30)
+        Me.cmdPcor.Size = New System.Drawing.Size(129, 45)
         Me.cmdPcor.TabIndex = 8
         Me.cmdPcor.Text = "pcor "
         Me.cmdPcor.UseVisualStyleBackColor = True
         '
         'cmdMmk
         '
-        Me.cmdMmk.Location = New System.Drawing.Point(262, 45)
+        Me.cmdMmk.Location = New System.Drawing.Point(393, 68)
+        Me.cmdMmk.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
         Me.cmdMmk.Name = "cmdMmk"
-        Me.cmdMmk.Size = New System.Drawing.Size(86, 30)
+        Me.cmdMmk.Size = New System.Drawing.Size(129, 45)
         Me.cmdMmk.TabIndex = 7
         Me.cmdMmk.Text = "mmk "
         Me.cmdMmk.UseVisualStyleBackColor = True
         '
         'cmdMk
         '
-        Me.cmdMk.Location = New System.Drawing.Point(176, 45)
+        Me.cmdMk.Location = New System.Drawing.Point(264, 68)
+        Me.cmdMk.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
         Me.cmdMk.Name = "cmdMk"
-        Me.cmdMk.Size = New System.Drawing.Size(86, 30)
+        Me.cmdMk.Size = New System.Drawing.Size(129, 45)
         Me.cmdMk.TabIndex = 6
         Me.cmdMk.Text = "mk"
         Me.cmdMk.UseVisualStyleBackColor = True
         '
         'cmdLanzante
         '
-        Me.cmdLanzante.Location = New System.Drawing.Point(90, 45)
+        Me.cmdLanzante.Location = New System.Drawing.Point(135, 68)
+        Me.cmdLanzante.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
         Me.cmdLanzante.Name = "cmdLanzante"
-        Me.cmdLanzante.Size = New System.Drawing.Size(86, 30)
+        Me.cmdLanzante.Size = New System.Drawing.Size(129, 45)
         Me.cmdLanzante.TabIndex = 5
         Me.cmdLanzante.Text = "lanzante"
         Me.cmdLanzante.UseVisualStyleBackColor = True
         '
         'cmdCsmk
         '
-        Me.cmdCsmk.Location = New System.Drawing.Point(4, 45)
+        Me.cmdCsmk.Location = New System.Drawing.Point(6, 68)
+        Me.cmdCsmk.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
         Me.cmdCsmk.Name = "cmdCsmk"
-        Me.cmdCsmk.Size = New System.Drawing.Size(86, 30)
+        Me.cmdCsmk.Size = New System.Drawing.Size(129, 45)
         Me.cmdCsmk.TabIndex = 4
         Me.cmdCsmk.Text = "csmk"
         Me.cmdCsmk.UseVisualStyleBackColor = True
         '
         'cmdCs
         '
-        Me.cmdCs.Location = New System.Drawing.Point(262, 14)
+        Me.cmdCs.Location = New System.Drawing.Point(393, 21)
+        Me.cmdCs.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
         Me.cmdCs.Name = "cmdCs"
-        Me.cmdCs.Size = New System.Drawing.Size(86, 30)
+        Me.cmdCs.Size = New System.Drawing.Size(129, 45)
         Me.cmdCs.TabIndex = 3
         Me.cmdCs.Text = "cs"
         Me.cmdCs.UseVisualStyleBackColor = True
         '
         'cmdBu
         '
-        Me.cmdBu.Location = New System.Drawing.Point(176, 14)
+        Me.cmdBu.Location = New System.Drawing.Point(264, 21)
+        Me.cmdBu.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
         Me.cmdBu.Name = "cmdBu"
-        Me.cmdBu.Size = New System.Drawing.Size(86, 30)
+        Me.cmdBu.Size = New System.Drawing.Size(129, 45)
         Me.cmdBu.TabIndex = 2
         Me.cmdBu.Text = "bu"
         Me.cmdBu.UseVisualStyleBackColor = True
         '
         'cmdBr
         '
-        Me.cmdBr.Location = New System.Drawing.Point(90, 14)
+        Me.cmdBr.Location = New System.Drawing.Point(135, 21)
+        Me.cmdBr.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
         Me.cmdBr.Name = "cmdBr"
-        Me.cmdBr.Size = New System.Drawing.Size(86, 30)
+        Me.cmdBr.Size = New System.Drawing.Size(129, 45)
         Me.cmdBr.TabIndex = 1
         Me.cmdBr.Text = "br"
         Me.cmdBr.UseVisualStyleBackColor = True
         '
         'cmdBartels
         '
-        Me.cmdBartels.Location = New System.Drawing.Point(4, 14)
+        Me.cmdBartels.Location = New System.Drawing.Point(6, 21)
+        Me.cmdBartels.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
         Me.cmdBartels.Name = "cmdBartels"
-        Me.cmdBartels.Size = New System.Drawing.Size(86, 30)
+        Me.cmdBartels.Size = New System.Drawing.Size(129, 45)
         Me.cmdBartels.TabIndex = 0
         Me.cmdBartels.Text = "bartels"
         Me.cmdBartels.UseVisualStyleBackColor = True
@@ -1488,41 +1473,41 @@ Partial Class dlgHypothesisTestsCalculator
         '
         Me.ucrChkDisplayModel.AutoSize = True
         Me.ucrChkDisplayModel.Checked = False
-        Me.ucrChkDisplayModel.Location = New System.Drawing.Point(10, 292)
-        Me.ucrChkDisplayModel.Margin = New System.Windows.Forms.Padding(4)
+        Me.ucrChkDisplayModel.Location = New System.Drawing.Point(15, 438)
+        Me.ucrChkDisplayModel.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
         Me.ucrChkDisplayModel.Name = "ucrChkDisplayModel"
-        Me.ucrChkDisplayModel.Size = New System.Drawing.Size(139, 23)
+        Me.ucrChkDisplayModel.Size = New System.Drawing.Size(208, 34)
         Me.ucrChkDisplayModel.TabIndex = 7
         '
         'ucrChkSummaryModel
         '
         Me.ucrChkSummaryModel.AutoSize = True
         Me.ucrChkSummaryModel.Checked = False
-        Me.ucrChkSummaryModel.Location = New System.Drawing.Point(10, 264)
-        Me.ucrChkSummaryModel.Margin = New System.Windows.Forms.Padding(4)
+        Me.ucrChkSummaryModel.Location = New System.Drawing.Point(15, 396)
+        Me.ucrChkSummaryModel.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
         Me.ucrChkSummaryModel.Name = "ucrChkSummaryModel"
-        Me.ucrChkSummaryModel.Size = New System.Drawing.Size(139, 23)
+        Me.ucrChkSummaryModel.Size = New System.Drawing.Size(208, 34)
         Me.ucrChkSummaryModel.TabIndex = 6
         '
         'ucrTryModelling
         '
         Me.ucrTryModelling.AutoSize = True
-        Me.ucrTryModelling.Location = New System.Drawing.Point(2, 360)
-        Me.ucrTryModelling.Margin = New System.Windows.Forms.Padding(4)
+        Me.ucrTryModelling.Location = New System.Drawing.Point(3, 540)
+        Me.ucrTryModelling.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
         Me.ucrTryModelling.Name = "ucrTryModelling"
         Me.ucrTryModelling.RunCommandAsMultipleLines = False
-        Me.ucrTryModelling.Size = New System.Drawing.Size(393, 30)
+        Me.ucrTryModelling.Size = New System.Drawing.Size(594, 55)
         Me.ucrTryModelling.TabIndex = 13
         '
         'ucrReceiverMultiple
         '
         Me.ucrReceiverMultiple.AutoSize = True
         Me.ucrReceiverMultiple.frmParent = Me
-        Me.ucrReceiverMultiple.Location = New System.Drawing.Point(165, 288)
+        Me.ucrReceiverMultiple.Location = New System.Drawing.Point(248, 432)
         Me.ucrReceiverMultiple.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverMultiple.Name = "ucrReceiverMultiple"
         Me.ucrReceiverMultiple.Selector = Nothing
-        Me.ucrReceiverMultiple.Size = New System.Drawing.Size(113, 61)
+        Me.ucrReceiverMultiple.Size = New System.Drawing.Size(170, 92)
         Me.ucrReceiverMultiple.strNcFilePath = ""
         Me.ucrReceiverMultiple.TabIndex = 9
         Me.ucrReceiverMultiple.ucrSelector = Nothing
@@ -1531,10 +1516,10 @@ Partial Class dlgHypothesisTestsCalculator
         'ucrSaveResult
         '
         Me.ucrSaveResult.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrSaveResult.Location = New System.Drawing.Point(10, 397)
-        Me.ucrSaveResult.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
+        Me.ucrSaveResult.Location = New System.Drawing.Point(15, 596)
+        Me.ucrSaveResult.Margin = New System.Windows.Forms.Padding(6, 8, 6, 8)
         Me.ucrSaveResult.Name = "ucrSaveResult"
-        Me.ucrSaveResult.Size = New System.Drawing.Size(294, 24)
+        Me.ucrSaveResult.Size = New System.Drawing.Size(441, 36)
         Me.ucrSaveResult.TabIndex = 14
         '
         'ucrInputComboRPackage
@@ -1543,20 +1528,20 @@ Partial Class dlgHypothesisTestsCalculator
         Me.ucrInputComboRPackage.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.ucrInputComboRPackage.GetSetSelectedIndex = -1
         Me.ucrInputComboRPackage.IsReadOnly = False
-        Me.ucrInputComboRPackage.Location = New System.Drawing.Point(308, 51)
-        Me.ucrInputComboRPackage.Margin = New System.Windows.Forms.Padding(7, 6, 7, 6)
+        Me.ucrInputComboRPackage.Location = New System.Drawing.Point(462, 76)
+        Me.ucrInputComboRPackage.Margin = New System.Windows.Forms.Padding(10, 9, 10, 9)
         Me.ucrInputComboRPackage.Name = "ucrInputComboRPackage"
-        Me.ucrInputComboRPackage.Size = New System.Drawing.Size(123, 21)
+        Me.ucrInputComboRPackage.Size = New System.Drawing.Size(184, 32)
         Me.ucrInputComboRPackage.TabIndex = 5
         '
         'ucrBase
         '
         Me.ucrBase.AutoSize = True
         Me.ucrBase.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrBase.Location = New System.Drawing.Point(10, 430)
-        Me.ucrBase.Margin = New System.Windows.Forms.Padding(4)
+        Me.ucrBase.Location = New System.Drawing.Point(15, 645)
+        Me.ucrBase.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
         Me.ucrBase.Name = "ucrBase"
-        Me.ucrBase.Size = New System.Drawing.Size(405, 52)
+        Me.ucrBase.Size = New System.Drawing.Size(611, 77)
         Me.ucrBase.TabIndex = 15
         '
         'ucrChkBy
@@ -1564,10 +1549,10 @@ Partial Class dlgHypothesisTestsCalculator
         Me.ucrChkBy.AutoSize = True
         Me.ucrChkBy.Checked = False
         Me.ucrChkBy.Enabled = False
-        Me.ucrChkBy.Location = New System.Drawing.Point(165, 264)
-        Me.ucrChkBy.Margin = New System.Windows.Forms.Padding(5)
+        Me.ucrChkBy.Location = New System.Drawing.Point(248, 396)
+        Me.ucrChkBy.Margin = New System.Windows.Forms.Padding(8, 8, 8, 8)
         Me.ucrChkBy.Name = "ucrChkBy"
-        Me.ucrChkBy.Size = New System.Drawing.Size(166, 23)
+        Me.ucrChkBy.Size = New System.Drawing.Size(249, 34)
         Me.ucrChkBy.TabIndex = 8
         '
         'ucrSelectorColumn
@@ -1576,41 +1561,41 @@ Partial Class dlgHypothesisTestsCalculator
         Me.ucrSelectorColumn.bDropUnusedFilterLevels = False
         Me.ucrSelectorColumn.bShowHiddenColumns = False
         Me.ucrSelectorColumn.bUseCurrentFilter = True
-        Me.ucrSelectorColumn.Location = New System.Drawing.Point(10, 56)
+        Me.ucrSelectorColumn.Location = New System.Drawing.Point(15, 84)
         Me.ucrSelectorColumn.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrSelectorColumn.Name = "ucrSelectorColumn"
-        Me.ucrSelectorColumn.Size = New System.Drawing.Size(213, 183)
+        Me.ucrSelectorColumn.Size = New System.Drawing.Size(320, 274)
         Me.ucrSelectorColumn.TabIndex = 3
         '
         'ucrChkIncludeArguments
         '
         Me.ucrChkIncludeArguments.AutoSize = True
         Me.ucrChkIncludeArguments.Checked = False
-        Me.ucrChkIncludeArguments.Location = New System.Drawing.Point(443, 26)
-        Me.ucrChkIncludeArguments.Margin = New System.Windows.Forms.Padding(5)
+        Me.ucrChkIncludeArguments.Location = New System.Drawing.Point(664, 39)
+        Me.ucrChkIncludeArguments.Margin = New System.Windows.Forms.Padding(8, 8, 8, 8)
         Me.ucrChkIncludeArguments.Name = "ucrChkIncludeArguments"
-        Me.ucrChkIncludeArguments.Size = New System.Drawing.Size(131, 23)
+        Me.ucrChkIncludeArguments.Size = New System.Drawing.Size(196, 34)
         Me.ucrChkIncludeArguments.TabIndex = 2
         '
         'ucrReceiverForTestColumn
         '
         Me.ucrReceiverForTestColumn.AutoSize = True
         Me.ucrReceiverForTestColumn.frmParent = Me
-        Me.ucrReceiverForTestColumn.Location = New System.Drawing.Point(55, 25)
-        Me.ucrReceiverForTestColumn.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.ucrReceiverForTestColumn.Location = New System.Drawing.Point(82, 38)
+        Me.ucrReceiverForTestColumn.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.ucrReceiverForTestColumn.Name = "ucrReceiverForTestColumn"
         Me.ucrReceiverForTestColumn.Selector = Nothing
-        Me.ucrReceiverForTestColumn.Size = New System.Drawing.Size(376, 27)
+        Me.ucrReceiverForTestColumn.Size = New System.Drawing.Size(564, 40)
         Me.ucrReceiverForTestColumn.strNcFilePath = ""
         Me.ucrReceiverForTestColumn.TabIndex = 1
         Me.ucrReceiverForTestColumn.ucrSelector = Nothing
         '
         'dlgHypothesisTestsCalculator
         '
-        Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(144.0!, 144.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
         Me.AutoSize = True
-        Me.ClientSize = New System.Drawing.Size(643, 485)
+        Me.ClientSize = New System.Drawing.Size(964, 728)
         Me.Controls.Add(Me.grpTrend)
         Me.Controls.Add(Me.grpCoin)
         Me.Controls.Add(Me.grpVerification)
@@ -1634,6 +1619,7 @@ Partial Class dlgHypothesisTestsCalculator
         Me.Controls.Add(Me.ucrReceiverForTestColumn)
         Me.Controls.Add(Me.grpAgricolae)
         Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow
+        Me.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
         Me.MaximizeBox = False
         Me.MinimizeBox = False
         Me.Name = "dlgHypothesisTestsCalculator"

--- a/instat/dlgHypothesisTestsCalculator.vb
+++ b/instat/dlgHypothesisTestsCalculator.vb
@@ -17,6 +17,7 @@
 
 Imports instat.Translations
 Imports RDotNet
+Imports System.IO
 Public Class dlgHypothesisTestsCalculator
     Public bFirstLoad As Boolean = True
     Private bReset As Boolean = True
@@ -665,13 +666,34 @@ Public Class dlgHypothesisTestsCalculator
     End Sub
 
     Private Sub cmdHelp_Click(sender As Object, e As EventArgs) Handles cmdHelp.Click
-        Dim clsHelp As New RFunction
+        Dim clsGetPortOperator As New ROperator
+        Dim clsStartDynamicServerFunction As New RFunction
 
-        clsHelp.SetPackageName("utils")
-        clsHelp.SetRCommand("help")
-        clsHelp.AddParameter("package", Chr(34) & strPackageName & Chr(34))
-        clsHelp.AddParameter("help_type", Chr(34) & "html" & Chr(34))
-        frmMain.clsRLink.RunScript(clsHelp.ToScript, strComment:="Opening help page for" & " " & strPackageName & " " & "Package. Generated from dialog Hypothesis Tests", iCallType:=2, bSeparateThread:=False, bUpdateGrids:=False)
+        clsGetPortOperator.SetOperation(":::")
+        clsGetPortOperator.AddParameter("left", "tools", iPosition:=0)
+        clsGetPortOperator.AddParameter("right", "httpdPort()", iPosition:=1)
+        clsGetPortOperator.bSpaceAroundOperation = False
+
+        clsStartDynamicServerFunction.SetPackageName("tools")
+        clsStartDynamicServerFunction.SetRCommand("startDynamicHelp")
+        clsStartDynamicServerFunction.AddParameter("start", "NA", iPosition:=0)
+        frmMain.clsRLink.RunScript(clsStartDynamicServerFunction.ToScript(), iCallType:=5, bSeparateThread:=False, bSilent:=False)
+
+        Dim expPortTemp As SymbolicExpression
+        expPortTemp = frmMain.clsRLink.RunInternalScriptGetValue(clsGetPortOperator.ToScript())
+        Dim strPort As String = ""
+        If expPortTemp IsNot Nothing AndAlso expPortTemp.Type <> Internals.SymbolicExpressionType.Null Then
+            strPort = expPortTemp.AsInteger(0)
+        End If
+
+        Dim strFilePath As String = Path.Combine("library", strPackageName, "html", "00Index.html")
+        Dim strLocalHost As String = "127.0.0.1:"
+        Dim strURL As String
+        strURL = Path.Combine(String.Concat("http://", strLocalHost), strPort, strFilePath)
+        If strURL <> "" Then
+            strURL = strURL.Replace("\", "/")
+            frmMaximiseOutput.Show(strFileName:=strURL, bReplace:=False)
+        End If
     End Sub
 
     Private Sub ucrSaveResult_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrSaveResult.ControlContentsChanged, ucrReceiverForTestColumn.ControlContentsChanged

--- a/instat/dlgHypothesisTestsCalculator.vb
+++ b/instat/dlgHypothesisTestsCalculator.vb
@@ -666,21 +666,14 @@ Public Class dlgHypothesisTestsCalculator
     End Sub
 
     Private Sub cmdHelp_Click(sender As Object, e As EventArgs) Handles cmdHelp.Click
-        Dim clsGetPortOperator As New ROperator
-        Dim clsStartDynamicServerFunction As New RFunction
+        Dim clsGetPortFunction As New RFunction
 
-        clsGetPortOperator.SetOperation(":::")
-        clsGetPortOperator.AddParameter("left", "tools", iPosition:=0)
-        clsGetPortOperator.AddParameter("right", "httpdPort()", iPosition:=1)
-        clsGetPortOperator.bSpaceAroundOperation = False
-
-        clsStartDynamicServerFunction.SetPackageName("tools")
-        clsStartDynamicServerFunction.SetRCommand("startDynamicHelp")
-        clsStartDynamicServerFunction.AddParameter("start", "NA", iPosition:=0)
-        frmMain.clsRLink.RunScript(clsStartDynamicServerFunction.ToScript(), iCallType:=5, bSeparateThread:=False, bSilent:=False)
+        clsGetPortFunction.SetPackageName("tools")
+        clsGetPortFunction.SetRCommand("startDynamicHelp")
+        clsGetPortFunction.AddParameter("start", "NA", iPosition:=0)
 
         Dim expPortTemp As SymbolicExpression
-        expPortTemp = frmMain.clsRLink.RunInternalScriptGetValue(clsGetPortOperator.ToScript())
+        expPortTemp = frmMain.clsRLink.RunInternalScriptGetValue(clsGetPortFunction.ToScript(), bSeparateThread:=False)
         Dim strPort As String = ""
         If expPortTemp IsNot Nothing AndAlso expPortTemp.Type <> Internals.SymbolicExpressionType.Null Then
             strPort = expPortTemp.AsInteger(0)

--- a/instat/dlgHypothesisTestsCalculator.vb
+++ b/instat/dlgHypothesisTestsCalculator.vb
@@ -666,8 +666,7 @@ Public Class dlgHypothesisTestsCalculator
 
     Private Sub cmdHelp_Click(sender As Object, e As EventArgs) Handles cmdHelp.Click
         If strPackageName <> "" Then
-            Dim strURL As String = dlgFromLibrary.GetFileURL(strPackageName:=strPackageName)
-            frmMaximiseOutput.Show(strFileName:=strURL, bReplace:=False)
+            frmMaximiseOutput.Show(strFileName:=clsFileUrlUtilities.GetHelpFileURL(strPackageName:=strPackageName), bReplace:=False)
         End If
     End Sub
 

--- a/instat/dlgHypothesisTestsCalculator.vb
+++ b/instat/dlgHypothesisTestsCalculator.vb
@@ -17,7 +17,6 @@
 
 Imports instat.Translations
 Imports RDotNet
-Imports System.IO
 Public Class dlgHypothesisTestsCalculator
     Public bFirstLoad As Boolean = True
     Private bReset As Boolean = True
@@ -666,25 +665,8 @@ Public Class dlgHypothesisTestsCalculator
     End Sub
 
     Private Sub cmdHelp_Click(sender As Object, e As EventArgs) Handles cmdHelp.Click
-        Dim clsGetPortFunction As New RFunction
-
-        clsGetPortFunction.SetPackageName("tools")
-        clsGetPortFunction.SetRCommand("startDynamicHelp")
-        clsGetPortFunction.AddParameter("start", "NA", iPosition:=0)
-
-        Dim expPortTemp As SymbolicExpression
-        expPortTemp = frmMain.clsRLink.RunInternalScriptGetValue(clsGetPortFunction.ToScript(), bSeparateThread:=False)
-        Dim strPort As String = ""
-        If expPortTemp IsNot Nothing AndAlso expPortTemp.Type <> Internals.SymbolicExpressionType.Null Then
-            strPort = expPortTemp.AsInteger(0)
-        End If
-
-        Dim strFilePath As String = Path.Combine("library", strPackageName, "html", "00Index.html")
-        Dim strLocalHost As String = "127.0.0.1:"
-        Dim strURL As String
-        strURL = Path.Combine(String.Concat("http://", strLocalHost), strPort, strFilePath)
-        If strURL <> "" Then
-            strURL = strURL.Replace("\", "/")
+        If strPackageName <> "" Then
+            Dim strURL As String = dlgFromLibrary.GetFileURL(strPackageName:=strPackageName)
             frmMaximiseOutput.Show(strFileName:=strURL, bReplace:=False)
         End If
     End Sub

--- a/instat/dlgModelling.Designer.vb
+++ b/instat/dlgModelling.Designer.vb
@@ -88,10 +88,9 @@ Partial Class dlgModelling
         '
         Me.lblModel.AutoSize = True
         Me.lblModel.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblModel.Location = New System.Drawing.Point(10, 17)
-        Me.lblModel.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
+        Me.lblModel.Location = New System.Drawing.Point(15, 26)
         Me.lblModel.Name = "lblModel"
-        Me.lblModel.Size = New System.Drawing.Size(39, 13)
+        Me.lblModel.Size = New System.Drawing.Size(56, 20)
         Me.lblModel.TabIndex = 0
         Me.lblModel.Tag = "Test"
         Me.lblModel.Text = "Model:"
@@ -99,10 +98,10 @@ Partial Class dlgModelling
         'cmdspline
         '
         Me.cmdspline.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdspline.Location = New System.Drawing.Point(140, 72)
-        Me.cmdspline.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdspline.Location = New System.Drawing.Point(210, 108)
+        Me.cmdspline.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdspline.Name = "cmdspline"
-        Me.cmdspline.Size = New System.Drawing.Size(69, 30)
+        Me.cmdspline.Size = New System.Drawing.Size(104, 45)
         Me.cmdspline.TabIndex = 164
         Me.cmdspline.Text = "spline"
         Me.cmdspline.UseVisualStyleBackColor = True
@@ -110,10 +109,10 @@ Partial Class dlgModelling
         'cmdarima
         '
         Me.cmdarima.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdarima.Location = New System.Drawing.Point(140, 14)
-        Me.cmdarima.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdarima.Location = New System.Drawing.Point(210, 21)
+        Me.cmdarima.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdarima.Name = "cmdarima"
-        Me.cmdarima.Size = New System.Drawing.Size(69, 30)
+        Me.cmdarima.Size = New System.Drawing.Size(104, 45)
         Me.cmdarima.TabIndex = 153
         Me.cmdarima.Text = "arima"
         Me.cmdarima.UseVisualStyleBackColor = True
@@ -121,10 +120,10 @@ Partial Class dlgModelling
         'cmdloglin
         '
         Me.cmdloglin.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdloglin.Location = New System.Drawing.Point(4, 72)
-        Me.cmdloglin.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdloglin.Location = New System.Drawing.Point(6, 108)
+        Me.cmdloglin.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdloglin.Name = "cmdloglin"
-        Me.cmdloglin.Size = New System.Drawing.Size(69, 30)
+        Me.cmdloglin.Size = New System.Drawing.Size(104, 45)
         Me.cmdloglin.TabIndex = 151
         Me.cmdloglin.Text = "loglin"
         Me.cmdloglin.UseVisualStyleBackColor = True
@@ -132,10 +131,10 @@ Partial Class dlgModelling
         'cmdloess
         '
         Me.cmdloess.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdloess.Location = New System.Drawing.Point(140, 43)
-        Me.cmdloess.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdloess.Location = New System.Drawing.Point(210, 64)
+        Me.cmdloess.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdloess.Name = "cmdloess"
-        Me.cmdloess.Size = New System.Drawing.Size(69, 30)
+        Me.cmdloess.Size = New System.Drawing.Size(104, 45)
         Me.cmdloess.TabIndex = 150
         Me.cmdloess.Text = "loess"
         Me.cmdloess.UseVisualStyleBackColor = True
@@ -143,10 +142,10 @@ Partial Class dlgModelling
         'cmdlowess
         '
         Me.cmdlowess.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdlowess.Location = New System.Drawing.Point(72, 72)
-        Me.cmdlowess.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdlowess.Location = New System.Drawing.Point(108, 108)
+        Me.cmdlowess.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdlowess.Name = "cmdlowess"
-        Me.cmdlowess.Size = New System.Drawing.Size(69, 30)
+        Me.cmdlowess.Size = New System.Drawing.Size(104, 45)
         Me.cmdlowess.TabIndex = 148
         Me.cmdlowess.Text = "lowess"
         Me.cmdlowess.UseVisualStyleBackColor = True
@@ -154,10 +153,10 @@ Partial Class dlgModelling
         'cmdglm
         '
         Me.cmdglm.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdglm.Location = New System.Drawing.Point(4, 43)
-        Me.cmdglm.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdglm.Location = New System.Drawing.Point(6, 64)
+        Me.cmdglm.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdglm.Name = "cmdglm"
-        Me.cmdglm.Size = New System.Drawing.Size(69, 30)
+        Me.cmdglm.Size = New System.Drawing.Size(104, 45)
         Me.cmdglm.TabIndex = 158
         Me.cmdglm.Text = "glm"
         Me.cmdglm.UseVisualStyleBackColor = True
@@ -165,10 +164,10 @@ Partial Class dlgModelling
         'cmdar
         '
         Me.cmdar.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdar.Location = New System.Drawing.Point(72, 14)
-        Me.cmdar.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdar.Location = New System.Drawing.Point(108, 21)
+        Me.cmdar.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdar.Name = "cmdar"
-        Me.cmdar.Size = New System.Drawing.Size(69, 30)
+        Me.cmdar.Size = New System.Drawing.Size(104, 45)
         Me.cmdar.TabIndex = 126
         Me.cmdar.Text = "ar"
         Me.cmdar.UseVisualStyleBackColor = True
@@ -176,10 +175,10 @@ Partial Class dlgModelling
         'cmdaov
         '
         Me.cmdaov.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdaov.Location = New System.Drawing.Point(4, 14)
-        Me.cmdaov.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdaov.Location = New System.Drawing.Point(6, 21)
+        Me.cmdaov.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdaov.Name = "cmdaov"
-        Me.cmdaov.Size = New System.Drawing.Size(69, 30)
+        Me.cmdaov.Size = New System.Drawing.Size(104, 45)
         Me.cmdaov.TabIndex = 124
         Me.cmdaov.Text = "aov"
         Me.cmdaov.UseVisualStyleBackColor = True
@@ -187,10 +186,10 @@ Partial Class dlgModelling
         'cmdlm
         '
         Me.cmdlm.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdlm.Location = New System.Drawing.Point(72, 43)
-        Me.cmdlm.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdlm.Location = New System.Drawing.Point(108, 64)
+        Me.cmdlm.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdlm.Name = "cmdlm"
-        Me.cmdlm.Size = New System.Drawing.Size(69, 30)
+        Me.cmdlm.Size = New System.Drawing.Size(104, 45)
         Me.cmdlm.TabIndex = 121
         Me.cmdlm.Text = "lm"
         Me.cmdlm.UseVisualStyleBackColor = True
@@ -209,11 +208,11 @@ Partial Class dlgModelling
         Me.grpStats.Controls.Add(Me.cmdlm)
         Me.grpStats.Controls.Add(Me.cmdaov)
         Me.grpStats.Controls.Add(Me.cmdar)
-        Me.grpStats.Location = New System.Drawing.Point(292, 68)
-        Me.grpStats.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.grpStats.Location = New System.Drawing.Point(438, 102)
+        Me.grpStats.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.grpStats.Name = "grpStats"
-        Me.grpStats.Padding = New System.Windows.Forms.Padding(2, 3, 2, 3)
-        Me.grpStats.Size = New System.Drawing.Size(213, 135)
+        Me.grpStats.Padding = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.grpStats.Size = New System.Drawing.Size(320, 202)
         Me.grpStats.TabIndex = 9
         Me.grpStats.TabStop = False
         Me.grpStats.Text = "stats"
@@ -221,10 +220,10 @@ Partial Class dlgModelling
         'cmdprincomp
         '
         Me.cmdprincomp.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdprincomp.Location = New System.Drawing.Point(140, 101)
-        Me.cmdprincomp.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdprincomp.Location = New System.Drawing.Point(210, 152)
+        Me.cmdprincomp.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdprincomp.Name = "cmdprincomp"
-        Me.cmdprincomp.Size = New System.Drawing.Size(69, 30)
+        Me.cmdprincomp.Size = New System.Drawing.Size(104, 45)
         Me.cmdprincomp.TabIndex = 167
         Me.cmdprincomp.Text = "princomp"
         Me.cmdprincomp.UseVisualStyleBackColor = True
@@ -232,10 +231,10 @@ Partial Class dlgModelling
         'cmdppr
         '
         Me.cmdppr.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdppr.Location = New System.Drawing.Point(72, 101)
-        Me.cmdppr.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdppr.Location = New System.Drawing.Point(108, 152)
+        Me.cmdppr.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdppr.Name = "cmdppr"
-        Me.cmdppr.Size = New System.Drawing.Size(69, 30)
+        Me.cmdppr.Size = New System.Drawing.Size(104, 45)
         Me.cmdppr.TabIndex = 166
         Me.cmdppr.Text = "ppr"
         Me.cmdppr.UseVisualStyleBackColor = True
@@ -243,10 +242,10 @@ Partial Class dlgModelling
         'cmdnls
         '
         Me.cmdnls.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdnls.Location = New System.Drawing.Point(4, 101)
-        Me.cmdnls.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdnls.Location = New System.Drawing.Point(6, 152)
+        Me.cmdnls.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdnls.Name = "cmdnls"
-        Me.cmdnls.Size = New System.Drawing.Size(69, 30)
+        Me.cmdnls.Size = New System.Drawing.Size(104, 45)
         Me.cmdnls.TabIndex = 165
         Me.cmdnls.Text = "nls"
         Me.cmdnls.UseVisualStyleBackColor = True
@@ -255,10 +254,10 @@ Partial Class dlgModelling
         '
         Me.cmdMultiply.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!)
         Me.cmdMultiply.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdMultiply.Location = New System.Drawing.Point(59, 10)
-        Me.cmdMultiply.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdMultiply.Location = New System.Drawing.Point(88, 15)
+        Me.cmdMultiply.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdMultiply.Name = "cmdMultiply"
-        Me.cmdMultiply.Size = New System.Drawing.Size(29, 30)
+        Me.cmdMultiply.Size = New System.Drawing.Size(44, 45)
         Me.cmdMultiply.TabIndex = 2
         Me.cmdMultiply.Text = "*"
         Me.cmdMultiply.UseVisualStyleBackColor = True
@@ -267,10 +266,10 @@ Partial Class dlgModelling
         '
         Me.cmdColon.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!)
         Me.cmdColon.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdColon.Location = New System.Drawing.Point(31, 10)
-        Me.cmdColon.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdColon.Location = New System.Drawing.Point(46, 15)
+        Me.cmdColon.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdColon.Name = "cmdColon"
-        Me.cmdColon.Size = New System.Drawing.Size(29, 30)
+        Me.cmdColon.Size = New System.Drawing.Size(44, 45)
         Me.cmdColon.TabIndex = 1
         Me.cmdColon.Text = ":"
         Me.cmdColon.UseVisualStyleBackColor = True
@@ -279,10 +278,10 @@ Partial Class dlgModelling
         '
         Me.cmdPlus.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!)
         Me.cmdPlus.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdPlus.Location = New System.Drawing.Point(3, 10)
-        Me.cmdPlus.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdPlus.Location = New System.Drawing.Point(4, 15)
+        Me.cmdPlus.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdPlus.Name = "cmdPlus"
-        Me.cmdPlus.Size = New System.Drawing.Size(29, 30)
+        Me.cmdPlus.Size = New System.Drawing.Size(44, 45)
         Me.cmdPlus.TabIndex = 0
         Me.cmdPlus.Text = "+"
         Me.cmdPlus.UseVisualStyleBackColor = True
@@ -291,10 +290,10 @@ Partial Class dlgModelling
         '
         Me.cmdPower.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!)
         Me.cmdPower.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdPower.Location = New System.Drawing.Point(87, 39)
-        Me.cmdPower.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdPower.Location = New System.Drawing.Point(130, 58)
+        Me.cmdPower.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdPower.Name = "cmdPower"
-        Me.cmdPower.Size = New System.Drawing.Size(29, 32)
+        Me.cmdPower.Size = New System.Drawing.Size(44, 48)
         Me.cmdPower.TabIndex = 7
         Me.cmdPower.Text = "^"
         Me.cmdPower.UseVisualStyleBackColor = True
@@ -303,10 +302,10 @@ Partial Class dlgModelling
         '
         Me.cmdClosingBracket.Font = New System.Drawing.Font("Microsoft Sans Serif", 9.75!)
         Me.cmdClosingBracket.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdClosingBracket.Location = New System.Drawing.Point(59, 39)
-        Me.cmdClosingBracket.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdClosingBracket.Location = New System.Drawing.Point(88, 58)
+        Me.cmdClosingBracket.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdClosingBracket.Name = "cmdClosingBracket"
-        Me.cmdClosingBracket.Size = New System.Drawing.Size(29, 32)
+        Me.cmdClosingBracket.Size = New System.Drawing.Size(44, 48)
         Me.cmdClosingBracket.TabIndex = 6
         Me.cmdClosingBracket.Text = ")"
         Me.cmdClosingBracket.UseVisualStyleBackColor = True
@@ -315,10 +314,10 @@ Partial Class dlgModelling
         '
         Me.cmdOpeningBracket.Font = New System.Drawing.Font("Microsoft Sans Serif", 9.75!)
         Me.cmdOpeningBracket.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdOpeningBracket.Location = New System.Drawing.Point(31, 39)
-        Me.cmdOpeningBracket.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdOpeningBracket.Location = New System.Drawing.Point(46, 58)
+        Me.cmdOpeningBracket.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdOpeningBracket.Name = "cmdOpeningBracket"
-        Me.cmdOpeningBracket.Size = New System.Drawing.Size(29, 32)
+        Me.cmdOpeningBracket.Size = New System.Drawing.Size(44, 48)
         Me.cmdOpeningBracket.TabIndex = 5
         Me.cmdOpeningBracket.Text = "("
         Me.cmdOpeningBracket.UseVisualStyleBackColor = True
@@ -327,10 +326,10 @@ Partial Class dlgModelling
         '
         Me.cmdDiv.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!)
         Me.cmdDiv.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdDiv.Location = New System.Drawing.Point(87, 10)
-        Me.cmdDiv.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdDiv.Location = New System.Drawing.Point(130, 15)
+        Me.cmdDiv.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdDiv.Name = "cmdDiv"
-        Me.cmdDiv.Size = New System.Drawing.Size(29, 30)
+        Me.cmdDiv.Size = New System.Drawing.Size(44, 45)
         Me.cmdDiv.TabIndex = 3
         Me.cmdDiv.Text = "/"
         Me.cmdDiv.UseVisualStyleBackColor = True
@@ -339,10 +338,10 @@ Partial Class dlgModelling
         '
         Me.cmdDoubleBracket.Font = New System.Drawing.Font("Microsoft Sans Serif", 9.75!)
         Me.cmdDoubleBracket.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdDoubleBracket.Location = New System.Drawing.Point(3, 39)
-        Me.cmdDoubleBracket.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdDoubleBracket.Location = New System.Drawing.Point(4, 58)
+        Me.cmdDoubleBracket.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdDoubleBracket.Name = "cmdDoubleBracket"
-        Me.cmdDoubleBracket.Size = New System.Drawing.Size(29, 32)
+        Me.cmdDoubleBracket.Size = New System.Drawing.Size(44, 48)
         Me.cmdDoubleBracket.TabIndex = 4
         Me.cmdDoubleBracket.Text = "( )"
         Me.cmdDoubleBracket.UseVisualStyleBackColor = True
@@ -350,10 +349,10 @@ Partial Class dlgModelling
         'cmdClear
         '
         Me.cmdClear.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdClear.Location = New System.Drawing.Point(417, 251)
-        Me.cmdClear.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdClear.Location = New System.Drawing.Point(626, 376)
+        Me.cmdClear.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdClear.Name = "cmdClear"
-        Me.cmdClear.Size = New System.Drawing.Size(57, 30)
+        Me.cmdClear.Size = New System.Drawing.Size(86, 45)
         Me.cmdClear.TabIndex = 10
         Me.cmdClear.Text = "Clear"
         Me.cmdClear.UseVisualStyleBackColor = True
@@ -362,10 +361,10 @@ Partial Class dlgModelling
         '
         Me.cmdSquareBrackets.Font = New System.Drawing.Font("Microsoft Sans Serif", 9.75!)
         Me.cmdSquareBrackets.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdSquareBrackets.Location = New System.Drawing.Point(31, 70)
-        Me.cmdSquareBrackets.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdSquareBrackets.Location = New System.Drawing.Point(46, 105)
+        Me.cmdSquareBrackets.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdSquareBrackets.Name = "cmdSquareBrackets"
-        Me.cmdSquareBrackets.Size = New System.Drawing.Size(29, 30)
+        Me.cmdSquareBrackets.Size = New System.Drawing.Size(44, 45)
         Me.cmdSquareBrackets.TabIndex = 9
         Me.cmdSquareBrackets.Text = "[ ]"
         Me.cmdSquareBrackets.UseVisualStyleBackColor = True
@@ -374,10 +373,10 @@ Partial Class dlgModelling
         '
         Me.cmdMinus.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!)
         Me.cmdMinus.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdMinus.Location = New System.Drawing.Point(3, 70)
-        Me.cmdMinus.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdMinus.Location = New System.Drawing.Point(4, 105)
+        Me.cmdMinus.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdMinus.Name = "cmdMinus"
-        Me.cmdMinus.Size = New System.Drawing.Size(29, 30)
+        Me.cmdMinus.Size = New System.Drawing.Size(44, 45)
         Me.cmdMinus.TabIndex = 8
         Me.cmdMinus.Text = "-"
         Me.cmdMinus.UseVisualStyleBackColor = True
@@ -395,9 +394,11 @@ Partial Class dlgModelling
         Me.grpFirstCalc.Controls.Add(Me.cmdDoubleBracket)
         Me.grpFirstCalc.Controls.Add(Me.cmdSquareBrackets)
         Me.grpFirstCalc.Controls.Add(Me.cmdMinus)
-        Me.grpFirstCalc.Location = New System.Drawing.Point(293, 205)
+        Me.grpFirstCalc.Location = New System.Drawing.Point(440, 308)
+        Me.grpFirstCalc.Margin = New System.Windows.Forms.Padding(4)
         Me.grpFirstCalc.Name = "grpFirstCalc"
-        Me.grpFirstCalc.Size = New System.Drawing.Size(119, 103)
+        Me.grpFirstCalc.Padding = New System.Windows.Forms.Padding(4)
+        Me.grpFirstCalc.Size = New System.Drawing.Size(178, 154)
         Me.grpFirstCalc.TabIndex = 10
         Me.grpFirstCalc.TabStop = False
         '
@@ -405,10 +406,10 @@ Partial Class dlgModelling
         '
         Me.cmdTilda.Font = New System.Drawing.Font("Microsoft Sans Serif", 18.0!)
         Me.cmdTilda.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdTilda.Location = New System.Drawing.Point(59, 70)
-        Me.cmdTilda.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdTilda.Location = New System.Drawing.Point(88, 105)
+        Me.cmdTilda.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdTilda.Name = "cmdTilda"
-        Me.cmdTilda.Size = New System.Drawing.Size(57, 30)
+        Me.cmdTilda.Size = New System.Drawing.Size(86, 45)
         Me.cmdTilda.TabIndex = 21
         Me.cmdTilda.Text = "~"
         Me.cmdTilda.UseVisualStyleBackColor = True
@@ -416,9 +417,10 @@ Partial Class dlgModelling
         'cmdDisplayOptions
         '
         Me.cmdDisplayOptions.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdDisplayOptions.Location = New System.Drawing.Point(287, 354)
+        Me.cmdDisplayOptions.Location = New System.Drawing.Point(430, 531)
+        Me.cmdDisplayOptions.Margin = New System.Windows.Forms.Padding(4)
         Me.cmdDisplayOptions.Name = "cmdDisplayOptions"
-        Me.cmdDisplayOptions.Size = New System.Drawing.Size(125, 23)
+        Me.cmdDisplayOptions.Size = New System.Drawing.Size(188, 34)
         Me.cmdDisplayOptions.TabIndex = 11
         Me.cmdDisplayOptions.Text = "Display Options"
         Me.cmdDisplayOptions.UseVisualStyleBackColor = True
@@ -427,9 +429,10 @@ Partial Class dlgModelling
         '
         Me.cmdPredict.Enabled = False
         Me.cmdPredict.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdPredict.Location = New System.Drawing.Point(418, 355)
+        Me.cmdPredict.Location = New System.Drawing.Point(627, 532)
+        Me.cmdPredict.Margin = New System.Windows.Forms.Padding(4)
         Me.cmdPredict.Name = "cmdPredict"
-        Me.cmdPredict.Size = New System.Drawing.Size(105, 23)
+        Me.cmdPredict.Size = New System.Drawing.Size(158, 34)
         Me.cmdPredict.TabIndex = 12
         Me.cmdPredict.Text = "Predict"
         Me.cmdPredict.UseVisualStyleBackColor = True
@@ -438,9 +441,11 @@ Partial Class dlgModelling
         '
         Me.grpextRemes.Controls.Add(Me.cmdfevd)
         Me.grpextRemes.Controls.Add(Me.cmdlevd)
-        Me.grpextRemes.Location = New System.Drawing.Point(292, 68)
+        Me.grpextRemes.Location = New System.Drawing.Point(438, 102)
+        Me.grpextRemes.Margin = New System.Windows.Forms.Padding(4)
         Me.grpextRemes.Name = "grpextRemes"
-        Me.grpextRemes.Size = New System.Drawing.Size(154, 49)
+        Me.grpextRemes.Padding = New System.Windows.Forms.Padding(4)
+        Me.grpextRemes.Size = New System.Drawing.Size(231, 74)
         Me.grpextRemes.TabIndex = 18
         Me.grpextRemes.TabStop = False
         Me.grpextRemes.Text = "extRemes"
@@ -448,10 +453,10 @@ Partial Class dlgModelling
         'cmdfevd
         '
         Me.cmdfevd.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdfevd.Location = New System.Drawing.Point(4, 14)
-        Me.cmdfevd.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdfevd.Location = New System.Drawing.Point(6, 21)
+        Me.cmdfevd.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdfevd.Name = "cmdfevd"
-        Me.cmdfevd.Size = New System.Drawing.Size(69, 30)
+        Me.cmdfevd.Size = New System.Drawing.Size(104, 45)
         Me.cmdfevd.TabIndex = 169
         Me.cmdfevd.Text = "fevd"
         Me.cmdfevd.UseVisualStyleBackColor = True
@@ -459,10 +464,10 @@ Partial Class dlgModelling
         'cmdlevd
         '
         Me.cmdlevd.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdlevd.Location = New System.Drawing.Point(72, 14)
-        Me.cmdlevd.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdlevd.Location = New System.Drawing.Point(108, 21)
+        Me.cmdlevd.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdlevd.Name = "cmdlevd"
-        Me.cmdlevd.Size = New System.Drawing.Size(69, 30)
+        Me.cmdlevd.Size = New System.Drawing.Size(104, 45)
         Me.cmdlevd.TabIndex = 129
         Me.cmdlevd.Text = "levd"
         Me.cmdlevd.UseVisualStyleBackColor = True
@@ -470,10 +475,10 @@ Partial Class dlgModelling
         'cmdnlmer
         '
         Me.cmdnlmer.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdnlmer.Location = New System.Drawing.Point(140, 14)
-        Me.cmdnlmer.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdnlmer.Location = New System.Drawing.Point(210, 21)
+        Me.cmdnlmer.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdnlmer.Name = "cmdnlmer"
-        Me.cmdnlmer.Size = New System.Drawing.Size(69, 30)
+        Me.cmdnlmer.Size = New System.Drawing.Size(104, 45)
         Me.cmdnlmer.TabIndex = 153
         Me.cmdnlmer.Text = "nlmer"
         Me.cmdnlmer.UseVisualStyleBackColor = True
@@ -481,10 +486,10 @@ Partial Class dlgModelling
         'cmdlmer
         '
         Me.cmdlmer.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdlmer.Location = New System.Drawing.Point(72, 14)
-        Me.cmdlmer.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdlmer.Location = New System.Drawing.Point(108, 21)
+        Me.cmdlmer.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdlmer.Name = "cmdlmer"
-        Me.cmdlmer.Size = New System.Drawing.Size(69, 30)
+        Me.cmdlmer.Size = New System.Drawing.Size(104, 45)
         Me.cmdlmer.TabIndex = 126
         Me.cmdlmer.Text = "lmer"
         Me.cmdlmer.UseVisualStyleBackColor = True
@@ -492,10 +497,10 @@ Partial Class dlgModelling
         'cmdglmer
         '
         Me.cmdglmer.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdglmer.Location = New System.Drawing.Point(4, 14)
-        Me.cmdglmer.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdglmer.Location = New System.Drawing.Point(6, 21)
+        Me.cmdglmer.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdglmer.Name = "cmdglmer"
-        Me.cmdglmer.Size = New System.Drawing.Size(69, 30)
+        Me.cmdglmer.Size = New System.Drawing.Size(104, 45)
         Me.cmdglmer.TabIndex = 124
         Me.cmdglmer.Text = "glmer"
         Me.cmdglmer.UseVisualStyleBackColor = True
@@ -505,11 +510,11 @@ Partial Class dlgModelling
         Me.grplme4.Controls.Add(Me.cmdlmer)
         Me.grplme4.Controls.Add(Me.cmdglmer)
         Me.grplme4.Controls.Add(Me.cmdnlmer)
-        Me.grplme4.Location = New System.Drawing.Point(292, 68)
-        Me.grplme4.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.grplme4.Location = New System.Drawing.Point(438, 102)
+        Me.grplme4.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.grplme4.Name = "grplme4"
-        Me.grplme4.Padding = New System.Windows.Forms.Padding(2, 3, 2, 3)
-        Me.grplme4.Size = New System.Drawing.Size(213, 47)
+        Me.grplme4.Padding = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.grplme4.Size = New System.Drawing.Size(320, 70)
         Me.grplme4.TabIndex = 6
         Me.grplme4.TabStop = False
         Me.grplme4.Text = "lme4"
@@ -517,10 +522,10 @@ Partial Class dlgModelling
         'cmdloglm
         '
         Me.cmdloglm.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdloglm.Location = New System.Drawing.Point(140, 14)
-        Me.cmdloglm.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdloglm.Location = New System.Drawing.Point(210, 21)
+        Me.cmdloglm.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdloglm.Name = "cmdloglm"
-        Me.cmdloglm.Size = New System.Drawing.Size(69, 30)
+        Me.cmdloglm.Size = New System.Drawing.Size(104, 45)
         Me.cmdloglm.TabIndex = 153
         Me.cmdloglm.Text = "loglm"
         Me.cmdloglm.UseVisualStyleBackColor = True
@@ -528,10 +533,10 @@ Partial Class dlgModelling
         'cmdpolr
         '
         Me.cmdpolr.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdpolr.Location = New System.Drawing.Point(4, 43)
-        Me.cmdpolr.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdpolr.Location = New System.Drawing.Point(6, 64)
+        Me.cmdpolr.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdpolr.Name = "cmdpolr"
-        Me.cmdpolr.Size = New System.Drawing.Size(69, 30)
+        Me.cmdpolr.Size = New System.Drawing.Size(104, 45)
         Me.cmdpolr.TabIndex = 158
         Me.cmdpolr.Text = "polr"
         Me.cmdpolr.UseVisualStyleBackColor = True
@@ -539,10 +544,10 @@ Partial Class dlgModelling
         'cmdglmmPQL
         '
         Me.cmdglmmPQL.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdglmmPQL.Location = New System.Drawing.Point(72, 14)
-        Me.cmdglmmPQL.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdglmmPQL.Location = New System.Drawing.Point(108, 21)
+        Me.cmdglmmPQL.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdglmmPQL.Name = "cmdglmmPQL"
-        Me.cmdglmmPQL.Size = New System.Drawing.Size(69, 30)
+        Me.cmdglmmPQL.Size = New System.Drawing.Size(104, 45)
         Me.cmdglmmPQL.TabIndex = 126
         Me.cmdglmmPQL.Text = "glmmPQL"
         Me.cmdglmmPQL.UseVisualStyleBackColor = True
@@ -550,10 +555,10 @@ Partial Class dlgModelling
         'cmdglmnb
         '
         Me.cmdglmnb.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdglmnb.Location = New System.Drawing.Point(4, 14)
-        Me.cmdglmnb.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdglmnb.Location = New System.Drawing.Point(6, 21)
+        Me.cmdglmnb.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdglmnb.Name = "cmdglmnb"
-        Me.cmdglmnb.Size = New System.Drawing.Size(69, 30)
+        Me.cmdglmnb.Size = New System.Drawing.Size(104, 45)
         Me.cmdglmnb.TabIndex = 124
         Me.cmdglmnb.Text = "glm.nb"
         Me.cmdglmnb.UseVisualStyleBackColor = True
@@ -561,10 +566,10 @@ Partial Class dlgModelling
         'cmdrlm
         '
         Me.cmdrlm.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdrlm.Location = New System.Drawing.Point(72, 43)
-        Me.cmdrlm.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdrlm.Location = New System.Drawing.Point(108, 64)
+        Me.cmdrlm.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdrlm.Name = "cmdrlm"
-        Me.cmdrlm.Size = New System.Drawing.Size(69, 30)
+        Me.cmdrlm.Size = New System.Drawing.Size(104, 45)
         Me.cmdrlm.TabIndex = 121
         Me.cmdrlm.Text = "rlm"
         Me.cmdrlm.UseVisualStyleBackColor = True
@@ -580,11 +585,11 @@ Partial Class dlgModelling
         Me.grpMASS.Controls.Add(Me.cmdglmnb)
         Me.grpMASS.Controls.Add(Me.cmdrlm)
         Me.grpMASS.Controls.Add(Me.cmdloglm)
-        Me.grpMASS.Location = New System.Drawing.Point(292, 68)
-        Me.grpMASS.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.grpMASS.Location = New System.Drawing.Point(438, 102)
+        Me.grpMASS.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.grpMASS.Name = "grpMASS"
-        Me.grpMASS.Padding = New System.Windows.Forms.Padding(2, 3, 2, 3)
-        Me.grpMASS.Size = New System.Drawing.Size(213, 106)
+        Me.grpMASS.Padding = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.grpMASS.Size = New System.Drawing.Size(320, 159)
         Me.grpMASS.TabIndex = 20
         Me.grpMASS.TabStop = False
         Me.grpMASS.Text = "MASS"
@@ -592,10 +597,10 @@ Partial Class dlgModelling
         'cmdqda
         '
         Me.cmdqda.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdqda.Location = New System.Drawing.Point(140, 72)
-        Me.cmdqda.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdqda.Location = New System.Drawing.Point(210, 108)
+        Me.cmdqda.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdqda.Name = "cmdqda"
-        Me.cmdqda.Size = New System.Drawing.Size(69, 30)
+        Me.cmdqda.Size = New System.Drawing.Size(104, 45)
         Me.cmdqda.TabIndex = 166
         Me.cmdqda.Text = "qda"
         Me.cmdqda.UseVisualStyleBackColor = True
@@ -603,10 +608,10 @@ Partial Class dlgModelling
         'cmdmca
         '
         Me.cmdmca.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdmca.Location = New System.Drawing.Point(4, 72)
-        Me.cmdmca.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdmca.Location = New System.Drawing.Point(6, 108)
+        Me.cmdmca.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdmca.Name = "cmdmca"
-        Me.cmdmca.Size = New System.Drawing.Size(69, 30)
+        Me.cmdmca.Size = New System.Drawing.Size(104, 45)
         Me.cmdmca.TabIndex = 161
         Me.cmdmca.Text = "mca"
         Me.cmdmca.UseVisualStyleBackColor = True
@@ -614,10 +619,10 @@ Partial Class dlgModelling
         'cmdlqs
         '
         Me.cmdlqs.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdlqs.Location = New System.Drawing.Point(72, 72)
-        Me.cmdlqs.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdlqs.Location = New System.Drawing.Point(108, 108)
+        Me.cmdlqs.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdlqs.Name = "cmdlqs"
-        Me.cmdlqs.Size = New System.Drawing.Size(69, 30)
+        Me.cmdlqs.Size = New System.Drawing.Size(104, 45)
         Me.cmdlqs.TabIndex = 160
         Me.cmdlqs.Text = "lqs"
         Me.cmdlqs.UseVisualStyleBackColor = True
@@ -625,10 +630,10 @@ Partial Class dlgModelling
         'cmdlda
         '
         Me.cmdlda.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdlda.Location = New System.Drawing.Point(140, 43)
-        Me.cmdlda.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdlda.Location = New System.Drawing.Point(210, 64)
+        Me.cmdlda.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdlda.Name = "cmdlda"
-        Me.cmdlda.Size = New System.Drawing.Size(69, 30)
+        Me.cmdlda.Size = New System.Drawing.Size(104, 45)
         Me.cmdlda.TabIndex = 159
         Me.cmdlda.Text = "lda"
         Me.cmdlda.UseVisualStyleBackColor = True
@@ -636,48 +641,52 @@ Partial Class dlgModelling
         'cmdHelp
         '
         Me.cmdHelp.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdHelp.Location = New System.Drawing.Point(493, 38)
+        Me.cmdHelp.Location = New System.Drawing.Point(740, 55)
+        Me.cmdHelp.Margin = New System.Windows.Forms.Padding(4)
         Me.cmdHelp.Name = "cmdHelp"
-        Me.cmdHelp.Size = New System.Drawing.Size(60, 23)
+        Me.cmdHelp.Size = New System.Drawing.Size(90, 34)
         Me.cmdHelp.TabIndex = 7
-        Me.cmdHelp.Text = "Help"
+        Me.cmdHelp.Text = "R Help"
         Me.cmdHelp.UseVisualStyleBackColor = True
         '
         'lblRpackage
         '
         Me.lblRpackage.AutoSize = True
         Me.lblRpackage.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblRpackage.Location = New System.Drawing.Point(292, 43)
+        Me.lblRpackage.Location = New System.Drawing.Point(438, 64)
+        Me.lblRpackage.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblRpackage.Name = "lblRpackage"
-        Me.lblRpackage.Size = New System.Drawing.Size(63, 13)
+        Me.lblRpackage.Size = New System.Drawing.Size(90, 20)
         Me.lblRpackage.TabIndex = 3
         Me.lblRpackage.Text = "R package:"
         '
         'ucrTryModelling
         '
         Me.ucrTryModelling.AutoSize = True
-        Me.ucrTryModelling.Location = New System.Drawing.Point(4, 314)
+        Me.ucrTryModelling.Location = New System.Drawing.Point(6, 471)
+        Me.ucrTryModelling.Margin = New System.Windows.Forms.Padding(6)
         Me.ucrTryModelling.Name = "ucrTryModelling"
         Me.ucrTryModelling.RunCommandAsMultipleLines = False
-        Me.ucrTryModelling.Size = New System.Drawing.Size(480, 33)
+        Me.ucrTryModelling.Size = New System.Drawing.Size(720, 55)
         Me.ucrTryModelling.TabIndex = 21
         '
         'ucrChkIncludeArguments
         '
         Me.ucrChkIncludeArguments.AutoSize = True
         Me.ucrChkIncludeArguments.Checked = False
-        Me.ucrChkIncludeArguments.Location = New System.Drawing.Point(442, 13)
+        Me.ucrChkIncludeArguments.Location = New System.Drawing.Point(663, 20)
+        Me.ucrChkIncludeArguments.Margin = New System.Windows.Forms.Padding(9)
         Me.ucrChkIncludeArguments.Name = "ucrChkIncludeArguments"
-        Me.ucrChkIncludeArguments.Size = New System.Drawing.Size(131, 23)
+        Me.ucrChkIncludeArguments.Size = New System.Drawing.Size(196, 34)
         Me.ucrChkIncludeArguments.TabIndex = 2
         '
         'ucrSaveResult
         '
         Me.ucrSaveResult.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrSaveResult.Location = New System.Drawing.Point(13, 355)
-        Me.ucrSaveResult.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
+        Me.ucrSaveResult.Location = New System.Drawing.Point(20, 532)
+        Me.ucrSaveResult.Margin = New System.Windows.Forms.Padding(6, 8, 6, 8)
         Me.ucrSaveResult.Name = "ucrSaveResult"
-        Me.ucrSaveResult.Size = New System.Drawing.Size(267, 24)
+        Me.ucrSaveResult.Size = New System.Drawing.Size(400, 36)
         Me.ucrSaveResult.TabIndex = 13
         '
         'ucrInputComboRPackage
@@ -686,20 +695,21 @@ Partial Class dlgModelling
         Me.ucrInputComboRPackage.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.ucrInputComboRPackage.GetSetSelectedIndex = -1
         Me.ucrInputComboRPackage.IsReadOnly = False
-        Me.ucrInputComboRPackage.Location = New System.Drawing.Point(364, 39)
+        Me.ucrInputComboRPackage.Location = New System.Drawing.Point(546, 58)
+        Me.ucrInputComboRPackage.Margin = New System.Windows.Forms.Padding(14)
         Me.ucrInputComboRPackage.Name = "ucrInputComboRPackage"
-        Me.ucrInputComboRPackage.Size = New System.Drawing.Size(123, 21)
+        Me.ucrInputComboRPackage.Size = New System.Drawing.Size(184, 32)
         Me.ucrInputComboRPackage.TabIndex = 4
         '
         'ucrReceiverForTestColumn
         '
         Me.ucrReceiverForTestColumn.AutoSize = True
         Me.ucrReceiverForTestColumn.frmParent = Me
-        Me.ucrReceiverForTestColumn.Location = New System.Drawing.Point(63, 13)
-        Me.ucrReceiverForTestColumn.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.ucrReceiverForTestColumn.Location = New System.Drawing.Point(94, 20)
+        Me.ucrReceiverForTestColumn.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.ucrReceiverForTestColumn.Name = "ucrReceiverForTestColumn"
         Me.ucrReceiverForTestColumn.Selector = Nothing
-        Me.ucrReceiverForTestColumn.Size = New System.Drawing.Size(368, 27)
+        Me.ucrReceiverForTestColumn.Size = New System.Drawing.Size(552, 40)
         Me.ucrReceiverForTestColumn.strNcFilePath = ""
         Me.ucrReceiverForTestColumn.TabIndex = 1
         Me.ucrReceiverForTestColumn.ucrSelector = Nothing
@@ -710,27 +720,28 @@ Partial Class dlgModelling
         Me.ucrSelectorModelling.bDropUnusedFilterLevels = False
         Me.ucrSelectorModelling.bShowHiddenColumns = False
         Me.ucrSelectorModelling.bUseCurrentFilter = True
-        Me.ucrSelectorModelling.Location = New System.Drawing.Point(10, 66)
+        Me.ucrSelectorModelling.Location = New System.Drawing.Point(15, 99)
         Me.ucrSelectorModelling.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrSelectorModelling.Name = "ucrSelectorModelling"
-        Me.ucrSelectorModelling.Size = New System.Drawing.Size(213, 183)
+        Me.ucrSelectorModelling.Size = New System.Drawing.Size(320, 274)
         Me.ucrSelectorModelling.TabIndex = 5
         '
         'ucrBase
         '
         Me.ucrBase.AutoSize = True
         Me.ucrBase.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrBase.Location = New System.Drawing.Point(13, 387)
+        Me.ucrBase.Location = New System.Drawing.Point(20, 580)
+        Me.ucrBase.Margin = New System.Windows.Forms.Padding(6)
         Me.ucrBase.Name = "ucrBase"
-        Me.ucrBase.Size = New System.Drawing.Size(405, 52)
+        Me.ucrBase.Size = New System.Drawing.Size(611, 77)
         Me.ucrBase.TabIndex = 14
         '
         'dlgModelling
         '
-        Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(144.0!, 144.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
         Me.AutoSize = True
-        Me.ClientSize = New System.Drawing.Size(566, 442)
+        Me.ClientSize = New System.Drawing.Size(849, 663)
         Me.Controls.Add(Me.ucrTryModelling)
         Me.Controls.Add(Me.grplme4)
         Me.Controls.Add(Me.grpMASS)
@@ -750,6 +761,7 @@ Partial Class dlgModelling
         Me.Controls.Add(Me.ucrBase)
         Me.Controls.Add(Me.grpStats)
         Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow
+        Me.Margin = New System.Windows.Forms.Padding(4)
         Me.MaximizeBox = False
         Me.MinimizeBox = False
         Me.Name = "dlgModelling"

--- a/instat/dlgModelling.vb
+++ b/instat/dlgModelling.vb
@@ -583,21 +583,14 @@ Public Class dlgModelling
 
 
     Private Sub cmdHelp_Click(sender As Object, e As EventArgs) Handles cmdHelp.Click
-        Dim clsGetPortOperator As New ROperator
-        Dim clsStartDynamicServerFunction As New RFunction
+        Dim clsGetPortFunction As New RFunction
 
-        clsGetPortOperator.SetOperation(":::")
-        clsGetPortOperator.AddParameter("left", "tools", iPosition:=0)
-        clsGetPortOperator.AddParameter("right", "httpdPort()", iPosition:=1)
-        clsGetPortOperator.bSpaceAroundOperation = False
-
-        clsStartDynamicServerFunction.SetPackageName("tools")
-        clsStartDynamicServerFunction.SetRCommand("startDynamicHelp")
-        clsStartDynamicServerFunction.AddParameter("start", "NA", iPosition:=0)
-        frmMain.clsRLink.RunScript(clsStartDynamicServerFunction.ToScript(), iCallType:=5, bSeparateThread:=False, bSilent:=False)
+        clsGetPortFunction.SetPackageName("tools")
+        clsGetPortFunction.SetRCommand("startDynamicHelp")
+        clsGetPortFunction.AddParameter("start", "NA", iPosition:=0)
 
         Dim expPortTemp As SymbolicExpression
-        expPortTemp = frmMain.clsRLink.RunInternalScriptGetValue(clsGetPortOperator.ToScript())
+        expPortTemp = frmMain.clsRLink.RunInternalScriptGetValue(clsGetPortFunction.ToScript(), bSeparateThread:=False)
         Dim strPort As String = ""
         If expPortTemp IsNot Nothing AndAlso expPortTemp.Type <> Internals.SymbolicExpressionType.Null Then
             strPort = expPortTemp.AsInteger(0)

--- a/instat/dlgModelling.vb
+++ b/instat/dlgModelling.vb
@@ -583,8 +583,7 @@ Public Class dlgModelling
     Private Sub cmdHelp_Click(sender As Object, e As EventArgs) Handles cmdHelp.Click
         Dim strPackageName As String = ucrInputComboRPackage.GetText
         If strPackageName <> "" Then
-            Dim strURL As String = dlgFromLibrary.GetFileURL(strPackageName:=strPackageName)
-            frmMaximiseOutput.Show(strFileName:=strURL, bReplace:=False)
+            frmMaximiseOutput.Show(strFileName:=clsFileUrlUtilities.GetHelpFileURL(strPackageName:=strPackageName), bReplace:=False)
         End If
     End Sub
 

--- a/instat/dlgModelling.vb
+++ b/instat/dlgModelling.vb
@@ -15,8 +15,6 @@
 ' along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 Imports instat.Translations
-Imports RDotNet
-Imports System.IO
 
 Public Class dlgModelling
     Public bFirstLoad As Boolean = True
@@ -583,26 +581,9 @@ Public Class dlgModelling
 
 
     Private Sub cmdHelp_Click(sender As Object, e As EventArgs) Handles cmdHelp.Click
-        Dim clsGetPortFunction As New RFunction
-
-        clsGetPortFunction.SetPackageName("tools")
-        clsGetPortFunction.SetRCommand("startDynamicHelp")
-        clsGetPortFunction.AddParameter("start", "NA", iPosition:=0)
-
-        Dim expPortTemp As SymbolicExpression
-        expPortTemp = frmMain.clsRLink.RunInternalScriptGetValue(clsGetPortFunction.ToScript(), bSeparateThread:=False)
-        Dim strPort As String = ""
-        If expPortTemp IsNot Nothing AndAlso expPortTemp.Type <> Internals.SymbolicExpressionType.Null Then
-            strPort = expPortTemp.AsInteger(0)
-        End If
-
         Dim strPackageName As String = ucrInputComboRPackage.GetText
-        Dim strFilePath As String = Path.Combine("library", strPackageName, "html", "00Index.html")
-        Dim strLocalHost As String = "127.0.0.1:"
-        Dim strURL As String
-        strURL = Path.Combine(String.Concat("http://", strLocalHost), strPort, strFilePath)
-        If strURL <> "" Then
-            strURL = strURL.Replace("\", "/")
+        If strPackageName <> "" Then
+            Dim strURL As String = dlgFromLibrary.GetFileURL(strPackageName:=strPackageName)
             frmMaximiseOutput.Show(strFileName:=strURL, bReplace:=False)
         End If
     End Sub

--- a/instat/dlgUseModel.Designer.vb
+++ b/instat/dlgUseModel.Designer.vb
@@ -84,10 +84,9 @@ Partial Class dlgUseModel
         '
         Me.lblModel.AutoSize = True
         Me.lblModel.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblModel.Location = New System.Drawing.Point(19, 18)
-        Me.lblModel.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
+        Me.lblModel.Location = New System.Drawing.Point(28, 27)
         Me.lblModel.Name = "lblModel"
-        Me.lblModel.Size = New System.Drawing.Size(58, 13)
+        Me.lblModel.Size = New System.Drawing.Size(87, 20)
         Me.lblModel.TabIndex = 11
         Me.lblModel.Tag = "Test"
         Me.lblModel.Text = "Expression"
@@ -95,10 +94,10 @@ Partial Class dlgUseModel
         'cmdsummary
         '
         Me.cmdsummary.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdsummary.Location = New System.Drawing.Point(72, 12)
-        Me.cmdsummary.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdsummary.Location = New System.Drawing.Point(108, 18)
+        Me.cmdsummary.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdsummary.Name = "cmdsummary"
-        Me.cmdsummary.Size = New System.Drawing.Size(69, 30)
+        Me.cmdsummary.Size = New System.Drawing.Size(104, 45)
         Me.cmdsummary.TabIndex = 126
         Me.cmdsummary.Text = "summary"
         Me.cmdsummary.UseVisualStyleBackColor = True
@@ -106,10 +105,10 @@ Partial Class dlgUseModel
         'cmdanova
         '
         Me.cmdanova.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdanova.Location = New System.Drawing.Point(3, 12)
-        Me.cmdanova.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdanova.Location = New System.Drawing.Point(4, 18)
+        Me.cmdanova.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdanova.Name = "cmdanova"
-        Me.cmdanova.Size = New System.Drawing.Size(69, 30)
+        Me.cmdanova.Size = New System.Drawing.Size(104, 45)
         Me.cmdanova.TabIndex = 124
         Me.cmdanova.Text = "anova"
         Me.cmdanova.UseVisualStyleBackColor = True
@@ -117,10 +116,10 @@ Partial Class dlgUseModel
         'cmdresiduals
         '
         Me.cmdresiduals.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdresiduals.Location = New System.Drawing.Point(140, 12)
-        Me.cmdresiduals.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdresiduals.Location = New System.Drawing.Point(210, 18)
+        Me.cmdresiduals.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdresiduals.Name = "cmdresiduals"
-        Me.cmdresiduals.Size = New System.Drawing.Size(69, 30)
+        Me.cmdresiduals.Size = New System.Drawing.Size(104, 45)
         Me.cmdresiduals.TabIndex = 153
         Me.cmdresiduals.Text = "residuals"
         Me.cmdresiduals.UseVisualStyleBackColor = True
@@ -138,11 +137,11 @@ Partial Class dlgUseModel
         Me.grpGeneral.Controls.Add(Me.cmdsummary)
         Me.grpGeneral.Controls.Add(Me.cmdanova)
         Me.grpGeneral.Controls.Add(Me.cmdresiduals)
-        Me.grpGeneral.Location = New System.Drawing.Point(258, 106)
-        Me.grpGeneral.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.grpGeneral.Location = New System.Drawing.Point(387, 159)
+        Me.grpGeneral.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.grpGeneral.Name = "grpGeneral"
-        Me.grpGeneral.Padding = New System.Windows.Forms.Padding(2, 3, 2, 3)
-        Me.grpGeneral.Size = New System.Drawing.Size(213, 142)
+        Me.grpGeneral.Padding = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.grpGeneral.Size = New System.Drawing.Size(320, 213)
         Me.grpGeneral.TabIndex = 25
         Me.grpGeneral.TabStop = False
         Me.grpGeneral.Text = "General"
@@ -150,10 +149,10 @@ Partial Class dlgUseModel
         'Button2
         '
         Me.Button2.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.Button2.Location = New System.Drawing.Point(140, 100)
-        Me.Button2.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.Button2.Location = New System.Drawing.Point(210, 150)
+        Me.Button2.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.Button2.Name = "Button2"
-        Me.Button2.Size = New System.Drawing.Size(69, 30)
+        Me.Button2.Size = New System.Drawing.Size(104, 45)
         Me.Button2.TabIndex = 161
         Me.Button2.Text = "Anova"
         Me.Button2.UseVisualStyleBackColor = True
@@ -161,10 +160,10 @@ Partial Class dlgUseModel
         'cmdDurbinWatsonTest
         '
         Me.cmdDurbinWatsonTest.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdDurbinWatsonTest.Location = New System.Drawing.Point(3, 100)
-        Me.cmdDurbinWatsonTest.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdDurbinWatsonTest.Location = New System.Drawing.Point(4, 150)
+        Me.cmdDurbinWatsonTest.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdDurbinWatsonTest.Name = "cmdDurbinWatsonTest"
-        Me.cmdDurbinWatsonTest.Size = New System.Drawing.Size(138, 30)
+        Me.cmdDurbinWatsonTest.Size = New System.Drawing.Size(207, 45)
         Me.cmdDurbinWatsonTest.TabIndex = 160
         Me.cmdDurbinWatsonTest.Text = "durbinWatsonTest"
         Me.cmdDurbinWatsonTest.UseVisualStyleBackColor = True
@@ -172,10 +171,10 @@ Partial Class dlgUseModel
         'cmdNcvTest
         '
         Me.cmdNcvTest.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdNcvTest.Location = New System.Drawing.Point(140, 70)
-        Me.cmdNcvTest.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdNcvTest.Location = New System.Drawing.Point(210, 105)
+        Me.cmdNcvTest.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdNcvTest.Name = "cmdNcvTest"
-        Me.cmdNcvTest.Size = New System.Drawing.Size(69, 30)
+        Me.cmdNcvTest.Size = New System.Drawing.Size(104, 45)
         Me.cmdNcvTest.TabIndex = 159
         Me.cmdNcvTest.Text = "ncvTest"
         Me.cmdNcvTest.UseVisualStyleBackColor = True
@@ -183,10 +182,10 @@ Partial Class dlgUseModel
         'cmdOutlierTest
         '
         Me.cmdOutlierTest.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdOutlierTest.Location = New System.Drawing.Point(72, 70)
-        Me.cmdOutlierTest.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdOutlierTest.Location = New System.Drawing.Point(108, 105)
+        Me.cmdOutlierTest.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdOutlierTest.Name = "cmdOutlierTest"
-        Me.cmdOutlierTest.Size = New System.Drawing.Size(69, 30)
+        Me.cmdOutlierTest.Size = New System.Drawing.Size(104, 45)
         Me.cmdOutlierTest.TabIndex = 158
         Me.cmdOutlierTest.Text = "outlierTest"
         Me.cmdOutlierTest.UseVisualStyleBackColor = True
@@ -194,10 +193,10 @@ Partial Class dlgUseModel
         'cmdBIC
         '
         Me.cmdBIC.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdBIC.Location = New System.Drawing.Point(3, 70)
-        Me.cmdBIC.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdBIC.Location = New System.Drawing.Point(4, 105)
+        Me.cmdBIC.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdBIC.Name = "cmdBIC"
-        Me.cmdBIC.Size = New System.Drawing.Size(69, 30)
+        Me.cmdBIC.Size = New System.Drawing.Size(104, 45)
         Me.cmdBIC.TabIndex = 157
         Me.cmdBIC.Text = "BIC"
         Me.cmdBIC.UseVisualStyleBackColor = True
@@ -205,10 +204,10 @@ Partial Class dlgUseModel
         'cmdAIC
         '
         Me.cmdAIC.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdAIC.Location = New System.Drawing.Point(140, 41)
-        Me.cmdAIC.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdAIC.Location = New System.Drawing.Point(210, 62)
+        Me.cmdAIC.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdAIC.Name = "cmdAIC"
-        Me.cmdAIC.Size = New System.Drawing.Size(69, 30)
+        Me.cmdAIC.Size = New System.Drawing.Size(104, 45)
         Me.cmdAIC.TabIndex = 156
         Me.cmdAIC.Text = "AIC"
         Me.cmdAIC.UseVisualStyleBackColor = True
@@ -216,10 +215,10 @@ Partial Class dlgUseModel
         'cmdCoefficient
         '
         Me.cmdCoefficient.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdCoefficient.Location = New System.Drawing.Point(72, 41)
-        Me.cmdCoefficient.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdCoefficient.Location = New System.Drawing.Point(108, 62)
+        Me.cmdCoefficient.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdCoefficient.Name = "cmdCoefficient"
-        Me.cmdCoefficient.Size = New System.Drawing.Size(69, 30)
+        Me.cmdCoefficient.Size = New System.Drawing.Size(104, 45)
         Me.cmdCoefficient.TabIndex = 155
         Me.cmdCoefficient.Text = "coefficient"
         Me.cmdCoefficient.UseVisualStyleBackColor = True
@@ -227,10 +226,10 @@ Partial Class dlgUseModel
         'cmdPrint
         '
         Me.cmdPrint.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdPrint.Location = New System.Drawing.Point(3, 41)
-        Me.cmdPrint.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdPrint.Location = New System.Drawing.Point(4, 62)
+        Me.cmdPrint.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdPrint.Name = "cmdPrint"
-        Me.cmdPrint.Size = New System.Drawing.Size(69, 30)
+        Me.cmdPrint.Size = New System.Drawing.Size(104, 45)
         Me.cmdPrint.TabIndex = 154
         Me.cmdPrint.Text = "print"
         Me.cmdPrint.UseVisualStyleBackColor = True
@@ -238,11 +237,11 @@ Partial Class dlgUseModel
         'grpPrediction
         '
         Me.grpPrediction.Controls.Add(Me.cmdPredict)
-        Me.grpPrediction.Location = New System.Drawing.Point(260, 106)
-        Me.grpPrediction.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.grpPrediction.Location = New System.Drawing.Point(390, 159)
+        Me.grpPrediction.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.grpPrediction.Name = "grpPrediction"
-        Me.grpPrediction.Padding = New System.Windows.Forms.Padding(2, 3, 2, 3)
-        Me.grpPrediction.Size = New System.Drawing.Size(213, 45)
+        Me.grpPrediction.Padding = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.grpPrediction.Size = New System.Drawing.Size(320, 68)
         Me.grpPrediction.TabIndex = 27
         Me.grpPrediction.TabStop = False
         Me.grpPrediction.Text = "Prediction"
@@ -250,10 +249,10 @@ Partial Class dlgUseModel
         'cmdPredict
         '
         Me.cmdPredict.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdPredict.Location = New System.Drawing.Point(3, 12)
-        Me.cmdPredict.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdPredict.Location = New System.Drawing.Point(4, 18)
+        Me.cmdPredict.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdPredict.Name = "cmdPredict"
-        Me.cmdPredict.Size = New System.Drawing.Size(72, 30)
+        Me.cmdPredict.Size = New System.Drawing.Size(108, 45)
         Me.cmdPredict.TabIndex = 124
         Me.cmdPredict.Text = "prediction"
         Me.cmdPredict.UseVisualStyleBackColor = True
@@ -261,9 +260,10 @@ Partial Class dlgUseModel
         'lblModels
         '
         Me.lblModels.AutoSize = True
-        Me.lblModels.Location = New System.Drawing.Point(84, 49)
+        Me.lblModels.Location = New System.Drawing.Point(126, 74)
+        Me.lblModels.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblModels.Name = "lblModels"
-        Me.lblModels.Size = New System.Drawing.Size(44, 13)
+        Me.lblModels.Size = New System.Drawing.Size(64, 20)
         Me.lblModels.TabIndex = 28
         Me.lblModels.Text = "Models:"
         '
@@ -278,11 +278,11 @@ Partial Class dlgUseModel
         Me.grpExtrRemes.Controls.Add(Me.cmdDistill)
         Me.grpExtrRemes.Controls.Add(Me.cmdCi)
         Me.grpExtrRemes.Controls.Add(Me.cmdErlevd)
-        Me.grpExtrRemes.Location = New System.Drawing.Point(260, 108)
-        Me.grpExtrRemes.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.grpExtrRemes.Location = New System.Drawing.Point(390, 162)
+        Me.grpExtrRemes.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.grpExtrRemes.Name = "grpExtrRemes"
-        Me.grpExtrRemes.Padding = New System.Windows.Forms.Padding(2, 3, 2, 3)
-        Me.grpExtrRemes.Size = New System.Drawing.Size(227, 110)
+        Me.grpExtrRemes.Padding = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.grpExtrRemes.Size = New System.Drawing.Size(340, 165)
         Me.grpExtrRemes.TabIndex = 30
         Me.grpExtrRemes.TabStop = False
         Me.grpExtrRemes.Text = "extRemes"
@@ -290,10 +290,10 @@ Partial Class dlgUseModel
         'cmdPlotFevd
         '
         Me.cmdPlotFevd.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdPlotFevd.Location = New System.Drawing.Point(152, 15)
-        Me.cmdPlotFevd.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdPlotFevd.Location = New System.Drawing.Point(228, 22)
+        Me.cmdPlotFevd.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdPlotFevd.Name = "cmdPlotFevd"
-        Me.cmdPlotFevd.Size = New System.Drawing.Size(69, 30)
+        Me.cmdPlotFevd.Size = New System.Drawing.Size(104, 45)
         Me.cmdPlotFevd.TabIndex = 159
         Me.cmdPlotFevd.Text = "plot.fevd"
         Me.cmdPlotFevd.UseVisualStyleBackColor = True
@@ -301,10 +301,10 @@ Partial Class dlgUseModel
         'cmdSummaryFevd
         '
         Me.cmdSummaryFevd.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdSummaryFevd.Location = New System.Drawing.Point(70, 15)
-        Me.cmdSummaryFevd.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdSummaryFevd.Location = New System.Drawing.Point(105, 22)
+        Me.cmdSummaryFevd.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdSummaryFevd.Name = "cmdSummaryFevd"
-        Me.cmdSummaryFevd.Size = New System.Drawing.Size(83, 30)
+        Me.cmdSummaryFevd.Size = New System.Drawing.Size(124, 45)
         Me.cmdSummaryFevd.TabIndex = 158
         Me.cmdSummaryFevd.Text = "summary.fevd"
         Me.cmdSummaryFevd.UseVisualStyleBackColor = True
@@ -312,10 +312,10 @@ Partial Class dlgUseModel
         'cmdPrintFevd
         '
         Me.cmdPrintFevd.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdPrintFevd.Location = New System.Drawing.Point(2, 15)
-        Me.cmdPrintFevd.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdPrintFevd.Location = New System.Drawing.Point(3, 22)
+        Me.cmdPrintFevd.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdPrintFevd.Name = "cmdPrintFevd"
-        Me.cmdPrintFevd.Size = New System.Drawing.Size(69, 30)
+        Me.cmdPrintFevd.Size = New System.Drawing.Size(104, 45)
         Me.cmdPrintFevd.TabIndex = 157
         Me.cmdPrintFevd.Text = "print.fevd"
         Me.cmdPrintFevd.UseVisualStyleBackColor = True
@@ -323,10 +323,10 @@ Partial Class dlgUseModel
         'cmdLrTest
         '
         Me.cmdLrTest.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdLrTest.Location = New System.Drawing.Point(152, 73)
-        Me.cmdLrTest.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdLrTest.Location = New System.Drawing.Point(228, 110)
+        Me.cmdLrTest.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdLrTest.Name = "cmdLrTest"
-        Me.cmdLrTest.Size = New System.Drawing.Size(69, 30)
+        Me.cmdLrTest.Size = New System.Drawing.Size(104, 45)
         Me.cmdLrTest.TabIndex = 156
         Me.cmdLrTest.Text = "lr.Test"
         Me.cmdLrTest.UseVisualStyleBackColor = True
@@ -334,10 +334,10 @@ Partial Class dlgUseModel
         'cmdIsFixedfevd
         '
         Me.cmdIsFixedfevd.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdIsFixedfevd.Location = New System.Drawing.Point(70, 73)
-        Me.cmdIsFixedfevd.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdIsFixedfevd.Location = New System.Drawing.Point(105, 110)
+        Me.cmdIsFixedfevd.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdIsFixedfevd.Name = "cmdIsFixedfevd"
-        Me.cmdIsFixedfevd.Size = New System.Drawing.Size(83, 30)
+        Me.cmdIsFixedfevd.Size = New System.Drawing.Size(124, 45)
         Me.cmdIsFixedfevd.TabIndex = 155
         Me.cmdIsFixedfevd.Text = "is.fixedfevd"
         Me.cmdIsFixedfevd.UseVisualStyleBackColor = True
@@ -345,10 +345,10 @@ Partial Class dlgUseModel
         'cmdFindpars
         '
         Me.cmdFindpars.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdFindpars.Location = New System.Drawing.Point(2, 73)
-        Me.cmdFindpars.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdFindpars.Location = New System.Drawing.Point(3, 110)
+        Me.cmdFindpars.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdFindpars.Name = "cmdFindpars"
-        Me.cmdFindpars.Size = New System.Drawing.Size(69, 30)
+        Me.cmdFindpars.Size = New System.Drawing.Size(104, 45)
         Me.cmdFindpars.TabIndex = 154
         Me.cmdFindpars.Text = "findpars"
         Me.cmdFindpars.UseVisualStyleBackColor = True
@@ -356,10 +356,10 @@ Partial Class dlgUseModel
         'cmdDistill
         '
         Me.cmdDistill.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdDistill.Location = New System.Drawing.Point(70, 44)
-        Me.cmdDistill.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdDistill.Location = New System.Drawing.Point(105, 66)
+        Me.cmdDistill.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdDistill.Name = "cmdDistill"
-        Me.cmdDistill.Size = New System.Drawing.Size(83, 30)
+        Me.cmdDistill.Size = New System.Drawing.Size(124, 45)
         Me.cmdDistill.TabIndex = 126
         Me.cmdDistill.Text = "distill"
         Me.cmdDistill.UseVisualStyleBackColor = True
@@ -367,10 +367,10 @@ Partial Class dlgUseModel
         'cmdCi
         '
         Me.cmdCi.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdCi.Location = New System.Drawing.Point(2, 44)
-        Me.cmdCi.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdCi.Location = New System.Drawing.Point(3, 66)
+        Me.cmdCi.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdCi.Name = "cmdCi"
-        Me.cmdCi.Size = New System.Drawing.Size(69, 30)
+        Me.cmdCi.Size = New System.Drawing.Size(104, 45)
         Me.cmdCi.TabIndex = 124
         Me.cmdCi.Text = "ci"
         Me.cmdCi.UseVisualStyleBackColor = True
@@ -378,10 +378,10 @@ Partial Class dlgUseModel
         'cmdErlevd
         '
         Me.cmdErlevd.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdErlevd.Location = New System.Drawing.Point(152, 44)
-        Me.cmdErlevd.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdErlevd.Location = New System.Drawing.Point(228, 66)
+        Me.cmdErlevd.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdErlevd.Name = "cmdErlevd"
-        Me.cmdErlevd.Size = New System.Drawing.Size(69, 30)
+        Me.cmdErlevd.Size = New System.Drawing.Size(104, 45)
         Me.cmdErlevd.TabIndex = 153
         Me.cmdErlevd.Text = "erlevd"
         Me.cmdErlevd.UseVisualStyleBackColor = True
@@ -389,10 +389,10 @@ Partial Class dlgUseModel
         'cmdClear
         '
         Me.cmdClear.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdClear.Location = New System.Drawing.Point(397, 254)
-        Me.cmdClear.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdClear.Location = New System.Drawing.Point(596, 381)
+        Me.cmdClear.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdClear.Name = "cmdClear"
-        Me.cmdClear.Size = New System.Drawing.Size(74, 23)
+        Me.cmdClear.Size = New System.Drawing.Size(111, 34)
         Me.cmdClear.TabIndex = 31
         Me.cmdClear.Text = "Clear"
         Me.cmdClear.UseVisualStyleBackColor = True
@@ -400,40 +400,42 @@ Partial Class dlgUseModel
         'cmdHelp
         '
         Me.cmdHelp.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdHelp.Location = New System.Drawing.Point(460, 79)
+        Me.cmdHelp.Location = New System.Drawing.Point(690, 118)
+        Me.cmdHelp.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
         Me.cmdHelp.Name = "cmdHelp"
-        Me.cmdHelp.Size = New System.Drawing.Size(60, 23)
+        Me.cmdHelp.Size = New System.Drawing.Size(90, 34)
         Me.cmdHelp.TabIndex = 33
-        Me.cmdHelp.Text = "Help"
+        Me.cmdHelp.Text = "R Help"
         Me.cmdHelp.UseVisualStyleBackColor = True
         '
         'lblRpackage
         '
         Me.lblRpackage.AutoSize = True
         Me.lblRpackage.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblRpackage.Location = New System.Drawing.Point(260, 83)
+        Me.lblRpackage.Location = New System.Drawing.Point(390, 124)
+        Me.lblRpackage.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblRpackage.Name = "lblRpackage"
-        Me.lblRpackage.Size = New System.Drawing.Size(63, 13)
+        Me.lblRpackage.Size = New System.Drawing.Size(90, 20)
         Me.lblRpackage.TabIndex = 36
         Me.lblRpackage.Text = "R package:"
         '
         'ucrSaveResult
         '
         Me.ucrSaveResult.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrSaveResult.Location = New System.Drawing.Point(10, 319)
-        Me.ucrSaveResult.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
+        Me.ucrSaveResult.Location = New System.Drawing.Point(15, 478)
+        Me.ucrSaveResult.Margin = New System.Windows.Forms.Padding(6, 8, 6, 8)
         Me.ucrSaveResult.Name = "ucrSaveResult"
-        Me.ucrSaveResult.Size = New System.Drawing.Size(277, 24)
+        Me.ucrSaveResult.Size = New System.Drawing.Size(416, 36)
         Me.ucrSaveResult.TabIndex = 35
         '
         'ucrChkIncludeArguments
         '
         Me.ucrChkIncludeArguments.AutoSize = True
         Me.ucrChkIncludeArguments.Checked = False
-        Me.ucrChkIncludeArguments.Location = New System.Drawing.Point(445, 12)
-        Me.ucrChkIncludeArguments.Margin = New System.Windows.Forms.Padding(5)
+        Me.ucrChkIncludeArguments.Location = New System.Drawing.Point(668, 18)
+        Me.ucrChkIncludeArguments.Margin = New System.Windows.Forms.Padding(8, 8, 8, 8)
         Me.ucrChkIncludeArguments.Name = "ucrChkIncludeArguments"
-        Me.ucrChkIncludeArguments.Size = New System.Drawing.Size(130, 23)
+        Me.ucrChkIncludeArguments.Size = New System.Drawing.Size(195, 34)
         Me.ucrChkIncludeArguments.TabIndex = 32
         '
         'grpSegmented
@@ -452,11 +454,11 @@ Partial Class dlgUseModel
         Me.grpSegmented.Controls.Add(Me.cmdAapc)
         Me.grpSegmented.Controls.Add(Me.cmdSegmented)
         Me.grpSegmented.Controls.Add(Me.cmdSegmentedPrint)
-        Me.grpSegmented.Location = New System.Drawing.Point(260, 107)
-        Me.grpSegmented.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.grpSegmented.Location = New System.Drawing.Point(390, 160)
+        Me.grpSegmented.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.grpSegmented.Name = "grpSegmented"
-        Me.grpSegmented.Padding = New System.Windows.Forms.Padding(2, 3, 2, 3)
-        Me.grpSegmented.Size = New System.Drawing.Size(277, 134)
+        Me.grpSegmented.Padding = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.grpSegmented.Size = New System.Drawing.Size(416, 201)
         Me.grpSegmented.TabIndex = 162
         Me.grpSegmented.TabStop = False
         Me.grpSegmented.Text = "segmented"
@@ -464,10 +466,10 @@ Partial Class dlgUseModel
         'cmdSlope
         '
         Me.cmdSlope.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdSlope.Location = New System.Drawing.Point(208, 70)
-        Me.cmdSlope.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdSlope.Location = New System.Drawing.Point(312, 105)
+        Me.cmdSlope.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdSlope.Name = "cmdSlope"
-        Me.cmdSlope.Size = New System.Drawing.Size(69, 30)
+        Me.cmdSlope.Size = New System.Drawing.Size(104, 45)
         Me.cmdSlope.TabIndex = 164
         Me.cmdSlope.Text = "slope"
         Me.cmdSlope.UseVisualStyleBackColor = True
@@ -475,10 +477,10 @@ Partial Class dlgUseModel
         'cmdPscore
         '
         Me.cmdPscore.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdPscore.Location = New System.Drawing.Point(140, 10)
-        Me.cmdPscore.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdPscore.Location = New System.Drawing.Point(210, 15)
+        Me.cmdPscore.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdPscore.Name = "cmdPscore"
-        Me.cmdPscore.Size = New System.Drawing.Size(69, 30)
+        Me.cmdPscore.Size = New System.Drawing.Size(104, 45)
         Me.cmdPscore.TabIndex = 163
         Me.cmdPscore.Text = "pscore"
         Me.cmdPscore.UseVisualStyleBackColor = True
@@ -486,10 +488,10 @@ Partial Class dlgUseModel
         'cmdDavies
         '
         Me.cmdDavies.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdDavies.Location = New System.Drawing.Point(3, 10)
-        Me.cmdDavies.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdDavies.Location = New System.Drawing.Point(4, 15)
+        Me.cmdDavies.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdDavies.Name = "cmdDavies"
-        Me.cmdDavies.Size = New System.Drawing.Size(69, 30)
+        Me.cmdDavies.Size = New System.Drawing.Size(104, 45)
         Me.cmdDavies.TabIndex = 162
         Me.cmdDavies.Text = "davies"
         Me.cmdDavies.UseVisualStyleBackColor = True
@@ -497,10 +499,10 @@ Partial Class dlgUseModel
         'cmdIntercept
         '
         Me.cmdIntercept.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdIntercept.Location = New System.Drawing.Point(140, 100)
-        Me.cmdIntercept.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdIntercept.Location = New System.Drawing.Point(210, 150)
+        Me.cmdIntercept.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdIntercept.Name = "cmdIntercept"
-        Me.cmdIntercept.Size = New System.Drawing.Size(69, 30)
+        Me.cmdIntercept.Size = New System.Drawing.Size(104, 45)
         Me.cmdIntercept.TabIndex = 161
         Me.cmdIntercept.Text = "intercept"
         Me.cmdIntercept.UseVisualStyleBackColor = True
@@ -508,10 +510,10 @@ Partial Class dlgUseModel
         'cmdBroken
         '
         Me.cmdBroken.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdBroken.Location = New System.Drawing.Point(3, 100)
-        Me.cmdBroken.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdBroken.Location = New System.Drawing.Point(4, 150)
+        Me.cmdBroken.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdBroken.Name = "cmdBroken"
-        Me.cmdBroken.Size = New System.Drawing.Size(69, 30)
+        Me.cmdBroken.Size = New System.Drawing.Size(104, 45)
         Me.cmdBroken.TabIndex = 160
         Me.cmdBroken.Text = "broken"
         Me.cmdBroken.UseVisualStyleBackColor = True
@@ -519,10 +521,10 @@ Partial Class dlgUseModel
         'cmdPoints
         '
         Me.cmdPoints.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdPoints.Location = New System.Drawing.Point(140, 70)
-        Me.cmdPoints.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdPoints.Location = New System.Drawing.Point(210, 105)
+        Me.cmdPoints.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdPoints.Name = "cmdPoints"
-        Me.cmdPoints.Size = New System.Drawing.Size(69, 30)
+        Me.cmdPoints.Size = New System.Drawing.Size(104, 45)
         Me.cmdPoints.TabIndex = 159
         Me.cmdPoints.Text = "points"
         Me.cmdPoints.UseVisualStyleBackColor = True
@@ -530,10 +532,10 @@ Partial Class dlgUseModel
         'cmdPlotLines
         '
         Me.cmdPlotLines.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdPlotLines.Location = New System.Drawing.Point(72, 70)
-        Me.cmdPlotLines.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdPlotLines.Location = New System.Drawing.Point(108, 105)
+        Me.cmdPlotLines.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdPlotLines.Name = "cmdPlotLines"
-        Me.cmdPlotLines.Size = New System.Drawing.Size(69, 30)
+        Me.cmdPlotLines.Size = New System.Drawing.Size(104, 45)
         Me.cmdPlotLines.TabIndex = 158
         Me.cmdPlotLines.Text = "plot "
         Me.cmdPlotLines.UseVisualStyleBackColor = True
@@ -541,10 +543,10 @@ Partial Class dlgUseModel
         'cmdSegmentedPredict
         '
         Me.cmdSegmentedPredict.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdSegmentedPredict.Location = New System.Drawing.Point(3, 70)
-        Me.cmdSegmentedPredict.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdSegmentedPredict.Location = New System.Drawing.Point(4, 105)
+        Me.cmdSegmentedPredict.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdSegmentedPredict.Name = "cmdSegmentedPredict"
-        Me.cmdSegmentedPredict.Size = New System.Drawing.Size(69, 30)
+        Me.cmdSegmentedPredict.Size = New System.Drawing.Size(104, 45)
         Me.cmdSegmentedPredict.TabIndex = 157
         Me.cmdSegmentedPredict.Text = "predict"
         Me.cmdSegmentedPredict.UseVisualStyleBackColor = True
@@ -552,10 +554,10 @@ Partial Class dlgUseModel
         'cmdVcov
         '
         Me.cmdVcov.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdVcov.Location = New System.Drawing.Point(140, 41)
-        Me.cmdVcov.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdVcov.Location = New System.Drawing.Point(210, 62)
+        Me.cmdVcov.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdVcov.Name = "cmdVcov"
-        Me.cmdVcov.Size = New System.Drawing.Size(69, 30)
+        Me.cmdVcov.Size = New System.Drawing.Size(104, 45)
         Me.cmdVcov.TabIndex = 156
         Me.cmdVcov.Text = "vcov"
         Me.cmdVcov.UseVisualStyleBackColor = True
@@ -563,10 +565,10 @@ Partial Class dlgUseModel
         'cmdConfint
         '
         Me.cmdConfint.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdConfint.Location = New System.Drawing.Point(72, 41)
-        Me.cmdConfint.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdConfint.Location = New System.Drawing.Point(108, 62)
+        Me.cmdConfint.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdConfint.Name = "cmdConfint"
-        Me.cmdConfint.Size = New System.Drawing.Size(69, 30)
+        Me.cmdConfint.Size = New System.Drawing.Size(104, 45)
         Me.cmdConfint.TabIndex = 155
         Me.cmdConfint.Text = "confint"
         Me.cmdConfint.UseVisualStyleBackColor = True
@@ -574,10 +576,10 @@ Partial Class dlgUseModel
         'cmdSegmentedSummary
         '
         Me.cmdSegmentedSummary.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdSegmentedSummary.Location = New System.Drawing.Point(3, 41)
-        Me.cmdSegmentedSummary.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdSegmentedSummary.Location = New System.Drawing.Point(4, 62)
+        Me.cmdSegmentedSummary.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdSegmentedSummary.Name = "cmdSegmentedSummary"
-        Me.cmdSegmentedSummary.Size = New System.Drawing.Size(69, 30)
+        Me.cmdSegmentedSummary.Size = New System.Drawing.Size(104, 45)
         Me.cmdSegmentedSummary.TabIndex = 154
         Me.cmdSegmentedSummary.Text = "summary"
         Me.cmdSegmentedSummary.UseVisualStyleBackColor = True
@@ -585,10 +587,10 @@ Partial Class dlgUseModel
         'cmdAapc
         '
         Me.cmdAapc.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdAapc.Location = New System.Drawing.Point(72, 100)
-        Me.cmdAapc.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdAapc.Location = New System.Drawing.Point(108, 150)
+        Me.cmdAapc.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdAapc.Name = "cmdAapc"
-        Me.cmdAapc.Size = New System.Drawing.Size(69, 30)
+        Me.cmdAapc.Size = New System.Drawing.Size(104, 45)
         Me.cmdAapc.TabIndex = 126
         Me.cmdAapc.Text = "aapc"
         Me.cmdAapc.UseVisualStyleBackColor = True
@@ -596,10 +598,10 @@ Partial Class dlgUseModel
         'cmdSegmented
         '
         Me.cmdSegmented.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdSegmented.Location = New System.Drawing.Point(72, 10)
-        Me.cmdSegmented.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdSegmented.Location = New System.Drawing.Point(108, 15)
+        Me.cmdSegmented.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdSegmented.Name = "cmdSegmented"
-        Me.cmdSegmented.Size = New System.Drawing.Size(69, 30)
+        Me.cmdSegmented.Size = New System.Drawing.Size(104, 45)
         Me.cmdSegmented.TabIndex = 124
         Me.cmdSegmented.Text = "segmented"
         Me.cmdSegmented.UseVisualStyleBackColor = True
@@ -607,10 +609,10 @@ Partial Class dlgUseModel
         'cmdSegmentedPrint
         '
         Me.cmdSegmentedPrint.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdSegmentedPrint.Location = New System.Drawing.Point(208, 41)
-        Me.cmdSegmentedPrint.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdSegmentedPrint.Location = New System.Drawing.Point(312, 62)
+        Me.cmdSegmentedPrint.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.cmdSegmentedPrint.Name = "cmdSegmentedPrint"
-        Me.cmdSegmentedPrint.Size = New System.Drawing.Size(69, 30)
+        Me.cmdSegmentedPrint.Size = New System.Drawing.Size(104, 45)
         Me.cmdSegmentedPrint.TabIndex = 153
         Me.cmdSegmentedPrint.Text = "print"
         Me.cmdSegmentedPrint.UseVisualStyleBackColor = True
@@ -621,10 +623,10 @@ Partial Class dlgUseModel
         Me.ucrInputModels.AutoSize = True
         Me.ucrInputModels.IsMultiline = False
         Me.ucrInputModels.IsReadOnly = False
-        Me.ucrInputModels.Location = New System.Drawing.Point(133, 45)
-        Me.ucrInputModels.Margin = New System.Windows.Forms.Padding(7, 6, 7, 6)
+        Me.ucrInputModels.Location = New System.Drawing.Point(200, 68)
+        Me.ucrInputModels.Margin = New System.Windows.Forms.Padding(10, 9, 10, 9)
         Me.ucrInputModels.Name = "ucrInputModels"
-        Me.ucrInputModels.Size = New System.Drawing.Size(214, 21)
+        Me.ucrInputModels.Size = New System.Drawing.Size(321, 32)
         Me.ucrInputModels.TabIndex = 29
         '
         'ucrSelectorUseModel
@@ -633,31 +635,31 @@ Partial Class dlgUseModel
         Me.ucrSelectorUseModel.bDropUnusedFilterLevels = False
         Me.ucrSelectorUseModel.bShowHiddenColumns = False
         Me.ucrSelectorUseModel.bUseCurrentFilter = True
-        Me.ucrSelectorUseModel.Location = New System.Drawing.Point(10, 68)
+        Me.ucrSelectorUseModel.Location = New System.Drawing.Point(15, 102)
         Me.ucrSelectorUseModel.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrSelectorUseModel.Name = "ucrSelectorUseModel"
-        Me.ucrSelectorUseModel.Size = New System.Drawing.Size(213, 183)
+        Me.ucrSelectorUseModel.Size = New System.Drawing.Size(320, 274)
         Me.ucrSelectorUseModel.TabIndex = 26
         '
         'ucrBase
         '
         Me.ucrBase.AutoSize = True
         Me.ucrBase.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrBase.Location = New System.Drawing.Point(9, 362)
-        Me.ucrBase.Margin = New System.Windows.Forms.Padding(4)
+        Me.ucrBase.Location = New System.Drawing.Point(14, 543)
+        Me.ucrBase.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
         Me.ucrBase.Name = "ucrBase"
-        Me.ucrBase.Size = New System.Drawing.Size(405, 52)
+        Me.ucrBase.Size = New System.Drawing.Size(611, 77)
         Me.ucrBase.TabIndex = 20
         '
         'ucrReceiverForTestColumn
         '
         Me.ucrReceiverForTestColumn.AutoSize = True
         Me.ucrReceiverForTestColumn.frmParent = Me
-        Me.ucrReceiverForTestColumn.Location = New System.Drawing.Point(82, 11)
-        Me.ucrReceiverForTestColumn.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.ucrReceiverForTestColumn.Location = New System.Drawing.Point(123, 16)
+        Me.ucrReceiverForTestColumn.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
         Me.ucrReceiverForTestColumn.Name = "ucrReceiverForTestColumn"
         Me.ucrReceiverForTestColumn.Selector = Nothing
-        Me.ucrReceiverForTestColumn.Size = New System.Drawing.Size(358, 27)
+        Me.ucrReceiverForTestColumn.Size = New System.Drawing.Size(537, 40)
         Me.ucrReceiverForTestColumn.strNcFilePath = ""
         Me.ucrReceiverForTestColumn.TabIndex = 12
         Me.ucrReceiverForTestColumn.ucrSelector = Nothing
@@ -668,28 +670,28 @@ Partial Class dlgUseModel
         Me.ucrInputComboRPackage.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.ucrInputComboRPackage.GetSetSelectedIndex = -1
         Me.ucrInputComboRPackage.IsReadOnly = False
-        Me.ucrInputComboRPackage.Location = New System.Drawing.Point(328, 80)
-        Me.ucrInputComboRPackage.Margin = New System.Windows.Forms.Padding(7, 6, 7, 6)
+        Me.ucrInputComboRPackage.Location = New System.Drawing.Point(492, 120)
+        Me.ucrInputComboRPackage.Margin = New System.Windows.Forms.Padding(10, 9, 10, 9)
         Me.ucrInputComboRPackage.Name = "ucrInputComboRPackage"
-        Me.ucrInputComboRPackage.Size = New System.Drawing.Size(122, 21)
+        Me.ucrInputComboRPackage.Size = New System.Drawing.Size(183, 32)
         Me.ucrInputComboRPackage.TabIndex = 5
         '
         'ucrTryModelling
         '
         Me.ucrTryModelling.AutoSize = True
-        Me.ucrTryModelling.Location = New System.Drawing.Point(2, 285)
-        Me.ucrTryModelling.Margin = New System.Windows.Forms.Padding(4)
+        Me.ucrTryModelling.Location = New System.Drawing.Point(3, 428)
+        Me.ucrTryModelling.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
         Me.ucrTryModelling.Name = "ucrTryModelling"
         Me.ucrTryModelling.RunCommandAsMultipleLines = False
-        Me.ucrTryModelling.Size = New System.Drawing.Size(480, 30)
+        Me.ucrTryModelling.Size = New System.Drawing.Size(720, 55)
         Me.ucrTryModelling.TabIndex = 163
         '
         'dlgUseModel
         '
-        Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(144.0!, 144.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
         Me.AutoSize = True
-        Me.ClientSize = New System.Drawing.Size(582, 423)
+        Me.ClientSize = New System.Drawing.Size(873, 634)
         Me.Controls.Add(Me.grpGeneral)
         Me.Controls.Add(Me.ucrTryModelling)
         Me.Controls.Add(Me.lblRpackage)
@@ -708,6 +710,7 @@ Partial Class dlgUseModel
         Me.Controls.Add(Me.ucrReceiverForTestColumn)
         Me.Controls.Add(Me.ucrInputComboRPackage)
         Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow
+        Me.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
         Me.MinimizeBox = False
         Me.Name = "dlgUseModel"
         Me.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen

--- a/instat/dlgUseModel.vb
+++ b/instat/dlgUseModel.vb
@@ -385,8 +385,7 @@ Public Class dlgUseModel
     Private Sub cmdHelp_Click(sender As Object, e As EventArgs) Handles cmdHelp.Click
         Dim strPackageName As String = ucrInputComboRPackage.GetText
         If strPackageName <> "" Then
-            Dim strURL As String = dlgFromLibrary.GetFileURL(strPackageName:=strPackageName)
-            frmMaximiseOutput.Show(strFileName:=strURL, bReplace:=False)
+            frmMaximiseOutput.Show(strFileName:=clsFileUrlUtilities.GetHelpFileURL(strPackageName:=strPackageName), bReplace:=False)
         End If
     End Sub
 

--- a/instat/dlgUseModel.vb
+++ b/instat/dlgUseModel.vb
@@ -384,21 +384,14 @@ Public Class dlgUseModel
     End Sub
 
     Private Sub cmdHelp_Click(sender As Object, e As EventArgs) Handles cmdHelp.Click
-        Dim clsGetPortOperator As New ROperator
-        Dim clsStartDynamicServerFunction As New RFunction
+        Dim clsGetPortFunction As New RFunction
 
-        clsGetPortOperator.SetOperation(":::")
-        clsGetPortOperator.AddParameter("left", "tools", iPosition:=0)
-        clsGetPortOperator.AddParameter("right", "httpdPort()", iPosition:=1)
-        clsGetPortOperator.bSpaceAroundOperation = False
-
-        clsStartDynamicServerFunction.SetPackageName("tools")
-        clsStartDynamicServerFunction.SetRCommand("startDynamicHelp")
-        clsStartDynamicServerFunction.AddParameter("start", "NA", iPosition:=0)
-        frmMain.clsRLink.RunScript(clsStartDynamicServerFunction.ToScript(), iCallType:=5, bSeparateThread:=False, bSilent:=False)
+        clsGetPortFunction.SetPackageName("tools")
+        clsGetPortFunction.SetRCommand("startDynamicHelp")
+        clsGetPortFunction.AddParameter("start", "NA", iPosition:=0)
 
         Dim expPortTemp As SymbolicExpression
-        expPortTemp = frmMain.clsRLink.RunInternalScriptGetValue(clsGetPortOperator.ToScript())
+        expPortTemp = frmMain.clsRLink.RunInternalScriptGetValue(clsGetPortFunction.ToScript(), bSeparateThread:=False)
         Dim strPort As String = ""
         If expPortTemp IsNot Nothing AndAlso expPortTemp.Type <> Internals.SymbolicExpressionType.Null Then
             strPort = expPortTemp.AsInteger(0)

--- a/instat/dlgUseModel.vb
+++ b/instat/dlgUseModel.vb
@@ -17,6 +17,7 @@
 Imports instat
 Imports instat.Translations
 Imports RDotNet
+Imports System.IO
 Public Class dlgUseModel
 
     Public bFirstLoad As Boolean = True
@@ -383,15 +384,35 @@ Public Class dlgUseModel
     End Sub
 
     Private Sub cmdHelp_Click(sender As Object, e As EventArgs) Handles cmdHelp.Click
-        Dim clsHelp As New RFunction
-        Dim strPackageName As String
+        Dim clsGetPortOperator As New ROperator
+        Dim clsStartDynamicServerFunction As New RFunction
 
-        strPackageName = ucrInputComboRPackage.GetText
-        clsHelp.SetPackageName("utils")
-        clsHelp.SetRCommand("help")
-        clsHelp.AddParameter("package", Chr(34) & strPackageName & Chr(34))
-        clsHelp.AddParameter("help_type", Chr(34) & "html" & Chr(34))
-        frmMain.clsRLink.RunScript(clsHelp.ToScript, strComment:="Opening help page for" & " " & strPackageName & " " & "Package. Generated from dialog Modelling", iCallType:=2, bSeparateThread:=False, bUpdateGrids:=False)
+        clsGetPortOperator.SetOperation(":::")
+        clsGetPortOperator.AddParameter("left", "tools", iPosition:=0)
+        clsGetPortOperator.AddParameter("right", "httpdPort()", iPosition:=1)
+        clsGetPortOperator.bSpaceAroundOperation = False
+
+        clsStartDynamicServerFunction.SetPackageName("tools")
+        clsStartDynamicServerFunction.SetRCommand("startDynamicHelp")
+        clsStartDynamicServerFunction.AddParameter("start", "NA", iPosition:=0)
+        frmMain.clsRLink.RunScript(clsStartDynamicServerFunction.ToScript(), iCallType:=5, bSeparateThread:=False, bSilent:=False)
+
+        Dim expPortTemp As SymbolicExpression
+        expPortTemp = frmMain.clsRLink.RunInternalScriptGetValue(clsGetPortOperator.ToScript())
+        Dim strPort As String = ""
+        If expPortTemp IsNot Nothing AndAlso expPortTemp.Type <> Internals.SymbolicExpressionType.Null Then
+            strPort = expPortTemp.AsInteger(0)
+        End If
+
+        Dim strPackageName As String = ucrInputComboRPackage.GetText
+        Dim strFilePath As String = Path.Combine("library", strPackageName, "html", "00Index.html")
+        Dim strLocalHost As String = "127.0.0.1:"
+        Dim strURL As String
+        strURL = Path.Combine(String.Concat("http://", strLocalHost), strPort, strFilePath)
+        If strURL <> "" Then
+            strURL = strURL.Replace("\", "/")
+            frmMaximiseOutput.Show(strFileName:=strURL, bReplace:=False)
+        End If
     End Sub
 
     Private Sub cmdClear_Click(sender As Object, e As EventArgs) Handles cmdClear.Click

--- a/instat/dlgUseModel.vb
+++ b/instat/dlgUseModel.vb
@@ -17,7 +17,6 @@
 Imports instat
 Imports instat.Translations
 Imports RDotNet
-Imports System.IO
 Public Class dlgUseModel
 
     Public bFirstLoad As Boolean = True
@@ -384,26 +383,9 @@ Public Class dlgUseModel
     End Sub
 
     Private Sub cmdHelp_Click(sender As Object, e As EventArgs) Handles cmdHelp.Click
-        Dim clsGetPortFunction As New RFunction
-
-        clsGetPortFunction.SetPackageName("tools")
-        clsGetPortFunction.SetRCommand("startDynamicHelp")
-        clsGetPortFunction.AddParameter("start", "NA", iPosition:=0)
-
-        Dim expPortTemp As SymbolicExpression
-        expPortTemp = frmMain.clsRLink.RunInternalScriptGetValue(clsGetPortFunction.ToScript(), bSeparateThread:=False)
-        Dim strPort As String = ""
-        If expPortTemp IsNot Nothing AndAlso expPortTemp.Type <> Internals.SymbolicExpressionType.Null Then
-            strPort = expPortTemp.AsInteger(0)
-        End If
-
         Dim strPackageName As String = ucrInputComboRPackage.GetText
-        Dim strFilePath As String = Path.Combine("library", strPackageName, "html", "00Index.html")
-        Dim strLocalHost As String = "127.0.0.1:"
-        Dim strURL As String
-        strURL = Path.Combine(String.Concat("http://", strLocalHost), strPort, strFilePath)
-        If strURL <> "" Then
-            strURL = strURL.Replace("\", "/")
+        If strPackageName <> "" Then
+            Dim strURL As String = dlgFromLibrary.GetFileURL(strPackageName:=strPackageName)
             frmMaximiseOutput.Show(strFileName:=strURL, bReplace:=False)
         End If
     End Sub

--- a/instat/instat.vbproj
+++ b/instat/instat.vbproj
@@ -215,6 +215,7 @@
   <ItemGroup>
     <Compile Include="ApplicationEvents.vb" />
     <Compile Include="clsBlockReader.vb" />
+    <Compile Include="clsFileUrlUtilities.vb" />
     <Compile Include="dlgApsimx.Designer.vb">
       <DependentUpon>dlgApsimx.vb</DependentUpon>
     </Compile>

--- a/instat/static/InstatObject/R/stand_alone_functions.R
+++ b/instat/static/InstatObject/R/stand_alone_functions.R
@@ -2842,7 +2842,66 @@ get_data_book_output_object_names <- function(output_object_list,
   
 }
 
-
+get_vignette <- function (package = NULL, lib.loc = NULL, all = TRUE) 
+{   
+  oneLink <- function(s) {
+    if (length(s) == 0L) 
+      return(character(0L))
+    title <- s[, "Title"]
+    if (port > 0L) 
+      prefix <- sprintf("/library/%s/doc", pkg)
+    else prefix <- sprintf("file://%s/doc", s[, "Dir"])
+    src <- s[, "File"]
+    pdf <- s[, "PDF"]
+    rcode <- s[, "R"]
+    pdfext <- sub("^.*\\.", "", pdf)
+    sprintf("  <li>%s  -  \n    %s  \n    %s  \n    %s \n  </li>\n", 
+            title, ifelse(nzchar(pdf), sprintf("<a href='%s/%s'>%s</a>&nbsp;", 
+                                               prefix, pdf, toupper(pdfext)), ""), sprintf("<a href='%s/%s'>source</a>&nbsp;", 
+                                                                                           prefix, src), ifelse(nzchar(rcode), sprintf("<a href='%s/%s'>R code</a>&nbsp;", 
+                                                                                                                                       prefix, rcode), ""))
+  }
+  
+  port <- tools::startDynamicHelp(NA)
+  file <- tempfile("Rvig.", fileext = ".html")
+  print(file)
+  sink(file = file, type = "output")
+  vinfo <- tools::getVignetteInfo(package, lib.loc, all)
+  pkgs <- unique(vinfo[, "Package"])
+  db <- lapply(pkgs, function(p) vinfo[vinfo[, "Package"] == 
+                                         p, , drop = FALSE])
+  names(db) <- pkgs
+  attr(db, "call") <- sys.call()
+  attr(db, "footer") <- if (all) 
+    ""
+  else sprintf(gettext("Use <code> %s </code> \n to list the vignettes in all <strong>available</strong> packages."), 
+               "browseVignettes(all = TRUE)")
+  if (port > 0L) 
+    css_file <- "/doc/html/R.css"
+  else css_file <- file.path(R.home("doc"), "html", 
+                             "R.css")
+  cat(sprintf("<!DOCTYPE html PUBLIC '-//W3C//DTD HTML 4.01 Transitional//EN'>\n<html>\n<head>\n<title>R Vignettes</title>\n<meta http-equiv='Content-Type' content='text/html; charset=iso-8859-1'>\n<meta name='viewport' content='width=device-width, initial-scale=1.0, user-scalable=yes' />\n<link rel='stylesheet' type='text/css' href='%s'>\n</head><body><div class='container'>\n", 
+              css_file))
+  
+  cat(sprintf("<center><h3>Vignettes found by <code><q>%s</q></code></h3></center>", 
+              deparse1(attr(db, "call"))))
+  cat("<div class=\"vignettes\">")
+  for (pkg in names(db)) {
+    cat(sprintf("<h4>Vignettes in package <code>%s</code></h4>\n", 
+                pkg))
+    cat("<ul>\n")
+    links <- oneLink(db[[pkg]])
+    cat(paste(links), collapse = "\n")
+    cat("\n</ul>\n")
+  }
+  cat("</div>")
+  sink()
+  if (port > 0L){
+    print(port)
+    return(sprintf("http://127.0.0.1:%d/session/%s", 
+                   port, basename(file)))}
+  else return(sprintf("file://%s", file))
+}
 
 
 

--- a/instat/static/InstatObject/R/stand_alone_functions.R
+++ b/instat/static/InstatObject/R/stand_alone_functions.R
@@ -2897,7 +2897,6 @@ get_vignette <- function (package = NULL, lib.loc = NULL, all = TRUE)
   cat("</div>")
   sink()
   if (port > 0L){
-    print(port)
     return(sprintf("http://127.0.0.1:%d/session/%s", 
                    port, basename(file)))}
   else return(sprintf("file://%s", file))

--- a/instat/ucrCalculator.vb
+++ b/instat/ucrCalculator.vb
@@ -1631,8 +1631,7 @@ Public Class ucrCalculator
 
     Private Sub OpenHelpPage()
         If strPackageName <> "" Then
-            Dim strURL As String = dlgFromLibrary.GetFileURL(strPackageName:=strPackageName)
-            frmMaximiseOutput.Show(strFileName:=strURL, bReplace:=False)
+            frmMaximiseOutput.Show(strFileName:=clsFileUrlUtilities.GetHelpFileURL(strPackageName:=strPackageName), bReplace:=False)
         End If
     End Sub
 

--- a/instat/ucrCalculator.vb
+++ b/instat/ucrCalculator.vb
@@ -14,6 +14,8 @@
 ' You should have received a copy of the GNU General Public License 
 ' along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+Imports System.IO
+Imports RDotNet
 Public Class ucrCalculator
     Public iHelpCalcID As Integer
     Public Event NameChanged()
@@ -1629,16 +1631,34 @@ Public Class ucrCalculator
 
 
     Private Sub OpenHelpPage()
-        Dim clsHelp As New RFunction
+        Dim clsGetPortOperator As New ROperator
+        Dim clsStartDynamicServerFunction As New RFunction
 
-        clsHelp.SetPackageName("utils")
-        clsHelp.SetRCommand("help")
-        clsHelp.AddParameter("package", Chr(34) & strPackageName & Chr(34))
-        clsHelp.AddParameter("help_type", Chr(34) & "html" & Chr(34))
-        frmMain.clsRLink.RunScript(clsHelp.ToScript,
-                                   strComment:="Opening help page for " &
-                                   strPackageName & " Package. Generated from dialog Calculator",
-                                   iCallType:=2, bSeparateThread:=False, bUpdateGrids:=False)
+        clsGetPortOperator.SetOperation(":::")
+        clsGetPortOperator.AddParameter("left", "tools", iPosition:=0)
+        clsGetPortOperator.AddParameter("right", "httpdPort()", iPosition:=1)
+        clsGetPortOperator.bSpaceAroundOperation = False
+
+        clsStartDynamicServerFunction.SetPackageName("tools")
+        clsStartDynamicServerFunction.SetRCommand("startDynamicHelp")
+        clsStartDynamicServerFunction.AddParameter("start", "NA", iPosition:=0)
+        frmMain.clsRLink.RunScript(clsStartDynamicServerFunction.ToScript(), iCallType:=5, bSeparateThread:=False, bSilent:=False)
+
+        Dim expPortTemp As SymbolicExpression
+        expPortTemp = frmMain.clsRLink.RunInternalScriptGetValue(clsGetPortOperator.ToScript())
+        Dim strPort As String = ""
+        If expPortTemp IsNot Nothing AndAlso expPortTemp.Type <> Internals.SymbolicExpressionType.Null Then
+            strPort = expPortTemp.AsInteger(0)
+        End If
+
+        Dim strFilePath As String = Path.Combine("library", strPackageName, "html", "00Index.html")
+        Dim strLocalHost As String = "127.0.0.1:"
+        Dim strURL As String
+        strURL = Path.Combine(String.Concat("http://", strLocalHost), strPort, strFilePath)
+        If strURL <> "" Then
+            strURL = strURL.Replace("\", "/")
+            frmMaximiseOutput.Show(strFileName:=strURL, bReplace:=False)
+        End If
     End Sub
 
     Private Sub cmdTry_Click(sender As Object, e As EventArgs)

--- a/instat/ucrCalculator.vb
+++ b/instat/ucrCalculator.vb
@@ -14,7 +14,6 @@
 ' You should have received a copy of the GNU General Public License 
 ' along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-Imports System.IO
 Imports RDotNet
 Public Class ucrCalculator
     Public iHelpCalcID As Integer
@@ -1631,25 +1630,8 @@ Public Class ucrCalculator
 
 
     Private Sub OpenHelpPage()
-        Dim clsGetPortFunction As New RFunction
-
-        clsGetPortFunction.SetPackageName("tools")
-        clsGetPortFunction.SetRCommand("startDynamicHelp")
-        clsGetPortFunction.AddParameter("start", "NA", iPosition:=0)
-
-        Dim expPortTemp As SymbolicExpression
-        expPortTemp = frmMain.clsRLink.RunInternalScriptGetValue(clsGetPortFunction.ToScript(), bSeparateThread:=False)
-        Dim strPort As String = ""
-        If expPortTemp IsNot Nothing AndAlso expPortTemp.Type <> Internals.SymbolicExpressionType.Null Then
-            strPort = expPortTemp.AsInteger(0)
-        End If
-
-        Dim strFilePath As String = Path.Combine("library", strPackageName, "html", "00Index.html")
-        Dim strLocalHost As String = "127.0.0.1:"
-        Dim strURL As String
-        strURL = Path.Combine(String.Concat("http://", strLocalHost), strPort, strFilePath)
-        If strURL <> "" Then
-            strURL = strURL.Replace("\", "/")
+        If strPackageName <> "" Then
+            Dim strURL As String = dlgFromLibrary.GetFileURL(strPackageName:=strPackageName)
             frmMaximiseOutput.Show(strFileName:=strURL, bReplace:=False)
         End If
     End Sub

--- a/instat/ucrCalculator.vb
+++ b/instat/ucrCalculator.vb
@@ -1631,21 +1631,14 @@ Public Class ucrCalculator
 
 
     Private Sub OpenHelpPage()
-        Dim clsGetPortOperator As New ROperator
-        Dim clsStartDynamicServerFunction As New RFunction
+        Dim clsGetPortFunction As New RFunction
 
-        clsGetPortOperator.SetOperation(":::")
-        clsGetPortOperator.AddParameter("left", "tools", iPosition:=0)
-        clsGetPortOperator.AddParameter("right", "httpdPort()", iPosition:=1)
-        clsGetPortOperator.bSpaceAroundOperation = False
-
-        clsStartDynamicServerFunction.SetPackageName("tools")
-        clsStartDynamicServerFunction.SetRCommand("startDynamicHelp")
-        clsStartDynamicServerFunction.AddParameter("start", "NA", iPosition:=0)
-        frmMain.clsRLink.RunScript(clsStartDynamicServerFunction.ToScript(), iCallType:=5, bSeparateThread:=False, bSilent:=False)
+        clsGetPortFunction.SetPackageName("tools")
+        clsGetPortFunction.SetRCommand("startDynamicHelp")
+        clsGetPortFunction.AddParameter("start", "NA", iPosition:=0)
 
         Dim expPortTemp As SymbolicExpression
-        expPortTemp = frmMain.clsRLink.RunInternalScriptGetValue(clsGetPortOperator.ToScript())
+        expPortTemp = frmMain.clsRLink.RunInternalScriptGetValue(clsGetPortFunction.ToScript(), bSeparateThread:=False)
         Dim strPort As String = ""
         If expPortTemp IsNot Nothing AndAlso expPortTemp.Type <> Internals.SymbolicExpressionType.Null Then
             strPort = expPortTemp.AsInteger(0)


### PR DESCRIPTION
@rdstern this is ready for you to test. I made the changes in the FromLibrary, HelpVignettes, HypothesisTestsCalculator, Modelling, UseModel, and Calculator Dialogues. Some dialogue `Help button` is still `Help` the changes will be make in another PR.
@lloyddewit could you have a look of the code?
Thanks