### PR TITLE
Ensured that number of indices selected is in the middle of the message in Climdex Indices dialog

### DIFF
--- a/instat/dlgClimdexIndices.Designer.vb
+++ b/instat/dlgClimdexIndices.Designer.vb
@@ -47,10 +47,10 @@ Partial Class dlgClimdexIndices
         Me.lblYear = New System.Windows.Forms.Label()
         Me.rdoAnnual = New System.Windows.Forms.RadioButton()
         Me.rdoMonthly = New System.Windows.Forms.RadioButton()
-        Me.lblIndicesSelectedOutOf = New System.Windows.Forms.Label()
         Me.lblSelectedIndices = New System.Windows.Forms.Label()
         Me.lblTotalIndices = New System.Windows.Forms.Label()
         Me.lblDate = New System.Windows.Forms.Label()
+        Me.lblOutof = New System.Windows.Forms.Label()
         Me.ucrReceiverDate = New instat.ucrReceiverSingle()
         Me.ucrPnlAnnualMonthly = New instat.UcrPanel()
         Me.ucrReceiverYear = New instat.ucrReceiverSingle()
@@ -175,23 +175,12 @@ Partial Class dlgClimdexIndices
         Me.rdoMonthly.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
         Me.rdoMonthly.UseVisualStyleBackColor = True
         '
-        'lblIndicesSelectedOutOf
-        '
-        Me.lblIndicesSelectedOutOf.AutoSize = True
-        Me.lblIndicesSelectedOutOf.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblIndicesSelectedOutOf.Location = New System.Drawing.Point(181, 359)
-        Me.lblIndicesSelectedOutOf.Name = "lblIndicesSelectedOutOf"
-        Me.lblIndicesSelectedOutOf.Size = New System.Drawing.Size(116, 13)
-        Me.lblIndicesSelectedOutOf.TabIndex = 17
-        Me.lblIndicesSelectedOutOf.Tag = "Month:"
-        Me.lblIndicesSelectedOutOf.Text = "indices  selected out of"
-        '
         'lblSelectedIndices
         '
         Me.lblSelectedIndices.AutoSize = True
         Me.lblSelectedIndices.ForeColor = System.Drawing.Color.Green
         Me.lblSelectedIndices.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblSelectedIndices.Location = New System.Drawing.Point(170, 360)
+        Me.lblSelectedIndices.Location = New System.Drawing.Point(190, 360)
         Me.lblSelectedIndices.Name = "lblSelectedIndices"
         Me.lblSelectedIndices.Size = New System.Drawing.Size(0, 13)
         Me.lblSelectedIndices.TabIndex = 16
@@ -218,6 +207,15 @@ Partial Class dlgClimdexIndices
         Me.lblDate.TabIndex = 21
         Me.lblDate.Tag = ""
         Me.lblDate.Text = "Date:"
+        '
+        'lblOutof
+        '
+        Me.lblOutof.AutoSize = True
+        Me.lblOutof.Location = New System.Drawing.Point(145, 360)
+        Me.lblOutof.Name = "lblOutof"
+        Me.lblOutof.Size = New System.Drawing.Size(150, 13)
+        Me.lblOutof.TabIndex = 23
+        Me.lblOutof.Text = "Indices             selected out of"
         '
         'ucrReceiverDate
         '
@@ -354,11 +352,11 @@ Partial Class dlgClimdexIndices
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
         Me.AutoSize = True
         Me.ClientSize = New System.Drawing.Size(417, 440)
+        Me.Controls.Add(Me.lblSelectedIndices)
+        Me.Controls.Add(Me.lblOutof)
         Me.Controls.Add(Me.lblDate)
         Me.Controls.Add(Me.ucrReceiverDate)
         Me.Controls.Add(Me.lblTotalIndices)
-        Me.Controls.Add(Me.lblSelectedIndices)
-        Me.Controls.Add(Me.lblIndicesSelectedOutOf)
         Me.Controls.Add(Me.rdoAnnual)
         Me.Controls.Add(Me.rdoMonthly)
         Me.Controls.Add(Me.ucrPnlAnnualMonthly)
@@ -412,7 +410,7 @@ Partial Class dlgClimdexIndices
     Friend WithEvents ucrPnlAnnualMonthly As UcrPanel
     Friend WithEvents lblTotalIndices As Label
     Friend WithEvents lblSelectedIndices As Label
-    Friend WithEvents lblIndicesSelectedOutOf As Label
     Friend WithEvents lblDate As Label
     Friend WithEvents ucrReceiverDate As ucrReceiverSingle
+    Friend WithEvents lblOutof As Label
 End Class

--- a/instat/dlgClimdexIndices.Designer.vb
+++ b/instat/dlgClimdexIndices.Designer.vb
@@ -179,19 +179,19 @@ Partial Class dlgClimdexIndices
         '
         Me.lblIndicesSelectedOutOf.AutoSize = True
         Me.lblIndicesSelectedOutOf.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblIndicesSelectedOutOf.Location = New System.Drawing.Point(100, 361)
+        Me.lblIndicesSelectedOutOf.Location = New System.Drawing.Point(181, 359)
         Me.lblIndicesSelectedOutOf.Name = "lblIndicesSelectedOutOf"
-        Me.lblIndicesSelectedOutOf.Size = New System.Drawing.Size(140, 13)
+        Me.lblIndicesSelectedOutOf.Size = New System.Drawing.Size(116, 13)
         Me.lblIndicesSelectedOutOf.TabIndex = 17
         Me.lblIndicesSelectedOutOf.Tag = "Month:"
-        Me.lblIndicesSelectedOutOf.Text = "indices          selected out of"
+        Me.lblIndicesSelectedOutOf.Text = "indices  selected out of"
         '
         'lblSelectedIndices
         '
         Me.lblSelectedIndices.AutoSize = True
         Me.lblSelectedIndices.ForeColor = System.Drawing.Color.Green
         Me.lblSelectedIndices.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblSelectedIndices.Location = New System.Drawing.Point(143, 361)
+        Me.lblSelectedIndices.Location = New System.Drawing.Point(170, 360)
         Me.lblSelectedIndices.Name = "lblSelectedIndices"
         Me.lblSelectedIndices.Size = New System.Drawing.Size(0, 13)
         Me.lblSelectedIndices.TabIndex = 16
@@ -202,7 +202,7 @@ Partial Class dlgClimdexIndices
         Me.lblTotalIndices.AutoSize = True
         Me.lblTotalIndices.ForeColor = System.Drawing.Color.Green
         Me.lblTotalIndices.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblTotalIndices.Location = New System.Drawing.Point(272, 361)
+        Me.lblTotalIndices.Location = New System.Drawing.Point(297, 360)
         Me.lblTotalIndices.Name = "lblTotalIndices"
         Me.lblTotalIndices.Size = New System.Drawing.Size(0, 13)
         Me.lblTotalIndices.TabIndex = 18
@@ -345,7 +345,7 @@ Partial Class dlgClimdexIndices
         Me.ucrBase.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.ucrBase.Location = New System.Drawing.Point(10, 383)
         Me.ucrBase.Name = "ucrBase"
-        Me.ucrBase.Size = New System.Drawing.Size(405, 52)
+        Me.ucrBase.Size = New System.Drawing.Size(408, 52)
         Me.ucrBase.TabIndex = 20
         '
         'dlgClimdexIndices


### PR DESCRIPTION
fixes #8225 
I changed the text that was displaced - so that the number of indices selected would be in the middle of the message.
This PR is ready for review 
@rdstern , @N-thony  can you test/approve