### PR TITLE
Improved Rhelp for Model Menu Dialogs

### DIFF
--- a/instat/dlgEnter.Designer.vb
+++ b/instat/dlgEnter.Designer.vb
@@ -81,8 +81,12 @@ Partial Class dlgEnter
         Me.ucrDataFrameEnter = New instat.ucrDataFrame()
         Me.ucrReceiverForEnterCalculation = New instat.ucrReceiverExpression()
         Me.ucrBase = New instat.ucrButtons()
+        Me.cmdRHelp = New instat.ucrSplitButton()
+        Me.ContextMenuStripBase = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.ToolStripMenuBase = New System.Windows.Forms.ToolStripMenuItem()
         Me.grpEnterKeyboard2.SuspendLayout()
         Me.grpBasic.SuspendLayout()
+        Me.ContextMenuStripBase.SuspendLayout()
         Me.SuspendLayout()
         '
         'chkShowEnterArguments
@@ -573,8 +577,32 @@ Partial Class dlgEnter
         Me.ucrBase.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.ucrBase.Location = New System.Drawing.Point(11, 278)
         Me.ucrBase.Name = "ucrBase"
-        Me.ucrBase.Size = New System.Drawing.Size(405, 52)
+        Me.ucrBase.Size = New System.Drawing.Size(408, 52)
         Me.ucrBase.TabIndex = 0
+        '
+        'cmdRHelp
+        '
+        Me.cmdRHelp.AutoSize = True
+        Me.cmdRHelp.ContextMenuStrip = Me.ContextMenuStripBase
+        Me.cmdRHelp.Location = New System.Drawing.Point(459, 187)
+        Me.cmdRHelp.Name = "cmdRHelp"
+        Me.cmdRHelp.Size = New System.Drawing.Size(68, 23)
+        Me.cmdRHelp.SplitMenuStrip = Me.ContextMenuStripBase
+        Me.cmdRHelp.TabIndex = 213
+        Me.cmdRHelp.Text = "R Help"
+        Me.cmdRHelp.UseVisualStyleBackColor = True
+        '
+        'ContextMenuStripBase
+        '
+        Me.ContextMenuStripBase.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuBase})
+        Me.ContextMenuStripBase.Name = "ContextMenuStrip1"
+        Me.ContextMenuStripBase.Size = New System.Drawing.Size(99, 26)
+        '
+        'ToolStripMenuBase
+        '
+        Me.ToolStripMenuBase.Name = "ToolStripMenuBase"
+        Me.ToolStripMenuBase.Size = New System.Drawing.Size(98, 22)
+        Me.ToolStripMenuBase.Text = "base"
         '
         'dlgEnter
         '
@@ -582,6 +610,7 @@ Partial Class dlgEnter
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
         Me.AutoSize = True
         Me.ClientSize = New System.Drawing.Size(538, 336)
+        Me.Controls.Add(Me.cmdRHelp)
         Me.Controls.Add(Me.ucrSaveEnterResultInto)
         Me.Controls.Add(Me.grpBasic)
         Me.Controls.Add(Me.btnExample)
@@ -600,6 +629,7 @@ Partial Class dlgEnter
         Me.Text = "Enter"
         Me.grpEnterKeyboard2.ResumeLayout(False)
         Me.grpBasic.ResumeLayout(False)
+        Me.ContextMenuStripBase.ResumeLayout(False)
         Me.ResumeLayout(False)
         Me.PerformLayout()
 
@@ -647,4 +677,7 @@ Partial Class dlgEnter
     Friend WithEvents cmdText As Button
     Friend WithEvents ucrSaveEnterResultInto As ucrSave
     Friend WithEvents ttEnter As ToolTip
+    Friend WithEvents cmdRHelp As ucrSplitButton
+    Friend WithEvents ContextMenuStripBase As ContextMenuStrip
+    Friend WithEvents ToolStripMenuBase As ToolStripMenuItem
 End Class

--- a/instat/dlgEnter.resx
+++ b/instat/dlgEnter.resx
@@ -121,6 +121,9 @@
     <value>17, 5</value>
   </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>25</value>
+    <value>124</value>
+  </metadata>
+  <metadata name="ContextMenuStripBase.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>519, 24</value>
   </metadata>
 </root>

--- a/instat/dlgEnter.vb
+++ b/instat/dlgEnter.vb
@@ -383,7 +383,7 @@ Public Class dlgEnter
         clsHelp.SetPackageName("utils")
         clsHelp.SetRCommand("help")
         clsHelp.AddParameter("package", Chr(34) & strPackageName & Chr(34))
-        If strPackageName <> "" Then
+        If Not String.IsNullOrEmpty(strPackageName) Then
             frmMaximiseOutput.Show(strFileName:=clsFileUrlUtilities.GetHelpFileURL(strPackageName:=strPackageName), bReplace:=False)
         End If
     End Sub

--- a/instat/dlgEnter.vb
+++ b/instat/dlgEnter.vb
@@ -23,6 +23,7 @@ Public Class dlgEnter
     Dim clsLength As New RFunction
     Public bFirstLoad As Boolean = True
     Public strOutput As String
+    Private strPackageName As String
     Public clsCommands As New RFunction
 
     Private Sub dlgEnter_Load(sender As Object, e As EventArgs) Handles MyBase.Load
@@ -374,5 +375,16 @@ Public Class dlgEnter
 
     Private Sub cmdRunif_Click(sender As Object, e As EventArgs)
         ucrReceiverForEnterCalculation.AddToReceiverAtCursorPosition("runif( )", 2)
+    End Sub
+
+    Private Sub cmdRHelp_Click(sender As Object, e As EventArgs) Handles cmdRHelp.Click, ToolStripMenuBase.Click
+        Dim clsHelp As New RFunction
+        strPackageName = "base"
+        clsHelp.SetPackageName("utils")
+        clsHelp.SetRCommand("help")
+        clsHelp.AddParameter("package", Chr(34) & strPackageName & Chr(34))
+        If strPackageName <> "" Then
+            frmMaximiseOutput.Show(strFileName:=clsFileUrlUtilities.GetHelpFileURL(strPackageName:=strPackageName), bReplace:=False)
+        End If
     End Sub
 End Class

--- a/instat/dlgEnter.vb
+++ b/instat/dlgEnter.vb
@@ -378,11 +378,7 @@ Public Class dlgEnter
     End Sub
 
     Private Sub cmdRHelp_Click(sender As Object, e As EventArgs) Handles cmdRHelp.Click, ToolStripMenuBase.Click
-        Dim clsHelp As New RFunction
         strPackageName = "base"
-        clsHelp.SetPackageName("utils")
-        clsHelp.SetRCommand("help")
-        clsHelp.AddParameter("package", Chr(34) & strPackageName & Chr(34))
         If Not String.IsNullOrEmpty(strPackageName) Then
             frmMaximiseOutput.Show(strFileName:=clsFileUrlUtilities.GetHelpFileURL(strPackageName:=strPackageName), bReplace:=False)
         End If

--- a/instat/dlgHypothesisTestsCalculator.Designer.vb
+++ b/instat/dlgHypothesisTestsCalculator.Designer.vb
@@ -89,7 +89,6 @@ Partial Class dlgHypothesisTestsCalculator
         Me.cmdLSD = New System.Windows.Forms.Button()
         Me.cmdDuncan = New System.Windows.Forms.Button()
         Me.cmdBIB = New System.Windows.Forms.Button()
-        Me.cmdHelp = New System.Windows.Forms.Button()
         Me.grpCoin = New System.Windows.Forms.GroupBox()
         Me.grpScale = New System.Windows.Forms.GroupBox()
         Me.cmdConover = New System.Windows.Forms.Button()
@@ -150,6 +149,21 @@ Partial Class dlgHypothesisTestsCalculator
         Me.ucrSelectorColumn = New instat.ucrSelectorByDataFrameAddRemove()
         Me.ucrChkIncludeArguments = New instat.ucrCheck()
         Me.ucrReceiverForTestColumn = New instat.ucrReceiverExpression()
+        Me.cmdRHelpStats = New instat.ucrSplitButton()
+        Me.ContextMenuStripStats = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.ToolStripMenuStats = New System.Windows.Forms.ToolStripMenuItem()
+        Me.cmdRHelpCoin = New instat.ucrSplitButton()
+        Me.ContextMenuStripCoin = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.ToolStripMenuCoin = New System.Windows.Forms.ToolStripMenuItem()
+        Me.cmdRHelpAgricolae = New instat.ucrSplitButton()
+        Me.ContextMenuStripAgricolae = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.ToolStripMenuAgricolae = New System.Windows.Forms.ToolStripMenuItem()
+        Me.cmdRHelpTrend = New instat.ucrSplitButton()
+        Me.ContextMenuStripTrend = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.ToolStripMenuTrend = New System.Windows.Forms.ToolStripMenuItem()
+        Me.cmdRHelpVerification = New instat.ucrSplitButton()
+        Me.ContextMenuStripVerification = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.ToolStripMenuVerification = New System.Windows.Forms.ToolStripMenuItem()
         Me.grpMainKeyboard.SuspendLayout()
         Me.grpStats1.SuspendLayout()
         Me.grpStats2.SuspendLayout()
@@ -162,15 +176,21 @@ Partial Class dlgHypothesisTestsCalculator
         Me.grpCorrelation.SuspendLayout()
         Me.grpLocation.SuspendLayout()
         Me.grpTrend.SuspendLayout()
+        Me.ContextMenuStripStats.SuspendLayout()
+        Me.ContextMenuStripCoin.SuspendLayout()
+        Me.ContextMenuStripAgricolae.SuspendLayout()
+        Me.ContextMenuStripTrend.SuspendLayout()
+        Me.ContextMenuStripVerification.SuspendLayout()
         Me.SuspendLayout()
         '
         'lblTest
         '
         Me.lblTest.AutoSize = True
         Me.lblTest.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblTest.Location = New System.Drawing.Point(14, 44)
+        Me.lblTest.Location = New System.Drawing.Point(9, 29)
+        Me.lblTest.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
         Me.lblTest.Name = "lblTest"
-        Me.lblTest.Size = New System.Drawing.Size(44, 20)
+        Me.lblTest.Size = New System.Drawing.Size(31, 13)
         Me.lblTest.TabIndex = 0
         Me.lblTest.Tag = "Test"
         Me.lblTest.Text = "Test:"
@@ -186,21 +206,21 @@ Partial Class dlgHypothesisTestsCalculator
         Me.grpMainKeyboard.Controls.Add(Me.cmdAlt)
         Me.grpMainKeyboard.Controls.Add(Me.cmdSquiggle)
         Me.grpMainKeyboard.Controls.Add(Me.cmdSquareBrackets)
-        Me.grpMainKeyboard.Location = New System.Drawing.Point(612, 432)
-        Me.grpMainKeyboard.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.grpMainKeyboard.Location = New System.Drawing.Point(408, 288)
+        Me.grpMainKeyboard.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.grpMainKeyboard.Name = "grpMainKeyboard"
-        Me.grpMainKeyboard.Padding = New System.Windows.Forms.Padding(3, 4, 3, 4)
-        Me.grpMainKeyboard.Size = New System.Drawing.Size(282, 150)
+        Me.grpMainKeyboard.Padding = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.grpMainKeyboard.Size = New System.Drawing.Size(188, 100)
         Me.grpMainKeyboard.TabIndex = 12
         Me.grpMainKeyboard.TabStop = False
         '
         'cmdZero
         '
         Me.cmdZero.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdZero.Location = New System.Drawing.Point(210, 99)
-        Me.cmdZero.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdZero.Location = New System.Drawing.Point(140, 66)
+        Me.cmdZero.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdZero.Name = "cmdZero"
-        Me.cmdZero.Size = New System.Drawing.Size(68, 45)
+        Me.cmdZero.Size = New System.Drawing.Size(45, 30)
         Me.cmdZero.TabIndex = 153
         Me.cmdZero.Text = "I()"
         Me.cmdZero.UseVisualStyleBackColor = True
@@ -208,10 +228,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdPlus
         '
         Me.cmdPlus.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdPlus.Location = New System.Drawing.Point(210, 12)
-        Me.cmdPlus.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdPlus.Location = New System.Drawing.Point(140, 8)
+        Me.cmdPlus.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdPlus.Name = "cmdPlus"
-        Me.cmdPlus.Size = New System.Drawing.Size(68, 45)
+        Me.cmdPlus.Size = New System.Drawing.Size(45, 30)
         Me.cmdPlus.TabIndex = 151
         Me.cmdPlus.Text = "+"
         Me.cmdPlus.UseVisualStyleBackColor = True
@@ -219,10 +239,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdComma
         '
         Me.cmdComma.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdComma.Location = New System.Drawing.Point(106, 12)
-        Me.cmdComma.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdComma.Location = New System.Drawing.Point(71, 8)
+        Me.cmdComma.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdComma.Name = "cmdComma"
-        Me.cmdComma.Size = New System.Drawing.Size(105, 45)
+        Me.cmdComma.Size = New System.Drawing.Size(70, 30)
         Me.cmdComma.TabIndex = 152
         Me.cmdComma.Tag = ""
         Me.cmdComma.Text = ","
@@ -231,10 +251,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdDelete
         '
         Me.cmdDelete.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdDelete.Location = New System.Drawing.Point(210, 56)
-        Me.cmdDelete.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdDelete.Location = New System.Drawing.Point(140, 37)
+        Me.cmdDelete.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdDelete.Name = "cmdDelete"
-        Me.cmdDelete.Size = New System.Drawing.Size(68, 45)
+        Me.cmdDelete.Size = New System.Drawing.Size(45, 30)
         Me.cmdDelete.TabIndex = 149
         Me.cmdDelete.Text = "Del"
         Me.cmdDelete.UseVisualStyleBackColor = True
@@ -243,10 +263,10 @@ Partial Class dlgHypothesisTestsCalculator
         '
         Me.cmdConf.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!)
         Me.cmdConf.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdConf.Location = New System.Drawing.Point(3, 99)
-        Me.cmdConf.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdConf.Location = New System.Drawing.Point(2, 66)
+        Me.cmdConf.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdConf.Name = "cmdConf"
-        Me.cmdConf.Size = New System.Drawing.Size(105, 45)
+        Me.cmdConf.Size = New System.Drawing.Size(70, 30)
         Me.cmdConf.TabIndex = 147
         Me.cmdConf.Tag = "Del"
         Me.cmdConf.Text = "Conf=0.95"
@@ -255,10 +275,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdBrackets
         '
         Me.cmdBrackets.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdBrackets.Location = New System.Drawing.Point(106, 56)
-        Me.cmdBrackets.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdBrackets.Location = New System.Drawing.Point(71, 37)
+        Me.cmdBrackets.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdBrackets.Name = "cmdBrackets"
-        Me.cmdBrackets.Size = New System.Drawing.Size(105, 45)
+        Me.cmdBrackets.Size = New System.Drawing.Size(70, 30)
         Me.cmdBrackets.TabIndex = 145
         Me.cmdBrackets.Text = "( )"
         Me.cmdBrackets.UseVisualStyleBackColor = True
@@ -267,10 +287,10 @@ Partial Class dlgHypothesisTestsCalculator
         '
         Me.cmdAlt.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!)
         Me.cmdAlt.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdAlt.Location = New System.Drawing.Point(106, 99)
-        Me.cmdAlt.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdAlt.Location = New System.Drawing.Point(71, 66)
+        Me.cmdAlt.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdAlt.Name = "cmdAlt"
-        Me.cmdAlt.Size = New System.Drawing.Size(105, 45)
+        Me.cmdAlt.Size = New System.Drawing.Size(70, 30)
         Me.cmdAlt.TabIndex = 143
         Me.cmdAlt.Text = "Alt=""two"""
         Me.cmdAlt.UseVisualStyleBackColor = True
@@ -278,10 +298,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdSquiggle
         '
         Me.cmdSquiggle.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdSquiggle.Location = New System.Drawing.Point(3, 12)
-        Me.cmdSquiggle.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdSquiggle.Location = New System.Drawing.Point(2, 8)
+        Me.cmdSquiggle.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdSquiggle.Name = "cmdSquiggle"
-        Me.cmdSquiggle.Size = New System.Drawing.Size(105, 45)
+        Me.cmdSquiggle.Size = New System.Drawing.Size(70, 30)
         Me.cmdSquiggle.TabIndex = 149
         Me.cmdSquiggle.Text = "~"
         Me.cmdSquiggle.UseVisualStyleBackColor = True
@@ -289,10 +309,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdSquareBrackets
         '
         Me.cmdSquareBrackets.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdSquareBrackets.Location = New System.Drawing.Point(3, 56)
-        Me.cmdSquareBrackets.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdSquareBrackets.Location = New System.Drawing.Point(2, 37)
+        Me.cmdSquareBrackets.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdSquareBrackets.Name = "cmdSquareBrackets"
-        Me.cmdSquareBrackets.Size = New System.Drawing.Size(105, 45)
+        Me.cmdSquareBrackets.Size = New System.Drawing.Size(70, 30)
         Me.cmdSquareBrackets.TabIndex = 142
         Me.cmdSquareBrackets.Text = "[ ]"
         Me.cmdSquareBrackets.UseVisualStyleBackColor = True
@@ -301,10 +321,10 @@ Partial Class dlgHypothesisTestsCalculator
         '
         Me.cmdClear.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!)
         Me.cmdClear.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdClear.Location = New System.Drawing.Point(660, 392)
-        Me.cmdClear.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdClear.Location = New System.Drawing.Point(440, 261)
+        Me.cmdClear.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdClear.Name = "cmdClear"
-        Me.cmdClear.Size = New System.Drawing.Size(112, 34)
+        Me.cmdClear.Size = New System.Drawing.Size(75, 23)
         Me.cmdClear.TabIndex = 10
         Me.cmdClear.Text = "Clear"
         Me.cmdClear.UseVisualStyleBackColor = True
@@ -327,11 +347,11 @@ Partial Class dlgHypothesisTestsCalculator
         Me.grpStats1.Controls.Add(Me.cmdBinom)
         Me.grpStats1.Controls.Add(Me.cmdBartlett)
         Me.grpStats1.Controls.Add(Me.cmdfisher)
-        Me.grpStats1.Location = New System.Drawing.Point(362, 118)
-        Me.grpStats1.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.grpStats1.Location = New System.Drawing.Point(241, 79)
+        Me.grpStats1.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.grpStats1.Name = "grpStats1"
-        Me.grpStats1.Padding = New System.Windows.Forms.Padding(3, 4, 3, 4)
-        Me.grpStats1.Size = New System.Drawing.Size(532, 212)
+        Me.grpStats1.Padding = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.grpStats1.Size = New System.Drawing.Size(355, 141)
         Me.grpStats1.TabIndex = 6
         Me.grpStats1.TabStop = False
         Me.grpStats1.Text = "Stats1"
@@ -339,10 +359,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdT
         '
         Me.cmdT.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdT.Location = New System.Drawing.Point(135, 160)
-        Me.cmdT.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdT.Location = New System.Drawing.Point(90, 107)
+        Me.cmdT.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdT.Name = "cmdT"
-        Me.cmdT.Size = New System.Drawing.Size(129, 45)
+        Me.cmdT.Size = New System.Drawing.Size(86, 30)
         Me.cmdT.TabIndex = 167
         Me.cmdT.Text = "t"
         Me.cmdT.UseVisualStyleBackColor = True
@@ -350,10 +370,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdProp
         '
         Me.cmdProp.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdProp.Location = New System.Drawing.Point(393, 114)
-        Me.cmdProp.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdProp.Location = New System.Drawing.Point(262, 76)
+        Me.cmdProp.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdProp.Name = "cmdProp"
-        Me.cmdProp.Size = New System.Drawing.Size(129, 45)
+        Me.cmdProp.Size = New System.Drawing.Size(86, 30)
         Me.cmdProp.TabIndex = 165
         Me.cmdProp.Text = "prop"
         Me.cmdProp.UseVisualStyleBackColor = True
@@ -361,10 +381,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdPoisson
         '
         Me.cmdPoisson.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdPoisson.Location = New System.Drawing.Point(264, 114)
-        Me.cmdPoisson.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdPoisson.Location = New System.Drawing.Point(176, 76)
+        Me.cmdPoisson.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdPoisson.Name = "cmdPoisson"
-        Me.cmdPoisson.Size = New System.Drawing.Size(129, 45)
+        Me.cmdPoisson.Size = New System.Drawing.Size(86, 30)
         Me.cmdPoisson.TabIndex = 164
         Me.cmdPoisson.Text = "poisson"
         Me.cmdPoisson.UseVisualStyleBackColor = True
@@ -372,10 +392,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdVar
         '
         Me.cmdVar.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdVar.Location = New System.Drawing.Point(264, 160)
-        Me.cmdVar.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdVar.Location = New System.Drawing.Point(176, 107)
+        Me.cmdVar.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdVar.Name = "cmdVar"
-        Me.cmdVar.Size = New System.Drawing.Size(129, 45)
+        Me.cmdVar.Size = New System.Drawing.Size(86, 30)
         Me.cmdVar.TabIndex = 162
         Me.cmdVar.Text = "var"
         Me.cmdVar.UseVisualStyleBackColor = True
@@ -383,10 +403,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdShapiro
         '
         Me.cmdShapiro.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdShapiro.Location = New System.Drawing.Point(6, 160)
-        Me.cmdShapiro.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdShapiro.Location = New System.Drawing.Point(4, 107)
+        Me.cmdShapiro.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdShapiro.Name = "cmdShapiro"
-        Me.cmdShapiro.Size = New System.Drawing.Size(129, 45)
+        Me.cmdShapiro.Size = New System.Drawing.Size(86, 30)
         Me.cmdShapiro.TabIndex = 161
         Me.cmdShapiro.Text = "shapiro"
         Me.cmdShapiro.UseVisualStyleBackColor = True
@@ -395,10 +415,10 @@ Partial Class dlgHypothesisTestsCalculator
         '
         Me.cmdWilcox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!)
         Me.cmdWilcox.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdWilcox.Location = New System.Drawing.Point(393, 160)
-        Me.cmdWilcox.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdWilcox.Location = New System.Drawing.Point(262, 107)
+        Me.cmdWilcox.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdWilcox.Name = "cmdWilcox"
-        Me.cmdWilcox.Size = New System.Drawing.Size(129, 45)
+        Me.cmdWilcox.Size = New System.Drawing.Size(86, 30)
         Me.cmdWilcox.TabIndex = 163
         Me.cmdWilcox.Tag = "Del"
         Me.cmdWilcox.Text = "wilcox"
@@ -407,10 +427,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdKruskal
         '
         Me.cmdKruskal.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdKruskal.Location = New System.Drawing.Point(393, 68)
-        Me.cmdKruskal.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdKruskal.Location = New System.Drawing.Point(262, 45)
+        Me.cmdKruskal.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdKruskal.Name = "cmdKruskal"
-        Me.cmdKruskal.Size = New System.Drawing.Size(129, 45)
+        Me.cmdKruskal.Size = New System.Drawing.Size(86, 30)
         Me.cmdKruskal.TabIndex = 155
         Me.cmdKruskal.Text = " kruskal"
         Me.cmdKruskal.UseVisualStyleBackColor = True
@@ -418,10 +438,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdChisq
         '
         Me.cmdChisq.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdChisq.Location = New System.Drawing.Point(393, 21)
-        Me.cmdChisq.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdChisq.Location = New System.Drawing.Point(262, 14)
+        Me.cmdChisq.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdChisq.Name = "cmdChisq"
-        Me.cmdChisq.Size = New System.Drawing.Size(129, 45)
+        Me.cmdChisq.Size = New System.Drawing.Size(86, 30)
         Me.cmdChisq.TabIndex = 154
         Me.cmdChisq.Text = "chisq"
         Me.cmdChisq.UseVisualStyleBackColor = True
@@ -429,10 +449,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdbox
         '
         Me.cmdbox.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdbox.Location = New System.Drawing.Point(264, 21)
-        Me.cmdbox.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdbox.Location = New System.Drawing.Point(176, 14)
+        Me.cmdbox.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdbox.Name = "cmdbox"
-        Me.cmdbox.Size = New System.Drawing.Size(129, 45)
+        Me.cmdbox.Size = New System.Drawing.Size(86, 30)
         Me.cmdbox.TabIndex = 153
         Me.cmdbox.Text = " box"
         Me.cmdbox.UseVisualStyleBackColor = True
@@ -440,10 +460,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdKs
         '
         Me.cmdKs.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdKs.Location = New System.Drawing.Point(6, 114)
-        Me.cmdKs.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdKs.Location = New System.Drawing.Point(4, 76)
+        Me.cmdKs.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdKs.Name = "cmdKs"
-        Me.cmdKs.Size = New System.Drawing.Size(129, 45)
+        Me.cmdKs.Size = New System.Drawing.Size(86, 30)
         Me.cmdKs.TabIndex = 151
         Me.cmdKs.Text = "ks"
         Me.cmdKs.UseVisualStyleBackColor = True
@@ -451,10 +471,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdFriedman
         '
         Me.cmdFriedman.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdFriedman.Location = New System.Drawing.Point(264, 68)
-        Me.cmdFriedman.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdFriedman.Location = New System.Drawing.Point(176, 45)
+        Me.cmdFriedman.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdFriedman.Name = "cmdFriedman"
-        Me.cmdFriedman.Size = New System.Drawing.Size(129, 45)
+        Me.cmdFriedman.Size = New System.Drawing.Size(86, 30)
         Me.cmdFriedman.TabIndex = 150
         Me.cmdFriedman.Text = "friedman"
         Me.cmdFriedman.UseVisualStyleBackColor = True
@@ -462,10 +482,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdOneway
         '
         Me.cmdOneway.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdOneway.Location = New System.Drawing.Point(135, 114)
-        Me.cmdOneway.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdOneway.Location = New System.Drawing.Point(90, 76)
+        Me.cmdOneway.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdOneway.Name = "cmdOneway"
-        Me.cmdOneway.Size = New System.Drawing.Size(129, 45)
+        Me.cmdOneway.Size = New System.Drawing.Size(86, 30)
         Me.cmdOneway.TabIndex = 148
         Me.cmdOneway.Text = "oneway"
         Me.cmdOneway.UseVisualStyleBackColor = True
@@ -473,10 +493,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdCor
         '
         Me.cmdCor.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdCor.Location = New System.Drawing.Point(6, 68)
-        Me.cmdCor.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdCor.Location = New System.Drawing.Point(4, 45)
+        Me.cmdCor.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdCor.Name = "cmdCor"
-        Me.cmdCor.Size = New System.Drawing.Size(129, 45)
+        Me.cmdCor.Size = New System.Drawing.Size(86, 30)
         Me.cmdCor.TabIndex = 158
         Me.cmdCor.Text = "cor"
         Me.cmdCor.UseVisualStyleBackColor = True
@@ -484,10 +504,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdBinom
         '
         Me.cmdBinom.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdBinom.Location = New System.Drawing.Point(135, 21)
-        Me.cmdBinom.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdBinom.Location = New System.Drawing.Point(90, 14)
+        Me.cmdBinom.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdBinom.Name = "cmdBinom"
-        Me.cmdBinom.Size = New System.Drawing.Size(129, 45)
+        Me.cmdBinom.Size = New System.Drawing.Size(86, 30)
         Me.cmdBinom.TabIndex = 126
         Me.cmdBinom.Text = " binom"
         Me.cmdBinom.UseVisualStyleBackColor = True
@@ -495,10 +515,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdBartlett
         '
         Me.cmdBartlett.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdBartlett.Location = New System.Drawing.Point(6, 21)
-        Me.cmdBartlett.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdBartlett.Location = New System.Drawing.Point(4, 14)
+        Me.cmdBartlett.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdBartlett.Name = "cmdBartlett"
-        Me.cmdBartlett.Size = New System.Drawing.Size(129, 45)
+        Me.cmdBartlett.Size = New System.Drawing.Size(86, 30)
         Me.cmdBartlett.TabIndex = 124
         Me.cmdBartlett.Text = "bartlett"
         Me.cmdBartlett.UseVisualStyleBackColor = True
@@ -506,10 +526,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdfisher
         '
         Me.cmdfisher.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdfisher.Location = New System.Drawing.Point(135, 68)
-        Me.cmdfisher.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdfisher.Location = New System.Drawing.Point(90, 45)
+        Me.cmdfisher.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdfisher.Name = "cmdfisher"
-        Me.cmdfisher.Size = New System.Drawing.Size(129, 45)
+        Me.cmdfisher.Size = New System.Drawing.Size(86, 30)
         Me.cmdfisher.TabIndex = 121
         Me.cmdfisher.Text = " fisher"
         Me.cmdfisher.UseVisualStyleBackColor = True
@@ -518,10 +538,10 @@ Partial Class dlgHypothesisTestsCalculator
         '
         Me.cmdClearStats2.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!)
         Me.cmdClearStats2.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdClearStats2.Location = New System.Drawing.Point(393, 160)
