### PR TITLE
Save summary, rather than save table in One, Two and Three-way frequency dialogs

### DIFF
--- a/instat/dlgOneWayFrequencies.Designer.vb
+++ b/instat/dlgOneWayFrequencies.Designer.vb
@@ -42,6 +42,7 @@ Partial Class dlgOneWayFrequencies
         Me.rdoDescending = New System.Windows.Forms.RadioButton()
         Me.rdoAscending = New System.Windows.Forms.RadioButton()
         Me.rdoNone = New System.Windows.Forms.RadioButton()
+        Me.ucrPnlSort = New instat.UcrPanel()
         Me.cmdOptions = New System.Windows.Forms.Button()
         Me.lblSelectedVariable = New System.Windows.Forms.Label()
         Me.rdoGraph = New System.Windows.Forms.RadioButton()
@@ -50,17 +51,16 @@ Partial Class dlgOneWayFrequencies
         Me.grpOutput = New System.Windows.Forms.GroupBox()
         Me.rdoAsTable = New System.Windows.Forms.RadioButton()
         Me.rdoAsDataFrame = New System.Windows.Forms.RadioButton()
+        Me.ucrPnlOutput = New instat.UcrPanel()
         Me.rdoStemAndLeaf = New System.Windows.Forms.RadioButton()
         Me.ucrNudWidth = New instat.ucrNud()
         Me.ucrReceiverStemAndLeaf = New instat.ucrReceiverSingle()
         Me.ucrNudScale = New instat.ucrNud()
         Me.ucrNudMinFreq = New instat.ucrNud()
-        Me.ucrPnlOutput = New instat.UcrPanel()
         Me.ucrSaveGraph = New instat.ucrSave()
         Me.ucrNudGroups = New instat.ucrNud()
         Me.ucrPnlFrequencies = New instat.UcrPanel()
         Me.ucrReceiverWeights = New instat.ucrReceiverSingle()
-        Me.ucrPnlSort = New instat.UcrPanel()
         Me.ucrBase = New instat.ucrButtons()
         Me.ucrSelectorOneWayFreq = New instat.ucrSelectorByDataFrameAddRemove()
         Me.ucrChkFlip = New instat.ucrCheck()
@@ -119,6 +119,14 @@ Partial Class dlgOneWayFrequencies
         Me.rdoNone.TabStop = True
         Me.rdoNone.Text = "None"
         Me.rdoNone.UseVisualStyleBackColor = True
+        '
+        'ucrPnlSort
+        '
+        Me.ucrPnlSort.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrPnlSort.Location = New System.Drawing.Point(3, 14)
+        Me.ucrPnlSort.Name = "ucrPnlSort"
+        Me.ucrPnlSort.Size = New System.Drawing.Size(158, 69)
+        Me.ucrPnlSort.TabIndex = 0
         '
         'cmdOptions
         '
@@ -207,9 +215,9 @@ Partial Class dlgOneWayFrequencies
         Me.rdoAsTable.ImeMode = System.Windows.Forms.ImeMode.NoControl
         Me.rdoAsTable.Location = New System.Drawing.Point(6, 20)
         Me.rdoAsTable.Name = "rdoAsTable"
-        Me.rdoAsTable.Size = New System.Drawing.Size(67, 17)
+        Me.rdoAsTable.Size = New System.Drawing.Size(113, 17)
         Me.rdoAsTable.TabIndex = 2
-        Me.rdoAsTable.Text = "As Table"
+        Me.rdoAsTable.Text = "As Summary Table"
         Me.rdoAsTable.UseVisualStyleBackColor = True
         '
         'rdoAsDataFrame
@@ -222,6 +230,14 @@ Partial Class dlgOneWayFrequencies
         Me.rdoAsDataFrame.TabIndex = 1
         Me.rdoAsDataFrame.Text = "As DataFrame"
         Me.rdoAsDataFrame.UseVisualStyleBackColor = True
+        '
+        'ucrPnlOutput
+        '
+        Me.ucrPnlOutput.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrPnlOutput.Location = New System.Drawing.Point(3, 16)
+        Me.ucrPnlOutput.Name = "ucrPnlOutput"
+        Me.ucrPnlOutput.Size = New System.Drawing.Size(150, 53)
+        Me.ucrPnlOutput.TabIndex = 0
         '
         'rdoStemAndLeaf
         '
