### PR TITLE
Changed grid to only update one cell if replace value is done

### DIFF
--- a/instat/UserControls/DataGrid/Linux/ucrDataViewLinuxGrid.vb
+++ b/instat/UserControls/DataGrid/Linux/ucrDataViewLinuxGrid.vb
@@ -101,6 +101,7 @@ Public Class ucrDataViewLinuxGrid
         RaiseEvent IDataViewGrid_ReplaceValueInData(dataGrid.CurrentCell.Value.ToString(),
                         GetCurrentDataFrameFocus().clsVisibleDataFramePage.lstColumns(dataGrid.CurrentCell.ColumnIndex).strName,
                         GetCurrentDataFrameFocus().clsVisibleDataFramePage.RowNames()(dataGrid.CurrentCell.RowIndex))
+        RefreshSingleCell(dataGrid.CurrentCell.ColumnIndex, dataGrid.CurrentCell.RowIndex)
     End Sub
 
     'ToDo allow editing
@@ -145,5 +146,10 @@ Public Class ucrDataViewLinuxGrid
 
     Private Sub tcTabs_SelectedIndexChanged(sender As Object, e As EventArgs) Handles tcTabs.SelectedIndexChanged
         RaiseEvent WorksheetChanged()
+    End Sub
+
+    Public Sub RefreshSingleCell(iColumn As Integer, iRow As Integer)
+        Dim dataGrid = GetDataGridFromSelectedTab()
+        dataGrid.Rows(iRow).Cells(iColumn).Value = GetCurrentDataFrameFocus.DisplayedData(iRow, iColumn)
     End Sub
 End Class

--- a/instat/UserControls/DataGrid/Linux/ucrDataViewLinuxGrid.vb
+++ b/instat/UserControls/DataGrid/Linux/ucrDataViewLinuxGrid.vb
@@ -148,7 +148,7 @@ Public Class ucrDataViewLinuxGrid
         RaiseEvent WorksheetChanged()
     End Sub
 
-    Public Sub RefreshSingleCell(iColumn As Integer, iRow As Integer)
+    Private Sub RefreshSingleCell(iColumn As Integer, iRow As Integer)
         Dim dataGrid = GetDataGridFromSelectedTab()
         dataGrid.Rows(iRow).Cells(iColumn).Value = GetCurrentDataFrameFocus.DisplayedData(iRow, iColumn)
     End Sub

--- a/instat/UserControls/DataGrid/ReoGrid/ucrDataViewReoGrid.vb
+++ b/instat/UserControls/DataGrid/ReoGrid/ucrDataViewReoGrid.vb
@@ -200,5 +200,4 @@ Public Class ucrDataViewReoGrid
         End If
     End Sub
 
-
 End Class

--- a/instat/UserControls/DataGrid/ReoGrid/ucrDataViewReoGrid.vb
+++ b/instat/UserControls/DataGrid/ReoGrid/ucrDataViewReoGrid.vb
@@ -94,7 +94,7 @@ Public Class ucrDataViewReoGrid
         grdData.CurrentWorksheet.RowHeaderWidth = TextRenderer.MeasureText(strLongestRowHeaderText, Me.Font).Width
     End Sub
 
-    Public Sub RefreshSingleCell(iColumn As Integer, iRow As Integer)
+    Private Sub RefreshSingleCell(iColumn As Integer, iRow As Integer)
         grdData.CurrentWorksheet(iRow, iColumn) = GetCurrentDataFrameFocus.DisplayedData(iRow, iColumn)
     End Sub
 

--- a/instat/UserControls/DataGrid/ReoGrid/ucrDataViewReoGrid.vb
+++ b/instat/UserControls/DataGrid/ReoGrid/ucrDataViewReoGrid.vb
@@ -94,6 +94,10 @@ Public Class ucrDataViewReoGrid
         grdData.CurrentWorksheet.RowHeaderWidth = TextRenderer.MeasureText(strLongestRowHeaderText, Me.Font).Width
     End Sub
 