-        Me.cmdClearStats2.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdClearStats2.Location = New System.Drawing.Point(262, 107)
+        Me.cmdClearStats2.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdClearStats2.Name = "cmdClearStats2"
-        Me.cmdClearStats2.Size = New System.Drawing.Size(129, 45)
+        Me.cmdClearStats2.Size = New System.Drawing.Size(86, 30)
         Me.cmdClearStats2.TabIndex = 168
         Me.cmdClearStats2.Text = "Clear"
         Me.cmdClearStats2.UseVisualStyleBackColor = True
@@ -529,10 +549,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdPropTrend
         '
         Me.cmdPropTrend.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdPropTrend.Location = New System.Drawing.Point(6, 160)
-        Me.cmdPropTrend.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdPropTrend.Location = New System.Drawing.Point(4, 107)
+        Me.cmdPropTrend.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdPropTrend.Name = "cmdPropTrend"
-        Me.cmdPropTrend.Size = New System.Drawing.Size(129, 45)
+        Me.cmdPropTrend.Size = New System.Drawing.Size(86, 30)
         Me.cmdPropTrend.TabIndex = 160
         Me.cmdPropTrend.Text = "prop.trend"
         Me.cmdPropTrend.UseVisualStyleBackColor = True
@@ -540,10 +560,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdPowerProp
         '
         Me.cmdPowerProp.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdPowerProp.Location = New System.Drawing.Point(264, 114)
-        Me.cmdPowerProp.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdPowerProp.Location = New System.Drawing.Point(176, 76)
+        Me.cmdPowerProp.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdPowerProp.Name = "cmdPowerProp"
-        Me.cmdPowerProp.Size = New System.Drawing.Size(129, 45)
+        Me.cmdPowerProp.Size = New System.Drawing.Size(86, 30)
         Me.cmdPowerProp.TabIndex = 159
         Me.cmdPowerProp.Text = "power.prop"
         Me.cmdPowerProp.UseVisualStyleBackColor = True
@@ -551,10 +571,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdPowerT
         '
         Me.cmdPowerT.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdPowerT.Location = New System.Drawing.Point(393, 114)
-        Me.cmdPowerT.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdPowerT.Location = New System.Drawing.Point(262, 76)
+        Me.cmdPowerT.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdPowerT.Name = "cmdPowerT"
-        Me.cmdPowerT.Size = New System.Drawing.Size(129, 45)
+        Me.cmdPowerT.Size = New System.Drawing.Size(86, 30)
         Me.cmdPowerT.TabIndex = 157
         Me.cmdPowerT.Text = "power.t"
         Me.cmdPowerT.UseVisualStyleBackColor = True
@@ -563,10 +583,10 @@ Partial Class dlgHypothesisTestsCalculator
         '
         Me.cmdPaiwiseWilcox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!)
         Me.cmdPaiwiseWilcox.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdPaiwiseWilcox.Location = New System.Drawing.Point(393, 68)
-        Me.cmdPaiwiseWilcox.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdPaiwiseWilcox.Location = New System.Drawing.Point(262, 45)
+        Me.cmdPaiwiseWilcox.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdPaiwiseWilcox.Name = "cmdPaiwiseWilcox"
-        Me.cmdPaiwiseWilcox.Size = New System.Drawing.Size(129, 45)
+        Me.cmdPaiwiseWilcox.Size = New System.Drawing.Size(86, 30)
         Me.cmdPaiwiseWilcox.TabIndex = 156
         Me.cmdPaiwiseWilcox.Tag = "Del"
         Me.cmdPaiwiseWilcox.Text = "pairwise.wilcox"
@@ -575,10 +595,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdMood
         '
         Me.cmdMood.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdMood.Location = New System.Drawing.Point(135, 68)
-        Me.cmdMood.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdMood.Location = New System.Drawing.Point(90, 45)
+        Me.cmdMood.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdMood.Name = "cmdMood"
-        Me.cmdMood.Size = New System.Drawing.Size(129, 45)
+        Me.cmdMood.Size = New System.Drawing.Size(86, 30)
         Me.cmdMood.TabIndex = 147
         Me.cmdMood.Text = "mood"
         Me.cmdMood.UseVisualStyleBackColor = True
@@ -586,10 +606,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdPowerAnova
         '
         Me.cmdPowerAnova.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdPowerAnova.Location = New System.Drawing.Point(135, 114)
-        Me.cmdPowerAnova.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdPowerAnova.Location = New System.Drawing.Point(90, 76)
+        Me.cmdPowerAnova.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdPowerAnova.Name = "cmdPowerAnova"
-        Me.cmdPowerAnova.Size = New System.Drawing.Size(129, 45)
+        Me.cmdPowerAnova.Size = New System.Drawing.Size(86, 30)
         Me.cmdPowerAnova.TabIndex = 146
         Me.cmdPowerAnova.Text = "power.anova"
         Me.cmdPowerAnova.UseVisualStyleBackColor = True
@@ -597,10 +617,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdMcnemar
         '
         Me.cmdMcnemar.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdMcnemar.Location = New System.Drawing.Point(6, 68)
-        Me.cmdMcnemar.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdMcnemar.Location = New System.Drawing.Point(4, 45)
+        Me.cmdMcnemar.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdMcnemar.Name = "cmdMcnemar"
-        Me.cmdMcnemar.Size = New System.Drawing.Size(129, 45)
+        Me.cmdMcnemar.Size = New System.Drawing.Size(86, 30)
         Me.cmdMcnemar.TabIndex = 145
         Me.cmdMcnemar.Text = "mcnemar"
         Me.cmdMcnemar.UseVisualStyleBackColor = True
@@ -609,10 +629,10 @@ Partial Class dlgHypothesisTestsCalculator
         '
         Me.cmdPairwiseProp.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!)
         Me.cmdPairwiseProp.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdPairwiseProp.Location = New System.Drawing.Point(264, 68)
-        Me.cmdPairwiseProp.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdPairwiseProp.Location = New System.Drawing.Point(176, 45)
+        Me.cmdPairwiseProp.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdPairwiseProp.Name = "cmdPairwiseProp"
-        Me.cmdPairwiseProp.Size = New System.Drawing.Size(129, 45)
+        Me.cmdPairwiseProp.Size = New System.Drawing.Size(86, 30)
         Me.cmdPairwiseProp.TabIndex = 132
         Me.cmdPairwiseProp.Tag = "Del"
         Me.cmdPairwiseProp.Text = "pairwise.Prop"
@@ -621,10 +641,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdfligner
         '
         Me.cmdfligner.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdfligner.Location = New System.Drawing.Point(135, 21)
-        Me.cmdfligner.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdfligner.Location = New System.Drawing.Point(90, 14)
+        Me.cmdfligner.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdfligner.Name = "cmdfligner"
-        Me.cmdfligner.Size = New System.Drawing.Size(129, 45)
+        Me.cmdfligner.Size = New System.Drawing.Size(86, 30)
         Me.cmdfligner.TabIndex = 129
         Me.cmdfligner.Text = "fligner"
         Me.cmdfligner.UseVisualStyleBackColor = True
@@ -633,10 +653,10 @@ Partial Class dlgHypothesisTestsCalculator
         '
         Me.cmdPairwiset.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
         Me.cmdPairwiset.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdPairwiset.Location = New System.Drawing.Point(6, 114)
-        Me.cmdPairwiset.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdPairwiset.Location = New System.Drawing.Point(4, 76)
+        Me.cmdPairwiset.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdPairwiset.Name = "cmdPairwiset"
-        Me.cmdPairwiset.Size = New System.Drawing.Size(129, 45)
+        Me.cmdPairwiset.Size = New System.Drawing.Size(86, 30)
         Me.cmdPairwiset.TabIndex = 144
         Me.cmdPairwiset.Text = "pairwise.t"
         Me.cmdPairwiset.UseVisualStyleBackColor = True
@@ -644,10 +664,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdMauchly
         '
         Me.cmdMauchly.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdMauchly.Location = New System.Drawing.Point(393, 21)
-        Me.cmdMauchly.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdMauchly.Location = New System.Drawing.Point(262, 14)
+        Me.cmdMauchly.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdMauchly.Name = "cmdMauchly"
-        Me.cmdMauchly.Size = New System.Drawing.Size(129, 45)
+        Me.cmdMauchly.Size = New System.Drawing.Size(86, 30)
         Me.cmdMauchly.TabIndex = 117
         Me.cmdMauchly.Text = "mauchly"
         Me.cmdMauchly.UseVisualStyleBackColor = True
@@ -655,20 +675,19 @@ Partial Class dlgHypothesisTestsCalculator
         'lblRpackage
         '
         Me.lblRpackage.AutoSize = True
-        Me.lblRpackage.Location = New System.Drawing.Point(362, 82)
-        Me.lblRpackage.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
+        Me.lblRpackage.Location = New System.Drawing.Point(241, 55)
         Me.lblRpackage.Name = "lblRpackage"
-        Me.lblRpackage.Size = New System.Drawing.Size(90, 20)
+        Me.lblRpackage.Size = New System.Drawing.Size(63, 13)
         Me.lblRpackage.TabIndex = 4
         Me.lblRpackage.Text = "R package:"
         '
         'cmdAnsari
         '
         Me.cmdAnsari.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdAnsari.Location = New System.Drawing.Point(6, 21)
-        Me.cmdAnsari.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdAnsari.Location = New System.Drawing.Point(4, 14)
+        Me.cmdAnsari.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdAnsari.Name = "cmdAnsari"
-        Me.cmdAnsari.Size = New System.Drawing.Size(129, 45)
+        Me.cmdAnsari.Size = New System.Drawing.Size(86, 30)
         Me.cmdAnsari.TabIndex = 169
         Me.cmdAnsari.Text = "ansari"
         Me.cmdAnsari.UseVisualStyleBackColor = True
@@ -676,10 +695,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdMantelhaen
         '
         Me.cmdMantelhaen.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdMantelhaen.Location = New System.Drawing.Point(264, 21)
-        Me.cmdMantelhaen.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdMantelhaen.Location = New System.Drawing.Point(176, 14)
+        Me.cmdMantelhaen.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdMantelhaen.Name = "cmdMantelhaen"
-        Me.cmdMantelhaen.Size = New System.Drawing.Size(129, 45)
+        Me.cmdMantelhaen.Size = New System.Drawing.Size(86, 30)
         Me.cmdMantelhaen.TabIndex = 170
         Me.cmdMantelhaen.Text = "mantelhaen"
         Me.cmdMantelhaen.UseVisualStyleBackColor = True
@@ -687,10 +706,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdQuade
         '
         Me.cmdQuade.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdQuade.Location = New System.Drawing.Point(264, 160)
-        Me.cmdQuade.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdQuade.Location = New System.Drawing.Point(176, 107)
+        Me.cmdQuade.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdQuade.Name = "cmdQuade"
-        Me.cmdQuade.Size = New System.Drawing.Size(129, 45)
+        Me.cmdQuade.Size = New System.Drawing.Size(86, 30)
         Me.cmdQuade.TabIndex = 171
         Me.cmdQuade.Text = "quade"
         Me.cmdQuade.UseVisualStyleBackColor = True
@@ -698,10 +717,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdPP
         '
         Me.cmdPP.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdPP.Location = New System.Drawing.Point(135, 160)
-        Me.cmdPP.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdPP.Location = New System.Drawing.Point(90, 107)
+        Me.cmdPP.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdPP.Name = "cmdPP"
-        Me.cmdPP.Size = New System.Drawing.Size(129, 45)
+        Me.cmdPP.Size = New System.Drawing.Size(86, 30)
         Me.cmdPP.TabIndex = 172
         Me.cmdPP.Text = "PP"
         Me.cmdPP.UseVisualStyleBackColor = True
@@ -724,11 +743,9 @@ Partial Class dlgHypothesisTestsCalculator
         Me.grpStats2.Controls.Add(Me.cmdPaiwiseWilcox)
         Me.grpStats2.Controls.Add(Me.cmdPowerT)
         Me.grpStats2.Controls.Add(Me.cmdPowerProp)
-        Me.grpStats2.Location = New System.Drawing.Point(362, 118)
-        Me.grpStats2.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
+        Me.grpStats2.Location = New System.Drawing.Point(241, 79)
         Me.grpStats2.Name = "grpStats2"
-        Me.grpStats2.Padding = New System.Windows.Forms.Padding(4, 4, 4, 4)
-        Me.grpStats2.Size = New System.Drawing.Size(532, 212)
+        Me.grpStats2.Size = New System.Drawing.Size(355, 141)
         Me.grpStats2.TabIndex = 14
         Me.grpStats2.TabStop = False
         Me.grpStats2.Text = "Stats2"
@@ -738,36 +755,41 @@ Partial Class dlgHypothesisTestsCalculator
         Me.grpVerification.Controls.Add(Me.cmdCont)
         Me.grpVerification.Controls.Add(Me.cmdCat)
         Me.grpVerification.Controls.Add(Me.cmdBinary)
-        Me.grpVerification.Location = New System.Drawing.Point(362, 118)
+        Me.grpVerification.Location = New System.Drawing.Point(241, 79)
+        Me.grpVerification.Margin = New System.Windows.Forms.Padding(2)
         Me.grpVerification.Name = "grpVerification"
-        Me.grpVerification.Size = New System.Drawing.Size(532, 74)
+        Me.grpVerification.Padding = New System.Windows.Forms.Padding(2)
+        Me.grpVerification.Size = New System.Drawing.Size(355, 49)
         Me.grpVerification.TabIndex = 18
         Me.grpVerification.TabStop = False
         Me.grpVerification.Text = "Verification"
         '
         'cmdCont
         '
-        Me.cmdCont.Location = New System.Drawing.Point(264, 21)
+        Me.cmdCont.Location = New System.Drawing.Point(176, 14)
+        Me.cmdCont.Margin = New System.Windows.Forms.Padding(2)
         Me.cmdCont.Name = "cmdCont"
-        Me.cmdCont.Size = New System.Drawing.Size(129, 45)
+        Me.cmdCont.Size = New System.Drawing.Size(86, 30)
         Me.cmdCont.TabIndex = 21
         Me.cmdCont.Text = "cont"
         Me.cmdCont.UseVisualStyleBackColor = True
         '
         'cmdCat
         '
-        Me.cmdCat.Location = New System.Drawing.Point(135, 21)
+        Me.cmdCat.Location = New System.Drawing.Point(90, 14)
+        Me.cmdCat.Margin = New System.Windows.Forms.Padding(2)
         Me.cmdCat.Name = "cmdCat"
-        Me.cmdCat.Size = New System.Drawing.Size(129, 45)
+        Me.cmdCat.Size = New System.Drawing.Size(86, 30)
         Me.cmdCat.TabIndex = 20
         Me.cmdCat.Text = "cat"
         Me.cmdCat.UseVisualStyleBackColor = True
         '
         'cmdBinary
         '
-        Me.cmdBinary.Location = New System.Drawing.Point(6, 21)
+        Me.cmdBinary.Location = New System.Drawing.Point(4, 14)
+        Me.cmdBinary.Margin = New System.Windows.Forms.Padding(2)
         Me.cmdBinary.Name = "cmdBinary"
-        Me.cmdBinary.Size = New System.Drawing.Size(129, 45)
+        Me.cmdBinary.Size = New System.Drawing.Size(86, 30)
         Me.cmdBinary.TabIndex = 19
         Me.cmdBinary.Text = "binary"
         Me.cmdBinary.UseVisualStyleBackColor = True
@@ -788,11 +810,9 @@ Partial Class dlgHypothesisTestsCalculator
         Me.grpAgricolae.Controls.Add(Me.cmdLSD)
         Me.grpAgricolae.Controls.Add(Me.cmdDuncan)
         Me.grpAgricolae.Controls.Add(Me.cmdBIB)
-        Me.grpAgricolae.Location = New System.Drawing.Point(362, 118)
-        Me.grpAgricolae.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
+        Me.grpAgricolae.Location = New System.Drawing.Point(241, 79)
         Me.grpAgricolae.Name = "grpAgricolae"
-        Me.grpAgricolae.Padding = New System.Windows.Forms.Padding(4, 4, 4, 4)
-        Me.grpAgricolae.Size = New System.Drawing.Size(532, 212)
+        Me.grpAgricolae.Size = New System.Drawing.Size(355, 141)
         Me.grpAgricolae.TabIndex = 15
         Me.grpAgricolae.TabStop = False
         Me.grpAgricolae.Text = "Agricolae"
@@ -800,10 +820,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdPBIB
         '
         Me.cmdPBIB.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdPBIB.Location = New System.Drawing.Point(6, 114)
-        Me.cmdPBIB.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdPBIB.Location = New System.Drawing.Point(4, 76)
+        Me.cmdPBIB.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdPBIB.Name = "cmdPBIB"
-        Me.cmdPBIB.Size = New System.Drawing.Size(129, 45)
+        Me.cmdPBIB.Size = New System.Drawing.Size(86, 30)
         Me.cmdPBIB.TabIndex = 186
         Me.cmdPBIB.Text = "PBIB"
         Me.cmdPBIB.UseVisualStyleBackColor = True
@@ -811,10 +831,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdAgriKruskal
         '
         Me.cmdAgriKruskal.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdAgriKruskal.Location = New System.Drawing.Point(6, 68)
-        Me.cmdAgriKruskal.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdAgriKruskal.Location = New System.Drawing.Point(4, 45)
+        Me.cmdAgriKruskal.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdAgriKruskal.Name = "cmdAgriKruskal"
-        Me.cmdAgriKruskal.Size = New System.Drawing.Size(129, 45)
+        Me.cmdAgriKruskal.Size = New System.Drawing.Size(86, 30)
         Me.cmdAgriKruskal.TabIndex = 185
         Me.cmdAgriKruskal.Text = "kruskal"
         Me.cmdAgriKruskal.UseVisualStyleBackColor = True
@@ -822,10 +842,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdScheffe
         '
         Me.cmdScheffe.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdScheffe.Location = New System.Drawing.Point(264, 114)
-        Me.cmdScheffe.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdScheffe.Location = New System.Drawing.Point(176, 76)
+        Me.cmdScheffe.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdScheffe.Name = "cmdScheffe"
-        Me.cmdScheffe.Size = New System.Drawing.Size(129, 45)
+        Me.cmdScheffe.Size = New System.Drawing.Size(86, 30)
         Me.cmdScheffe.TabIndex = 184
         Me.cmdScheffe.Text = "scheffe"
         Me.cmdScheffe.UseVisualStyleBackColor = True
@@ -833,10 +853,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdDurbin
         '
         Me.cmdDurbin.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdDurbin.Location = New System.Drawing.Point(262, 21)
-        Me.cmdDurbin.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdDurbin.Location = New System.Drawing.Point(175, 14)
+        Me.cmdDurbin.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdDurbin.Name = "cmdDurbin"
-        Me.cmdDurbin.Size = New System.Drawing.Size(129, 45)
+        Me.cmdDurbin.Size = New System.Drawing.Size(86, 30)
         Me.cmdDurbin.TabIndex = 183
         Me.cmdDurbin.Text = "durbin"
         Me.cmdDurbin.UseVisualStyleBackColor = True
@@ -844,10 +864,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdAgriFriedman
         '
         Me.cmdAgriFriedman.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdAgriFriedman.Location = New System.Drawing.Point(392, 21)
-        Me.cmdAgriFriedman.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdAgriFriedman.Location = New System.Drawing.Point(261, 14)
+        Me.cmdAgriFriedman.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdAgriFriedman.Name = "cmdAgriFriedman"
-        Me.cmdAgriFriedman.Size = New System.Drawing.Size(129, 45)
+        Me.cmdAgriFriedman.Size = New System.Drawing.Size(86, 30)
         Me.cmdAgriFriedman.TabIndex = 182
         Me.cmdAgriFriedman.Text = "friedman"
         Me.cmdAgriFriedman.UseVisualStyleBackColor = True
@@ -855,10 +875,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdSNK
         '
         Me.cmdSNK.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdSNK.Location = New System.Drawing.Point(6, 160)
-        Me.cmdSNK.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdSNK.Location = New System.Drawing.Point(4, 107)
+        Me.cmdSNK.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdSNK.Name = "cmdSNK"
-        Me.cmdSNK.Size = New System.Drawing.Size(129, 45)
+        Me.cmdSNK.Size = New System.Drawing.Size(86, 30)
         Me.cmdSNK.TabIndex = 181
         Me.cmdSNK.Text = "SNK"
         Me.cmdSNK.UseVisualStyleBackColor = True
@@ -866,10 +886,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdWaerden
         '
         Me.cmdWaerden.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdWaerden.Location = New System.Drawing.Point(135, 160)
-        Me.cmdWaerden.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdWaerden.Location = New System.Drawing.Point(90, 107)
+        Me.cmdWaerden.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdWaerden.Name = "cmdWaerden"
-        Me.cmdWaerden.Size = New System.Drawing.Size(129, 45)
+        Me.cmdWaerden.Size = New System.Drawing.Size(86, 30)
         Me.cmdWaerden.TabIndex = 180
         Me.cmdWaerden.Text = "waerden"
         Me.cmdWaerden.UseVisualStyleBackColor = True
@@ -877,10 +897,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdAgriWaller
         '
         Me.cmdAgriWaller.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdAgriWaller.Location = New System.Drawing.Point(264, 160)
-        Me.cmdAgriWaller.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdAgriWaller.Location = New System.Drawing.Point(176, 107)
+        Me.cmdAgriWaller.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdAgriWaller.Name = "cmdAgriWaller"
-        Me.cmdAgriWaller.Size = New System.Drawing.Size(129, 45)
+        Me.cmdAgriWaller.Size = New System.Drawing.Size(86, 30)
         Me.cmdAgriWaller.TabIndex = 179
         Me.cmdAgriWaller.Text = "waller "
         Me.cmdAgriWaller.UseVisualStyleBackColor = True
@@ -888,10 +908,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdAgriNonAdditivity
         '
         Me.cmdAgriNonAdditivity.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdAgriNonAdditivity.Location = New System.Drawing.Point(393, 68)
-        Me.cmdAgriNonAdditivity.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdAgriNonAdditivity.Location = New System.Drawing.Point(262, 45)
+        Me.cmdAgriNonAdditivity.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdAgriNonAdditivity.Name = "cmdAgriNonAdditivity"
-        Me.cmdAgriNonAdditivity.Size = New System.Drawing.Size(129, 45)
+        Me.cmdAgriNonAdditivity.Size = New System.Drawing.Size(86, 30)
         Me.cmdAgriNonAdditivity.TabIndex = 178
         Me.cmdAgriNonAdditivity.Text = "nonadditivity "
         Me.cmdAgriNonAdditivity.UseVisualStyleBackColor = True
@@ -899,10 +919,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdMedian
         '
         Me.cmdMedian.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdMedian.Location = New System.Drawing.Point(264, 68)
-        Me.cmdMedian.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdMedian.Location = New System.Drawing.Point(176, 45)
+        Me.cmdMedian.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdMedian.Name = "cmdMedian"
-        Me.cmdMedian.Size = New System.Drawing.Size(129, 45)
+        Me.cmdMedian.Size = New System.Drawing.Size(86, 30)
         Me.cmdMedian.TabIndex = 177
         Me.cmdMedian.Text = "median"
         Me.cmdMedian.UseVisualStyleBackColor = True
@@ -910,10 +930,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdREGW
         '
         Me.cmdREGW.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdREGW.Location = New System.Drawing.Point(135, 114)
-        Me.cmdREGW.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdREGW.Location = New System.Drawing.Point(90, 76)
+        Me.cmdREGW.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdREGW.Name = "cmdREGW"
-        Me.cmdREGW.Size = New System.Drawing.Size(129, 45)
+        Me.cmdREGW.Size = New System.Drawing.Size(86, 30)
         Me.cmdREGW.TabIndex = 176
         Me.cmdREGW.Text = "REGW"
         Me.cmdREGW.UseVisualStyleBackColor = True
@@ -921,10 +941,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdLSD
         '
         Me.cmdLSD.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdLSD.Location = New System.Drawing.Point(135, 68)
-        Me.cmdLSD.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdLSD.Location = New System.Drawing.Point(90, 45)
+        Me.cmdLSD.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdLSD.Name = "cmdLSD"
-        Me.cmdLSD.Size = New System.Drawing.Size(129, 45)
+        Me.cmdLSD.Size = New System.Drawing.Size(86, 30)
         Me.cmdLSD.TabIndex = 175
         Me.cmdLSD.Text = "LSD"
         Me.cmdLSD.UseVisualStyleBackColor = True
@@ -932,10 +952,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdDuncan
         '
         Me.cmdDuncan.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdDuncan.Location = New System.Drawing.Point(135, 21)
-        Me.cmdDuncan.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdDuncan.Location = New System.Drawing.Point(90, 14)
+        Me.cmdDuncan.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdDuncan.Name = "cmdDuncan"
-        Me.cmdDuncan.Size = New System.Drawing.Size(129, 45)
+        Me.cmdDuncan.Size = New System.Drawing.Size(86, 30)
         Me.cmdDuncan.TabIndex = 174
         Me.cmdDuncan.Text = "duncan"
         Me.cmdDuncan.UseVisualStyleBackColor = True
@@ -943,24 +963,13 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdBIB
         '
         Me.cmdBIB.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdBIB.Location = New System.Drawing.Point(6, 21)
-        Me.cmdBIB.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdBIB.Location = New System.Drawing.Point(4, 14)
+        Me.cmdBIB.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdBIB.Name = "cmdBIB"
-        Me.cmdBIB.Size = New System.Drawing.Size(129, 45)
+        Me.cmdBIB.Size = New System.Drawing.Size(86, 30)
         Me.cmdBIB.TabIndex = 173
         Me.cmdBIB.Text = "BIB"
         Me.cmdBIB.UseVisualStyleBackColor = True
-        '
-        'cmdHelp
-        '
-        Me.cmdHelp.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdHelp.Location = New System.Drawing.Point(782, 392)
-        Me.cmdHelp.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
-        Me.cmdHelp.Name = "cmdHelp"
-        Me.cmdHelp.Size = New System.Drawing.Size(112, 34)
-        Me.cmdHelp.TabIndex = 11
-        Me.cmdHelp.Text = "R Help"
-        Me.cmdHelp.UseVisualStyleBackColor = True
         '
         'grpCoin
         '
@@ -969,9 +978,11 @@ Partial Class dlgHypothesisTestsCalculator
         Me.grpCoin.Controls.Add(Me.grpSymmetry)
         Me.grpCoin.Controls.Add(Me.grpCorrelation)
         Me.grpCoin.Controls.Add(Me.grpLocation)
-        Me.grpCoin.Location = New System.Drawing.Point(362, 118)
+        Me.grpCoin.Location = New System.Drawing.Point(241, 79)
+        Me.grpCoin.Margin = New System.Windows.Forms.Padding(2)
         Me.grpCoin.Name = "grpCoin"
-        Me.grpCoin.Size = New System.Drawing.Size(574, 262)
+        Me.grpCoin.Padding = New System.Windows.Forms.Padding(2)
+        Me.grpCoin.Size = New System.Drawing.Size(383, 175)
         Me.grpCoin.TabIndex = 22
         Me.grpCoin.TabStop = False
         Me.grpCoin.Text = "Coin"
@@ -985,63 +996,71 @@ Partial Class dlgHypothesisTestsCalculator
         Me.grpScale.Controls.Add(Me.cmdMood1)
         Me.grpScale.Controls.Add(Me.cmdKlotz)
         Me.grpScale.Controls.Add(Me.cmdTaha)
-        Me.grpScale.Location = New System.Drawing.Point(386, 16)
+        Me.grpScale.Location = New System.Drawing.Point(257, 11)
+        Me.grpScale.Margin = New System.Windows.Forms.Padding(2)
         Me.grpScale.Name = "grpScale"
-        Me.grpScale.Size = New System.Drawing.Size(186, 132)
+        Me.grpScale.Padding = New System.Windows.Forms.Padding(2)
+        Me.grpScale.Size = New System.Drawing.Size(124, 88)
         Me.grpScale.TabIndex = 4
         Me.grpScale.TabStop = False
         Me.grpScale.Text = "Scale"
         '
         'cmdConover
         '
-        Me.cmdConover.Location = New System.Drawing.Point(92, 87)
+        Me.cmdConover.Location = New System.Drawing.Point(61, 58)
+        Me.cmdConover.Margin = New System.Windows.Forms.Padding(2)
         Me.cmdConover.Name = "cmdConover"
-        Me.cmdConover.Size = New System.Drawing.Size(90, 36)
+        Me.cmdConover.Size = New System.Drawing.Size(60, 24)
         Me.cmdConover.TabIndex = 6
         Me.cmdConover.Text = "conover"
         Me.cmdConover.UseVisualStyleBackColor = True
         '
         'cmdFligner1
         '