@@ -291,14 +307,6 @@ Partial Class dlgOneWayFrequencies
         Me.ucrNudMinFreq.TabIndex = 21
         Me.ucrNudMinFreq.Value = New Decimal(New Integer() {0, 0, 0, 0})
         '
-        'ucrPnlOutput
-        '
-        Me.ucrPnlOutput.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrPnlOutput.Location = New System.Drawing.Point(3, 16)
-        Me.ucrPnlOutput.Name = "ucrPnlOutput"
-        Me.ucrPnlOutput.Size = New System.Drawing.Size(150, 53)
-        Me.ucrPnlOutput.TabIndex = 0
-        '
         'ucrSaveGraph
         '
         Me.ucrSaveGraph.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
@@ -341,14 +349,6 @@ Partial Class dlgOneWayFrequencies
         Me.ucrReceiverWeights.strNcFilePath = ""
         Me.ucrReceiverWeights.TabIndex = 15
         Me.ucrReceiverWeights.ucrSelector = Nothing
-        '
-        'ucrPnlSort
-        '
-        Me.ucrPnlSort.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrPnlSort.Location = New System.Drawing.Point(3, 14)
-        Me.ucrPnlSort.Name = "ucrPnlSort"
-        Me.ucrPnlSort.Size = New System.Drawing.Size(158, 69)
-        Me.ucrPnlSort.TabIndex = 0
         '
         'ucrBase
         '

--- a/instat/dlgOneWayFrequencies.vb
+++ b/instat/dlgOneWayFrequencies.vb
@@ -339,16 +339,16 @@ Public Class dlgOneWayFrequencies
     Private Sub ChangeOutputObject()
         If rdoTable.Checked Then
             If rdoAsTable.Checked Then
-                ucrSaveGraph.SetSaveType(strRObjectType:=RObjectTypeLabel.Table, strRObjectFormat:=RObjectFormat.Text)
-                ucrSaveGraph.SetCheckBoxText("Save Table")
-                ucrSaveGraph.SetPrefix("freq_table")
+                ucrSaveGraph.SetSaveType(strRObjectType:=RObjectTypeLabel.Summary, strRObjectFormat:=RObjectFormat.Text)
+                ucrSaveGraph.SetCheckBoxText("Save Summary")
+                ucrSaveGraph.SetPrefix("freq_summary")
                 ucrSaveGraph.SetIsComboBox()
-                ucrSaveGraph.SetAssignToIfUncheckedValue("last_table")
-                clsSjMiscFrq.SetAssignToOutputObject(strRObjectToAssignTo:="last_table",
-                                                      strRObjectTypeLabelToAssignTo:=RObjectTypeLabel.Table,
+                ucrSaveGraph.SetAssignToIfUncheckedValue("last_summary")
+                clsSjMiscFrq.SetAssignToOutputObject(strRObjectToAssignTo:="last_summary",
+                                                      strRObjectTypeLabelToAssignTo:=RObjectTypeLabel.Summary,
                                                       strRObjectFormatToAssignTo:=RObjectFormat.Text,
                                                       strRDataFrameNameToAddObjectTo:=ucrSelectorOneWayFreq.strCurrentDataFrame,
-                                                      strObjectName:="last_table")
+                                                      strObjectName:="last_summary")
             Else
                 clsSjMiscFrq.RemoveAssignTo()
 

--- a/instat/dlgThreeVariableFrequencies.vb
+++ b/instat/dlgThreeVariableFrequencies.vb
@@ -172,11 +172,11 @@ Public Class dlgThreeVariableFrequencies
         clsTableBaseOperator.AddParameter("select", clsRFunctionParameter:=clsSelectFunction, iPosition:=2)
         clsTableBaseOperator.AddParameter("arrange", clsRFunctionParameter:=clsArrangeFunction, iPosition:=3)
         clsTableBaseOperator.AddParameter("sjtab", clsRFunctionParameter:=clsSjTabFunction, iPosition:=4)
-        clsTableBaseOperator.SetAssignToOutputObject(strRObjectToAssignTo:="last_table",
-                                                     strRObjectTypeLabelToAssignTo:=RObjectTypeLabel.Table,
+        clsTableBaseOperator.SetAssignToOutputObject(strRObjectToAssignTo:="last_summary",
+                                                     strRObjectTypeLabelToAssignTo:=RObjectTypeLabel.Summary,
                                                      strRObjectFormatToAssignTo:=RObjectFormat.Html,
                                                      strRDataFrameNameToAddObjectTo:=ucrSelectorThreeVariableFrequencies.strCurrentDataFrame,
-                                                     strObjectName:="last_table")
+                                                     strObjectName:="last_summary")
 
         clsGraphBaseOperator.SetOperation("%>%")
         'iPosition should follow in the folowing order for this operator