+    Public Sub RefreshSingleCell(iColumn As Integer, iRow As Integer)
+        grdData.CurrentWorksheet(iRow, iColumn) = GetCurrentDataFrameFocus.DisplayedData(iRow, iColumn)
+    End Sub
+
     Private Function GetInnerBracketedString(strData As String) As String
         Dim intFirstRightBracket As Integer = InStr(strData, ")")
         Dim intLastLeftBracket As Integer = InStrRev(strData, "(")
@@ -168,6 +172,7 @@ Public Class ucrDataViewReoGrid
                            GetCurrentDataFrameFocus().clsVisibleDataFramePage.lstColumns(e.Cell.Column).strName,
                            GetCurrentDataFrameFocus().clsVisibleDataFramePage.RowNames()(e.Cell.Row))
         e.EndReason = unvell.ReoGrid.EndEditReason.Cancel
+        RefreshSingleCell(e.Cell.Column, e.Cell.Row)
     End Sub
 
 
@@ -194,5 +199,6 @@ Public Class ucrDataViewReoGrid
             RaiseEvent DeleteValueToDataframe()
         End If
     End Sub
+
 
 End Class

--- a/instat/ucrDataView.vb
+++ b/instat/ucrDataView.vb
@@ -22,7 +22,7 @@ Imports instat.Translations
 Public Class ucrDataView
     Private _clsDataBook As clsDataBook
     Private _grid As IDataViewGrid
-    Private OnlyUpdateOneCell As Boolean = False
+    Private bOnlyUpdateOneCell As Boolean = False
 
     Public WriteOnly Property DataBook() As clsDataBook
         Set(value As clsDataBook)
@@ -145,7 +145,7 @@ Public Class ucrDataView
         _clsDataBook.RefreshData()
         'If we are updating one cell we do not need to refresh the grid and the 
         'refresh of that cell will be done manually 
-        If Not OnlyUpdateOneCell Then
+        If Not bOnlyUpdateOneCell Then
             AddAndUpdateWorksheets()
             _grid.RemoveOldWorksheets()
             If _clsDataBook.DataFrames.Count = 0 Then
@@ -375,9 +375,9 @@ Public Class ucrDataView
             End Select
         End If
         StartWait()
-        OnlyUpdateOneCell = True
+        bOnlyUpdateOneCell = True
         GetCurrentDataFrameFocus().clsPrepareFunctions.ReplaceValueInData(strNewValue, strColumnName, strRowText, bWithQuotes, bListOfVector)
-        OnlyUpdateOneCell = False
+        bOnlyUpdateOneCell = False
         EndWait()
     End Sub
 

--- a/instat/ucrDataView.vb
+++ b/instat/ucrDataView.vb
@@ -22,6 +22,7 @@ Imports instat.Translations
 Public Class ucrDataView
     Private _clsDataBook As clsDataBook
     Private _grid As IDataViewGrid
+    Private OnlyUpdateOneCell As Boolean = False
 
     Public WriteOnly Property DataBook() As clsDataBook
         Set(value As clsDataBook)
@@ -142,10 +143,14 @@ Public Class ucrDataView
             Exit Sub
         End If
         _clsDataBook.RefreshData()
-        AddAndUpdateWorksheets()
-        _grid.RemoveOldWorksheets()
-        If _clsDataBook.DataFrames.Count = 0 Then
-            RefreshDisplayInformation()
+        'If we are updating one cell we do not need to refresh the grid and the 
+        'refresh of that cell will be done manually 
+        If Not OnlyUpdateOneCell Then
+            AddAndUpdateWorksheets()
+            _grid.RemoveOldWorksheets()
+            If _clsDataBook.DataFrames.Count = 0 Then
+                RefreshDisplayInformation()
+            End If
         End If
     End Sub
 
@@ -370,7 +375,9 @@ Public Class ucrDataView
             End Select
         End If
         StartWait()
+        OnlyUpdateOneCell = True
         GetCurrentDataFrameFocus().clsPrepareFunctions.ReplaceValueInData(strNewValue, strColumnName, strRowText, bWithQuotes, bListOfVector)
+        OnlyUpdateOneCell = False
         EndWait()
     End Sub
 


### PR DESCRIPTION
Updated ReplaceValueInCell to only update the changed cell.

At the moment we still bring back the entire dataframe from R so there is still a delay. This would be a much bigger change and could run into errors. This change should at least half the time taken to refresh