-        Me.cmdFligner1.Location = New System.Drawing.Point(3, 87)
+        Me.cmdFligner1.Location = New System.Drawing.Point(2, 58)
+        Me.cmdFligner1.Margin = New System.Windows.Forms.Padding(2)
         Me.cmdFligner1.Name = "cmdFligner1"
-        Me.cmdFligner1.Size = New System.Drawing.Size(90, 36)
+        Me.cmdFligner1.Size = New System.Drawing.Size(60, 24)
         Me.cmdFligner1.TabIndex = 5
         Me.cmdFligner1.Text = "fligner"
         Me.cmdFligner1.UseVisualStyleBackColor = True
         '
         'cmdAnsari1
         '
-        Me.cmdAnsari1.Location = New System.Drawing.Point(92, 52)
+        Me.cmdAnsari1.Location = New System.Drawing.Point(61, 35)
+        Me.cmdAnsari1.Margin = New System.Windows.Forms.Padding(2)
         Me.cmdAnsari1.Name = "cmdAnsari1"
-        Me.cmdAnsari1.Size = New System.Drawing.Size(90, 36)
+        Me.cmdAnsari1.Size = New System.Drawing.Size(60, 24)
         Me.cmdAnsari1.TabIndex = 4
         Me.cmdAnsari1.Text = "ansari"
         Me.cmdAnsari1.UseVisualStyleBackColor = True
         '
         'cmdMood1
         '
-        Me.cmdMood1.Location = New System.Drawing.Point(3, 52)
+        Me.cmdMood1.Location = New System.Drawing.Point(2, 35)
+        Me.cmdMood1.Margin = New System.Windows.Forms.Padding(2)
         Me.cmdMood1.Name = "cmdMood1"
-        Me.cmdMood1.Size = New System.Drawing.Size(90, 36)
+        Me.cmdMood1.Size = New System.Drawing.Size(60, 24)
         Me.cmdMood1.TabIndex = 3
         Me.cmdMood1.Text = "mood"
         Me.cmdMood1.UseVisualStyleBackColor = True
         '
         'cmdKlotz
         '
-        Me.cmdKlotz.Location = New System.Drawing.Point(92, 18)
+        Me.cmdKlotz.Location = New System.Drawing.Point(61, 12)
+        Me.cmdKlotz.Margin = New System.Windows.Forms.Padding(2)
         Me.cmdKlotz.Name = "cmdKlotz"
-        Me.cmdKlotz.Size = New System.Drawing.Size(90, 36)
+        Me.cmdKlotz.Size = New System.Drawing.Size(60, 24)
         Me.cmdKlotz.TabIndex = 2
         Me.cmdKlotz.Text = "klotz"
         Me.cmdKlotz.UseVisualStyleBackColor = True
         '
         'cmdTaha
         '
-        Me.cmdTaha.Location = New System.Drawing.Point(3, 18)
+        Me.cmdTaha.Location = New System.Drawing.Point(2, 12)
+        Me.cmdTaha.Margin = New System.Windows.Forms.Padding(2)
         Me.cmdTaha.Name = "cmdTaha"
-        Me.cmdTaha.Size = New System.Drawing.Size(90, 36)
+        Me.cmdTaha.Size = New System.Drawing.Size(60, 24)
         Me.cmdTaha.TabIndex = 1
         Me.cmdTaha.Text = "taha"
         Me.cmdTaha.UseVisualStyleBackColor = True
@@ -1052,36 +1071,41 @@ Partial Class dlgHypothesisTestsCalculator
         Me.grpContigency.Controls.Add(Me.cmdLbl)
         Me.grpContigency.Controls.Add(Me.cmdCmh)
         Me.grpContigency.Controls.Add(Me.cmdChisq1)
-        Me.grpContigency.Location = New System.Drawing.Point(207, 152)
+        Me.grpContigency.Location = New System.Drawing.Point(138, 101)
+        Me.grpContigency.Margin = New System.Windows.Forms.Padding(2)
         Me.grpContigency.Name = "grpContigency"
-        Me.grpContigency.Size = New System.Drawing.Size(278, 75)
+        Me.grpContigency.Padding = New System.Windows.Forms.Padding(2)
+        Me.grpContigency.Size = New System.Drawing.Size(185, 50)
         Me.grpContigency.TabIndex = 3
         Me.grpContigency.TabStop = False
         Me.grpContigency.Text = "Contingency"
         '
         'cmdLbl
         '
-        Me.cmdLbl.Location = New System.Drawing.Point(180, 24)
+        Me.cmdLbl.Location = New System.Drawing.Point(120, 16)
+        Me.cmdLbl.Margin = New System.Windows.Forms.Padding(2)
         Me.cmdLbl.Name = "cmdLbl"
-        Me.cmdLbl.Size = New System.Drawing.Size(90, 36)
+        Me.cmdLbl.Size = New System.Drawing.Size(60, 24)
         Me.cmdLbl.TabIndex = 3
         Me.cmdLbl.Text = "lbl"
         Me.cmdLbl.UseVisualStyleBackColor = True
         '
         'cmdCmh
         '
-        Me.cmdCmh.Location = New System.Drawing.Point(92, 24)
+        Me.cmdCmh.Location = New System.Drawing.Point(61, 16)
+        Me.cmdCmh.Margin = New System.Windows.Forms.Padding(2)
         Me.cmdCmh.Name = "cmdCmh"
-        Me.cmdCmh.Size = New System.Drawing.Size(90, 36)
+        Me.cmdCmh.Size = New System.Drawing.Size(60, 24)
         Me.cmdCmh.TabIndex = 2
         Me.cmdCmh.Text = "cmh"
         Me.cmdCmh.UseVisualStyleBackColor = True
         '
         'cmdChisq1
         '
-        Me.cmdChisq1.Location = New System.Drawing.Point(3, 24)
+        Me.cmdChisq1.Location = New System.Drawing.Point(2, 16)
+        Me.cmdChisq1.Margin = New System.Windows.Forms.Padding(2)
         Me.cmdChisq1.Name = "cmdChisq1"
-        Me.cmdChisq1.Size = New System.Drawing.Size(90, 36)
+        Me.cmdChisq1.Size = New System.Drawing.Size(60, 24)
         Me.cmdChisq1.TabIndex = 1
         Me.cmdChisq1.Text = "chisq"
         Me.cmdChisq1.UseVisualStyleBackColor = True
@@ -1092,45 +1116,51 @@ Partial Class dlgHypothesisTestsCalculator
         Me.grpSymmetry.Controls.Add(Me.cmdFriedman1)
         Me.grpSymmetry.Controls.Add(Me.cmdWilcoxsign)
         Me.grpSymmetry.Controls.Add(Me.cmdSign)
-        Me.grpSymmetry.Location = New System.Drawing.Point(192, 16)
+        Me.grpSymmetry.Location = New System.Drawing.Point(128, 11)
+        Me.grpSymmetry.Margin = New System.Windows.Forms.Padding(2)
         Me.grpSymmetry.Name = "grpSymmetry"
-        Me.grpSymmetry.Size = New System.Drawing.Size(190, 132)
+        Me.grpSymmetry.Padding = New System.Windows.Forms.Padding(2)
+        Me.grpSymmetry.Size = New System.Drawing.Size(127, 88)
         Me.grpSymmetry.TabIndex = 2
         Me.grpSymmetry.TabStop = False
         Me.grpSymmetry.Text = "Symmetry"
         '
         'cmdQuade1
         '
-        Me.cmdQuade1.Location = New System.Drawing.Point(90, 57)
+        Me.cmdQuade1.Location = New System.Drawing.Point(60, 38)
+        Me.cmdQuade1.Margin = New System.Windows.Forms.Padding(2)
         Me.cmdQuade1.Name = "cmdQuade1"
-        Me.cmdQuade1.Size = New System.Drawing.Size(98, 36)
+        Me.cmdQuade1.Size = New System.Drawing.Size(65, 24)
         Me.cmdQuade1.TabIndex = 4
         Me.cmdQuade1.Text = "quade"
         Me.cmdQuade1.UseVisualStyleBackColor = True
         '
         'cmdFriedman1
         '
-        Me.cmdFriedman1.Location = New System.Drawing.Point(2, 57)
+        Me.cmdFriedman1.Location = New System.Drawing.Point(1, 38)
+        Me.cmdFriedman1.Margin = New System.Windows.Forms.Padding(2)
         Me.cmdFriedman1.Name = "cmdFriedman1"
-        Me.cmdFriedman1.Size = New System.Drawing.Size(90, 36)
+        Me.cmdFriedman1.Size = New System.Drawing.Size(60, 24)
         Me.cmdFriedman1.TabIndex = 3
         Me.cmdFriedman1.Text = "friedman"
         Me.cmdFriedman1.UseVisualStyleBackColor = True
         '
         'cmdWilcoxsign
         '
-        Me.cmdWilcoxsign.Location = New System.Drawing.Point(90, 22)
+        Me.cmdWilcoxsign.Location = New System.Drawing.Point(60, 15)
+        Me.cmdWilcoxsign.Margin = New System.Windows.Forms.Padding(2)
         Me.cmdWilcoxsign.Name = "cmdWilcoxsign"
-        Me.cmdWilcoxsign.Size = New System.Drawing.Size(98, 36)
+        Me.cmdWilcoxsign.Size = New System.Drawing.Size(65, 24)
         Me.cmdWilcoxsign.TabIndex = 2
         Me.cmdWilcoxsign.Text = "wilcoxsign"
         Me.cmdWilcoxsign.UseVisualStyleBackColor = True
         '
         'cmdSign
         '
-        Me.cmdSign.Location = New System.Drawing.Point(2, 22)
+        Me.cmdSign.Location = New System.Drawing.Point(1, 15)
+        Me.cmdSign.Margin = New System.Windows.Forms.Padding(2)
         Me.cmdSign.Name = "cmdSign"
-        Me.cmdSign.Size = New System.Drawing.Size(90, 36)
+        Me.cmdSign.Size = New System.Drawing.Size(60, 24)
         Me.cmdSign.TabIndex = 1
         Me.cmdSign.Text = "sign"
         Me.cmdSign.UseVisualStyleBackColor = True
@@ -1142,45 +1172,51 @@ Partial Class dlgHypothesisTestsCalculator
         Me.grpCorrelation.Controls.Add(Me.cmdQuadrant)
         Me.grpCorrelation.Controls.Add(Me.cmdFisyat)
         Me.grpCorrelation.Controls.Add(Me.cmdSpearman)
-        Me.grpCorrelation.Location = New System.Drawing.Point(3, 152)
+        Me.grpCorrelation.Location = New System.Drawing.Point(2, 101)
+        Me.grpCorrelation.Margin = New System.Windows.Forms.Padding(2)
         Me.grpCorrelation.Name = "grpCorrelation"
-        Me.grpCorrelation.Size = New System.Drawing.Size(200, 106)
+        Me.grpCorrelation.Padding = New System.Windows.Forms.Padding(2)
+        Me.grpCorrelation.Size = New System.Drawing.Size(133, 71)
         Me.grpCorrelation.TabIndex = 1
         Me.grpCorrelation.TabStop = False
         Me.grpCorrelation.Text = "Correlation"
         '
         'cmdKoziol
         '
-        Me.cmdKoziol.Location = New System.Drawing.Point(100, 56)
+        Me.cmdKoziol.Location = New System.Drawing.Point(67, 37)
+        Me.cmdKoziol.Margin = New System.Windows.Forms.Padding(2)
         Me.cmdKoziol.Name = "cmdKoziol"
-        Me.cmdKoziol.Size = New System.Drawing.Size(90, 36)
+        Me.cmdKoziol.Size = New System.Drawing.Size(60, 24)
         Me.cmdKoziol.TabIndex = 4
         Me.cmdKoziol.Text = "koziol"
         Me.cmdKoziol.UseVisualStyleBackColor = True
         '
         'cmdQuadrant
         '
-        Me.cmdQuadrant.Location = New System.Drawing.Point(2, 56)
+        Me.cmdQuadrant.Location = New System.Drawing.Point(1, 37)
+        Me.cmdQuadrant.Margin = New System.Windows.Forms.Padding(2)
         Me.cmdQuadrant.Name = "cmdQuadrant"
-        Me.cmdQuadrant.Size = New System.Drawing.Size(100, 36)
+        Me.cmdQuadrant.Size = New System.Drawing.Size(67, 24)
         Me.cmdQuadrant.TabIndex = 3
         Me.cmdQuadrant.Text = "quadrant"
         Me.cmdQuadrant.UseVisualStyleBackColor = True
         '
         'cmdFisyat
         '
-        Me.cmdFisyat.Location = New System.Drawing.Point(100, 21)
+        Me.cmdFisyat.Location = New System.Drawing.Point(67, 14)
+        Me.cmdFisyat.Margin = New System.Windows.Forms.Padding(2)
         Me.cmdFisyat.Name = "cmdFisyat"
-        Me.cmdFisyat.Size = New System.Drawing.Size(90, 36)
+        Me.cmdFisyat.Size = New System.Drawing.Size(60, 24)
         Me.cmdFisyat.TabIndex = 2
         Me.cmdFisyat.Text = "fisyat"
         Me.cmdFisyat.UseVisualStyleBackColor = True
         '
         'cmdSpearman
         '
-        Me.cmdSpearman.Location = New System.Drawing.Point(2, 21)
+        Me.cmdSpearman.Location = New System.Drawing.Point(1, 14)
+        Me.cmdSpearman.Margin = New System.Windows.Forms.Padding(2)
         Me.cmdSpearman.Name = "cmdSpearman"
-        Me.cmdSpearman.Size = New System.Drawing.Size(100, 36)
+        Me.cmdSpearman.Size = New System.Drawing.Size(67, 24)
         Me.cmdSpearman.TabIndex = 1
         Me.cmdSpearman.Text = "spearman"
         Me.cmdSpearman.UseVisualStyleBackColor = True
@@ -1193,18 +1229,21 @@ Partial Class dlgHypothesisTestsCalculator
         Me.grpLocation.Controls.Add(Me.cmdKruskal1)
         Me.grpLocation.Controls.Add(Me.cmdWilcox1)
         Me.grpLocation.Controls.Add(Me.cmdOneway1)
-        Me.grpLocation.Location = New System.Drawing.Point(3, 16)
+        Me.grpLocation.Location = New System.Drawing.Point(2, 11)
+        Me.grpLocation.Margin = New System.Windows.Forms.Padding(2)
         Me.grpLocation.Name = "grpLocation"
-        Me.grpLocation.Size = New System.Drawing.Size(186, 132)
+        Me.grpLocation.Padding = New System.Windows.Forms.Padding(2)
+        Me.grpLocation.Size = New System.Drawing.Size(124, 88)
         Me.grpLocation.TabIndex = 0
         Me.grpLocation.TabStop = False
         Me.grpLocation.Text = "Location"
         '
         'cmdSavage
         '
-        Me.cmdSavage.Location = New System.Drawing.Point(90, 90)
+        Me.cmdSavage.Location = New System.Drawing.Point(60, 60)
+        Me.cmdSavage.Margin = New System.Windows.Forms.Padding(2)
         Me.cmdSavage.Name = "cmdSavage"
-        Me.cmdSavage.Size = New System.Drawing.Size(90, 36)
+        Me.cmdSavage.Size = New System.Drawing.Size(60, 24)
         Me.cmdSavage.TabIndex = 5
         Me.cmdSavage.Text = "savage"
         Me.cmdSavage.UseVisualStyleBackColor = True
@@ -1212,9 +1251,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdMedian1
         '
         Me.cmdMedian1.AccessibleDescription = ""
-        Me.cmdMedian1.Location = New System.Drawing.Point(2, 90)
+        Me.cmdMedian1.Location = New System.Drawing.Point(1, 60)
+        Me.cmdMedian1.Margin = New System.Windows.Forms.Padding(2)
         Me.cmdMedian1.Name = "cmdMedian1"
-        Me.cmdMedian1.Size = New System.Drawing.Size(90, 36)
+        Me.cmdMedian1.Size = New System.Drawing.Size(60, 24)
         Me.cmdMedian1.TabIndex = 4
         Me.cmdMedian1.Text = "median"
         Me.cmdMedian1.UseVisualStyleBackColor = True
@@ -1222,9 +1262,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdNormal
         '
         Me.cmdNormal.AccessibleDescription = ""
-        Me.cmdNormal.Location = New System.Drawing.Point(90, 56)
+        Me.cmdNormal.Location = New System.Drawing.Point(60, 37)
+        Me.cmdNormal.Margin = New System.Windows.Forms.Padding(2)
         Me.cmdNormal.Name = "cmdNormal"
-        Me.cmdNormal.Size = New System.Drawing.Size(90, 36)
+        Me.cmdNormal.Size = New System.Drawing.Size(60, 24)
         Me.cmdNormal.TabIndex = 3
         Me.cmdNormal.Text = "normal"
         Me.cmdNormal.UseVisualStyleBackColor = True
@@ -1232,9 +1273,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdKruskal1
         '
         Me.cmdKruskal1.AccessibleDescription = ""
-        Me.cmdKruskal1.Location = New System.Drawing.Point(2, 56)
+        Me.cmdKruskal1.Location = New System.Drawing.Point(1, 37)
+        Me.cmdKruskal1.Margin = New System.Windows.Forms.Padding(2)
         Me.cmdKruskal1.Name = "cmdKruskal1"
-        Me.cmdKruskal1.Size = New System.Drawing.Size(90, 36)
+        Me.cmdKruskal1.Size = New System.Drawing.Size(60, 24)
         Me.cmdKruskal1.TabIndex = 2
         Me.cmdKruskal1.Text = "kruskal"
         Me.cmdKruskal1.UseVisualStyleBackColor = True
@@ -1242,9 +1284,10 @@ Partial Class dlgHypothesisTestsCalculator
         'cmdWilcox1
         '
         Me.cmdWilcox1.AccessibleDescription = "cmdWilcox"
-        Me.cmdWilcox1.Location = New System.Drawing.Point(90, 21)
+        Me.cmdWilcox1.Location = New System.Drawing.Point(60, 14)
+        Me.cmdWilcox1.Margin = New System.Windows.Forms.Padding(2)
         Me.cmdWilcox1.Name = "cmdWilcox1"
-        Me.cmdWilcox1.Size = New System.Drawing.Size(90, 36)
+        Me.cmdWilcox1.Size = New System.Drawing.Size(60, 24)
         Me.cmdWilcox1.TabIndex = 1
         Me.cmdWilcox1.Text = "wilcox"
         Me.cmdWilcox1.UseVisualStyleBackColor = True
@@ -1253,9 +1296,10 @@ Partial Class dlgHypothesisTestsCalculator
         '
         Me.cmdOneway1.AccessibleDescription = ""
         Me.cmdOneway1.AccessibleName = ""
-        Me.cmdOneway1.Location = New System.Drawing.Point(2, 21)
+        Me.cmdOneway1.Location = New System.Drawing.Point(1, 14)
+        Me.cmdOneway1.Margin = New System.Windows.Forms.Padding(2)
         Me.cmdOneway1.Name = "cmdOneway1"
-        Me.cmdOneway1.Size = New System.Drawing.Size(90, 36)
+        Me.cmdOneway1.Size = New System.Drawing.Size(60, 24)
         Me.cmdOneway1.TabIndex = 0
         Me.cmdOneway1.Text = "oneway"
         Me.cmdOneway1.UseVisualStyleBackColor = True
@@ -1280,191 +1324,171 @@ Partial Class dlgHypothesisTestsCalculator
         Me.grpTrend.Controls.Add(Me.cmdBu)
         Me.grpTrend.Controls.Add(Me.cmdBr)
         Me.grpTrend.Controls.Add(Me.cmdBartels)
-        Me.grpTrend.Location = New System.Drawing.Point(362, 118)
-        Me.grpTrend.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
+        Me.grpTrend.Location = New System.Drawing.Point(241, 79)
         Me.grpTrend.Name = "grpTrend"
-        Me.grpTrend.Padding = New System.Windows.Forms.Padding(4, 4, 4, 4)
-        Me.grpTrend.Size = New System.Drawing.Size(532, 262)
+        Me.grpTrend.Size = New System.Drawing.Size(355, 175)
         Me.grpTrend.TabIndex = 23
         Me.grpTrend.TabStop = False
         Me.grpTrend.Text = "Trend"
         '
         'cmdWm
         '
-        Me.cmdWm.Location = New System.Drawing.Point(6, 207)
-        Me.cmdWm.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
+        Me.cmdWm.Location = New System.Drawing.Point(4, 138)
         Me.cmdWm.Name = "cmdWm"
-        Me.cmdWm.Size = New System.Drawing.Size(129, 45)
+        Me.cmdWm.Size = New System.Drawing.Size(86, 30)
         Me.cmdWm.TabIndex = 17
         Me.cmdWm.Text = "wm"
         Me.cmdWm.UseVisualStyleBackColor = True
         '
         'cmdWw
         '
-        Me.cmdWw.Location = New System.Drawing.Point(135, 207)
-        Me.cmdWw.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
+        Me.cmdWw.Location = New System.Drawing.Point(90, 138)
         Me.cmdWw.Name = "cmdWw"
-        Me.cmdWw.Size = New System.Drawing.Size(129, 45)
+        Me.cmdWw.Size = New System.Drawing.Size(86, 30)
         Me.cmdWw.TabIndex = 16
         Me.cmdWw.Text = "ww "
         Me.cmdWw.UseVisualStyleBackColor = True
         '
         'cmdSnh
         '
-        Me.cmdSnh.Location = New System.Drawing.Point(393, 160)
-        Me.cmdSnh.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
+        Me.cmdSnh.Location = New System.Drawing.Point(262, 107)
         Me.cmdSnh.Name = "cmdSnh"
-        Me.cmdSnh.Size = New System.Drawing.Size(129, 45)
+        Me.cmdSnh.Size = New System.Drawing.Size(86, 30)
         Me.cmdSnh.TabIndex = 15
         Me.cmdSnh.Text = "snh "
         Me.cmdSnh.UseVisualStyleBackColor = True
         '
         'cmdSmk
         '
-        Me.cmdSmk.Location = New System.Drawing.Point(264, 160)
-        Me.cmdSmk.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
+        Me.cmdSmk.Location = New System.Drawing.Point(176, 107)
         Me.cmdSmk.Name = "cmdSmk"
-        Me.cmdSmk.Size = New System.Drawing.Size(129, 45)
+        Me.cmdSmk.Size = New System.Drawing.Size(86, 30)
         Me.cmdSmk.TabIndex = 14
         Me.cmdSmk.Text = "smk "
         Me.cmdSmk.UseVisualStyleBackColor = True
         '
         'cmdSens
         '
-        Me.cmdSens.Location = New System.Drawing.Point(135, 160)
-        Me.cmdSens.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
+        Me.cmdSens.Location = New System.Drawing.Point(90, 107)
         Me.cmdSens.Name = "cmdSens"
-        Me.cmdSens.Size = New System.Drawing.Size(129, 45)
+        Me.cmdSens.Size = New System.Drawing.Size(86, 30)
         Me.cmdSens.TabIndex = 13
         Me.cmdSens.Text = "sens "
         Me.cmdSens.UseVisualStyleBackColor = True
         '
         'cmdSsens
         '
-        Me.cmdSsens.Location = New System.Drawing.Point(6, 160)
-        Me.cmdSsens.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
+        Me.cmdSsens.Location = New System.Drawing.Point(4, 107)
         Me.cmdSsens.Name = "cmdSsens"
-        Me.cmdSsens.Size = New System.Drawing.Size(129, 45)
+        Me.cmdSsens.Size = New System.Drawing.Size(86, 30)
         Me.cmdSsens.TabIndex = 12
         Me.cmdSsens.Text = "ssens "
         Me.cmdSsens.UseVisualStyleBackColor = True
         '
         'cmdRrod
         '
-        Me.cmdRrod.Location = New System.Drawing.Point(393, 114)
-        Me.cmdRrod.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
+        Me.cmdRrod.Location = New System.Drawing.Point(262, 76)
         Me.cmdRrod.Name = "cmdRrod"
-        Me.cmdRrod.Size = New System.Drawing.Size(129, 45)
+        Me.cmdRrod.Size = New System.Drawing.Size(86, 30)
         Me.cmdRrod.TabIndex = 11
         Me.cmdRrod.Text = "rrod "
         Me.cmdRrod.UseVisualStyleBackColor = True
         '
         'cmdPettitt
         '
-        Me.cmdPettitt.Location = New System.Drawing.Point(264, 114)
-        Me.cmdPettitt.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
+        Me.cmdPettitt.Location = New System.Drawing.Point(176, 76)
         Me.cmdPettitt.Name = "cmdPettitt"
-        Me.cmdPettitt.Size = New System.Drawing.Size(129, 45)
+        Me.cmdPettitt.Size = New System.Drawing.Size(86, 30)
         Me.cmdPettitt.TabIndex = 10
         Me.cmdPettitt.Text = "pettitt "
         Me.cmdPettitt.UseVisualStyleBackColor = True
         '
         'cmdPmk
         '
-        Me.cmdPmk.Location = New System.Drawing.Point(135, 114)
-        Me.cmdPmk.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
+        Me.cmdPmk.Location = New System.Drawing.Point(90, 76)
         Me.cmdPmk.Name = "cmdPmk"
-        Me.cmdPmk.Size = New System.Drawing.Size(129, 45)
+        Me.cmdPmk.Size = New System.Drawing.Size(86, 30)
         Me.cmdPmk.TabIndex = 9
         Me.cmdPmk.Text = "pmk "
         Me.cmdPmk.UseVisualStyleBackColor = True
         '
         'cmdPcor
         '
-        Me.cmdPcor.Location = New System.Drawing.Point(6, 114)
-        Me.cmdPcor.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
+        Me.cmdPcor.Location = New System.Drawing.Point(4, 76)
         Me.cmdPcor.Name = "cmdPcor"
-        Me.cmdPcor.Size = New System.Drawing.Size(129, 45)
+        Me.cmdPcor.Size = New System.Drawing.Size(86, 30)
         Me.cmdPcor.TabIndex = 8
         Me.cmdPcor.Text = "pcor "
         Me.cmdPcor.UseVisualStyleBackColor = True
         '
         'cmdMmk
         '
-        Me.cmdMmk.Location = New System.Drawing.Point(393, 68)
-        Me.cmdMmk.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
+        Me.cmdMmk.Location = New System.Drawing.Point(262, 45)
         Me.cmdMmk.Name = "cmdMmk"
-        Me.cmdMmk.Size = New System.Drawing.Size(129, 45)
+        Me.cmdMmk.Size = New System.Drawing.Size(86, 30)
         Me.cmdMmk.TabIndex = 7
         Me.cmdMmk.Text = "mmk "
         Me.cmdMmk.UseVisualStyleBackColor = True
         '
         'cmdMk
         '
-        Me.cmdMk.Location = New System.Drawing.Point(264, 68)
-        Me.cmdMk.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
+        Me.cmdMk.Location = New System.Drawing.Point(176, 45)
         Me.cmdMk.Name = "cmdMk"
-        Me.cmdMk.Size = New System.Drawing.Size(129, 45)
+        Me.cmdMk.Size = New System.Drawing.Size(86, 30)
         Me.cmdMk.TabIndex = 6
         Me.cmdMk.Text = "mk"
         Me.cmdMk.UseVisualStyleBackColor = True
         '
         'cmdLanzante
         '
-        Me.cmdLanzante.Location = New System.Drawing.Point(135, 68)
-        Me.cmdLanzante.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
+        Me.cmdLanzante.Location = New System.Drawing.Point(90, 45)
         Me.cmdLanzante.Name = "cmdLanzante"
-        Me.cmdLanzante.Size = New System.Drawing.Size(129, 45)
+        Me.cmdLanzante.Size = New System.Drawing.Size(86, 30)
         Me.cmdLanzante.TabIndex = 5
         Me.cmdLanzante.Text = "lanzante"
         Me.cmdLanzante.UseVisualStyleBackColor = True
         '
         'cmdCsmk
         '
-        Me.cmdCsmk.Location = New System.Drawing.Point(6, 68)
-        Me.cmdCsmk.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
+        Me.cmdCsmk.Location = New System.Drawing.Point(4, 45)
         Me.cmdCsmk.Name = "cmdCsmk"
-        Me.cmdCsmk.Size = New System.Drawing.Size(129, 45)
+        Me.cmdCsmk.Size = New System.Drawing.Size(86, 30)
         Me.cmdCsmk.TabIndex = 4
         Me.cmdCsmk.Text = "csmk"
         Me.cmdCsmk.UseVisualStyleBackColor = True
         '
         'cmdCs
         '
-        Me.cmdCs.Location = New System.Drawing.Point(393, 21)
-        Me.cmdCs.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
+        Me.cmdCs.Location = New System.Drawing.Point(262, 14)
         Me.cmdCs.Name = "cmdCs"