@@ -290,8 +290,8 @@ Public Class dlgThreeVariableFrequencies
         If rdoTable.Checked OrElse rdoBoth.Checked Then
             ucrBase.clsRsyntax.SetBaseROperator(clsTableBaseOperator)
             ucrSaveGraph.SetSaveType(RObjectTypeLabel.Table, strRObjectFormat:=RObjectFormat.Html)
-            ucrSaveGraph.SetAssignToIfUncheckedValue("last_table")
-            ucrSaveGraph.SetCheckBoxText("Save Table")
+            ucrSaveGraph.SetAssignToIfUncheckedValue("last_summary")
+            ucrSaveGraph.SetCheckBoxText("Save Summary")
         ElseIf rdoGraph.Checked Then
             ucrBase.clsRsyntax.SetBaseRFunction(clsGridArrangeFunction)
             ucrSaveGraph.SetSaveType(RObjectTypeLabel.Graph, strRObjectFormat:=RObjectFormat.Image)

--- a/instat/dlgTwoWayFrequencies.vb
+++ b/instat/dlgTwoWayFrequencies.vb
@@ -159,7 +159,7 @@ Public Class dlgTwoWayFrequencies
         ucrReceiverRowFactor.SetMeAsReceiver()
         ucrSaveGraph.Reset()
 
-        'Defining Table functions and default functions
+        'Defining Summary Table functions and default functions
         clsSjTab.SetPackageName("sjPlot")
         clsSjTab.SetRCommand("sjtab")
         clsSjTab.AddParameter("show.obs", "TRUE")
@@ -168,11 +168,11 @@ Public Class dlgTwoWayFrequencies
         clsSjTab.AddParameter("fun", Chr(34) & "xtab" & Chr(34))
         clsSjTab.AddParameter("title", Chr(34) & "" & Chr(34))
         clsSjTab.AddParameter("string.total", Chr(34) & "Total" & Chr(34))
-        clsSjTab.SetAssignToOutputObject(strRObjectToAssignTo:="last_table",
-                                               strRObjectTypeLabelToAssignTo:=RObjectTypeLabel.Table,
+        clsSjTab.SetAssignToOutputObject(strRObjectToAssignTo:="last_summary",
+                                               strRObjectTypeLabelToAssignTo:=RObjectTypeLabel.Summary,
                                                strRObjectFormatToAssignTo:=RObjectFormat.Html,
                                                strRDataFrameNameToAddObjectTo:=ucrSelectorTwoWayFrequencies.strCurrentDataFrame,
-                                               strObjectName:="last_table")
+                                               strObjectName:="last_summary")
 
         'Defining Plot functions and default functions
         clsSjPlot.SetPackageName("sjPlot")
@@ -377,9 +377,9 @@ Public Class dlgTwoWayFrequencies
     Private Sub SetBaseFunction()
         If rdoTable.Checked OrElse rdoBoth.Checked Then
             ucrBase.clsRsyntax.SetBaseRFunction(clsSjTab)
-            ucrSaveGraph.SetSaveType(RObjectTypeLabel.Table, strRObjectFormat:=RObjectFormat.Html)
-            ucrSaveGraph.SetAssignToIfUncheckedValue("last_table")
-            ucrSaveGraph.SetCheckBoxText("Save Table")
+            ucrSaveGraph.SetSaveType(RObjectTypeLabel.Summary, strRObjectFormat:=RObjectFormat.Html)
+            ucrSaveGraph.SetAssignToIfUncheckedValue("last_summary")
+            ucrSaveGraph.SetCheckBoxText("Save Summary")
         ElseIf rdoGraph.Checked Then
             ucrBase.clsRsyntax.SetBaseRFunction(clsSjPlot)
             ucrSaveGraph.SetSaveType(RObjectTypeLabel.Graph, strRObjectFormat:=RObjectFormat.Image)


### PR DESCRIPTION
Fixes part(a) of #8163 

I have changed the saved objects from table to summary.
This is ready.