### PR TITLE
Ensured that 'tmin' & 'rain' fill automatically in Climatic Boxplot dialog

### DIFF
--- a/instat/dlgClimaticBoxPlot.vb
+++ b/instat/dlgClimaticBoxPlot.vb
@@ -420,13 +420,17 @@ Public Class dlgClimaticBoxPlot
         Dim strMonthCol As String
         Dim strDataFrame As String
         Dim strRainCol As String
+        Dim strTempCol As String
 
         strDataFrame = ucrSelectorClimaticBoxPlot.ucrAvailableDataFrames.cboAvailableDataFrames.Text
         strMonthCol = frmMain.clsRLink.GetClimaticColumnOfType(strDataFrame, "month_label")
         strRainCol = frmMain.clsRLink.GetClimaticColumnOfType(strDataFrame, "rain_label")
-
-        If strRainCol <> "" Then
+        strTempCol = frmMain.clsRLink.GetClimaticColumnOfType(strDataFrame, "temp_min_label")
+        If strTempCol <> "" Then
+            ucrReceiverElement.Add(strTempCol, strDataFrame)
+        Else
             ucrReceiverElement.Add(strRainCol, strDataFrame)
+
         End If
         If strMonthCol <> "" Then
             ucrReceiverWithinYear.Add(strMonthCol, strDataFrame)
@@ -578,5 +582,9 @@ Public Class dlgClimaticBoxPlot
     End Sub
     Private Sub ucrReceiverStation_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverStation.ControlValueChanged, ucrReceiverWithinYear.ControlValueChanged, ucrReceiverYear.ControlValueChanged
         AddRemoveFacets()
+    End Sub
+
+    Private Sub ucrReceiverElement_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverElement.ControlValueChanged
+        AutoFill()
     End Sub
 End Class

--- a/instat/dlgClimaticBoxPlot.vb
+++ b/instat/dlgClimaticBoxPlot.vb
@@ -426,7 +426,7 @@ Public Class dlgClimaticBoxPlot
         strMonthCol = frmMain.clsRLink.GetClimaticColumnOfType(strDataFrame, "month_label")
         strRainCol = frmMain.clsRLink.GetClimaticColumnOfType(strDataFrame, "rain_label")
         strTempCol = frmMain.clsRLink.GetClimaticColumnOfType(strDataFrame, "temp_min_label")
-        If strTempCol <> "" Then
+        If Not String.IsNullOrEmpty(strTempCol) Then
             ucrReceiverElement.Add(strTempCol, strDataFrame)
         Else
             ucrReceiverElement.Add(strRainCol, strDataFrame)


### PR DESCRIPTION
Fixes partially #8213 
Fixes part h) of the issue
@rdstern , @lloyddewit , Made `tmin `variable be completed automatically and if `tmin` is missing, then `rain `be filled automatically