-        Me.cmdCs.Size = New System.Drawing.Size(129, 45)
+        Me.cmdCs.Size = New System.Drawing.Size(86, 30)
         Me.cmdCs.TabIndex = 3
         Me.cmdCs.Text = "cs"
         Me.cmdCs.UseVisualStyleBackColor = True
         '
         'cmdBu
         '
-        Me.cmdBu.Location = New System.Drawing.Point(264, 21)
-        Me.cmdBu.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
+        Me.cmdBu.Location = New System.Drawing.Point(176, 14)
         Me.cmdBu.Name = "cmdBu"
-        Me.cmdBu.Size = New System.Drawing.Size(129, 45)
+        Me.cmdBu.Size = New System.Drawing.Size(86, 30)
         Me.cmdBu.TabIndex = 2
         Me.cmdBu.Text = "bu"
         Me.cmdBu.UseVisualStyleBackColor = True
         '
         'cmdBr
         '
-        Me.cmdBr.Location = New System.Drawing.Point(135, 21)
-        Me.cmdBr.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
+        Me.cmdBr.Location = New System.Drawing.Point(90, 14)
         Me.cmdBr.Name = "cmdBr"
-        Me.cmdBr.Size = New System.Drawing.Size(129, 45)
+        Me.cmdBr.Size = New System.Drawing.Size(86, 30)
         Me.cmdBr.TabIndex = 1
         Me.cmdBr.Text = "br"
         Me.cmdBr.UseVisualStyleBackColor = True
         '
         'cmdBartels
         '
-        Me.cmdBartels.Location = New System.Drawing.Point(6, 21)
-        Me.cmdBartels.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
+        Me.cmdBartels.Location = New System.Drawing.Point(4, 14)
         Me.cmdBartels.Name = "cmdBartels"
-        Me.cmdBartels.Size = New System.Drawing.Size(129, 45)
+        Me.cmdBartels.Size = New System.Drawing.Size(86, 30)
         Me.cmdBartels.TabIndex = 0
         Me.cmdBartels.Text = "bartels"
         Me.cmdBartels.UseVisualStyleBackColor = True
@@ -1473,41 +1497,41 @@ Partial Class dlgHypothesisTestsCalculator
         '
         Me.ucrChkDisplayModel.AutoSize = True
         Me.ucrChkDisplayModel.Checked = False
-        Me.ucrChkDisplayModel.Location = New System.Drawing.Point(15, 438)
-        Me.ucrChkDisplayModel.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
+        Me.ucrChkDisplayModel.Location = New System.Drawing.Point(10, 292)
+        Me.ucrChkDisplayModel.Margin = New System.Windows.Forms.Padding(4)
         Me.ucrChkDisplayModel.Name = "ucrChkDisplayModel"
-        Me.ucrChkDisplayModel.Size = New System.Drawing.Size(208, 34)
+        Me.ucrChkDisplayModel.Size = New System.Drawing.Size(139, 23)
         Me.ucrChkDisplayModel.TabIndex = 7
         '
         'ucrChkSummaryModel
         '
         Me.ucrChkSummaryModel.AutoSize = True
         Me.ucrChkSummaryModel.Checked = False
-        Me.ucrChkSummaryModel.Location = New System.Drawing.Point(15, 396)
-        Me.ucrChkSummaryModel.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
+        Me.ucrChkSummaryModel.Location = New System.Drawing.Point(10, 264)
+        Me.ucrChkSummaryModel.Margin = New System.Windows.Forms.Padding(4)
         Me.ucrChkSummaryModel.Name = "ucrChkSummaryModel"
-        Me.ucrChkSummaryModel.Size = New System.Drawing.Size(208, 34)
+        Me.ucrChkSummaryModel.Size = New System.Drawing.Size(139, 23)
         Me.ucrChkSummaryModel.TabIndex = 6
         '
         'ucrTryModelling
         '
         Me.ucrTryModelling.AutoSize = True
-        Me.ucrTryModelling.Location = New System.Drawing.Point(3, 540)
-        Me.ucrTryModelling.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
+        Me.ucrTryModelling.Location = New System.Drawing.Point(2, 360)
+        Me.ucrTryModelling.Margin = New System.Windows.Forms.Padding(4)
         Me.ucrTryModelling.Name = "ucrTryModelling"
         Me.ucrTryModelling.RunCommandAsMultipleLines = False
-        Me.ucrTryModelling.Size = New System.Drawing.Size(594, 55)
+        Me.ucrTryModelling.Size = New System.Drawing.Size(396, 37)
         Me.ucrTryModelling.TabIndex = 13
         '
         'ucrReceiverMultiple
         '
         Me.ucrReceiverMultiple.AutoSize = True
         Me.ucrReceiverMultiple.frmParent = Me
-        Me.ucrReceiverMultiple.Location = New System.Drawing.Point(248, 432)
+        Me.ucrReceiverMultiple.Location = New System.Drawing.Point(165, 288)
         Me.ucrReceiverMultiple.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverMultiple.Name = "ucrReceiverMultiple"
         Me.ucrReceiverMultiple.Selector = Nothing
-        Me.ucrReceiverMultiple.Size = New System.Drawing.Size(170, 92)
+        Me.ucrReceiverMultiple.Size = New System.Drawing.Size(113, 61)
         Me.ucrReceiverMultiple.strNcFilePath = ""
         Me.ucrReceiverMultiple.TabIndex = 9
         Me.ucrReceiverMultiple.ucrSelector = Nothing
@@ -1516,10 +1540,10 @@ Partial Class dlgHypothesisTestsCalculator
         'ucrSaveResult
         '
         Me.ucrSaveResult.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrSaveResult.Location = New System.Drawing.Point(15, 596)
-        Me.ucrSaveResult.Margin = New System.Windows.Forms.Padding(6, 8, 6, 8)
+        Me.ucrSaveResult.Location = New System.Drawing.Point(10, 397)
+        Me.ucrSaveResult.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
         Me.ucrSaveResult.Name = "ucrSaveResult"
-        Me.ucrSaveResult.Size = New System.Drawing.Size(441, 36)
+        Me.ucrSaveResult.Size = New System.Drawing.Size(294, 24)
         Me.ucrSaveResult.TabIndex = 14
         '
         'ucrInputComboRPackage
@@ -1528,20 +1552,20 @@ Partial Class dlgHypothesisTestsCalculator
         Me.ucrInputComboRPackage.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.ucrInputComboRPackage.GetSetSelectedIndex = -1
         Me.ucrInputComboRPackage.IsReadOnly = False
-        Me.ucrInputComboRPackage.Location = New System.Drawing.Point(462, 76)
-        Me.ucrInputComboRPackage.Margin = New System.Windows.Forms.Padding(10, 9, 10, 9)
+        Me.ucrInputComboRPackage.Location = New System.Drawing.Point(308, 51)
+        Me.ucrInputComboRPackage.Margin = New System.Windows.Forms.Padding(7, 6, 7, 6)
         Me.ucrInputComboRPackage.Name = "ucrInputComboRPackage"
-        Me.ucrInputComboRPackage.Size = New System.Drawing.Size(184, 32)
+        Me.ucrInputComboRPackage.Size = New System.Drawing.Size(123, 21)
         Me.ucrInputComboRPackage.TabIndex = 5
         '
         'ucrBase
         '
         Me.ucrBase.AutoSize = True
         Me.ucrBase.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrBase.Location = New System.Drawing.Point(15, 645)
-        Me.ucrBase.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
+        Me.ucrBase.Location = New System.Drawing.Point(10, 430)
+        Me.ucrBase.Margin = New System.Windows.Forms.Padding(4)
         Me.ucrBase.Name = "ucrBase"
-        Me.ucrBase.Size = New System.Drawing.Size(611, 77)
+        Me.ucrBase.Size = New System.Drawing.Size(408, 52)
         Me.ucrBase.TabIndex = 15
         '
         'ucrChkBy
@@ -1549,10 +1573,10 @@ Partial Class dlgHypothesisTestsCalculator
         Me.ucrChkBy.AutoSize = True
         Me.ucrChkBy.Checked = False
         Me.ucrChkBy.Enabled = False
-        Me.ucrChkBy.Location = New System.Drawing.Point(248, 396)
-        Me.ucrChkBy.Margin = New System.Windows.Forms.Padding(8, 8, 8, 8)
+        Me.ucrChkBy.Location = New System.Drawing.Point(165, 264)
+        Me.ucrChkBy.Margin = New System.Windows.Forms.Padding(5)
         Me.ucrChkBy.Name = "ucrChkBy"
-        Me.ucrChkBy.Size = New System.Drawing.Size(249, 34)
+        Me.ucrChkBy.Size = New System.Drawing.Size(166, 23)
         Me.ucrChkBy.TabIndex = 8
         '
         'ucrSelectorColumn
@@ -1561,41 +1585,166 @@ Partial Class dlgHypothesisTestsCalculator
         Me.ucrSelectorColumn.bDropUnusedFilterLevels = False
         Me.ucrSelectorColumn.bShowHiddenColumns = False
         Me.ucrSelectorColumn.bUseCurrentFilter = True
-        Me.ucrSelectorColumn.Location = New System.Drawing.Point(15, 84)
+        Me.ucrSelectorColumn.Location = New System.Drawing.Point(10, 56)
         Me.ucrSelectorColumn.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrSelectorColumn.Name = "ucrSelectorColumn"
-        Me.ucrSelectorColumn.Size = New System.Drawing.Size(320, 274)
+        Me.ucrSelectorColumn.Size = New System.Drawing.Size(213, 183)
         Me.ucrSelectorColumn.TabIndex = 3
         '
         'ucrChkIncludeArguments
         '
         Me.ucrChkIncludeArguments.AutoSize = True
         Me.ucrChkIncludeArguments.Checked = False
-        Me.ucrChkIncludeArguments.Location = New System.Drawing.Point(664, 39)
-        Me.ucrChkIncludeArguments.Margin = New System.Windows.Forms.Padding(8, 8, 8, 8)
+        Me.ucrChkIncludeArguments.Location = New System.Drawing.Point(443, 26)
+        Me.ucrChkIncludeArguments.Margin = New System.Windows.Forms.Padding(5)
         Me.ucrChkIncludeArguments.Name = "ucrChkIncludeArguments"
-        Me.ucrChkIncludeArguments.Size = New System.Drawing.Size(196, 34)
+        Me.ucrChkIncludeArguments.Size = New System.Drawing.Size(131, 23)
         Me.ucrChkIncludeArguments.TabIndex = 2
         '
         'ucrReceiverForTestColumn
         '
         Me.ucrReceiverForTestColumn.AutoSize = True
         Me.ucrReceiverForTestColumn.frmParent = Me
-        Me.ucrReceiverForTestColumn.Location = New System.Drawing.Point(82, 38)
-        Me.ucrReceiverForTestColumn.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.ucrReceiverForTestColumn.Location = New System.Drawing.Point(55, 25)
+        Me.ucrReceiverForTestColumn.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.ucrReceiverForTestColumn.Name = "ucrReceiverForTestColumn"
         Me.ucrReceiverForTestColumn.Selector = Nothing
-        Me.ucrReceiverForTestColumn.Size = New System.Drawing.Size(564, 40)
+        Me.ucrReceiverForTestColumn.Size = New System.Drawing.Size(376, 27)
         Me.ucrReceiverForTestColumn.strNcFilePath = ""
         Me.ucrReceiverForTestColumn.TabIndex = 1
         Me.ucrReceiverForTestColumn.ucrSelector = Nothing
         '
+        'cmdRHelpStats
+        '
+        Me.cmdRHelpStats.AutoSize = True
+        Me.cmdRHelpStats.ContextMenuStrip = Me.ContextMenuStripStats
+        Me.cmdRHelpStats.Location = New System.Drawing.Point(520, 260)
+        Me.cmdRHelpStats.Name = "cmdRHelpStats"
+        Me.cmdRHelpStats.Size = New System.Drawing.Size(68, 23)
+        Me.cmdRHelpStats.SplitMenuStrip = Me.ContextMenuStripStats
+        Me.cmdRHelpStats.TabIndex = 223
+        Me.cmdRHelpStats.Text = "R Help"
+        Me.cmdRHelpStats.UseVisualStyleBackColor = True
+        '
+        'ContextMenuStripStats
+        '
+        Me.ContextMenuStripStats.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuStats})
+        Me.ContextMenuStripStats.Name = "ContextMenuStrip1"
+        Me.ContextMenuStripStats.Size = New System.Drawing.Size(99, 26)
+        '
+        'ToolStripMenuStats
+        '
+        Me.ToolStripMenuStats.Name = "ToolStripMenuStats"
+        Me.ToolStripMenuStats.Size = New System.Drawing.Size(98, 22)
+        Me.ToolStripMenuStats.Text = "stats"
+        '
+        'cmdRHelpCoin
+        '
+        Me.cmdRHelpCoin.AutoSize = True
+        Me.cmdRHelpCoin.ContextMenuStrip = Me.ContextMenuStripCoin
+        Me.cmdRHelpCoin.Location = New System.Drawing.Point(520, 260)
+        Me.cmdRHelpCoin.Name = "cmdRHelpCoin"
+        Me.cmdRHelpCoin.Size = New System.Drawing.Size(68, 23)
+        Me.cmdRHelpCoin.SplitMenuStrip = Me.ContextMenuStripCoin
+        Me.cmdRHelpCoin.TabIndex = 225
+        Me.cmdRHelpCoin.Text = "R Help"
+        Me.cmdRHelpCoin.UseVisualStyleBackColor = True
+        '
+        'ContextMenuStripCoin
+        '
+        Me.ContextMenuStripCoin.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuCoin})
+        Me.ContextMenuStripCoin.Name = "ContextMenuStrip1"
+        Me.ContextMenuStripCoin.Size = New System.Drawing.Size(98, 26)
+        '
+        'ToolStripMenuCoin
+        '
+        Me.ToolStripMenuCoin.Name = "ToolStripMenuCoin"
+        Me.ToolStripMenuCoin.Size = New System.Drawing.Size(97, 22)
+        Me.ToolStripMenuCoin.Text = "coin"
+        '
+        'cmdRHelpAgricolae
+        '
+        Me.cmdRHelpAgricolae.AutoSize = True
+        Me.cmdRHelpAgricolae.ContextMenuStrip = Me.ContextMenuStripAgricolae
+        Me.cmdRHelpAgricolae.Location = New System.Drawing.Point(520, 261)
+        Me.cmdRHelpAgricolae.Name = "cmdRHelpAgricolae"
+        Me.cmdRHelpAgricolae.Size = New System.Drawing.Size(68, 23)
+        Me.cmdRHelpAgricolae.SplitMenuStrip = Me.ContextMenuStripAgricolae
+        Me.cmdRHelpAgricolae.TabIndex = 226
+        Me.cmdRHelpAgricolae.Text = "R Help"
+        Me.cmdRHelpAgricolae.UseVisualStyleBackColor = True
+        '
+        'ContextMenuStripAgricolae
+        '
+        Me.ContextMenuStripAgricolae.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuAgricolae})
+        Me.ContextMenuStripAgricolae.Name = "ContextMenuStrip1"
+        Me.ContextMenuStripAgricolae.Size = New System.Drawing.Size(123, 26)
+        '
+        'ToolStripMenuAgricolae
+        '
+        Me.ToolStripMenuAgricolae.Name = "ToolStripMenuAgricolae"
+        Me.ToolStripMenuAgricolae.Size = New System.Drawing.Size(122, 22)
+        Me.ToolStripMenuAgricolae.Text = "agricolae"
+        '
+        'cmdRHelpTrend
+        '
+        Me.cmdRHelpTrend.AutoSize = True
+        Me.cmdRHelpTrend.ContextMenuStrip = Me.ContextMenuStripTrend
+        Me.cmdRHelpTrend.Location = New System.Drawing.Point(520, 259)
+        Me.cmdRHelpTrend.Name = "cmdRHelpTrend"
+        Me.cmdRHelpTrend.Size = New System.Drawing.Size(68, 23)
+        Me.cmdRHelpTrend.SplitMenuStrip = Me.ContextMenuStripTrend
+        Me.cmdRHelpTrend.TabIndex = 227
+        Me.cmdRHelpTrend.Text = "R Help"
+        Me.cmdRHelpTrend.UseVisualStyleBackColor = True
+        '
+        'ContextMenuStripTrend
+        '
+        Me.ContextMenuStripTrend.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuTrend})
+        Me.ContextMenuStripTrend.Name = "ContextMenuStrip1"
+        Me.ContextMenuStripTrend.Size = New System.Drawing.Size(103, 26)
+        '
+        'ToolStripMenuTrend
+        '
+        Me.ToolStripMenuTrend.Name = "ToolStripMenuTrend"
+        Me.ToolStripMenuTrend.Size = New System.Drawing.Size(102, 22)
+        Me.ToolStripMenuTrend.Text = "trend"
+        '
+        'cmdRHelpVerification
+        '
+        Me.cmdRHelpVerification.AutoSize = True
+        Me.cmdRHelpVerification.ContextMenuStrip = Me.ContextMenuStripVerification
+        Me.cmdRHelpVerification.Location = New System.Drawing.Point(521, 260)
+        Me.cmdRHelpVerification.Name = "cmdRHelpVerification"
+        Me.cmdRHelpVerification.Size = New System.Drawing.Size(68, 23)
+        Me.cmdRHelpVerification.SplitMenuStrip = Me.ContextMenuStripVerification
+        Me.cmdRHelpVerification.TabIndex = 228
+        Me.cmdRHelpVerification.Text = "R Help"
+        Me.cmdRHelpVerification.UseVisualStyleBackColor = True
+        '
+        'ContextMenuStripVerification
+        '
+        Me.ContextMenuStripVerification.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuVerification})
+        Me.ContextMenuStripVerification.Name = "ContextMenuStrip1"
+        Me.ContextMenuStripVerification.Size = New System.Drawing.Size(134, 26)
+        '
+        'ToolStripMenuVerification
+        '
+        Me.ToolStripMenuVerification.Name = "ToolStripMenuVerification"
+        Me.ToolStripMenuVerification.Size = New System.Drawing.Size(133, 22)
+        Me.ToolStripMenuVerification.Text = "verification"
+        '
         'dlgHypothesisTestsCalculator
         '
-        Me.AutoScaleDimensions = New System.Drawing.SizeF(144.0!, 144.0!)
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
         Me.AutoSize = True
-        Me.ClientSize = New System.Drawing.Size(964, 728)
+        Me.ClientSize = New System.Drawing.Size(643, 485)
+        Me.Controls.Add(Me.cmdRHelpVerification)
+        Me.Controls.Add(Me.cmdRHelpTrend)
+        Me.Controls.Add(Me.cmdRHelpAgricolae)
+        Me.Controls.Add(Me.cmdRHelpCoin)
+        Me.Controls.Add(Me.cmdRHelpStats)
         Me.Controls.Add(Me.grpTrend)
         Me.Controls.Add(Me.grpCoin)
         Me.Controls.Add(Me.grpVerification)
@@ -1603,7 +1752,6 @@ Partial Class dlgHypothesisTestsCalculator
         Me.Controls.Add(Me.ucrChkDisplayModel)
         Me.Controls.Add(Me.ucrChkSummaryModel)
         Me.Controls.Add(Me.ucrTryModelling)
-        Me.Controls.Add(Me.cmdHelp)
         Me.Controls.Add(Me.ucrReceiverMultiple)
         Me.Controls.Add(Me.grpStats2)
         Me.Controls.Add(Me.grpStats1)
@@ -1619,7 +1767,6 @@ Partial Class dlgHypothesisTestsCalculator
         Me.Controls.Add(Me.ucrReceiverForTestColumn)
         Me.Controls.Add(Me.grpAgricolae)
         Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow
-        Me.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
         Me.MaximizeBox = False
         Me.MinimizeBox = False
         Me.Name = "dlgHypothesisTestsCalculator"
@@ -1637,6 +1784,11 @@ Partial Class dlgHypothesisTestsCalculator
         Me.grpCorrelation.ResumeLayout(False)
         Me.grpLocation.ResumeLayout(False)
         Me.grpTrend.ResumeLayout(False)
+        Me.ContextMenuStripStats.ResumeLayout(False)
+        Me.ContextMenuStripCoin.ResumeLayout(False)
+        Me.ContextMenuStripAgricolae.ResumeLayout(False)
+        Me.ContextMenuStripTrend.ResumeLayout(False)
+        Me.ContextMenuStripVerification.ResumeLayout(False)
         Me.ResumeLayout(False)
         Me.PerformLayout()
 
@@ -1710,7 +1862,6 @@ Partial Class dlgHypothesisTestsCalculator
     Friend WithEvents cmdLSD As Button
     Friend WithEvents cmdDuncan As Button
     Friend WithEvents cmdBIB As Button
-    Friend WithEvents cmdHelp As Button
     Friend WithEvents ucrTryModelling As ucrTry
     Friend WithEvents grpVerification As GroupBox
     Friend WithEvents cmdCont As Button
@@ -1768,4 +1919,19 @@ Partial Class dlgHypothesisTestsCalculator
     Friend WithEvents cmdSnh As Button
     Friend WithEvents ttHypothesisTests As ToolTip
     Friend WithEvents cmdZero As Button
+    Friend WithEvents cmdRHelpStats As ucrSplitButton
+    Friend WithEvents cmdRHelpVerification As ucrSplitButton
+    Friend WithEvents cmdRHelpTrend As ucrSplitButton
+    Friend WithEvents cmdRHelpAgricolae As ucrSplitButton
+    Friend WithEvents cmdRHelpCoin As ucrSplitButton
+    Friend WithEvents ContextMenuStripStats As ContextMenuStrip
+    Friend WithEvents ToolStripMenuStats As ToolStripMenuItem
+    Friend WithEvents ContextMenuStripAgricolae As ContextMenuStrip
+    Friend WithEvents ToolStripMenuAgricolae As ToolStripMenuItem
+    Friend WithEvents ContextMenuStripVerification As ContextMenuStrip
+    Friend WithEvents ToolStripMenuVerification As ToolStripMenuItem
+    Friend WithEvents ContextMenuStripCoin As ContextMenuStrip
+    Friend WithEvents ToolStripMenuCoin As ToolStripMenuItem
+    Friend WithEvents ContextMenuStripTrend As ContextMenuStrip
+    Friend WithEvents ToolStripMenuTrend As ToolStripMenuItem
 End Class

--- a/instat/dlgHypothesisTestsCalculator.resx
+++ b/instat/dlgHypothesisTestsCalculator.resx
@@ -120,7 +120,19 @@
   <metadata name="ttHypothesisTests.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>20, 6</value>
   </metadata>
-  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>46</value>
+  <metadata name="ContextMenuStripVerification.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>569, 11</value>
+  </metadata>
+  <metadata name="ContextMenuStripTrend.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 48</value>
+  </metadata>
+  <metadata name="ContextMenuStripAgricolae.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>373, 10</value>
+  </metadata>
+  <metadata name="ContextMenuStripCoin.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>775, 9</value>
+  </metadata>
+  <metadata name="ContextMenuStripStats.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>172, 12</value>
   </metadata>
 </root>

--- a/instat/dlgHypothesisTestsCalculator.vb
+++ b/instat/dlgHypothesisTestsCalculator.vb
@@ -614,6 +614,11 @@ Public Class dlgHypothesisTestsCalculator
                 grpVerification.Visible = False
                 grpCoin.Visible = False
                 grpTrend.Visible = False
+                cmdRHelpStats.Visible = True
+                cmdRHelpAgricolae.Visible = False
+                cmdRHelpCoin.Visible = False
+                cmdRHelpVerification.Visible = False
+                cmdRHelpTrend.Visible = False
             Case "Stats2"
                 strPackageName = "stats"
                 grpAgricolae.Visible = False
@@ -622,6 +627,11 @@ Public Class dlgHypothesisTestsCalculator
                 grpVerification.Visible = False
                 grpCoin.Visible = False
                 grpTrend.Visible = False
+                cmdRHelpStats.Visible = True
+                cmdRHelpAgricolae.Visible = False
+                cmdRHelpCoin.Visible = False
+                cmdRHelpVerification.Visible = False
+                cmdRHelpTrend.Visible = False
             Case "Agricolae"
                 strPackageName = "agricolae"
                 grpStats1.Visible = False
@@ -630,6 +640,11 @@ Public Class dlgHypothesisTestsCalculator
                 grpVerification.Visible = False
                 grpCoin.Visible = False
                 grpTrend.Visible = False
+                cmdRHelpStats.Visible = False
+                cmdRHelpAgricolae.Visible = True
+                cmdRHelpCoin.Visible = False
+                cmdRHelpVerification.Visible = False
+                cmdRHelpTrend.Visible = False
             Case "Verification"
                 strPackageName = "verification"
                 grpStats1.Visible = False
@@ -638,6 +653,11 @@ Public Class dlgHypothesisTestsCalculator
                 grpVerification.Visible = True
                 grpCoin.Visible = False
                 grpTrend.Visible = False
+                cmdRHelpStats.Visible = False
+                cmdRHelpAgricolae.Visible = False
+                cmdRHelpCoin.Visible = False
+                cmdRHelpVerification.Visible = True
+                cmdRHelpTrend.Visible = False
             Case "Coin"
                 strPackageName = "coin"
                 grpStats1.Visible = False
@@ -646,6 +666,11 @@ Public Class dlgHypothesisTestsCalculator
                 grpVerification.Visible = False
                 grpCoin.Visible = True
                 grpTrend.Visible = False
+                cmdRHelpStats.Visible = False
+                cmdRHelpAgricolae.Visible = False
+                cmdRHelpCoin.Visible = True
+                cmdRHelpVerification.Visible = False
+                cmdRHelpTrend.Visible = False
             Case "Trend"
                 strPackageName = "trend"
                 grpStats1.Visible = False
@@ -654,6 +679,11 @@ Public Class dlgHypothesisTestsCalculator
                 grpVerification.Visible = False
                 grpCoin.Visible = False
                 grpTrend.Visible = True
+                cmdRHelpStats.Visible = False
+                cmdRHelpAgricolae.Visible = False
+                cmdRHelpCoin.Visible = False
+                cmdRHelpVerification.Visible = False
+                cmdRHelpTrend.Visible = True
 
         End Select
     End Sub
@@ -664,7 +694,7 @@ Public Class dlgHypothesisTestsCalculator
         TestOKEnabled()
     End Sub
 
-    Private Sub cmdHelp_Click(sender As Object, e As EventArgs) Handles cmdHelp.Click
+    Private Sub OpenHelpPage()
         If strPackageName <> "" Then
             frmMaximiseOutput.Show(strFileName:=clsFileUrlUtilities.GetHelpFileURL(strPackageName:=strPackageName), bReplace:=False)
         End If
@@ -1052,5 +1082,42 @@ Public Class dlgHypothesisTestsCalculator
 
     Private Sub cmdZero_Click(sender As Object, e As EventArgs) Handles cmdZero.Click
         ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("I()", 1)
+    End Sub
+
+    Private Sub cmdRHelpStats_Click(sender As Object, e As EventArgs) Handles cmdRHelpStats.Click, ToolStripMenuStats.Click
+        If ucrInputComboRPackage.GetText = "Stats1" Then
+            strPackageName = "stats"
+        ElseIf ucrInputComboRPackage.GetText = "Stats2" Then
+            strPackageName = "stats"
+        End If
+        OpenHelpPage()
+    End Sub
+
+    Private Sub cmdRHelpAgricolae_Click(sender As Object, e As EventArgs) Handles cmdRHelpAgricolae.Click, ToolStripMenuAgricolae.Click
+        If ucrInputComboRPackage.GetText = "Agricolae" Then
+            strPackageName = "agricolae"
+        End If
+        OpenHelpPage()
+    End Sub
+
+    Private Sub cmdRHelpCoin_Click(sender As Object, e As EventArgs) Handles cmdRHelpCoin.Click, ToolStripMenuCoin.Click
+        If ucrInputComboRPackage.GetText = "Coin" Then
+            strPackageName = "coin"
+        End If
+        OpenHelpPage()
+    End Sub
+
+    Private Sub cmdRHelpTrend_Click(sender As Object, e As EventArgs) Handles cmdRHelpTrend.Click, ToolStripMenuTrend.Click
+        If ucrInputComboRPackage.GetText = "Trend" Then
+            strPackageName = "trend"
+        End If
+        OpenHelpPage()
+    End Sub
+
+    Private Sub cmdRHelpVerification_Click(sender As Object, e As EventArgs) Handles cmdRHelpVerification.Click, ToolStripMenuVerification.Click
+        If ucrInputComboRPackage.GetText = "Verification" Then
+            strPackageName = "verification"
+        End If
+        OpenHelpPage()
     End Sub
 End Class

