### PR TITLE
Increased the number of preview lines in Import dialog

### DIFF
--- a/instat/dlgImportDataset.vb
+++ b/instat/dlgImportDataset.vb
@@ -117,6 +117,7 @@ Public Class dlgImportDataset
         ucrSaveFile.ucrInputTextSave.bAutoChangeOnLeave = True
 
         ucrNudPreviewLines.Value = 10
+        ucrNudPreviewLines.Maximum = 1000
 
         '##############################################################
         'RDS Controls


### PR DESCRIPTION
Fixes partly #8025  

I have increased the preview line option to go from 100 to 1000. 
This works well for `xls` files but it takes a little time for `csv` files but not enough to cause an inconvenience 
@Patowhiz , @N-thony this PR is ready for review. 

Thanks