### PR TITLE
Ensured buttons/options to display Script window show a tick when Script window is open

### DIFF
--- a/instat/ucrButtons.vb
+++ b/instat/ucrButtons.vb
@@ -55,6 +55,7 @@ Public Class ucrButtons
     '"To Script", "To Script and Close" and "To Script and Keep" Click event 
     Private Sub ToScript_Click(sender As Object, e As EventArgs) Handles cmdPaste.Click, toolStripMenuItemToScriptClose.Click, toolStripMenuItemToScriptKeep.Click
         OnScriptButtonsClick(sender, e, False, Not sender Is toolStripMenuItemToScriptKeep)
+        frmMain.mnuScriptWindow.Checked = True
     End Sub
 
     Private Sub txtComment_TextChanged(sender As Object, e As EventArgs) Handles txtComment.TextChanged


### PR DESCRIPTION
fixes #8153 fixes #7932

This fixes the issues with If a user clicks the To Script button on the dialogue and the toolbar icon doesn't get its tick - though the View > Script Window is ticked.

@lloyddewit , @N-thony  this PR is ready for review. 