--- a/instat/dlgHypothesisTestsCalculator.vb
+++ b/instat/dlgHypothesisTestsCalculator.vb
@@ -695,7 +695,7 @@ Public Class dlgHypothesisTestsCalculator
     End Sub
 
     Private Sub OpenHelpPage()
-        If strPackageName <> "" Then
+        If Not String.IsNullOrEmpty(strPackageName) Then
             frmMaximiseOutput.Show(strFileName:=clsFileUrlUtilities.GetHelpFileURL(strPackageName:=strPackageName), bReplace:=False)
         End If
     End Sub
@@ -1085,9 +1085,7 @@ Public Class dlgHypothesisTestsCalculator
     End Sub
 
     Private Sub cmdRHelpStats_Click(sender As Object, e As EventArgs) Handles cmdRHelpStats.Click, ToolStripMenuStats.Click
-        If ucrInputComboRPackage.GetText = "Stats1" Then
-            strPackageName = "stats"
-        ElseIf ucrInputComboRPackage.GetText = "Stats2" Then
+        If ucrInputComboRPackage.GetText = "Stats1" OrElse ucrInputComboRPackage.GetText = "Stats2" Then
             strPackageName = "stats"
         End If
         OpenHelpPage()

--- a/instat/dlgModelling.Designer.vb
+++ b/instat/dlgModelling.Designer.vb
@@ -22,6 +22,7 @@ Partial Class dlgModelling
     'Do not modify it using the code editor.
     <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
+        Me.components = New System.ComponentModel.Container()
         Me.lblModel = New System.Windows.Forms.Label()
         Me.cmdspline = New System.Windows.Forms.Button()
         Me.cmdarima = New System.Windows.Forms.Button()
@@ -68,7 +69,6 @@ Partial Class dlgModelling
         Me.cmdmca = New System.Windows.Forms.Button()
         Me.cmdlqs = New System.Windows.Forms.Button()
         Me.cmdlda = New System.Windows.Forms.Button()
-        Me.cmdHelp = New System.Windows.Forms.Button()
         Me.lblRpackage = New System.Windows.Forms.Label()
         Me.ucrTryModelling = New instat.ucrTry()
         Me.ucrChkIncludeArguments = New instat.ucrCheck()
@@ -77,20 +77,37 @@ Partial Class dlgModelling
         Me.ucrReceiverForTestColumn = New instat.ucrReceiverExpression()
         Me.ucrSelectorModelling = New instat.ucrSelectorByDataFrameAddRemove()
         Me.ucrBase = New instat.ucrButtons()
+        Me.cmdRHelpStats = New instat.ucrSplitButton()
+        Me.ContextMenuStripStats = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.ToolStripMenuStats = New System.Windows.Forms.ToolStripMenuItem()
+        Me.cmdRHelpExtRemes = New instat.ucrSplitButton()
+        Me.ContextMenuStripExtRemes = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.ToolStripMenuExtRemes = New System.Windows.Forms.ToolStripMenuItem()
+        Me.cmdRHelpLme4 = New instat.ucrSplitButton()
+        Me.ContextMenuStripLme4 = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.ToolStripMenuLme4 = New System.Windows.Forms.ToolStripMenuItem()
+        Me.cmdRHelpMASS = New instat.ucrSplitButton()
+        Me.ContextMenuStripMASS = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.ToolStripMenuMASS = New System.Windows.Forms.ToolStripMenuItem()
         Me.grpStats.SuspendLayout()
         Me.grpFirstCalc.SuspendLayout()
         Me.grpextRemes.SuspendLayout()
         Me.grplme4.SuspendLayout()
         Me.grpMASS.SuspendLayout()
+        Me.ContextMenuStripStats.SuspendLayout()
+        Me.ContextMenuStripExtRemes.SuspendLayout()
+        Me.ContextMenuStripLme4.SuspendLayout()
+        Me.ContextMenuStripMASS.SuspendLayout()
         Me.SuspendLayout()
         '
         'lblModel
         '
         Me.lblModel.AutoSize = True
         Me.lblModel.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblModel.Location = New System.Drawing.Point(15, 26)
+        Me.lblModel.Location = New System.Drawing.Point(10, 17)
+        Me.lblModel.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
         Me.lblModel.Name = "lblModel"
-        Me.lblModel.Size = New System.Drawing.Size(56, 20)
+        Me.lblModel.Size = New System.Drawing.Size(39, 13)
         Me.lblModel.TabIndex = 0
         Me.lblModel.Tag = "Test"
         Me.lblModel.Text = "Model:"
@@ -98,10 +115,10 @@ Partial Class dlgModelling
         'cmdspline
         '
         Me.cmdspline.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdspline.Location = New System.Drawing.Point(210, 108)
-        Me.cmdspline.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdspline.Location = New System.Drawing.Point(140, 72)
+        Me.cmdspline.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdspline.Name = "cmdspline"
-        Me.cmdspline.Size = New System.Drawing.Size(104, 45)
+        Me.cmdspline.Size = New System.Drawing.Size(69, 30)
         Me.cmdspline.TabIndex = 164
         Me.cmdspline.Text = "spline"
         Me.cmdspline.UseVisualStyleBackColor = True
@@ -109,10 +126,10 @@ Partial Class dlgModelling
         'cmdarima
         '
         Me.cmdarima.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdarima.Location = New System.Drawing.Point(210, 21)
-        Me.cmdarima.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdarima.Location = New System.Drawing.Point(140, 14)
+        Me.cmdarima.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdarima.Name = "cmdarima"
-        Me.cmdarima.Size = New System.Drawing.Size(104, 45)
+        Me.cmdarima.Size = New System.Drawing.Size(69, 30)
         Me.cmdarima.TabIndex = 153
         Me.cmdarima.Text = "arima"
         Me.cmdarima.UseVisualStyleBackColor = True
@@ -120,10 +137,10 @@ Partial Class dlgModelling
         'cmdloglin
         '
         Me.cmdloglin.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdloglin.Location = New System.Drawing.Point(6, 108)
-        Me.cmdloglin.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdloglin.Location = New System.Drawing.Point(4, 72)
+        Me.cmdloglin.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdloglin.Name = "cmdloglin"
-        Me.cmdloglin.Size = New System.Drawing.Size(104, 45)
+        Me.cmdloglin.Size = New System.Drawing.Size(69, 30)
         Me.cmdloglin.TabIndex = 151
         Me.cmdloglin.Text = "loglin"
         Me.cmdloglin.UseVisualStyleBackColor = True
@@ -131,10 +148,10 @@ Partial Class dlgModelling
         'cmdloess
         '
         Me.cmdloess.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdloess.Location = New System.Drawing.Point(210, 64)
-        Me.cmdloess.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdloess.Location = New System.Drawing.Point(140, 43)
+        Me.cmdloess.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdloess.Name = "cmdloess"
-        Me.cmdloess.Size = New System.Drawing.Size(104, 45)
+        Me.cmdloess.Size = New System.Drawing.Size(69, 30)
         Me.cmdloess.TabIndex = 150
         Me.cmdloess.Text = "loess"
         Me.cmdloess.UseVisualStyleBackColor = True
@@ -142,10 +159,10 @@ Partial Class dlgModelling
         'cmdlowess
         '
         Me.cmdlowess.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdlowess.Location = New System.Drawing.Point(108, 108)
-        Me.cmdlowess.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdlowess.Location = New System.Drawing.Point(72, 72)
+        Me.cmdlowess.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdlowess.Name = "cmdlowess"
-        Me.cmdlowess.Size = New System.Drawing.Size(104, 45)
+        Me.cmdlowess.Size = New System.Drawing.Size(69, 30)
         Me.cmdlowess.TabIndex = 148
         Me.cmdlowess.Text = "lowess"
         Me.cmdlowess.UseVisualStyleBackColor = True
@@ -153,10 +170,10 @@ Partial Class dlgModelling
         'cmdglm
         '
         Me.cmdglm.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdglm.Location = New System.Drawing.Point(6, 64)
-        Me.cmdglm.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdglm.Location = New System.Drawing.Point(4, 43)
+        Me.cmdglm.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdglm.Name = "cmdglm"
-        Me.cmdglm.Size = New System.Drawing.Size(104, 45)
+        Me.cmdglm.Size = New System.Drawing.Size(69, 30)
         Me.cmdglm.TabIndex = 158
         Me.cmdglm.Text = "glm"
         Me.cmdglm.UseVisualStyleBackColor = True
@@ -164,10 +181,10 @@ Partial Class dlgModelling
         'cmdar
         '
         Me.cmdar.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdar.Location = New System.Drawing.Point(108, 21)
-        Me.cmdar.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdar.Location = New System.Drawing.Point(72, 14)
+        Me.cmdar.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdar.Name = "cmdar"
-        Me.cmdar.Size = New System.Drawing.Size(104, 45)
+        Me.cmdar.Size = New System.Drawing.Size(69, 30)
         Me.cmdar.TabIndex = 126
         Me.cmdar.Text = "ar"
         Me.cmdar.UseVisualStyleBackColor = True
@@ -175,10 +192,10 @@ Partial Class dlgModelling
         'cmdaov
         '
         Me.cmdaov.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdaov.Location = New System.Drawing.Point(6, 21)
-        Me.cmdaov.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdaov.Location = New System.Drawing.Point(4, 14)
+        Me.cmdaov.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdaov.Name = "cmdaov"
-        Me.cmdaov.Size = New System.Drawing.Size(104, 45)
+        Me.cmdaov.Size = New System.Drawing.Size(69, 30)
         Me.cmdaov.TabIndex = 124
         Me.cmdaov.Text = "aov"
         Me.cmdaov.UseVisualStyleBackColor = True
@@ -186,10 +203,10 @@ Partial Class dlgModelling
         'cmdlm
         '
         Me.cmdlm.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdlm.Location = New System.Drawing.Point(108, 64)
-        Me.cmdlm.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdlm.Location = New System.Drawing.Point(72, 43)
+        Me.cmdlm.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdlm.Name = "cmdlm"
-        Me.cmdlm.Size = New System.Drawing.Size(104, 45)
+        Me.cmdlm.Size = New System.Drawing.Size(69, 30)
         Me.cmdlm.TabIndex = 121
         Me.cmdlm.Text = "lm"
         Me.cmdlm.UseVisualStyleBackColor = True
@@ -208,11 +225,11 @@ Partial Class dlgModelling
         Me.grpStats.Controls.Add(Me.cmdlm)
         Me.grpStats.Controls.Add(Me.cmdaov)
         Me.grpStats.Controls.Add(Me.cmdar)
-        Me.grpStats.Location = New System.Drawing.Point(438, 102)
-        Me.grpStats.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.grpStats.Location = New System.Drawing.Point(292, 68)
+        Me.grpStats.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.grpStats.Name = "grpStats"
-        Me.grpStats.Padding = New System.Windows.Forms.Padding(3, 4, 3, 4)
-        Me.grpStats.Size = New System.Drawing.Size(320, 202)
+        Me.grpStats.Padding = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.grpStats.Size = New System.Drawing.Size(213, 135)
         Me.grpStats.TabIndex = 9
         Me.grpStats.TabStop = False
         Me.grpStats.Text = "stats"
@@ -220,10 +237,10 @@ Partial Class dlgModelling
         'cmdprincomp
         '
         Me.cmdprincomp.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdprincomp.Location = New System.Drawing.Point(210, 152)
-        Me.cmdprincomp.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdprincomp.Location = New System.Drawing.Point(140, 101)
+        Me.cmdprincomp.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdprincomp.Name = "cmdprincomp"
-        Me.cmdprincomp.Size = New System.Drawing.Size(104, 45)
+        Me.cmdprincomp.Size = New System.Drawing.Size(69, 30)
         Me.cmdprincomp.TabIndex = 167
         Me.cmdprincomp.Text = "princomp"
         Me.cmdprincomp.UseVisualStyleBackColor = True
@@ -231,10 +248,10 @@ Partial Class dlgModelling
         'cmdppr
         '
         Me.cmdppr.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdppr.Location = New System.Drawing.Point(108, 152)
-        Me.cmdppr.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdppr.Location = New System.Drawing.Point(72, 101)
+        Me.cmdppr.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdppr.Name = "cmdppr"
-        Me.cmdppr.Size = New System.Drawing.Size(104, 45)
+        Me.cmdppr.Size = New System.Drawing.Size(69, 30)
         Me.cmdppr.TabIndex = 166
         Me.cmdppr.Text = "ppr"
         Me.cmdppr.UseVisualStyleBackColor = True
@@ -242,10 +259,10 @@ Partial Class dlgModelling
         'cmdnls
         '
         Me.cmdnls.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdnls.Location = New System.Drawing.Point(6, 152)
-        Me.cmdnls.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdnls.Location = New System.Drawing.Point(4, 101)
+        Me.cmdnls.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdnls.Name = "cmdnls"
-        Me.cmdnls.Size = New System.Drawing.Size(104, 45)
+        Me.cmdnls.Size = New System.Drawing.Size(69, 30)
         Me.cmdnls.TabIndex = 165
         Me.cmdnls.Text = "nls"
         Me.cmdnls.UseVisualStyleBackColor = True
@@ -254,10 +271,10 @@ Partial Class dlgModelling
         '
         Me.cmdMultiply.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!)
         Me.cmdMultiply.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdMultiply.Location = New System.Drawing.Point(88, 15)
-        Me.cmdMultiply.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdMultiply.Location = New System.Drawing.Point(59, 10)
+        Me.cmdMultiply.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdMultiply.Name = "cmdMultiply"
-        Me.cmdMultiply.Size = New System.Drawing.Size(44, 45)
+        Me.cmdMultiply.Size = New System.Drawing.Size(29, 30)
         Me.cmdMultiply.TabIndex = 2
         Me.cmdMultiply.Text = "*"
         Me.cmdMultiply.UseVisualStyleBackColor = True
@@ -266,10 +283,10 @@ Partial Class dlgModelling
         '
         Me.cmdColon.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!)
         Me.cmdColon.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdColon.Location = New System.Drawing.Point(46, 15)
-        Me.cmdColon.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdColon.Location = New System.Drawing.Point(31, 10)
+        Me.cmdColon.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdColon.Name = "cmdColon"
-        Me.cmdColon.Size = New System.Drawing.Size(44, 45)
+        Me.cmdColon.Size = New System.Drawing.Size(29, 30)
         Me.cmdColon.TabIndex = 1
         Me.cmdColon.Text = ":"
         Me.cmdColon.UseVisualStyleBackColor = True
@@ -278,10 +295,10 @@ Partial Class dlgModelling
         '
         Me.cmdPlus.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!)
         Me.cmdPlus.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdPlus.Location = New System.Drawing.Point(4, 15)
-        Me.cmdPlus.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdPlus.Location = New System.Drawing.Point(3, 10)
+        Me.cmdPlus.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdPlus.Name = "cmdPlus"
-        Me.cmdPlus.Size = New System.Drawing.Size(44, 45)
+        Me.cmdPlus.Size = New System.Drawing.Size(29, 30)
         Me.cmdPlus.TabIndex = 0
         Me.cmdPlus.Text = "+"
         Me.cmdPlus.UseVisualStyleBackColor = True
@@ -290,10 +307,10 @@ Partial Class dlgModelling
         '
         Me.cmdPower.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!)
         Me.cmdPower.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdPower.Location = New System.Drawing.Point(130, 58)
-        Me.cmdPower.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdPower.Location = New System.Drawing.Point(87, 39)
+        Me.cmdPower.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdPower.Name = "cmdPower"
-        Me.cmdPower.Size = New System.Drawing.Size(44, 48)
+        Me.cmdPower.Size = New System.Drawing.Size(29, 32)
         Me.cmdPower.TabIndex = 7
         Me.cmdPower.Text = "^"
         Me.cmdPower.UseVisualStyleBackColor = True
@@ -302,10 +319,10 @@ Partial Class dlgModelling
         '
         Me.cmdClosingBracket.Font = New System.Drawing.Font("Microsoft Sans Serif", 9.75!)
         Me.cmdClosingBracket.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdClosingBracket.Location = New System.Drawing.Point(88, 58)
-        Me.cmdClosingBracket.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdClosingBracket.Location = New System.Drawing.Point(59, 39)
+        Me.cmdClosingBracket.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdClosingBracket.Name = "cmdClosingBracket"
-        Me.cmdClosingBracket.Size = New System.Drawing.Size(44, 48)
+        Me.cmdClosingBracket.Size = New System.Drawing.Size(29, 32)
         Me.cmdClosingBracket.TabIndex = 6
         Me.cmdClosingBracket.Text = ")"
         Me.cmdClosingBracket.UseVisualStyleBackColor = True
@@ -314,10 +331,10 @@ Partial Class dlgModelling
         '
         Me.cmdOpeningBracket.Font = New System.Drawing.Font("Microsoft Sans Serif", 9.75!)
         Me.cmdOpeningBracket.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdOpeningBracket.Location = New System.Drawing.Point(46, 58)
-        Me.cmdOpeningBracket.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdOpeningBracket.Location = New System.Drawing.Point(31, 39)
+        Me.cmdOpeningBracket.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdOpeningBracket.Name = "cmdOpeningBracket"
-        Me.cmdOpeningBracket.Size = New System.Drawing.Size(44, 48)
+        Me.cmdOpeningBracket.Size = New System.Drawing.Size(29, 32)
         Me.cmdOpeningBracket.TabIndex = 5
         Me.cmdOpeningBracket.Text = "("
         Me.cmdOpeningBracket.UseVisualStyleBackColor = True
@@ -326,10 +343,10 @@ Partial Class dlgModelling
         '
         Me.cmdDiv.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!)
         Me.cmdDiv.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdDiv.Location = New System.Drawing.Point(130, 15)
-        Me.cmdDiv.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdDiv.Location = New System.Drawing.Point(87, 10)
+        Me.cmdDiv.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdDiv.Name = "cmdDiv"
-        Me.cmdDiv.Size = New System.Drawing.Size(44, 45)
+        Me.cmdDiv.Size = New System.Drawing.Size(29, 30)
         Me.cmdDiv.TabIndex = 3
         Me.cmdDiv.Text = "/"
         Me.cmdDiv.UseVisualStyleBackColor = True
@@ -338,10 +355,10 @@ Partial Class dlgModelling
         '
         Me.cmdDoubleBracket.Font = New System.Drawing.Font("Microsoft Sans Serif", 9.75!)
         Me.cmdDoubleBracket.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdDoubleBracket.Location = New System.Drawing.Point(4, 58)
-        Me.cmdDoubleBracket.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdDoubleBracket.Location = New System.Drawing.Point(3, 39)
+        Me.cmdDoubleBracket.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdDoubleBracket.Name = "cmdDoubleBracket"
-        Me.cmdDoubleBracket.Size = New System.Drawing.Size(44, 48)
+        Me.cmdDoubleBracket.Size = New System.Drawing.Size(29, 32)
         Me.cmdDoubleBracket.TabIndex = 4
         Me.cmdDoubleBracket.Text = "( )"
         Me.cmdDoubleBracket.UseVisualStyleBackColor = True
@@ -349,10 +366,10 @@ Partial Class dlgModelling
         'cmdClear
         '
         Me.cmdClear.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdClear.Location = New System.Drawing.Point(626, 376)
-        Me.cmdClear.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdClear.Location = New System.Drawing.Point(417, 251)
+        Me.cmdClear.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdClear.Name = "cmdClear"
-        Me.cmdClear.Size = New System.Drawing.Size(86, 45)
+        Me.cmdClear.Size = New System.Drawing.Size(57, 30)
         Me.cmdClear.TabIndex = 10
         Me.cmdClear.Text = "Clear"
         Me.cmdClear.UseVisualStyleBackColor = True
@@ -361,10 +378,10 @@ Partial Class dlgModelling
         '
         Me.cmdSquareBrackets.Font = New System.Drawing.Font("Microsoft Sans Serif", 9.75!)
         Me.cmdSquareBrackets.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdSquareBrackets.Location = New System.Drawing.Point(46, 105)
-        Me.cmdSquareBrackets.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdSquareBrackets.Location = New System.Drawing.Point(31, 70)
+        Me.cmdSquareBrackets.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdSquareBrackets.Name = "cmdSquareBrackets"
-        Me.cmdSquareBrackets.Size = New System.Drawing.Size(44, 45)
+        Me.cmdSquareBrackets.Size = New System.Drawing.Size(29, 30)
         Me.cmdSquareBrackets.TabIndex = 9
         Me.cmdSquareBrackets.Text = "[ ]"
         Me.cmdSquareBrackets.UseVisualStyleBackColor = True
@@ -373,10 +390,10 @@ Partial Class dlgModelling
         '
         Me.cmdMinus.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!)
         Me.cmdMinus.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdMinus.Location = New System.Drawing.Point(4, 105)
-        Me.cmdMinus.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdMinus.Location = New System.Drawing.Point(3, 70)
+        Me.cmdMinus.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdMinus.Name = "cmdMinus"
-        Me.cmdMinus.Size = New System.Drawing.Size(44, 45)
+        Me.cmdMinus.Size = New System.Drawing.Size(29, 30)
         Me.cmdMinus.TabIndex = 8
         Me.cmdMinus.Text = "-"
         Me.cmdMinus.UseVisualStyleBackColor = True
@@ -394,11 +411,9 @@ Partial Class dlgModelling
         Me.grpFirstCalc.Controls.Add(Me.cmdDoubleBracket)
         Me.grpFirstCalc.Controls.Add(Me.cmdSquareBrackets)
         Me.grpFirstCalc.Controls.Add(Me.cmdMinus)
-        Me.grpFirstCalc.Location = New System.Drawing.Point(440, 308)
-        Me.grpFirstCalc.Margin = New System.Windows.Forms.Padding(4)
+        Me.grpFirstCalc.Location = New System.Drawing.Point(293, 205)
         Me.grpFirstCalc.Name = "grpFirstCalc"
-        Me.grpFirstCalc.Padding = New System.Windows.Forms.Padding(4)
-        Me.grpFirstCalc.Size = New System.Drawing.Size(178, 154)
+        Me.grpFirstCalc.Size = New System.Drawing.Size(119, 103)
         Me.grpFirstCalc.TabIndex = 10
         Me.grpFirstCalc.TabStop = False
         '
@@ -406,10 +421,10 @@ Partial Class dlgModelling
         '
         Me.cmdTilda.Font = New System.Drawing.Font("Microsoft Sans Serif", 18.0!)
         Me.cmdTilda.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdTilda.Location = New System.Drawing.Point(88, 105)
-        Me.cmdTilda.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdTilda.Location = New System.Drawing.Point(59, 70)
+        Me.cmdTilda.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdTilda.Name = "cmdTilda"
-        Me.cmdTilda.Size = New System.Drawing.Size(86, 45)
+        Me.cmdTilda.Size = New System.Drawing.Size(57, 30)
         Me.cmdTilda.TabIndex = 21
         Me.cmdTilda.Text = "~"
         Me.cmdTilda.UseVisualStyleBackColor = True
@@ -417,10 +432,9 @@ Partial Class dlgModelling
         'cmdDisplayOptions
         '
         Me.cmdDisplayOptions.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdDisplayOptions.Location = New System.Drawing.Point(430, 531)
-        Me.cmdDisplayOptions.Margin = New System.Windows.Forms.Padding(4)
+        Me.cmdDisplayOptions.Location = New System.Drawing.Point(287, 354)
         Me.cmdDisplayOptions.Name = "cmdDisplayOptions"
-        Me.cmdDisplayOptions.Size = New System.Drawing.Size(188, 34)
+        Me.cmdDisplayOptions.Size = New System.Drawing.Size(125, 23)
         Me.cmdDisplayOptions.TabIndex = 11
         Me.cmdDisplayOptions.Text = "Display Options"
         Me.cmdDisplayOptions.UseVisualStyleBackColor = True
@@ -429,10 +443,9 @@ Partial Class dlgModelling
         '
         Me.cmdPredict.Enabled = False
         Me.cmdPredict.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdPredict.Location = New System.Drawing.Point(627, 532)
-        Me.cmdPredict.Margin = New System.Windows.Forms.Padding(4)
+        Me.cmdPredict.Location = New System.Drawing.Point(418, 355)
         Me.cmdPredict.Name = "cmdPredict"
-        Me.cmdPredict.Size = New System.Drawing.Size(158, 34)
+        Me.cmdPredict.Size = New System.Drawing.Size(105, 23)
         Me.cmdPredict.TabIndex = 12
         Me.cmdPredict.Text = "Predict"
         Me.cmdPredict.UseVisualStyleBackColor = True
@@ -441,11 +454,9 @@ Partial Class dlgModelling
         '
         Me.grpextRemes.Controls.Add(Me.cmdfevd)
         Me.grpextRemes.Controls.Add(Me.cmdlevd)
-        Me.grpextRemes.Location = New System.Drawing.Point(438, 102)
-        Me.grpextRemes.Margin = New System.Windows.Forms.Padding(4)
+        Me.grpextRemes.Location = New System.Drawing.Point(292, 68)
         Me.grpextRemes.Name = "grpextRemes"
-        Me.grpextRemes.Padding = New System.Windows.Forms.Padding(4)
-        Me.grpextRemes.Size = New System.Drawing.Size(231, 74)
+        Me.grpextRemes.Size = New System.Drawing.Size(154, 49)
         Me.grpextRemes.TabIndex = 18
         Me.grpextRemes.TabStop = False
         Me.grpextRemes.Text = "extRemes"
@@ -453,10 +464,10 @@ Partial Class dlgModelling
         'cmdfevd
         '
         Me.cmdfevd.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdfevd.Location = New System.Drawing.Point(6, 21)
-        Me.cmdfevd.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdfevd.Location = New System.Drawing.Point(4, 14)
+        Me.cmdfevd.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdfevd.Name = "cmdfevd"
-        Me.cmdfevd.Size = New System.Drawing.Size(104, 45)
+        Me.cmdfevd.Size = New System.Drawing.Size(69, 30)
         Me.cmdfevd.TabIndex = 169
         Me.cmdfevd.Text = "fevd"
         Me.cmdfevd.UseVisualStyleBackColor = True
@@ -464,10 +475,10 @@ Partial Class dlgModelling
         'cmdlevd
         '
         Me.cmdlevd.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdlevd.Location = New System.Drawing.Point(108, 21)
-        Me.cmdlevd.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdlevd.Location = New System.Drawing.Point(72, 14)
+        Me.cmdlevd.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdlevd.Name = "cmdlevd"
-        Me.cmdlevd.Size = New System.Drawing.Size(104, 45)
+        Me.cmdlevd.Size = New System.Drawing.Size(69, 30)
         Me.cmdlevd.TabIndex = 129
         Me.cmdlevd.Text = "levd"
         Me.cmdlevd.UseVisualStyleBackColor = True
@@ -475,10 +486,10 @@ Partial Class dlgModelling
         'cmdnlmer
         '
         Me.cmdnlmer.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdnlmer.Location = New System.Drawing.Point(210, 21)
-        Me.cmdnlmer.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdnlmer.Location = New System.Drawing.Point(140, 14)
+        Me.cmdnlmer.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdnlmer.Name = "cmdnlmer"
-        Me.cmdnlmer.Size = New System.Drawing.Size(104, 45)
+        Me.cmdnlmer.Size = New System.Drawing.Size(69, 30)
         Me.cmdnlmer.TabIndex = 153
         Me.cmdnlmer.Text = "nlmer"
         Me.cmdnlmer.UseVisualStyleBackColor = True
@@ -486,10 +497,10 @@ Partial Class dlgModelling
         'cmdlmer
         '
         Me.cmdlmer.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdlmer.Location = New System.Drawing.Point(108, 21)
-        Me.cmdlmer.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdlmer.Location = New System.Drawing.Point(72, 14)
+        Me.cmdlmer.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdlmer.Name = "cmdlmer"
-        Me.cmdlmer.Size = New System.Drawing.Size(104, 45)
+        Me.cmdlmer.Size = New System.Drawing.Size(69, 30)
         Me.cmdlmer.TabIndex = 126
         Me.cmdlmer.Text = "lmer"
         Me.cmdlmer.UseVisualStyleBackColor = True
@@ -497,10 +508,10 @@ Partial Class dlgModelling
         'cmdglmer
         '
         Me.cmdglmer.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdglmer.Location = New System.Drawing.Point(6, 21)
-        Me.cmdglmer.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdglmer.Location = New System.Drawing.Point(4, 14)
+        Me.cmdglmer.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdglmer.Name = "cmdglmer"
-        Me.cmdglmer.Size = New System.Drawing.Size(104, 45)
+        Me.cmdglmer.Size = New System.Drawing.Size(69, 30)
         Me.cmdglmer.TabIndex = 124
         Me.cmdglmer.Text = "glmer"
         Me.cmdglmer.UseVisualStyleBackColor = True
