### PR TITLE
Ensured that 'Colour Columns by Structure' check box works correctly in Column Structure dialog

### DIFF
--- a/instat/dlgColumnStructures.vb
+++ b/instat/dlgColumnStructures.vb
@@ -59,6 +59,9 @@ Public Class dlgColumnStructure
         ucrChkColourColumnsByStructure.SetText("Colour Columns by Structure")
         ucrChkColourColumnsByStructure.AddFunctionNamesCondition(True, frmMain.clsRLink.strInstatDataObject & "$set_column_colours_by_metadata")
         ucrChkColourColumnsByStructure.AddFunctionNamesCondition(False, frmMain.clsRLink.strInstatDataObject & "$remove_column_colours")
+        ucrChkColourColumnsByStructure.SetParameter(New RParameter("checked"))
+        ucrChkColourColumnsByStructure.SetValuesCheckedAndUnchecked("TRUE", "FALSE")
+        ucrChkColourColumnsByStructure.SetRDefault("TRUE")
     End Sub
 
     Private Sub SetDefaults()
@@ -86,10 +89,13 @@ Public Class dlgColumnStructure
         ucrSelectorColumnStructure.AddAdditionalCodeParameterPair(clsUncolourByMetadata, ucrSelectorColumnStructure.GetParameter(), iAdditionalPairNo:=2)
 
         ucrSelectorColumnStructure.SetRCode(clsColumnStructure, bReset)
-        ucrReceiverLayout.SetRCode(clsColumnStructure, bReset)
-        ucrReceiverTreatment.SetRCode(clsColumnStructure, bReset)
-        ucrReceiverMeasurement.SetRCode(clsColumnStructure, bReset)
         ucrChkColourColumnsByStructure.SetRCode(clsColourStructure, bReset)
+
+        If bReset Then
+            ucrReceiverLayout.SetRCode(clsColumnStructure, bReset)
+            ucrReceiverTreatment.SetRCode(clsColumnStructure, bReset)
+            ucrReceiverMeasurement.SetRCode(clsColumnStructure, bReset)
+        End If
     End Sub
 
     Private Sub TestOKEnabled()


### PR DESCRIPTION
fixes partially #7232 
I made the checkbox for the colour the default. So it starts with the checkbox ticked and also fixed the problem of the dialogue remembering the variables in each control when the dialogue is re-opened. 
@rdstern  this PR is ready for review. 
Thanks 