### PR TITLE
Tell Git to ignore Newtonsoft Json NuGet package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -251,3 +251,4 @@ installer/Output/
 /packages/jacobslusser.ScintillaNET.*/
 
 /packages/NLog.*/
+/packages/Newtonsoft.Json.*/


### PR DESCRIPTION
I have a Git branch to explore writing control states to Json files (PR #8193). This requires the Newtonsoft JSON NuGet package to be installed. If I don't tell the main branch to ignore this lib, then each time I switch branches I need to uninstall the NuGet package.