@@ -510,11 +521,11 @@ Partial Class dlgModelling
         Me.grplme4.Controls.Add(Me.cmdlmer)
         Me.grplme4.Controls.Add(Me.cmdglmer)
         Me.grplme4.Controls.Add(Me.cmdnlmer)
-        Me.grplme4.Location = New System.Drawing.Point(438, 102)
-        Me.grplme4.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.grplme4.Location = New System.Drawing.Point(292, 68)
+        Me.grplme4.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.grplme4.Name = "grplme4"
-        Me.grplme4.Padding = New System.Windows.Forms.Padding(3, 4, 3, 4)
-        Me.grplme4.Size = New System.Drawing.Size(320, 70)
+        Me.grplme4.Padding = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.grplme4.Size = New System.Drawing.Size(213, 47)
         Me.grplme4.TabIndex = 6
         Me.grplme4.TabStop = False
         Me.grplme4.Text = "lme4"
@@ -522,10 +533,10 @@ Partial Class dlgModelling
         'cmdloglm
         '
         Me.cmdloglm.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdloglm.Location = New System.Drawing.Point(210, 21)
-        Me.cmdloglm.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdloglm.Location = New System.Drawing.Point(140, 14)
+        Me.cmdloglm.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdloglm.Name = "cmdloglm"
-        Me.cmdloglm.Size = New System.Drawing.Size(104, 45)
+        Me.cmdloglm.Size = New System.Drawing.Size(69, 30)
         Me.cmdloglm.TabIndex = 153
         Me.cmdloglm.Text = "loglm"
         Me.cmdloglm.UseVisualStyleBackColor = True
@@ -533,10 +544,10 @@ Partial Class dlgModelling
         'cmdpolr
         '
         Me.cmdpolr.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdpolr.Location = New System.Drawing.Point(6, 64)
-        Me.cmdpolr.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdpolr.Location = New System.Drawing.Point(4, 43)
+        Me.cmdpolr.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdpolr.Name = "cmdpolr"
-        Me.cmdpolr.Size = New System.Drawing.Size(104, 45)
+        Me.cmdpolr.Size = New System.Drawing.Size(69, 30)
         Me.cmdpolr.TabIndex = 158
         Me.cmdpolr.Text = "polr"
         Me.cmdpolr.UseVisualStyleBackColor = True
@@ -544,10 +555,10 @@ Partial Class dlgModelling
         'cmdglmmPQL
         '
         Me.cmdglmmPQL.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdglmmPQL.Location = New System.Drawing.Point(108, 21)
-        Me.cmdglmmPQL.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdglmmPQL.Location = New System.Drawing.Point(72, 14)
+        Me.cmdglmmPQL.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdglmmPQL.Name = "cmdglmmPQL"
-        Me.cmdglmmPQL.Size = New System.Drawing.Size(104, 45)
+        Me.cmdglmmPQL.Size = New System.Drawing.Size(69, 30)
         Me.cmdglmmPQL.TabIndex = 126
         Me.cmdglmmPQL.Text = "glmmPQL"
         Me.cmdglmmPQL.UseVisualStyleBackColor = True
@@ -555,10 +566,10 @@ Partial Class dlgModelling
         'cmdglmnb
         '
         Me.cmdglmnb.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdglmnb.Location = New System.Drawing.Point(6, 21)
-        Me.cmdglmnb.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdglmnb.Location = New System.Drawing.Point(4, 14)
+        Me.cmdglmnb.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdglmnb.Name = "cmdglmnb"
-        Me.cmdglmnb.Size = New System.Drawing.Size(104, 45)
+        Me.cmdglmnb.Size = New System.Drawing.Size(69, 30)
         Me.cmdglmnb.TabIndex = 124
         Me.cmdglmnb.Text = "glm.nb"
         Me.cmdglmnb.UseVisualStyleBackColor = True
@@ -566,10 +577,10 @@ Partial Class dlgModelling
         'cmdrlm
         '
         Me.cmdrlm.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdrlm.Location = New System.Drawing.Point(108, 64)
-        Me.cmdrlm.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdrlm.Location = New System.Drawing.Point(72, 43)
+        Me.cmdrlm.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdrlm.Name = "cmdrlm"
-        Me.cmdrlm.Size = New System.Drawing.Size(104, 45)
+        Me.cmdrlm.Size = New System.Drawing.Size(69, 30)
         Me.cmdrlm.TabIndex = 121
         Me.cmdrlm.Text = "rlm"
         Me.cmdrlm.UseVisualStyleBackColor = True
@@ -585,11 +596,11 @@ Partial Class dlgModelling
         Me.grpMASS.Controls.Add(Me.cmdglmnb)
         Me.grpMASS.Controls.Add(Me.cmdrlm)
         Me.grpMASS.Controls.Add(Me.cmdloglm)
-        Me.grpMASS.Location = New System.Drawing.Point(438, 102)
-        Me.grpMASS.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.grpMASS.Location = New System.Drawing.Point(292, 68)
+        Me.grpMASS.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.grpMASS.Name = "grpMASS"
-        Me.grpMASS.Padding = New System.Windows.Forms.Padding(3, 4, 3, 4)
-        Me.grpMASS.Size = New System.Drawing.Size(320, 159)
+        Me.grpMASS.Padding = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.grpMASS.Size = New System.Drawing.Size(213, 106)
         Me.grpMASS.TabIndex = 20
         Me.grpMASS.TabStop = False
         Me.grpMASS.Text = "MASS"
@@ -597,10 +608,10 @@ Partial Class dlgModelling
         'cmdqda
         '
         Me.cmdqda.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdqda.Location = New System.Drawing.Point(210, 108)
-        Me.cmdqda.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdqda.Location = New System.Drawing.Point(140, 72)
+        Me.cmdqda.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdqda.Name = "cmdqda"
-        Me.cmdqda.Size = New System.Drawing.Size(104, 45)
+        Me.cmdqda.Size = New System.Drawing.Size(69, 30)
         Me.cmdqda.TabIndex = 166
         Me.cmdqda.Text = "qda"
         Me.cmdqda.UseVisualStyleBackColor = True
@@ -608,10 +619,10 @@ Partial Class dlgModelling
         'cmdmca
         '
         Me.cmdmca.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdmca.Location = New System.Drawing.Point(6, 108)
-        Me.cmdmca.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdmca.Location = New System.Drawing.Point(4, 72)
+        Me.cmdmca.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdmca.Name = "cmdmca"
-        Me.cmdmca.Size = New System.Drawing.Size(104, 45)
+        Me.cmdmca.Size = New System.Drawing.Size(69, 30)
         Me.cmdmca.TabIndex = 161
         Me.cmdmca.Text = "mca"
         Me.cmdmca.UseVisualStyleBackColor = True
@@ -619,10 +630,10 @@ Partial Class dlgModelling
         'cmdlqs
         '
         Me.cmdlqs.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdlqs.Location = New System.Drawing.Point(108, 108)
-        Me.cmdlqs.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdlqs.Location = New System.Drawing.Point(72, 72)
+        Me.cmdlqs.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdlqs.Name = "cmdlqs"
-        Me.cmdlqs.Size = New System.Drawing.Size(104, 45)
+        Me.cmdlqs.Size = New System.Drawing.Size(69, 30)
         Me.cmdlqs.TabIndex = 160
         Me.cmdlqs.Text = "lqs"
         Me.cmdlqs.UseVisualStyleBackColor = True
@@ -630,63 +641,51 @@ Partial Class dlgModelling
         'cmdlda
         '
         Me.cmdlda.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdlda.Location = New System.Drawing.Point(210, 64)
-        Me.cmdlda.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdlda.Location = New System.Drawing.Point(140, 43)
+        Me.cmdlda.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdlda.Name = "cmdlda"
-        Me.cmdlda.Size = New System.Drawing.Size(104, 45)
+        Me.cmdlda.Size = New System.Drawing.Size(69, 30)
         Me.cmdlda.TabIndex = 159
         Me.cmdlda.Text = "lda"
         Me.cmdlda.UseVisualStyleBackColor = True
-        '
-        'cmdHelp
-        '
-        Me.cmdHelp.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdHelp.Location = New System.Drawing.Point(740, 55)
-        Me.cmdHelp.Margin = New System.Windows.Forms.Padding(4)
-        Me.cmdHelp.Name = "cmdHelp"
-        Me.cmdHelp.Size = New System.Drawing.Size(90, 34)
-        Me.cmdHelp.TabIndex = 7
-        Me.cmdHelp.Text = "R Help"
-        Me.cmdHelp.UseVisualStyleBackColor = True
         '
         'lblRpackage
         '
         Me.lblRpackage.AutoSize = True
         Me.lblRpackage.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblRpackage.Location = New System.Drawing.Point(438, 64)
-        Me.lblRpackage.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
+        Me.lblRpackage.Location = New System.Drawing.Point(292, 43)
         Me.lblRpackage.Name = "lblRpackage"
-        Me.lblRpackage.Size = New System.Drawing.Size(90, 20)
+        Me.lblRpackage.Size = New System.Drawing.Size(63, 13)
         Me.lblRpackage.TabIndex = 3
         Me.lblRpackage.Text = "R package:"
         '
         'ucrTryModelling
         '
         Me.ucrTryModelling.AutoSize = True
-        Me.ucrTryModelling.Location = New System.Drawing.Point(6, 471)
-        Me.ucrTryModelling.Margin = New System.Windows.Forms.Padding(6)
+        Me.ucrTryModelling.Location = New System.Drawing.Point(4, 314)
+        Me.ucrTryModelling.Margin = New System.Windows.Forms.Padding(4)
         Me.ucrTryModelling.Name = "ucrTryModelling"
         Me.ucrTryModelling.RunCommandAsMultipleLines = False
-        Me.ucrTryModelling.Size = New System.Drawing.Size(720, 55)
+        Me.ucrTryModelling.Size = New System.Drawing.Size(480, 37)
         Me.ucrTryModelling.TabIndex = 21
         '
         'ucrChkIncludeArguments
         '
         Me.ucrChkIncludeArguments.AutoSize = True
         Me.ucrChkIncludeArguments.Checked = False
-        Me.ucrChkIncludeArguments.Location = New System.Drawing.Point(663, 20)
-        Me.ucrChkIncludeArguments.Margin = New System.Windows.Forms.Padding(9)
+        Me.ucrChkIncludeArguments.Location = New System.Drawing.Point(442, 13)
+        Me.ucrChkIncludeArguments.Margin = New System.Windows.Forms.Padding(6)
         Me.ucrChkIncludeArguments.Name = "ucrChkIncludeArguments"
-        Me.ucrChkIncludeArguments.Size = New System.Drawing.Size(196, 34)
+        Me.ucrChkIncludeArguments.Size = New System.Drawing.Size(131, 23)
         Me.ucrChkIncludeArguments.TabIndex = 2
         '
         'ucrSaveResult
         '
         Me.ucrSaveResult.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrSaveResult.Location = New System.Drawing.Point(20, 532)
-        Me.ucrSaveResult.Margin = New System.Windows.Forms.Padding(6, 8, 6, 8)
+        Me.ucrSaveResult.Location = New System.Drawing.Point(13, 355)
+        Me.ucrSaveResult.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
         Me.ucrSaveResult.Name = "ucrSaveResult"
-        Me.ucrSaveResult.Size = New System.Drawing.Size(400, 36)
+        Me.ucrSaveResult.Size = New System.Drawing.Size(267, 24)
         Me.ucrSaveResult.TabIndex = 13
         '
         'ucrInputComboRPackage
@@ -695,21 +694,21 @@ Partial Class dlgModelling
         Me.ucrInputComboRPackage.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.ucrInputComboRPackage.GetSetSelectedIndex = -1
         Me.ucrInputComboRPackage.IsReadOnly = False
-        Me.ucrInputComboRPackage.Location = New System.Drawing.Point(546, 58)
-        Me.ucrInputComboRPackage.Margin = New System.Windows.Forms.Padding(14)
+        Me.ucrInputComboRPackage.Location = New System.Drawing.Point(364, 39)
+        Me.ucrInputComboRPackage.Margin = New System.Windows.Forms.Padding(9)
         Me.ucrInputComboRPackage.Name = "ucrInputComboRPackage"
-        Me.ucrInputComboRPackage.Size = New System.Drawing.Size(184, 32)
+        Me.ucrInputComboRPackage.Size = New System.Drawing.Size(123, 21)
         Me.ucrInputComboRPackage.TabIndex = 4
         '
         'ucrReceiverForTestColumn
         '
         Me.ucrReceiverForTestColumn.AutoSize = True
         Me.ucrReceiverForTestColumn.frmParent = Me
-        Me.ucrReceiverForTestColumn.Location = New System.Drawing.Point(94, 20)
-        Me.ucrReceiverForTestColumn.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.ucrReceiverForTestColumn.Location = New System.Drawing.Point(63, 13)
+        Me.ucrReceiverForTestColumn.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.ucrReceiverForTestColumn.Name = "ucrReceiverForTestColumn"
         Me.ucrReceiverForTestColumn.Selector = Nothing
-        Me.ucrReceiverForTestColumn.Size = New System.Drawing.Size(552, 40)
+        Me.ucrReceiverForTestColumn.Size = New System.Drawing.Size(368, 27)
         Me.ucrReceiverForTestColumn.strNcFilePath = ""
         Me.ucrReceiverForTestColumn.TabIndex = 1
         Me.ucrReceiverForTestColumn.ucrSelector = Nothing
@@ -720,35 +719,134 @@ Partial Class dlgModelling
         Me.ucrSelectorModelling.bDropUnusedFilterLevels = False
         Me.ucrSelectorModelling.bShowHiddenColumns = False
         Me.ucrSelectorModelling.bUseCurrentFilter = True
-        Me.ucrSelectorModelling.Location = New System.Drawing.Point(15, 99)
+        Me.ucrSelectorModelling.Location = New System.Drawing.Point(10, 66)
         Me.ucrSelectorModelling.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrSelectorModelling.Name = "ucrSelectorModelling"
-        Me.ucrSelectorModelling.Size = New System.Drawing.Size(320, 274)
+        Me.ucrSelectorModelling.Size = New System.Drawing.Size(213, 183)
         Me.ucrSelectorModelling.TabIndex = 5
         '
         'ucrBase
         '
         Me.ucrBase.AutoSize = True
         Me.ucrBase.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrBase.Location = New System.Drawing.Point(20, 580)
-        Me.ucrBase.Margin = New System.Windows.Forms.Padding(6)
+        Me.ucrBase.Location = New System.Drawing.Point(13, 387)
+        Me.ucrBase.Margin = New System.Windows.Forms.Padding(4)
         Me.ucrBase.Name = "ucrBase"
-        Me.ucrBase.Size = New System.Drawing.Size(611, 77)
+        Me.ucrBase.Size = New System.Drawing.Size(408, 52)
         Me.ucrBase.TabIndex = 14
+        '
+        'cmdRHelpStats
+        '
+        Me.cmdRHelpStats.AutoSize = True
+        Me.cmdRHelpStats.ContextMenuStrip = Me.ContextMenuStripStats
+        Me.cmdRHelpStats.Location = New System.Drawing.Point(493, 39)
+        Me.cmdRHelpStats.Name = "cmdRHelpStats"
+        Me.cmdRHelpStats.Size = New System.Drawing.Size(68, 23)
+        Me.cmdRHelpStats.SplitMenuStrip = Me.ContextMenuStripStats
+        Me.cmdRHelpStats.TabIndex = 214
+        Me.cmdRHelpStats.Text = "R Help"
+        Me.cmdRHelpStats.UseVisualStyleBackColor = True
+        '
+        'ContextMenuStripStats
+        '
+        Me.ContextMenuStripStats.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuStats})
+        Me.ContextMenuStripStats.Name = "ContextMenuStrip1"
+        Me.ContextMenuStripStats.Size = New System.Drawing.Size(99, 26)
+        '
+        'ToolStripMenuStats
+        '
+        Me.ToolStripMenuStats.Name = "ToolStripMenuStats"
+        Me.ToolStripMenuStats.Size = New System.Drawing.Size(98, 22)
+        Me.ToolStripMenuStats.Text = "stats"
+        '
+        'cmdRHelpExtRemes
+        '
+        Me.cmdRHelpExtRemes.AutoSize = True
+        Me.cmdRHelpExtRemes.ContextMenuStrip = Me.ContextMenuStripExtRemes
+        Me.cmdRHelpExtRemes.Location = New System.Drawing.Point(493, 39)
+        Me.cmdRHelpExtRemes.Name = "cmdRHelpExtRemes"
+        Me.cmdRHelpExtRemes.Size = New System.Drawing.Size(68, 23)
+        Me.cmdRHelpExtRemes.SplitMenuStrip = Me.ContextMenuStripExtRemes
+        Me.cmdRHelpExtRemes.TabIndex = 216
+        Me.cmdRHelpExtRemes.Text = "R Help"
+        Me.cmdRHelpExtRemes.UseVisualStyleBackColor = True
+        '
+        'ContextMenuStripExtRemes
+        '
+        Me.ContextMenuStripExtRemes.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuExtRemes})
+        Me.ContextMenuStripExtRemes.Name = "ContextMenuStrip1"
+        Me.ContextMenuStripExtRemes.Size = New System.Drawing.Size(126, 26)
+        '
+        'ToolStripMenuExtRemes
+        '
+        Me.ToolStripMenuExtRemes.Name = "ToolStripMenuExtRemes"
+        Me.ToolStripMenuExtRemes.Size = New System.Drawing.Size(125, 22)
+        Me.ToolStripMenuExtRemes.Text = "extRemes"
+        '
+        'cmdRHelpLme4
+        '
+        Me.cmdRHelpLme4.AutoSize = True
+        Me.cmdRHelpLme4.ContextMenuStrip = Me.ContextMenuStripLme4
+        Me.cmdRHelpLme4.Location = New System.Drawing.Point(493, 39)
+        Me.cmdRHelpLme4.Name = "cmdRHelpLme4"
+        Me.cmdRHelpLme4.Size = New System.Drawing.Size(68, 23)
+        Me.cmdRHelpLme4.SplitMenuStrip = Me.ContextMenuStripLme4
+        Me.cmdRHelpLme4.TabIndex = 217
+        Me.cmdRHelpLme4.Text = "R Help"
+        Me.cmdRHelpLme4.UseVisualStyleBackColor = True
+        '
+        'ContextMenuStripLme4
+        '
+        Me.ContextMenuStripLme4.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuLme4})
+        Me.ContextMenuStripLme4.Name = "ContextMenuStrip1"
+        Me.ContextMenuStripLme4.Size = New System.Drawing.Size(101, 26)
+        '
+        'ToolStripMenuLme4
+        '
+        Me.ToolStripMenuLme4.Name = "ToolStripMenuLme4"
+        Me.ToolStripMenuLme4.Size = New System.Drawing.Size(100, 22)
+        Me.ToolStripMenuLme4.Text = "lme4"
+        '
+        'cmdRHelpMASS
+        '
+        Me.cmdRHelpMASS.AutoSize = True
+        Me.cmdRHelpMASS.ContextMenuStrip = Me.ContextMenuStripMASS
+        Me.cmdRHelpMASS.Location = New System.Drawing.Point(493, 39)
+        Me.cmdRHelpMASS.Name = "cmdRHelpMASS"
+        Me.cmdRHelpMASS.Size = New System.Drawing.Size(68, 23)
+        Me.cmdRHelpMASS.SplitMenuStrip = Me.ContextMenuStripMASS
+        Me.cmdRHelpMASS.TabIndex = 218
+        Me.cmdRHelpMASS.Text = "R Help"
+        Me.cmdRHelpMASS.UseVisualStyleBackColor = True
+        '
+        'ContextMenuStripMASS
+        '
+        Me.ContextMenuStripMASS.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuMASS})
+        Me.ContextMenuStripMASS.Name = "ContextMenuStrip1"
+        Me.ContextMenuStripMASS.Size = New System.Drawing.Size(106, 26)
+        '
+        'ToolStripMenuMASS
+        '
+        Me.ToolStripMenuMASS.Name = "ToolStripMenuMASS"
+        Me.ToolStripMenuMASS.Size = New System.Drawing.Size(105, 22)
+        Me.ToolStripMenuMASS.Text = "MASS"
         '
         'dlgModelling
         '
-        Me.AutoScaleDimensions = New System.Drawing.SizeF(144.0!, 144.0!)
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
         Me.AutoSize = True
-        Me.ClientSize = New System.Drawing.Size(849, 663)
+        Me.ClientSize = New System.Drawing.Size(566, 442)
+        Me.Controls.Add(Me.cmdRHelpMASS)
+        Me.Controls.Add(Me.cmdRHelpLme4)
+        Me.Controls.Add(Me.cmdRHelpExtRemes)
+        Me.Controls.Add(Me.cmdRHelpStats)
         Me.Controls.Add(Me.ucrTryModelling)
         Me.Controls.Add(Me.grplme4)
         Me.Controls.Add(Me.grpMASS)
         Me.Controls.Add(Me.grpextRemes)
         Me.Controls.Add(Me.ucrChkIncludeArguments)
         Me.Controls.Add(Me.lblRpackage)
-        Me.Controls.Add(Me.cmdHelp)
         Me.Controls.Add(Me.cmdDisplayOptions)
         Me.Controls.Add(Me.cmdPredict)
         Me.Controls.Add(Me.cmdClear)
@@ -761,7 +859,6 @@ Partial Class dlgModelling
         Me.Controls.Add(Me.ucrBase)
         Me.Controls.Add(Me.grpStats)
         Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow
-        Me.Margin = New System.Windows.Forms.Padding(4)
         Me.MaximizeBox = False
         Me.MinimizeBox = False
         Me.Name = "dlgModelling"
@@ -772,6 +869,10 @@ Partial Class dlgModelling
         Me.grpextRemes.ResumeLayout(False)
         Me.grplme4.ResumeLayout(False)
         Me.grpMASS.ResumeLayout(False)
+        Me.ContextMenuStripStats.ResumeLayout(False)
+        Me.ContextMenuStripExtRemes.ResumeLayout(False)
+        Me.ContextMenuStripLme4.ResumeLayout(False)
+        Me.ContextMenuStripMASS.ResumeLayout(False)
         Me.ResumeLayout(False)
         Me.PerformLayout()
 
@@ -820,7 +921,6 @@ Partial Class dlgModelling
     Friend WithEvents cmdglmmPQL As Button
     Friend WithEvents cmdglmnb As Button
     Friend WithEvents cmdrlm As Button
-    Friend WithEvents cmdHelp As Button
     Friend WithEvents lblRpackage As Label
     Friend WithEvents ucrChkIncludeArguments As ucrCheck
     Friend WithEvents cmdTilda As Button
@@ -832,4 +932,16 @@ Partial Class dlgModelling
     Friend WithEvents cmdmca As Button
     Friend WithEvents cmdqda As Button
     Friend WithEvents ucrTryModelling As ucrTry
+    Friend WithEvents cmdRHelpStats As ucrSplitButton
+    Friend WithEvents cmdRHelpExtRemes As ucrSplitButton
+    Friend WithEvents ContextMenuStripStats As ContextMenuStrip
+    Friend WithEvents ToolStripMenuStats As ToolStripMenuItem
+    Friend WithEvents cmdRHelpMASS As ucrSplitButton
+    Friend WithEvents ContextMenuStripMASS As ContextMenuStrip
+    Friend WithEvents ToolStripMenuMASS As ToolStripMenuItem
+    Friend WithEvents cmdRHelpLme4 As ucrSplitButton
+    Friend WithEvents ContextMenuStripLme4 As ContextMenuStrip
+    Friend WithEvents ToolStripMenuLme4 As ToolStripMenuItem
+    Friend WithEvents ContextMenuStripExtRemes As ContextMenuStrip
+    Friend WithEvents ToolStripMenuExtRemes As ToolStripMenuItem
 End Class

--- a/instat/dlgModelling.resx
+++ b/instat/dlgModelling.resx
@@ -117,4 +117,16 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="ContextMenuStripMASS.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>656, 19</value>
+  </metadata>
+  <metadata name="ContextMenuStripLme4.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>464, 15</value>
+  </metadata>
+  <metadata name="ContextMenuStripExtRemes.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>229, 15</value>
+  </metadata>
+  <metadata name="ContextMenuStripStats.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>

--- a/instat/dlgModelling.vb
+++ b/instat/dlgModelling.vb
@@ -20,7 +20,7 @@ Public Class dlgModelling
     Public bFirstLoad As Boolean = True
     Private bReset As Boolean = True
     Private clsAttach, clsDetach As New RFunction
-
+    Private strPackageName As String
     Public clsRModelFunction As New RFunction
     Public clsRYVariable, clsRXVariable As String
     Private ucrAvailableDataframe As ucrDataFrame
@@ -579,9 +579,7 @@ Public Class dlgModelling
         bResetDisplayOptions = False
     End Sub
 
-
-    Private Sub cmdHelp_Click(sender As Object, e As EventArgs) Handles cmdHelp.Click
-        Dim strPackageName As String = ucrInputComboRPackage.GetText
+    Private Sub OpenHelpPage()
         If strPackageName <> "" Then
             frmMaximiseOutput.Show(strFileName:=clsFileUrlUtilities.GetHelpFileURL(strPackageName:=strPackageName), bReplace:=False)
         End If
@@ -610,29 +608,74 @@ Public Class dlgModelling
     Private Sub ucrInputComboRPackage_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrInputComboRPackage.ControlValueChanged
         Select Case ucrInputComboRPackage.GetText
             Case "stats"
+                strPackageName = "stats"
                 grpStats.Visible = True
                 grpextRemes.Visible = False
                 grplme4.Visible = False
                 grpMASS.Visible = False
+                cmdRHelpStats.Visible = True
+                cmdRHelpExtRemes.Visible = False
+                cmdRHelpLme4.Visible = False
+                cmdRHelpMASS.Visible = False
             Case "extRemes"
+                strPackageName = "extRemes"
                 grpStats.Visible = False
                 grpextRemes.Visible = True
                 grplme4.Visible = False
                 grpMASS.Visible = False
+                cmdRHelpStats.Visible = False
+                cmdRHelpExtRemes.Visible = True
+                cmdRHelpLme4.Visible = False
+                cmdRHelpMASS.Visible = False
             Case "lme4"
+                strPackageName = "lme4"
                 grpStats.Visible = False
                 grpextRemes.Visible = False
                 grplme4.Visible = True
                 grpMASS.Visible = False
+                cmdRHelpStats.Visible = False
+                cmdRHelpExtRemes.Visible = False
+                cmdRHelpLme4.Visible = True
+                cmdRHelpMASS.Visible = False
             Case "MASS"
+                strPackageName = "MASS"
                 grpStats.Visible = False
                 grpextRemes.Visible = False
                 grplme4.Visible = False
                 grpMASS.Visible = True
+                cmdRHelpStats.Visible = False
+                cmdRHelpExtRemes.Visible = False
+                cmdRHelpLme4.Visible = False
+                cmdRHelpMASS.Visible = True
         End Select
     End Sub
 
+    Private Sub cmdRHelpStats_Click(sender As Object, e As EventArgs) Handles cmdRHelpStats.Click, ToolStripMenuStats.Click
+        If ucrInputComboRPackage.GetText = "stats" Then
+            strPackageName = "stats"
+        End If
+        OpenHelpPage()
+    End Sub
+    Private Sub cmdRHelpExtRemes_Click(sender As Object, e As EventArgs) Handles cmdRHelpExtRemes.Click, ToolStripMenuExtRemes.Click
+        If ucrInputComboRPackage.GetText = "extRemes" Then
+            strPackageName = "extRemes"
+        End If
+        OpenHelpPage()
+    End Sub
 
+    Private Sub cmdRHelpLme4_Click(sender As Object, e As EventArgs) Handles cmdRHelpLme4.Click, ToolStripMenuLme4.Click
+        If ucrInputComboRPackage.GetText = "lme4" Then
+            strPackageName = "lme4"
+        End If
+        OpenHelpPage()
+    End Sub
+
+    Private Sub cmdRHelpMASS_Click(sender As Object, e As EventArgs) Handles cmdRHelpMASS.Click, ToolStripMenuMASS.Click
+        If ucrInputComboRPackage.GetText = "MASS" Then
+            strPackageName = "MASS"
+        End If
+        OpenHelpPage()
+    End Sub
     Private Sub ucrBase_ClickOk(sender As Object, e As EventArgs) Handles ucrBase.ClickOk
         ucrReceiverForTestColumn.AddtoCombobox(ucrReceiverForTestColumn.GetText)
     End Sub

--- a/instat/dlgModelling.vb
+++ b/instat/dlgModelling.vb
@@ -580,7 +580,7 @@ Public Class dlgModelling
     End Sub
 
     Private Sub OpenHelpPage()
-        If strPackageName <> "" Then
+        If Not String.IsNullOrEmpty(strPackageName) Then
             frmMaximiseOutput.Show(strFileName:=clsFileUrlUtilities.GetHelpFileURL(strPackageName:=strPackageName), bReplace:=False)
         End If
     End Sub

