### PR TITLE
Reset the Data View scroll bar to the top

### DIFF
--- a/instat/UserControls/DataGrid/ReoGrid/ucrDataViewReoGrid.vb
+++ b/instat/UserControls/DataGrid/ReoGrid/ucrDataViewReoGrid.vb
@@ -86,7 +86,7 @@ Public Class ucrDataViewReoGrid
             End If
         Next
 
-        grdData.CurrentWorksheet.ScrollToCell("A1") ' will always set the scrollbar at the top when filter is applied. see issue #8116
+        grdData.CurrentWorksheet.ScrollToCell("A1") ' will always set the scrollbar at the top.
 
         'todo. As of 30/05/2022, the reogrid control version used did not have this setting option
         'see issue #7221 for more information.

--- a/instat/UserControls/DataGrid/ReoGrid/ucrDataViewReoGrid.vb
+++ b/instat/UserControls/DataGrid/ReoGrid/ucrDataViewReoGrid.vb
@@ -64,7 +64,6 @@ Public Class ucrDataViewReoGrid
 
         If dataFrame.clsFilterOrColumnSelection.bFilterApplied Then
             textColour = Color.Red
-            grdData.CurrentWorksheet.ScrollToCell("A1") ' will always set the scrollbar at the top when filter is applied. see issue #8116
         Else
             textColour = Color.DarkBlue
         End If
@@ -86,6 +85,8 @@ Public Class ucrDataViewReoGrid
                 strLongestRowHeaderText = strRowNames(i)
             End If
         Next
+
+        grdData.CurrentWorksheet.ScrollToCell("A1") ' will always set the scrollbar at the top when filter is applied. see issue #8116
 
         'todo. As of 30/05/2022, the reogrid control version used did not have this setting option
         'see issue #7221 for more information.


### PR DESCRIPTION
@rdstern following our chat on Skype few minutes ago, I made the changes as you have noticed during the workshop when paging sometimes it is giving you blank page. This will always set the scroll bar at the top. You can test it also try with the filter for the rows.
I'm checking about the column if easy will just do it here.