--- a/instat/dlgModelling.vb
+++ b/instat/dlgModelling.vb
@@ -676,6 +676,7 @@ Public Class dlgModelling
         End If
         OpenHelpPage()
     End Sub
+
     Private Sub ucrBase_ClickOk(sender As Object, e As EventArgs) Handles ucrBase.ClickOk
         ucrReceiverForTestColumn.AddtoCombobox(ucrReceiverForTestColumn.GetText)
     End Sub

--- a/instat/dlgUseModel.Designer.vb
+++ b/instat/dlgUseModel.Designer.vb
@@ -22,6 +22,7 @@ Partial Class dlgUseModel
     'Do not modify it using the code editor.
     <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
+        Me.components = New System.ComponentModel.Container()
         Me.lblModel = New System.Windows.Forms.Label()
         Me.cmdsummary = New System.Windows.Forms.Button()
         Me.cmdanova = New System.Windows.Forms.Button()
@@ -49,7 +50,6 @@ Partial Class dlgUseModel
         Me.cmdCi = New System.Windows.Forms.Button()
         Me.cmdErlevd = New System.Windows.Forms.Button()
         Me.cmdClear = New System.Windows.Forms.Button()
-        Me.cmdHelp = New System.Windows.Forms.Button()
         Me.lblRpackage = New System.Windows.Forms.Label()
         Me.ucrSaveResult = New instat.ucrSave()
         Me.ucrChkIncludeArguments = New instat.ucrCheck()
@@ -74,19 +74,37 @@ Partial Class dlgUseModel
         Me.ucrReceiverForTestColumn = New instat.ucrReceiverExpression()
         Me.ucrInputComboRPackage = New instat.ucrInputComboBox()
         Me.ucrTryModelling = New instat.ucrTry()
+        Me.cmdRHelpPrediction = New instat.ucrSplitButton()
+        Me.ContextMenuStripPrediction = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.ToolStripMenuPrediction = New System.Windows.Forms.ToolStripMenuItem()
+        Me.cmdRHelpGeneral = New instat.ucrSplitButton()
+        Me.ContextMenuStripGeneral = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.ToolStripMenuStats = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ToolStripMenuCar = New System.Windows.Forms.ToolStripMenuItem()
+        Me.cmdRHelpExtRemes = New instat.ucrSplitButton()
+        Me.ContextMenuStripExtRemes = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.ToolStripMenuExtRemes = New System.Windows.Forms.ToolStripMenuItem()
+        Me.cmdRHelpSegmented = New instat.ucrSplitButton()
+        Me.ContextMenuStripSegmented = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.ToolStripMenuSegmented = New System.Windows.Forms.ToolStripMenuItem()
         Me.grpGeneral.SuspendLayout()
         Me.grpPrediction.SuspendLayout()
         Me.grpExtrRemes.SuspendLayout()
         Me.grpSegmented.SuspendLayout()
+        Me.ContextMenuStripPrediction.SuspendLayout()
+        Me.ContextMenuStripGeneral.SuspendLayout()
+        Me.ContextMenuStripExtRemes.SuspendLayout()
+        Me.ContextMenuStripSegmented.SuspendLayout()
         Me.SuspendLayout()
         '
         'lblModel
         '
         Me.lblModel.AutoSize = True
         Me.lblModel.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblModel.Location = New System.Drawing.Point(28, 27)
+        Me.lblModel.Location = New System.Drawing.Point(19, 18)
+        Me.lblModel.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
         Me.lblModel.Name = "lblModel"
-        Me.lblModel.Size = New System.Drawing.Size(87, 20)
+        Me.lblModel.Size = New System.Drawing.Size(58, 13)
         Me.lblModel.TabIndex = 11
         Me.lblModel.Tag = "Test"
         Me.lblModel.Text = "Expression"
@@ -94,10 +112,10 @@ Partial Class dlgUseModel
         'cmdsummary
         '
         Me.cmdsummary.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdsummary.Location = New System.Drawing.Point(108, 18)
-        Me.cmdsummary.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdsummary.Location = New System.Drawing.Point(72, 12)
+        Me.cmdsummary.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdsummary.Name = "cmdsummary"
-        Me.cmdsummary.Size = New System.Drawing.Size(104, 45)
+        Me.cmdsummary.Size = New System.Drawing.Size(69, 30)
         Me.cmdsummary.TabIndex = 126
         Me.cmdsummary.Text = "summary"
         Me.cmdsummary.UseVisualStyleBackColor = True
@@ -105,10 +123,10 @@ Partial Class dlgUseModel
         'cmdanova
         '
         Me.cmdanova.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdanova.Location = New System.Drawing.Point(4, 18)
-        Me.cmdanova.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdanova.Location = New System.Drawing.Point(3, 12)
+        Me.cmdanova.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdanova.Name = "cmdanova"
-        Me.cmdanova.Size = New System.Drawing.Size(104, 45)
+        Me.cmdanova.Size = New System.Drawing.Size(69, 30)
         Me.cmdanova.TabIndex = 124
         Me.cmdanova.Text = "anova"
         Me.cmdanova.UseVisualStyleBackColor = True
@@ -116,10 +134,10 @@ Partial Class dlgUseModel
         'cmdresiduals
         '
         Me.cmdresiduals.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdresiduals.Location = New System.Drawing.Point(210, 18)
-        Me.cmdresiduals.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdresiduals.Location = New System.Drawing.Point(140, 12)
+        Me.cmdresiduals.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdresiduals.Name = "cmdresiduals"
-        Me.cmdresiduals.Size = New System.Drawing.Size(104, 45)
+        Me.cmdresiduals.Size = New System.Drawing.Size(69, 30)
         Me.cmdresiduals.TabIndex = 153
         Me.cmdresiduals.Text = "residuals"
         Me.cmdresiduals.UseVisualStyleBackColor = True
@@ -137,11 +155,11 @@ Partial Class dlgUseModel
         Me.grpGeneral.Controls.Add(Me.cmdsummary)
         Me.grpGeneral.Controls.Add(Me.cmdanova)
         Me.grpGeneral.Controls.Add(Me.cmdresiduals)
-        Me.grpGeneral.Location = New System.Drawing.Point(387, 159)
-        Me.grpGeneral.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.grpGeneral.Location = New System.Drawing.Point(258, 106)
+        Me.grpGeneral.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.grpGeneral.Name = "grpGeneral"
-        Me.grpGeneral.Padding = New System.Windows.Forms.Padding(3, 4, 3, 4)
-        Me.grpGeneral.Size = New System.Drawing.Size(320, 213)
+        Me.grpGeneral.Padding = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.grpGeneral.Size = New System.Drawing.Size(213, 142)
         Me.grpGeneral.TabIndex = 25
         Me.grpGeneral.TabStop = False
         Me.grpGeneral.Text = "General"
@@ -149,10 +167,10 @@ Partial Class dlgUseModel
         'Button2
         '
         Me.Button2.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.Button2.Location = New System.Drawing.Point(210, 150)
-        Me.Button2.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.Button2.Location = New System.Drawing.Point(140, 100)
+        Me.Button2.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.Button2.Name = "Button2"
-        Me.Button2.Size = New System.Drawing.Size(104, 45)
+        Me.Button2.Size = New System.Drawing.Size(69, 30)
         Me.Button2.TabIndex = 161
         Me.Button2.Text = "Anova"
         Me.Button2.UseVisualStyleBackColor = True
@@ -160,10 +178,10 @@ Partial Class dlgUseModel
         'cmdDurbinWatsonTest
         '
         Me.cmdDurbinWatsonTest.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdDurbinWatsonTest.Location = New System.Drawing.Point(4, 150)
-        Me.cmdDurbinWatsonTest.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdDurbinWatsonTest.Location = New System.Drawing.Point(3, 100)
+        Me.cmdDurbinWatsonTest.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdDurbinWatsonTest.Name = "cmdDurbinWatsonTest"
-        Me.cmdDurbinWatsonTest.Size = New System.Drawing.Size(207, 45)
+        Me.cmdDurbinWatsonTest.Size = New System.Drawing.Size(138, 30)
         Me.cmdDurbinWatsonTest.TabIndex = 160
         Me.cmdDurbinWatsonTest.Text = "durbinWatsonTest"
         Me.cmdDurbinWatsonTest.UseVisualStyleBackColor = True
@@ -171,10 +189,10 @@ Partial Class dlgUseModel
         'cmdNcvTest
         '
         Me.cmdNcvTest.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdNcvTest.Location = New System.Drawing.Point(210, 105)
-        Me.cmdNcvTest.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdNcvTest.Location = New System.Drawing.Point(140, 70)
+        Me.cmdNcvTest.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdNcvTest.Name = "cmdNcvTest"
-        Me.cmdNcvTest.Size = New System.Drawing.Size(104, 45)
+        Me.cmdNcvTest.Size = New System.Drawing.Size(69, 30)
         Me.cmdNcvTest.TabIndex = 159
         Me.cmdNcvTest.Text = "ncvTest"
         Me.cmdNcvTest.UseVisualStyleBackColor = True
@@ -182,10 +200,10 @@ Partial Class dlgUseModel
         'cmdOutlierTest
         '
         Me.cmdOutlierTest.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdOutlierTest.Location = New System.Drawing.Point(108, 105)
-        Me.cmdOutlierTest.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdOutlierTest.Location = New System.Drawing.Point(72, 70)
+        Me.cmdOutlierTest.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdOutlierTest.Name = "cmdOutlierTest"
-        Me.cmdOutlierTest.Size = New System.Drawing.Size(104, 45)
+        Me.cmdOutlierTest.Size = New System.Drawing.Size(69, 30)
         Me.cmdOutlierTest.TabIndex = 158
         Me.cmdOutlierTest.Text = "outlierTest"
         Me.cmdOutlierTest.UseVisualStyleBackColor = True
@@ -193,10 +211,10 @@ Partial Class dlgUseModel
         'cmdBIC
         '
         Me.cmdBIC.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdBIC.Location = New System.Drawing.Point(4, 105)
-        Me.cmdBIC.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdBIC.Location = New System.Drawing.Point(3, 70)
+        Me.cmdBIC.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdBIC.Name = "cmdBIC"
-        Me.cmdBIC.Size = New System.Drawing.Size(104, 45)
+        Me.cmdBIC.Size = New System.Drawing.Size(69, 30)
         Me.cmdBIC.TabIndex = 157
         Me.cmdBIC.Text = "BIC"
         Me.cmdBIC.UseVisualStyleBackColor = True
@@ -204,10 +222,10 @@ Partial Class dlgUseModel
         'cmdAIC
         '
         Me.cmdAIC.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdAIC.Location = New System.Drawing.Point(210, 62)
-        Me.cmdAIC.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdAIC.Location = New System.Drawing.Point(140, 41)
+        Me.cmdAIC.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdAIC.Name = "cmdAIC"
-        Me.cmdAIC.Size = New System.Drawing.Size(104, 45)
+        Me.cmdAIC.Size = New System.Drawing.Size(69, 30)
         Me.cmdAIC.TabIndex = 156
         Me.cmdAIC.Text = "AIC"
         Me.cmdAIC.UseVisualStyleBackColor = True
@@ -215,10 +233,10 @@ Partial Class dlgUseModel
         'cmdCoefficient
         '
         Me.cmdCoefficient.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdCoefficient.Location = New System.Drawing.Point(108, 62)
-        Me.cmdCoefficient.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdCoefficient.Location = New System.Drawing.Point(72, 41)
+        Me.cmdCoefficient.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdCoefficient.Name = "cmdCoefficient"
-        Me.cmdCoefficient.Size = New System.Drawing.Size(104, 45)
+        Me.cmdCoefficient.Size = New System.Drawing.Size(69, 30)
         Me.cmdCoefficient.TabIndex = 155
         Me.cmdCoefficient.Text = "coefficient"
         Me.cmdCoefficient.UseVisualStyleBackColor = True
@@ -226,10 +244,10 @@ Partial Class dlgUseModel
         'cmdPrint
         '
         Me.cmdPrint.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdPrint.Location = New System.Drawing.Point(4, 62)
-        Me.cmdPrint.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdPrint.Location = New System.Drawing.Point(3, 41)
+        Me.cmdPrint.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdPrint.Name = "cmdPrint"
-        Me.cmdPrint.Size = New System.Drawing.Size(104, 45)
+        Me.cmdPrint.Size = New System.Drawing.Size(69, 30)
         Me.cmdPrint.TabIndex = 154
         Me.cmdPrint.Text = "print"
         Me.cmdPrint.UseVisualStyleBackColor = True
@@ -237,11 +255,11 @@ Partial Class dlgUseModel
         'grpPrediction
         '
         Me.grpPrediction.Controls.Add(Me.cmdPredict)
-        Me.grpPrediction.Location = New System.Drawing.Point(390, 159)
-        Me.grpPrediction.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.grpPrediction.Location = New System.Drawing.Point(260, 106)
+        Me.grpPrediction.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.grpPrediction.Name = "grpPrediction"
-        Me.grpPrediction.Padding = New System.Windows.Forms.Padding(3, 4, 3, 4)
-        Me.grpPrediction.Size = New System.Drawing.Size(320, 68)
+        Me.grpPrediction.Padding = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.grpPrediction.Size = New System.Drawing.Size(213, 45)
         Me.grpPrediction.TabIndex = 27
         Me.grpPrediction.TabStop = False
         Me.grpPrediction.Text = "Prediction"
@@ -249,10 +267,10 @@ Partial Class dlgUseModel
         'cmdPredict
         '
         Me.cmdPredict.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdPredict.Location = New System.Drawing.Point(4, 18)
-        Me.cmdPredict.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdPredict.Location = New System.Drawing.Point(3, 12)
+        Me.cmdPredict.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdPredict.Name = "cmdPredict"
-        Me.cmdPredict.Size = New System.Drawing.Size(108, 45)
+        Me.cmdPredict.Size = New System.Drawing.Size(72, 30)
         Me.cmdPredict.TabIndex = 124
         Me.cmdPredict.Text = "prediction"
         Me.cmdPredict.UseVisualStyleBackColor = True
@@ -260,10 +278,9 @@ Partial Class dlgUseModel
         'lblModels
         '
         Me.lblModels.AutoSize = True
-        Me.lblModels.Location = New System.Drawing.Point(126, 74)
-        Me.lblModels.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
+        Me.lblModels.Location = New System.Drawing.Point(84, 49)
         Me.lblModels.Name = "lblModels"
-        Me.lblModels.Size = New System.Drawing.Size(64, 20)
+        Me.lblModels.Size = New System.Drawing.Size(44, 13)
         Me.lblModels.TabIndex = 28
         Me.lblModels.Text = "Models:"
         '
@@ -278,11 +295,11 @@ Partial Class dlgUseModel
         Me.grpExtrRemes.Controls.Add(Me.cmdDistill)
         Me.grpExtrRemes.Controls.Add(Me.cmdCi)
         Me.grpExtrRemes.Controls.Add(Me.cmdErlevd)
-        Me.grpExtrRemes.Location = New System.Drawing.Point(390, 162)
-        Me.grpExtrRemes.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.grpExtrRemes.Location = New System.Drawing.Point(260, 108)
+        Me.grpExtrRemes.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.grpExtrRemes.Name = "grpExtrRemes"
-        Me.grpExtrRemes.Padding = New System.Windows.Forms.Padding(3, 4, 3, 4)
-        Me.grpExtrRemes.Size = New System.Drawing.Size(340, 165)
+        Me.grpExtrRemes.Padding = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.grpExtrRemes.Size = New System.Drawing.Size(227, 110)
         Me.grpExtrRemes.TabIndex = 30
         Me.grpExtrRemes.TabStop = False
         Me.grpExtrRemes.Text = "extRemes"
@@ -290,10 +307,10 @@ Partial Class dlgUseModel
         'cmdPlotFevd
         '
         Me.cmdPlotFevd.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdPlotFevd.Location = New System.Drawing.Point(228, 22)
-        Me.cmdPlotFevd.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdPlotFevd.Location = New System.Drawing.Point(152, 15)
+        Me.cmdPlotFevd.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdPlotFevd.Name = "cmdPlotFevd"
-        Me.cmdPlotFevd.Size = New System.Drawing.Size(104, 45)
+        Me.cmdPlotFevd.Size = New System.Drawing.Size(69, 30)
         Me.cmdPlotFevd.TabIndex = 159
         Me.cmdPlotFevd.Text = "plot.fevd"
         Me.cmdPlotFevd.UseVisualStyleBackColor = True
@@ -301,10 +318,10 @@ Partial Class dlgUseModel
         'cmdSummaryFevd
         '
         Me.cmdSummaryFevd.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdSummaryFevd.Location = New System.Drawing.Point(105, 22)
-        Me.cmdSummaryFevd.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdSummaryFevd.Location = New System.Drawing.Point(70, 15)
+        Me.cmdSummaryFevd.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdSummaryFevd.Name = "cmdSummaryFevd"
-        Me.cmdSummaryFevd.Size = New System.Drawing.Size(124, 45)
+        Me.cmdSummaryFevd.Size = New System.Drawing.Size(83, 30)
         Me.cmdSummaryFevd.TabIndex = 158
         Me.cmdSummaryFevd.Text = "summary.fevd"
         Me.cmdSummaryFevd.UseVisualStyleBackColor = True
@@ -312,10 +329,10 @@ Partial Class dlgUseModel
         'cmdPrintFevd
         '
         Me.cmdPrintFevd.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdPrintFevd.Location = New System.Drawing.Point(3, 22)
-        Me.cmdPrintFevd.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdPrintFevd.Location = New System.Drawing.Point(2, 15)
+        Me.cmdPrintFevd.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdPrintFevd.Name = "cmdPrintFevd"
-        Me.cmdPrintFevd.Size = New System.Drawing.Size(104, 45)
+        Me.cmdPrintFevd.Size = New System.Drawing.Size(69, 30)
         Me.cmdPrintFevd.TabIndex = 157
         Me.cmdPrintFevd.Text = "print.fevd"
         Me.cmdPrintFevd.UseVisualStyleBackColor = True
@@ -323,10 +340,10 @@ Partial Class dlgUseModel
         'cmdLrTest
         '
         Me.cmdLrTest.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdLrTest.Location = New System.Drawing.Point(228, 110)
-        Me.cmdLrTest.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdLrTest.Location = New System.Drawing.Point(152, 73)
+        Me.cmdLrTest.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdLrTest.Name = "cmdLrTest"
-        Me.cmdLrTest.Size = New System.Drawing.Size(104, 45)
+        Me.cmdLrTest.Size = New System.Drawing.Size(69, 30)
         Me.cmdLrTest.TabIndex = 156
         Me.cmdLrTest.Text = "lr.Test"
         Me.cmdLrTest.UseVisualStyleBackColor = True
@@ -334,10 +351,10 @@ Partial Class dlgUseModel
         'cmdIsFixedfevd
         '
         Me.cmdIsFixedfevd.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdIsFixedfevd.Location = New System.Drawing.Point(105, 110)
-        Me.cmdIsFixedfevd.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdIsFixedfevd.Location = New System.Drawing.Point(70, 73)
+        Me.cmdIsFixedfevd.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdIsFixedfevd.Name = "cmdIsFixedfevd"
-        Me.cmdIsFixedfevd.Size = New System.Drawing.Size(124, 45)
+        Me.cmdIsFixedfevd.Size = New System.Drawing.Size(83, 30)
         Me.cmdIsFixedfevd.TabIndex = 155
         Me.cmdIsFixedfevd.Text = "is.fixedfevd"
         Me.cmdIsFixedfevd.UseVisualStyleBackColor = True
@@ -345,10 +362,10 @@ Partial Class dlgUseModel
         'cmdFindpars
         '
         Me.cmdFindpars.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdFindpars.Location = New System.Drawing.Point(3, 110)
-        Me.cmdFindpars.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdFindpars.Location = New System.Drawing.Point(2, 73)
+        Me.cmdFindpars.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdFindpars.Name = "cmdFindpars"
-        Me.cmdFindpars.Size = New System.Drawing.Size(104, 45)
+        Me.cmdFindpars.Size = New System.Drawing.Size(69, 30)
         Me.cmdFindpars.TabIndex = 154
         Me.cmdFindpars.Text = "findpars"
         Me.cmdFindpars.UseVisualStyleBackColor = True
@@ -356,10 +373,10 @@ Partial Class dlgUseModel
         'cmdDistill
         '
         Me.cmdDistill.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdDistill.Location = New System.Drawing.Point(105, 66)
-        Me.cmdDistill.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdDistill.Location = New System.Drawing.Point(70, 44)
+        Me.cmdDistill.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdDistill.Name = "cmdDistill"
-        Me.cmdDistill.Size = New System.Drawing.Size(124, 45)
+        Me.cmdDistill.Size = New System.Drawing.Size(83, 30)
         Me.cmdDistill.TabIndex = 126
         Me.cmdDistill.Text = "distill"
         Me.cmdDistill.UseVisualStyleBackColor = True
@@ -367,10 +384,10 @@ Partial Class dlgUseModel
         'cmdCi
         '
         Me.cmdCi.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdCi.Location = New System.Drawing.Point(3, 66)
-        Me.cmdCi.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdCi.Location = New System.Drawing.Point(2, 44)
+        Me.cmdCi.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdCi.Name = "cmdCi"
-        Me.cmdCi.Size = New System.Drawing.Size(104, 45)
+        Me.cmdCi.Size = New System.Drawing.Size(69, 30)
         Me.cmdCi.TabIndex = 124
         Me.cmdCi.Text = "ci"
         Me.cmdCi.UseVisualStyleBackColor = True
@@ -378,10 +395,10 @@ Partial Class dlgUseModel
         'cmdErlevd
         '
         Me.cmdErlevd.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdErlevd.Location = New System.Drawing.Point(228, 66)
-        Me.cmdErlevd.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdErlevd.Location = New System.Drawing.Point(152, 44)
+        Me.cmdErlevd.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdErlevd.Name = "cmdErlevd"
-        Me.cmdErlevd.Size = New System.Drawing.Size(104, 45)
+        Me.cmdErlevd.Size = New System.Drawing.Size(69, 30)
         Me.cmdErlevd.TabIndex = 153
         Me.cmdErlevd.Text = "erlevd"
         Me.cmdErlevd.UseVisualStyleBackColor = True
@@ -389,53 +406,41 @@ Partial Class dlgUseModel
         'cmdClear
         '
         Me.cmdClear.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdClear.Location = New System.Drawing.Point(596, 381)
-        Me.cmdClear.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdClear.Location = New System.Drawing.Point(397, 254)
+        Me.cmdClear.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdClear.Name = "cmdClear"
-        Me.cmdClear.Size = New System.Drawing.Size(111, 34)
+        Me.cmdClear.Size = New System.Drawing.Size(74, 23)
         Me.cmdClear.TabIndex = 31
         Me.cmdClear.Text = "Clear"
         Me.cmdClear.UseVisualStyleBackColor = True
-        '
-        'cmdHelp
-        '
-        Me.cmdHelp.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdHelp.Location = New System.Drawing.Point(690, 118)
-        Me.cmdHelp.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
-        Me.cmdHelp.Name = "cmdHelp"
-        Me.cmdHelp.Size = New System.Drawing.Size(90, 34)
-        Me.cmdHelp.TabIndex = 33
-        Me.cmdHelp.Text = "R Help"
-        Me.cmdHelp.UseVisualStyleBackColor = True
         '
         'lblRpackage
         '
         Me.lblRpackage.AutoSize = True
         Me.lblRpackage.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblRpackage.Location = New System.Drawing.Point(390, 124)
-        Me.lblRpackage.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
+        Me.lblRpackage.Location = New System.Drawing.Point(260, 83)
         Me.lblRpackage.Name = "lblRpackage"
-        Me.lblRpackage.Size = New System.Drawing.Size(90, 20)
+        Me.lblRpackage.Size = New System.Drawing.Size(63, 13)
         Me.lblRpackage.TabIndex = 36
         Me.lblRpackage.Text = "R package:"
         '
         'ucrSaveResult
         '
         Me.ucrSaveResult.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrSaveResult.Location = New System.Drawing.Point(15, 478)
-        Me.ucrSaveResult.Margin = New System.Windows.Forms.Padding(6, 8, 6, 8)
+        Me.ucrSaveResult.Location = New System.Drawing.Point(10, 319)
+        Me.ucrSaveResult.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
         Me.ucrSaveResult.Name = "ucrSaveResult"
-        Me.ucrSaveResult.Size = New System.Drawing.Size(416, 36)
+        Me.ucrSaveResult.Size = New System.Drawing.Size(277, 24)
         Me.ucrSaveResult.TabIndex = 35
         '
         'ucrChkIncludeArguments
         '
         Me.ucrChkIncludeArguments.AutoSize = True
         Me.ucrChkIncludeArguments.Checked = False
-        Me.ucrChkIncludeArguments.Location = New System.Drawing.Point(668, 18)
-        Me.ucrChkIncludeArguments.Margin = New System.Windows.Forms.Padding(8, 8, 8, 8)
+        Me.ucrChkIncludeArguments.Location = New System.Drawing.Point(445, 12)
+        Me.ucrChkIncludeArguments.Margin = New System.Windows.Forms.Padding(5)
         Me.ucrChkIncludeArguments.Name = "ucrChkIncludeArguments"
-        Me.ucrChkIncludeArguments.Size = New System.Drawing.Size(195, 34)
+        Me.ucrChkIncludeArguments.Size = New System.Drawing.Size(130, 23)
         Me.ucrChkIncludeArguments.TabIndex = 32
         '
         'grpSegmented
@@ -454,11 +459,11 @@ Partial Class dlgUseModel
         Me.grpSegmented.Controls.Add(Me.cmdAapc)
         Me.grpSegmented.Controls.Add(Me.cmdSegmented)
         Me.grpSegmented.Controls.Add(Me.cmdSegmentedPrint)
-        Me.grpSegmented.Location = New System.Drawing.Point(390, 160)
-        Me.grpSegmented.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.grpSegmented.Location = New System.Drawing.Point(260, 107)
+        Me.grpSegmented.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.grpSegmented.Name = "grpSegmented"
-        Me.grpSegmented.Padding = New System.Windows.Forms.Padding(3, 4, 3, 4)
-        Me.grpSegmented.Size = New System.Drawing.Size(416, 201)
+        Me.grpSegmented.Padding = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.grpSegmented.Size = New System.Drawing.Size(277, 134)
         Me.grpSegmented.TabIndex = 162
         Me.grpSegmented.TabStop = False
         Me.grpSegmented.Text = "segmented"
@@ -466,10 +471,10 @@ Partial Class dlgUseModel
         'cmdSlope
         '
         Me.cmdSlope.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdSlope.Location = New System.Drawing.Point(312, 105)
-        Me.cmdSlope.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdSlope.Location = New System.Drawing.Point(208, 70)
+        Me.cmdSlope.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdSlope.Name = "cmdSlope"
-        Me.cmdSlope.Size = New System.Drawing.Size(104, 45)
+        Me.cmdSlope.Size = New System.Drawing.Size(69, 30)
         Me.cmdSlope.TabIndex = 164
         Me.cmdSlope.Text = "slope"
         Me.cmdSlope.UseVisualStyleBackColor = True
@@ -477,10 +482,10 @@ Partial Class dlgUseModel
         'cmdPscore
         '
         Me.cmdPscore.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdPscore.Location = New System.Drawing.Point(210, 15)
-        Me.cmdPscore.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdPscore.Location = New System.Drawing.Point(140, 10)
+        Me.cmdPscore.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdPscore.Name = "cmdPscore"
-        Me.cmdPscore.Size = New System.Drawing.Size(104, 45)
+        Me.cmdPscore.Size = New System.Drawing.Size(69, 30)
         Me.cmdPscore.TabIndex = 163
         Me.cmdPscore.Text = "pscore"
         Me.cmdPscore.UseVisualStyleBackColor = True
@@ -488,10 +493,10 @@ Partial Class dlgUseModel
         'cmdDavies
         '
         Me.cmdDavies.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdDavies.Location = New System.Drawing.Point(4, 15)
-        Me.cmdDavies.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdDavies.Location = New System.Drawing.Point(3, 10)
+        Me.cmdDavies.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdDavies.Name = "cmdDavies"
-        Me.cmdDavies.Size = New System.Drawing.Size(104, 45)
+        Me.cmdDavies.Size = New System.Drawing.Size(69, 30)
         Me.cmdDavies.TabIndex = 162
         Me.cmdDavies.Text = "davies"
         Me.cmdDavies.UseVisualStyleBackColor = True
@@ -499,10 +504,10 @@ Partial Class dlgUseModel
         'cmdIntercept
         '
         Me.cmdIntercept.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdIntercept.Location = New System.Drawing.Point(210, 150)
-        Me.cmdIntercept.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdIntercept.Location = New System.Drawing.Point(140, 100)
+        Me.cmdIntercept.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdIntercept.Name = "cmdIntercept"
-        Me.cmdIntercept.Size = New System.Drawing.Size(104, 45)
+        Me.cmdIntercept.Size = New System.Drawing.Size(69, 30)
         Me.cmdIntercept.TabIndex = 161
         Me.cmdIntercept.Text = "intercept"
         Me.cmdIntercept.UseVisualStyleBackColor = True
@@ -510,10 +515,10 @@ Partial Class dlgUseModel
         'cmdBroken
         '
         Me.cmdBroken.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdBroken.Location = New System.Drawing.Point(4, 150)
-        Me.cmdBroken.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdBroken.Location = New System.Drawing.Point(3, 100)
+        Me.cmdBroken.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdBroken.Name = "cmdBroken"
-        Me.cmdBroken.Size = New System.Drawing.Size(104, 45)
+        Me.cmdBroken.Size = New System.Drawing.Size(69, 30)
         Me.cmdBroken.TabIndex = 160
         Me.cmdBroken.Text = "broken"
         Me.cmdBroken.UseVisualStyleBackColor = True
@@ -521,10 +526,10 @@ Partial Class dlgUseModel
         'cmdPoints
         '
         Me.cmdPoints.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdPoints.Location = New System.Drawing.Point(210, 105)
-        Me.cmdPoints.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdPoints.Location = New System.Drawing.Point(140, 70)
+        Me.cmdPoints.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdPoints.Name = "cmdPoints"
-        Me.cmdPoints.Size = New System.Drawing.Size(104, 45)
+        Me.cmdPoints.Size = New System.Drawing.Size(69, 30)
         Me.cmdPoints.TabIndex = 159
         Me.cmdPoints.Text = "points"
         Me.cmdPoints.UseVisualStyleBackColor = True
@@ -532,10 +537,10 @@ Partial Class dlgUseModel
         'cmdPlotLines
         '
         Me.cmdPlotLines.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdPlotLines.Location = New System.Drawing.Point(108, 105)
-        Me.cmdPlotLines.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdPlotLines.Location = New System.Drawing.Point(72, 70)
+        Me.cmdPlotLines.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdPlotLines.Name = "cmdPlotLines"
-        Me.cmdPlotLines.Size = New System.Drawing.Size(104, 45)
+        Me.cmdPlotLines.Size = New System.Drawing.Size(69, 30)
         Me.cmdPlotLines.TabIndex = 158
         Me.cmdPlotLines.Text = "plot "
         Me.cmdPlotLines.UseVisualStyleBackColor = True
@@ -543,10 +548,10 @@ Partial Class dlgUseModel
         'cmdSegmentedPredict
         '
         Me.cmdSegmentedPredict.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdSegmentedPredict.Location = New System.Drawing.Point(4, 105)
-        Me.cmdSegmentedPredict.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdSegmentedPredict.Location = New System.Drawing.Point(3, 70)
+        Me.cmdSegmentedPredict.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdSegmentedPredict.Name = "cmdSegmentedPredict"
-        Me.cmdSegmentedPredict.Size = New System.Drawing.Size(104, 45)
+        Me.cmdSegmentedPredict.Size = New System.Drawing.Size(69, 30)
         Me.cmdSegmentedPredict.TabIndex = 157
         Me.cmdSegmentedPredict.Text = "predict"
         Me.cmdSegmentedPredict.UseVisualStyleBackColor = True
@@ -554,10 +559,10 @@ Partial Class dlgUseModel
         'cmdVcov
         '
         Me.cmdVcov.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdVcov.Location = New System.Drawing.Point(210, 62)
-        Me.cmdVcov.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdVcov.Location = New System.Drawing.Point(140, 41)
+        Me.cmdVcov.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdVcov.Name = "cmdVcov"
-        Me.cmdVcov.Size = New System.Drawing.Size(104, 45)
+        Me.cmdVcov.Size = New System.Drawing.Size(69, 30)
         Me.cmdVcov.TabIndex = 156
         Me.cmdVcov.Text = "vcov"
         Me.cmdVcov.UseVisualStyleBackColor = True
@@ -565,10 +570,10 @@ Partial Class dlgUseModel
         'cmdConfint
         '
         Me.cmdConfint.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdConfint.Location = New System.Drawing.Point(108, 62)
-        Me.cmdConfint.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdConfint.Location = New System.Drawing.Point(72, 41)
+        Me.cmdConfint.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdConfint.Name = "cmdConfint"
-        Me.cmdConfint.Size = New System.Drawing.Size(104, 45)
+        Me.cmdConfint.Size = New System.Drawing.Size(69, 30)
         Me.cmdConfint.TabIndex = 155
         Me.cmdConfint.Text = "confint"
         Me.cmdConfint.UseVisualStyleBackColor = True
@@ -576,10 +581,10 @@ Partial Class dlgUseModel
         'cmdSegmentedSummary
         '
         Me.cmdSegmentedSummary.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdSegmentedSummary.Location = New System.Drawing.Point(4, 62)
-        Me.cmdSegmentedSummary.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdSegmentedSummary.Location = New System.Drawing.Point(3, 41)
+        Me.cmdSegmentedSummary.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdSegmentedSummary.Name = "cmdSegmentedSummary"
-        Me.cmdSegmentedSummary.Size = New System.Drawing.Size(104, 45)
+        Me.cmdSegmentedSummary.Size = New System.Drawing.Size(69, 30)
         Me.cmdSegmentedSummary.TabIndex = 154
         Me.cmdSegmentedSummary.Text = "summary"
         Me.cmdSegmentedSummary.UseVisualStyleBackColor = True
@@ -587,10 +592,10 @@ Partial Class dlgUseModel
         'cmdAapc
         '
         Me.cmdAapc.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdAapc.Location = New System.Drawing.Point(108, 150)
-        Me.cmdAapc.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdAapc.Location = New System.Drawing.Point(72, 100)
+        Me.cmdAapc.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdAapc.Name = "cmdAapc"
-        Me.cmdAapc.Size = New System.Drawing.Size(104, 45)
+        Me.cmdAapc.Size = New System.Drawing.Size(69, 30)
         Me.cmdAapc.TabIndex = 126
         Me.cmdAapc.Text = "aapc"
         Me.cmdAapc.UseVisualStyleBackColor = True
@@ -598,10 +603,10 @@ Partial Class dlgUseModel
         'cmdSegmented
         '
         Me.cmdSegmented.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdSegmented.Location = New System.Drawing.Point(108, 15)
-        Me.cmdSegmented.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdSegmented.Location = New System.Drawing.Point(72, 10)
+        Me.cmdSegmented.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdSegmented.Name = "cmdSegmented"
-        Me.cmdSegmented.Size = New System.Drawing.Size(104, 45)
+        Me.cmdSegmented.Size = New System.Drawing.Size(69, 30)
         Me.cmdSegmented.TabIndex = 124
         Me.cmdSegmented.Text = "segmented"
         Me.cmdSegmented.UseVisualStyleBackColor = True
@@ -609,10 +614,10 @@ Partial Class dlgUseModel
         'cmdSegmentedPrint
         '
         Me.cmdSegmentedPrint.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdSegmentedPrint.Location = New System.Drawing.Point(312, 62)
-        Me.cmdSegmentedPrint.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.cmdSegmentedPrint.Location = New System.Drawing.Point(208, 41)
+        Me.cmdSegmentedPrint.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.cmdSegmentedPrint.Name = "cmdSegmentedPrint"
-        Me.cmdSegmentedPrint.Size = New System.Drawing.Size(104, 45)
+        Me.cmdSegmentedPrint.Size = New System.Drawing.Size(69, 30)
         Me.cmdSegmentedPrint.TabIndex = 153
         Me.cmdSegmentedPrint.Text = "print"
         Me.cmdSegmentedPrint.UseVisualStyleBackColor = True
@@ -623,10 +628,10 @@ Partial Class dlgUseModel
         Me.ucrInputModels.AutoSize = True
         Me.ucrInputModels.IsMultiline = False
         Me.ucrInputModels.IsReadOnly = False
-        Me.ucrInputModels.Location = New System.Drawing.Point(200, 68)
-        Me.ucrInputModels.Margin = New System.Windows.Forms.Padding(10, 9, 10, 9)
+        Me.ucrInputModels.Location = New System.Drawing.Point(133, 45)
+        Me.ucrInputModels.Margin = New System.Windows.Forms.Padding(7, 6, 7, 6)
         Me.ucrInputModels.Name = "ucrInputModels"
-        Me.ucrInputModels.Size = New System.Drawing.Size(321, 32)
+        Me.ucrInputModels.Size = New System.Drawing.Size(214, 21)
         Me.ucrInputModels.TabIndex = 29
         '
         'ucrSelectorUseModel
@@ -635,31 +640,31 @@ Partial Class dlgUseModel
         Me.ucrSelectorUseModel.bDropUnusedFilterLevels = False
         Me.ucrSelectorUseModel.bShowHiddenColumns = False
         Me.ucrSelectorUseModel.bUseCurrentFilter = True
-        Me.ucrSelectorUseModel.Location = New System.Drawing.Point(15, 102)
+        Me.ucrSelectorUseModel.Location = New System.Drawing.Point(10, 68)
         Me.ucrSelectorUseModel.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrSelectorUseModel.Name = "ucrSelectorUseModel"
-        Me.ucrSelectorUseModel.Size = New System.Drawing.Size(320, 274)
+        Me.ucrSelectorUseModel.Size = New System.Drawing.Size(213, 183)
         Me.ucrSelectorUseModel.TabIndex = 26
         '
         'ucrBase
         '
         Me.ucrBase.AutoSize = True
         Me.ucrBase.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrBase.Location = New System.Drawing.Point(14, 543)
-        Me.ucrBase.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
+        Me.ucrBase.Location = New System.Drawing.Point(9, 362)
+        Me.ucrBase.Margin = New System.Windows.Forms.Padding(4)
         Me.ucrBase.Name = "ucrBase"
-        Me.ucrBase.Size = New System.Drawing.Size(611, 77)
+        Me.ucrBase.Size = New System.Drawing.Size(408, 52)
         Me.ucrBase.TabIndex = 20
         '
         'ucrReceiverForTestColumn
         '
         Me.ucrReceiverForTestColumn.AutoSize = True
         Me.ucrReceiverForTestColumn.frmParent = Me
-        Me.ucrReceiverForTestColumn.Location = New System.Drawing.Point(123, 16)
-        Me.ucrReceiverForTestColumn.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.ucrReceiverForTestColumn.Location = New System.Drawing.Point(82, 11)
+        Me.ucrReceiverForTestColumn.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.ucrReceiverForTestColumn.Name = "ucrReceiverForTestColumn"
         Me.ucrReceiverForTestColumn.Selector = Nothing
-        Me.ucrReceiverForTestColumn.Size = New System.Drawing.Size(537, 40)
+        Me.ucrReceiverForTestColumn.Size = New System.Drawing.Size(358, 27)
         Me.ucrReceiverForTestColumn.strNcFilePath = ""
         Me.ucrReceiverForTestColumn.TabIndex = 12
         Me.ucrReceiverForTestColumn.ucrSelector = Nothing
@@ -670,33 +675,138 @@ Partial Class dlgUseModel
         Me.ucrInputComboRPackage.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.ucrInputComboRPackage.GetSetSelectedIndex = -1
         Me.ucrInputComboRPackage.IsReadOnly = False
-        Me.ucrInputComboRPackage.Location = New System.Drawing.Point(492, 120)
-        Me.ucrInputComboRPackage.Margin = New System.Windows.Forms.Padding(10, 9, 10, 9)
+        Me.ucrInputComboRPackage.Location = New System.Drawing.Point(328, 80)
+        Me.ucrInputComboRPackage.Margin = New System.Windows.Forms.Padding(7, 6, 7, 6)
         Me.ucrInputComboRPackage.Name = "ucrInputComboRPackage"
-        Me.ucrInputComboRPackage.Size = New System.Drawing.Size(183, 32)
+        Me.ucrInputComboRPackage.Size = New System.Drawing.Size(122, 21)
         Me.ucrInputComboRPackage.TabIndex = 5
         '
         'ucrTryModelling
         '
         Me.ucrTryModelling.AutoSize = True
-        Me.ucrTryModelling.Location = New System.Drawing.Point(3, 428)
-        Me.ucrTryModelling.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
+        Me.ucrTryModelling.Location = New System.Drawing.Point(2, 285)
+        Me.ucrTryModelling.Margin = New System.Windows.Forms.Padding(4)
         Me.ucrTryModelling.Name = "ucrTryModelling"
         Me.ucrTryModelling.RunCommandAsMultipleLines = False
-        Me.ucrTryModelling.Size = New System.Drawing.Size(720, 55)
+        Me.ucrTryModelling.Size = New System.Drawing.Size(480, 37)
         Me.ucrTryModelling.TabIndex = 163
+        '
+        'cmdRHelpPrediction
+        '
+        Me.cmdRHelpPrediction.AutoSize = True
+        Me.cmdRHelpPrediction.ContextMenuStrip = Me.ContextMenuStripPrediction
+        Me.cmdRHelpPrediction.Location = New System.Drawing.Point(460, 79)
+        Me.cmdRHelpPrediction.Name = "cmdRHelpPrediction"
+        Me.cmdRHelpPrediction.Size = New System.Drawing.Size(68, 23)
+        Me.cmdRHelpPrediction.SplitMenuStrip = Me.ContextMenuStripPrediction
+        Me.cmdRHelpPrediction.TabIndex = 219
+        Me.cmdRHelpPrediction.Text = "R Help"
+        Me.cmdRHelpPrediction.UseVisualStyleBackColor = True
+        '
+        'ContextMenuStripPrediction
+        '
+        Me.ContextMenuStripPrediction.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuPrediction})
+        Me.ContextMenuStripPrediction.Name = "ContextMenuStrip1"
+        Me.ContextMenuStripPrediction.Size = New System.Drawing.Size(129, 26)
+        '
+        'ToolStripMenuPrediction
+        '
+        Me.ToolStripMenuPrediction.Name = "ToolStripMenuPrediction"
+        Me.ToolStripMenuPrediction.Size = New System.Drawing.Size(128, 22)
+        Me.ToolStripMenuPrediction.Text = "prediction"
+        '
+        'cmdRHelpGeneral
+        '
+        Me.cmdRHelpGeneral.AutoSize = True
+        Me.cmdRHelpGeneral.ContextMenuStrip = Me.ContextMenuStripGeneral
+        Me.cmdRHelpGeneral.Location = New System.Drawing.Point(460, 80)
+        Me.cmdRHelpGeneral.Name = "cmdRHelpGeneral"
+        Me.cmdRHelpGeneral.Size = New System.Drawing.Size(68, 23)
+        Me.cmdRHelpGeneral.SplitMenuStrip = Me.ContextMenuStripGeneral
+        Me.cmdRHelpGeneral.TabIndex = 220
+        Me.cmdRHelpGeneral.Text = "R Help"
+        Me.cmdRHelpGeneral.UseVisualStyleBackColor = True
+        '
+        'ContextMenuStripGeneral
+        '
+        Me.ContextMenuStripGeneral.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuStats, Me.ToolStripMenuCar})
+        Me.ContextMenuStripGeneral.Name = "ContextMenuStrip1"
+        Me.ContextMenuStripGeneral.Size = New System.Drawing.Size(99, 48)
+        '
+        'ToolStripMenuStats
+        '
+        Me.ToolStripMenuStats.Name = "ToolStripMenuStats"
+        Me.ToolStripMenuStats.Size = New System.Drawing.Size(98, 22)
+        Me.ToolStripMenuStats.Text = "stats"
+        '
+        'ToolStripMenuCar
+        '
+        Me.ToolStripMenuCar.Name = "ToolStripMenuCar"
+        Me.ToolStripMenuCar.Size = New System.Drawing.Size(98, 22)
+        Me.ToolStripMenuCar.Text = "car"
+        '
+        'cmdRHelpExtRemes
+        '
+        Me.cmdRHelpExtRemes.AutoSize = True
+        Me.cmdRHelpExtRemes.ContextMenuStrip = Me.ContextMenuStripExtRemes
+        Me.cmdRHelpExtRemes.Location = New System.Drawing.Point(461, 79)
+        Me.cmdRHelpExtRemes.Name = "cmdRHelpExtRemes"
+        Me.cmdRHelpExtRemes.Size = New System.Drawing.Size(68, 23)
+        Me.cmdRHelpExtRemes.SplitMenuStrip = Me.ContextMenuStripExtRemes
+        Me.cmdRHelpExtRemes.TabIndex = 221
+        Me.cmdRHelpExtRemes.Text = "R Help"
+        Me.cmdRHelpExtRemes.UseVisualStyleBackColor = True
+        '
+        'ContextMenuStripExtRemes
+        '
+        Me.ContextMenuStripExtRemes.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuExtRemes})
+        Me.ContextMenuStripExtRemes.Name = "ContextMenuStrip1"
+        Me.ContextMenuStripExtRemes.Size = New System.Drawing.Size(126, 26)
+        '
+        'ToolStripMenuExtRemes
+        '
+        Me.ToolStripMenuExtRemes.Name = "ToolStripMenuExtRemes"
+        Me.ToolStripMenuExtRemes.Size = New System.Drawing.Size(125, 22)
+        Me.ToolStripMenuExtRemes.Text = "extRemes"
+        '
+        'cmdRHelpSegmented
+        '
+        Me.cmdRHelpSegmented.AutoSize = True
+        Me.cmdRHelpSegmented.ContextMenuStrip = Me.ContextMenuStripSegmented
+        Me.cmdRHelpSegmented.Location = New System.Drawing.Point(460, 80)
+        Me.cmdRHelpSegmented.Name = "cmdRHelpSegmented"
+        Me.cmdRHelpSegmented.Size = New System.Drawing.Size(68, 23)
+        Me.cmdRHelpSegmented.SplitMenuStrip = Me.ContextMenuStripSegmented
+        Me.cmdRHelpSegmented.TabIndex = 222
+        Me.cmdRHelpSegmented.Text = "R Help"
+        Me.cmdRHelpSegmented.UseVisualStyleBackColor = True
+        '
+        'ContextMenuStripSegmented
+        '
+        Me.ContextMenuStripSegmented.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuSegmented})
+        Me.ContextMenuStripSegmented.Name = "ContextMenuStrip1"
+        Me.ContextMenuStripSegmented.Size = New System.Drawing.Size(134, 26)
+        '
+        'ToolStripMenuSegmented
+        '
+        Me.ToolStripMenuSegmented.Name = "ToolStripMenuSegmented"
+        Me.ToolStripMenuSegmented.Size = New System.Drawing.Size(133, 22)
+        Me.ToolStripMenuSegmented.Text = "segmented"
         '
         'dlgUseModel
         '
-        Me.AutoScaleDimensions = New System.Drawing.SizeF(144.0!, 144.0!)
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
         Me.AutoSize = True
-        Me.ClientSize = New System.Drawing.Size(873, 634)
+        Me.ClientSize = New System.Drawing.Size(582, 423)
+        Me.Controls.Add(Me.cmdRHelpSegmented)
+        Me.Controls.Add(Me.cmdRHelpExtRemes)
+        Me.Controls.Add(Me.cmdRHelpGeneral)
+        Me.Controls.Add(Me.cmdRHelpPrediction)
         Me.Controls.Add(Me.grpGeneral)
         Me.Controls.Add(Me.ucrTryModelling)
         Me.Controls.Add(Me.lblRpackage)
         Me.Controls.Add(Me.ucrSaveResult)
-        Me.Controls.Add(Me.cmdHelp)
         Me.Controls.Add(Me.ucrChkIncludeArguments)
         Me.Controls.Add(Me.grpSegmented)
         Me.Controls.Add(Me.cmdClear)
@@ -710,7 +820,6 @@ Partial Class dlgUseModel
         Me.Controls.Add(Me.ucrReceiverForTestColumn)
         Me.Controls.Add(Me.ucrInputComboRPackage)
         Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow
-        Me.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
         Me.MinimizeBox = False
         Me.Name = "dlgUseModel"
         Me.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen
@@ -719,6 +828,10 @@ Partial Class dlgUseModel
         Me.grpPrediction.ResumeLayout(False)
         Me.grpExtrRemes.ResumeLayout(False)
         Me.grpSegmented.ResumeLayout(False)
+        Me.ContextMenuStripPrediction.ResumeLayout(False)
+        Me.ContextMenuStripGeneral.ResumeLayout(False)
+        Me.ContextMenuStripExtRemes.ResumeLayout(False)
+        Me.ContextMenuStripSegmented.ResumeLayout(False)
         Me.ResumeLayout(False)
         Me.PerformLayout()
 
@@ -755,7 +868,6 @@ Partial Class dlgUseModel
     Friend WithEvents cmdClear As Button
 
     Friend WithEvents ucrChkIncludeArguments As ucrCheck
-    Friend WithEvents cmdHelp As Button
     Friend WithEvents ucrSaveResult As ucrSave
     Friend WithEvents lblRpackage As Label
     Friend WithEvents cmdPlotFevd As Button
@@ -778,4 +890,17 @@ Partial Class dlgUseModel
     Friend WithEvents cmdSlope As Button
     Friend WithEvents cmdPscore As Button
     Friend WithEvents ucrTryModelling As ucrTry
+    Friend WithEvents cmdRHelpSegmented As ucrSplitButton
+    Friend WithEvents cmdRHelpExtRemes As ucrSplitButton
+    Friend WithEvents cmdRHelpGeneral As ucrSplitButton
+    Friend WithEvents cmdRHelpPrediction As ucrSplitButton
+    Friend WithEvents ContextMenuStripGeneral As ContextMenuStrip
+    Friend WithEvents ToolStripMenuStats As ToolStripMenuItem
+    Friend WithEvents ToolStripMenuCar As ToolStripMenuItem
+    Friend WithEvents ContextMenuStripPrediction As ContextMenuStrip
+    Friend WithEvents ToolStripMenuPrediction As ToolStripMenuItem
+    Friend WithEvents ContextMenuStripExtRemes As ContextMenuStrip
+    Friend WithEvents ToolStripMenuExtRemes As ToolStripMenuItem
+    Friend WithEvents ContextMenuStripSegmented As ContextMenuStrip
+    Friend WithEvents ToolStripMenuSegmented As ToolStripMenuItem
 End Class

--- a/instat/dlgUseModel.resx
+++ b/instat/dlgUseModel.resx
@@ -117,4 +117,16 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="ContextMenuStripSegmented.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>656, 17</value>
+  </metadata>
+  <metadata name="ContextMenuStripExtRemes.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>444, 17</value>
+  </metadata>
+  <metadata name="ContextMenuStripGeneral.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <metadata name="ContextMenuStripPrediction.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>229, 18</value>
+  </metadata>
 </root>

--- a/instat/dlgUseModel.vb
+++ b/instat/dlgUseModel.vb
@@ -397,7 +397,8 @@ Public Class dlgUseModel
             ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("extRemes::lr.test()", 1)
         End If
     End Sub
-    Private Sub OpenHelpPage()
+
+        Private Sub OpenHelpPage()
         If strPackageName <> "" Then
             frmMaximiseOutput.Show(strFileName:=clsFileUrlUtilities.GetHelpFileURL(strPackageName:=strPackageName), bReplace:=False)
         End If

--- a/instat/dlgUseModel.vb
+++ b/instat/dlgUseModel.vb
@@ -18,7 +18,7 @@ Imports instat
 Imports instat.Translations
 Imports RDotNet
 Public Class dlgUseModel
-
+    Private strPackageName As String
     Public bFirstLoad As Boolean = True
     Public bReset As Boolean = True
     Public bUpdating As Boolean = False
@@ -201,12 +201,28 @@ Public Class dlgUseModel
         Select Case ucrInputComboRPackage.GetText
             Case "General"
                 grpGeneral.Visible = True
+                cmdRHelpGeneral.Visible = True
+                cmdRHelpExtRemes.Visible = False
+                cmdRHelpPrediction.Visible = False
+                cmdRHelpSegmented.Visible = False
             Case "Prediction"
                 grpPrediction.Visible = True
+                cmdRHelpGeneral.Visible = False
+                cmdRHelpExtRemes.Visible = False
+                cmdRHelpPrediction.Visible = True
+                cmdRHelpSegmented.Visible = False
             Case "extRemes"
                 grpExtrRemes.Visible = True
+                cmdRHelpGeneral.Visible = False
+                cmdRHelpExtRemes.Visible = True
+                cmdRHelpPrediction.Visible = False
+                cmdRHelpSegmented.Visible = False
             Case "segmented"
                 grpSegmented.Visible = True
+                cmdRHelpGeneral.Visible = False
+                cmdRHelpExtRemes.Visible = False
+                cmdRHelpPrediction.Visible = False
+                cmdRHelpSegmented.Visible = True
         End Select
     End Sub
 
@@ -381,8 +397,13 @@ Public Class dlgUseModel
             ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("extRemes::lr.test()", 1)
         End If
     End Sub
+    Private Sub OpenHelpPage()
+        If strPackageName <> "" Then
+            frmMaximiseOutput.Show(strFileName:=clsFileUrlUtilities.GetHelpFileURL(strPackageName:=strPackageName), bReplace:=False)
+        End If
+    End Sub
 
-    Private Sub cmdHelp_Click(sender As Object, e As EventArgs) Handles cmdHelp.Click
+    Private Sub cmdHelp_Click(sender As Object, e As EventArgs)
         Dim strPackageName As String = ucrInputComboRPackage.GetText
         If strPackageName <> "" Then
             frmMaximiseOutput.Show(strFileName:=clsFileUrlUtilities.GetHelpFileURL(strPackageName:=strPackageName), bReplace:=False)
@@ -461,5 +482,40 @@ Public Class dlgUseModel
 
     Private Sub cmdIntercept_Click(sender As Object, e As EventArgs) Handles cmdIntercept.Click
         ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("segmented::intercept()", 1)
+    End Sub
+
+    Private Sub cmdRHelpGeneral_Click(sender As Object, e As EventArgs) Handles cmdRHelpGeneral.Click, ToolStripMenuStats.Click
+        If ucrInputComboRPackage.GetText = "General" Then
+            strPackageName = "stats"
+        End If
+        OpenHelpPage()
+    End Sub
+
+    Private Sub ToolStripCar_Click(sender As Object, e As EventArgs) Handles ToolStripMenuCar.Click
+        If ucrInputComboRPackage.GetText = "General" Then
+            strPackageName = "car"
+        End If
+        OpenHelpPage()
+    End Sub
+
+    Private Sub cmdRHelpExtRemes_Click(sender As Object, e As EventArgs) Handles cmdRHelpExtRemes.Click, ToolStripMenuExtRemes.Click
+        If ucrInputComboRPackage.GetText = "extRemes" Then
+            strPackageName = "extRemes"
+        End If
+        OpenHelpPage()
+    End Sub
+
+    Private Sub cmdRHelpPrediction_Click(sender As Object, e As EventArgs) Handles cmdRHelpPrediction.Click, ToolStripMenuPrediction.Click
+        If ucrInputComboRPackage.GetText = "Prediction" Then
+            strPackageName = "prediction"
+        End If
+        OpenHelpPage()
+    End Sub
+
+    Private Sub cmdRHelpSegmented_Click(sender As Object, e As EventArgs) Handles cmdRHelpSegmented.Click, ToolStripMenuSegmented.Click
+        If ucrInputComboRPackage.GetText = "segmented" Then
+            strPackageName = "segmented"
+        End If
+        OpenHelpPage()
     End Sub
 End Class

--- a/instat/dlgUseModel.vb
+++ b/instat/dlgUseModel.vb
@@ -399,14 +399,7 @@ Public Class dlgUseModel
     End Sub
 
         Private Sub OpenHelpPage()
-        If strPackageName <> "" Then
-            frmMaximiseOutput.Show(strFileName:=clsFileUrlUtilities.GetHelpFileURL(strPackageName:=strPackageName), bReplace:=False)
-        End If
-    End Sub
-
-    Private Sub cmdHelp_Click(sender As Object, e As EventArgs)
-        Dim strPackageName As String = ucrInputComboRPackage.GetText
-        If strPackageName <> "" Then
+        If Not String.IsNullOrEmpty(strPackageName) Then
             frmMaximiseOutput.Show(strFileName:=clsFileUrlUtilities.GetHelpFileURL(strPackageName:=strPackageName), bReplace:=False)
         End If
     End Sub


### PR DESCRIPTION
fixes #8160 
replaces #8165 

I have updated this branch with the changes done on PR  #8159  added the `Rhelp dropdown` to the Use `Model keyboard`, `Hypothesis Tests`, `Fit Mode`l and `Prepare > Column: Numeric > Enter dialogue.`

@N-thony , @rdstern this PR is ready for review. 