### PR TITLE
Added bayesian Keyboard to  the Model keyboards

### DIFF
--- a/instat/dlgHypothesisTestsCalculator.Designer.vb
+++ b/instat/dlgHypothesisTestsCalculator.Designer.vb
@@ -138,6 +138,24 @@ Partial Class dlgHypothesisTestsCalculator
         Me.cmdBr = New System.Windows.Forms.Button()
         Me.cmdBartels = New System.Windows.Forms.Button()
         Me.ttHypothesisTests = New System.Windows.Forms.ToolTip(Me.components)
+        Me.ContextMenuStripStats = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.ToolStripMenuStats = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ContextMenuStripCoin = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.ToolStripMenuCoin = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ContextMenuStripAgricolae = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.ToolStripMenuAgricolae = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ContextMenuStripTrend = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.ToolStripMenuTrend = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ContextMenuStripVerification = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.ToolStripMenuVerification = New System.Windows.Forms.ToolStripMenuItem()
+        Me.grpBayesianPlus = New System.Windows.Forms.GroupBox()
+        Me.cmdinference = New System.Windows.Forms.Button()
+        Me.cmdbayesinference = New System.Windows.Forms.Button()
+        Me.cmdRHelpVerification = New instat.ucrSplitButton()
+        Me.cmdRHelpTrend = New instat.ucrSplitButton()
+        Me.cmdRHelpAgricolae = New instat.ucrSplitButton()
+        Me.cmdRHelpCoin = New instat.ucrSplitButton()
+        Me.cmdRHelpStats = New instat.ucrSplitButton()
         Me.ucrChkDisplayModel = New instat.ucrCheck()
         Me.ucrChkSummaryModel = New instat.ucrCheck()
         Me.ucrTryModelling = New instat.ucrTry()
@@ -149,21 +167,9 @@ Partial Class dlgHypothesisTestsCalculator
         Me.ucrSelectorColumn = New instat.ucrSelectorByDataFrameAddRemove()
         Me.ucrChkIncludeArguments = New instat.ucrCheck()
         Me.ucrReceiverForTestColumn = New instat.ucrReceiverExpression()
-        Me.cmdRHelpStats = New instat.ucrSplitButton()
-        Me.ContextMenuStripStats = New System.Windows.Forms.ContextMenuStrip(Me.components)
-        Me.ToolStripMenuStats = New System.Windows.Forms.ToolStripMenuItem()
-        Me.cmdRHelpCoin = New instat.ucrSplitButton()
-        Me.ContextMenuStripCoin = New System.Windows.Forms.ContextMenuStrip(Me.components)
-        Me.ToolStripMenuCoin = New System.Windows.Forms.ToolStripMenuItem()
-        Me.cmdRHelpAgricolae = New instat.ucrSplitButton()
-        Me.ContextMenuStripAgricolae = New System.Windows.Forms.ContextMenuStrip(Me.components)
-        Me.ToolStripMenuAgricolae = New System.Windows.Forms.ToolStripMenuItem()
-        Me.cmdRHelpTrend = New instat.ucrSplitButton()
-        Me.ContextMenuStripTrend = New System.Windows.Forms.ContextMenuStrip(Me.components)
-        Me.ToolStripMenuTrend = New System.Windows.Forms.ToolStripMenuItem()
-        Me.cmdRHelpVerification = New instat.ucrSplitButton()
-        Me.ContextMenuStripVerification = New System.Windows.Forms.ContextMenuStrip(Me.components)
-        Me.ToolStripMenuVerification = New System.Windows.Forms.ToolStripMenuItem()
+        Me.cmdRHelpStatsr = New instat.ucrSplitButton()
+        Me.ContextMenuStatsr = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.ToolStripMenuStatsr = New System.Windows.Forms.ToolStripMenuItem()
         Me.grpMainKeyboard.SuspendLayout()
         Me.grpStats1.SuspendLayout()
         Me.grpStats2.SuspendLayout()
@@ -181,6 +187,8 @@ Partial Class dlgHypothesisTestsCalculator
         Me.ContextMenuStripAgricolae.SuspendLayout()
         Me.ContextMenuStripTrend.SuspendLayout()
         Me.ContextMenuStripVerification.SuspendLayout()
+        Me.grpBayesianPlus.SuspendLayout()
+        Me.ContextMenuStatsr.SuspendLayout()
         Me.SuspendLayout()
         '
         'lblTest
@@ -755,7 +763,7 @@ Partial Class dlgHypothesisTestsCalculator
         Me.grpVerification.Controls.Add(Me.cmdCont)
         Me.grpVerification.Controls.Add(Me.cmdCat)
         Me.grpVerification.Controls.Add(Me.cmdBinary)
-        Me.grpVerification.Location = New System.Drawing.Point(241, 79)
+        Me.grpVerification.Location = New System.Drawing.Point(233, 79)
         Me.grpVerification.Margin = New System.Windows.Forms.Padding(2)
         Me.grpVerification.Name = "grpVerification"
         Me.grpVerification.Padding = New System.Windows.Forms.Padding(2)
@@ -1493,6 +1501,159 @@ Partial Class dlgHypothesisTestsCalculator
         Me.cmdBartels.Text = "bartels"
         Me.cmdBartels.UseVisualStyleBackColor = True
         '
+        'ContextMenuStripStats
+        '
+        Me.ContextMenuStripStats.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuStats})
+        Me.ContextMenuStripStats.Name = "ContextMenuStrip1"
+        Me.ContextMenuStripStats.Size = New System.Drawing.Size(99, 26)
+        '
+        'ToolStripMenuStats
+        '
+        Me.ToolStripMenuStats.Name = "ToolStripMenuStats"
+        Me.ToolStripMenuStats.Size = New System.Drawing.Size(98, 22)
+        Me.ToolStripMenuStats.Text = "stats"
+        '
+        'ContextMenuStripCoin
+        '
+        Me.ContextMenuStripCoin.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuCoin})
+        Me.ContextMenuStripCoin.Name = "ContextMenuStrip1"
+        Me.ContextMenuStripCoin.Size = New System.Drawing.Size(98, 26)
+        '
+        'ToolStripMenuCoin
+        '
+        Me.ToolStripMenuCoin.Name = "ToolStripMenuCoin"
+        Me.ToolStripMenuCoin.Size = New System.Drawing.Size(97, 22)
+        Me.ToolStripMenuCoin.Text = "coin"
+        '
+        'ContextMenuStripAgricolae
+        '
+        Me.ContextMenuStripAgricolae.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuAgricolae})
+        Me.ContextMenuStripAgricolae.Name = "ContextMenuStrip1"
+        Me.ContextMenuStripAgricolae.Size = New System.Drawing.Size(123, 26)
+        '
+        'ToolStripMenuAgricolae
+        '
+        Me.ToolStripMenuAgricolae.Name = "ToolStripMenuAgricolae"
+        Me.ToolStripMenuAgricolae.Size = New System.Drawing.Size(122, 22)
+        Me.ToolStripMenuAgricolae.Text = "agricolae"
+        '
+        'ContextMenuStripTrend
+        '
+        Me.ContextMenuStripTrend.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuTrend})
+        Me.ContextMenuStripTrend.Name = "ContextMenuStrip1"
+        Me.ContextMenuStripTrend.Size = New System.Drawing.Size(103, 26)
+        '
+        'ToolStripMenuTrend
+        '
+        Me.ToolStripMenuTrend.Name = "ToolStripMenuTrend"
+        Me.ToolStripMenuTrend.Size = New System.Drawing.Size(102, 22)
+        Me.ToolStripMenuTrend.Text = "trend"
+        '
+        'ContextMenuStripVerification
+        '
+        Me.ContextMenuStripVerification.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuVerification})
+        Me.ContextMenuStripVerification.Name = "ContextMenuStrip1"
+        Me.ContextMenuStripVerification.Size = New System.Drawing.Size(134, 26)
+        '
+        'ToolStripMenuVerification
+        '
+        Me.ToolStripMenuVerification.Name = "ToolStripMenuVerification"
+        Me.ToolStripMenuVerification.Size = New System.Drawing.Size(133, 22)
+        Me.ToolStripMenuVerification.Text = "verification"
+        '
+        'grpBayesianPlus
+        '
+        Me.grpBayesianPlus.Controls.Add(Me.cmdinference)
+        Me.grpBayesianPlus.Controls.Add(Me.cmdbayesinference)
+        Me.grpBayesianPlus.Location = New System.Drawing.Point(233, 79)
+        Me.grpBayesianPlus.Margin = New System.Windows.Forms.Padding(2)
+        Me.grpBayesianPlus.Name = "grpBayesianPlus"
+        Me.grpBayesianPlus.Padding = New System.Windows.Forms.Padding(2)
+        Me.grpBayesianPlus.Size = New System.Drawing.Size(228, 50)
+        Me.grpBayesianPlus.TabIndex = 22
+        Me.grpBayesianPlus.TabStop = False
+        Me.grpBayesianPlus.Text = "Statsr"
+        '
+        'cmdinference
+        '
+        Me.cmdinference.Location = New System.Drawing.Point(97, 14)
+        Me.cmdinference.Margin = New System.Windows.Forms.Padding(2)
+        Me.cmdinference.Name = "cmdinference"
+        Me.cmdinference.Size = New System.Drawing.Size(94, 30)
+        Me.cmdinference.TabIndex = 20
+        Me.cmdinference.Text = "inference "
+        Me.cmdinference.UseVisualStyleBackColor = True
+        '
+        'cmdbayesinference
+        '
+        Me.cmdbayesinference.Location = New System.Drawing.Point(4, 14)
+        Me.cmdbayesinference.Margin = New System.Windows.Forms.Padding(2)
+        Me.cmdbayesinference.Name = "cmdbayesinference"
+        Me.cmdbayesinference.Size = New System.Drawing.Size(94, 30)
+        Me.cmdbayesinference.TabIndex = 19
+        Me.cmdbayesinference.Text = "bayes_inference"
+        Me.cmdbayesinference.UseVisualStyleBackColor = True
+        '
+        'cmdRHelpVerification
+        '
+        Me.cmdRHelpVerification.AutoSize = True
+        Me.cmdRHelpVerification.ContextMenuStrip = Me.ContextMenuStripVerification
+        Me.cmdRHelpVerification.Location = New System.Drawing.Point(521, 260)
+        Me.cmdRHelpVerification.Name = "cmdRHelpVerification"
+        Me.cmdRHelpVerification.Size = New System.Drawing.Size(68, 23)
+        Me.cmdRHelpVerification.SplitMenuStrip = Me.ContextMenuStripVerification
+        Me.cmdRHelpVerification.TabIndex = 228
+        Me.cmdRHelpVerification.Text = "R Help"
+        Me.cmdRHelpVerification.UseVisualStyleBackColor = True
+        '
+        'cmdRHelpTrend
+        '
+        Me.cmdRHelpTrend.AutoSize = True
+        Me.cmdRHelpTrend.ContextMenuStrip = Me.ContextMenuStripTrend
+        Me.cmdRHelpTrend.Location = New System.Drawing.Point(520, 259)
+        Me.cmdRHelpTrend.Name = "cmdRHelpTrend"
+        Me.cmdRHelpTrend.Size = New System.Drawing.Size(68, 23)
+        Me.cmdRHelpTrend.SplitMenuStrip = Me.ContextMenuStripTrend
+        Me.cmdRHelpTrend.TabIndex = 227
+        Me.cmdRHelpTrend.Text = "R Help"
+        Me.cmdRHelpTrend.UseVisualStyleBackColor = True
+        '
+        'cmdRHelpAgricolae
+        '
+        Me.cmdRHelpAgricolae.AutoSize = True
+        Me.cmdRHelpAgricolae.ContextMenuStrip = Me.ContextMenuStripAgricolae
+        Me.cmdRHelpAgricolae.Location = New System.Drawing.Point(520, 261)
+        Me.cmdRHelpAgricolae.Name = "cmdRHelpAgricolae"
+        Me.cmdRHelpAgricolae.Size = New System.Drawing.Size(68, 23)
+        Me.cmdRHelpAgricolae.SplitMenuStrip = Me.ContextMenuStripAgricolae
+        Me.cmdRHelpAgricolae.TabIndex = 226
+        Me.cmdRHelpAgricolae.Text = "R Help"
+        Me.cmdRHelpAgricolae.UseVisualStyleBackColor = True
+        '
+        'cmdRHelpCoin
+        '
+        Me.cmdRHelpCoin.AutoSize = True
+        Me.cmdRHelpCoin.ContextMenuStrip = Me.ContextMenuStripCoin
+        Me.cmdRHelpCoin.Location = New System.Drawing.Point(520, 260)
+        Me.cmdRHelpCoin.Name = "cmdRHelpCoin"
+        Me.cmdRHelpCoin.Size = New System.Drawing.Size(68, 23)
+        Me.cmdRHelpCoin.SplitMenuStrip = Me.ContextMenuStripCoin
+        Me.cmdRHelpCoin.TabIndex = 225
+        Me.cmdRHelpCoin.Text = "R Help"
+        Me.cmdRHelpCoin.UseVisualStyleBackColor = True
+        '
+        'cmdRHelpStats
+        '
+        Me.cmdRHelpStats.AutoSize = True
+        Me.cmdRHelpStats.ContextMenuStrip = Me.ContextMenuStripStats
+        Me.cmdRHelpStats.Location = New System.Drawing.Point(520, 260)
+        Me.cmdRHelpStats.Name = "cmdRHelpStats"
+        Me.cmdRHelpStats.Size = New System.Drawing.Size(68, 23)
+        Me.cmdRHelpStats.SplitMenuStrip = Me.ContextMenuStripStats
+        Me.cmdRHelpStats.TabIndex = 223
+        Me.cmdRHelpStats.Text = "R Help"
+        Me.cmdRHelpStats.UseVisualStyleBackColor = True
+        '
         'ucrChkDisplayModel
         '
         Me.ucrChkDisplayModel.AutoSize = True
@@ -1614,125 +1775,29 @@ Partial Class dlgHypothesisTestsCalculator
         Me.ucrReceiverForTestColumn.TabIndex = 1
         Me.ucrReceiverForTestColumn.ucrSelector = Nothing
         '
-        'cmdRHelpStats
+        'cmdRHelpStatsr
         '
-        Me.cmdRHelpStats.AutoSize = True
-        Me.cmdRHelpStats.ContextMenuStrip = Me.ContextMenuStripStats
-        Me.cmdRHelpStats.Location = New System.Drawing.Point(520, 260)
-        Me.cmdRHelpStats.Name = "cmdRHelpStats"
-        Me.cmdRHelpStats.Size = New System.Drawing.Size(68, 23)
-        Me.cmdRHelpStats.SplitMenuStrip = Me.ContextMenuStripStats
-        Me.cmdRHelpStats.TabIndex = 223
-        Me.cmdRHelpStats.Text = "R Help"
-        Me.cmdRHelpStats.UseVisualStyleBackColor = True
+        Me.cmdRHelpStatsr.AutoSize = True
+        Me.cmdRHelpStatsr.ContextMenuStrip = Me.ContextMenuStatsr
+        Me.cmdRHelpStatsr.Location = New System.Drawing.Point(520, 259)
+        Me.cmdRHelpStatsr.Name = "cmdRHelpStatsr"
+        Me.cmdRHelpStatsr.Size = New System.Drawing.Size(68, 23)
+        Me.cmdRHelpStatsr.SplitMenuStrip = Me.ContextMenuStatsr
+        Me.cmdRHelpStatsr.TabIndex = 229
+        Me.cmdRHelpStatsr.Text = "R Help"
+        Me.cmdRHelpStatsr.UseVisualStyleBackColor = True
         '
-        'ContextMenuStripStats
+        'ContextMenuStatsr
         '
-        Me.ContextMenuStripStats.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuStats})
-        Me.ContextMenuStripStats.Name = "ContextMenuStrip1"
-        Me.ContextMenuStripStats.Size = New System.Drawing.Size(99, 26)
+        Me.ContextMenuStatsr.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuStatsr})
+        Me.ContextMenuStatsr.Name = "ContextMenuStrip1"
+        Me.ContextMenuStatsr.Size = New System.Drawing.Size(103, 26)
         '
-        'ToolStripMenuStats
+        'ToolStripMenuStatsr
         '
-        Me.ToolStripMenuStats.Name = "ToolStripMenuStats"
-        Me.ToolStripMenuStats.Size = New System.Drawing.Size(98, 22)
-        Me.ToolStripMenuStats.Text = "stats"
-        '
-        'cmdRHelpCoin
-        '
-        Me.cmdRHelpCoin.AutoSize = True
-        Me.cmdRHelpCoin.ContextMenuStrip = Me.ContextMenuStripCoin
-        Me.cmdRHelpCoin.Location = New System.Drawing.Point(520, 260)
-        Me.cmdRHelpCoin.Name = "cmdRHelpCoin"
-        Me.cmdRHelpCoin.Size = New System.Drawing.Size(68, 23)
-        Me.cmdRHelpCoin.SplitMenuStrip = Me.ContextMenuStripCoin
-        Me.cmdRHelpCoin.TabIndex = 225
-        Me.cmdRHelpCoin.Text = "R Help"
-        Me.cmdRHelpCoin.UseVisualStyleBackColor = True
-        '
-        'ContextMenuStripCoin
-        '
-        Me.ContextMenuStripCoin.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuCoin})
-        Me.ContextMenuStripCoin.Name = "ContextMenuStrip1"
-        Me.ContextMenuStripCoin.Size = New System.Drawing.Size(98, 26)
-        '
-        'ToolStripMenuCoin
-        '
-        Me.ToolStripMenuCoin.Name = "ToolStripMenuCoin"
-        Me.ToolStripMenuCoin.Size = New System.Drawing.Size(97, 22)
-        Me.ToolStripMenuCoin.Text = "coin"
-        '
-        'cmdRHelpAgricolae
-        '
-        Me.cmdRHelpAgricolae.AutoSize = True
-        Me.cmdRHelpAgricolae.ContextMenuStrip = Me.ContextMenuStripAgricolae
-        Me.cmdRHelpAgricolae.Location = New System.Drawing.Point(520, 261)
-        Me.cmdRHelpAgricolae.Name = "cmdRHelpAgricolae"
-        Me.cmdRHelpAgricolae.Size = New System.Drawing.Size(68, 23)
-        Me.cmdRHelpAgricolae.SplitMenuStrip = Me.ContextMenuStripAgricolae
-        Me.cmdRHelpAgricolae.TabIndex = 226
-        Me.cmdRHelpAgricolae.Text = "R Help"
-        Me.cmdRHelpAgricolae.UseVisualStyleBackColor = True
-        '
-        'ContextMenuStripAgricolae
-        '
-        Me.ContextMenuStripAgricolae.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuAgricolae})
-        Me.ContextMenuStripAgricolae.Name = "ContextMenuStrip1"
-        Me.ContextMenuStripAgricolae.Size = New System.Drawing.Size(123, 26)
-        '
-        'ToolStripMenuAgricolae
-        '
-        Me.ToolStripMenuAgricolae.Name = "ToolStripMenuAgricolae"
-        Me.ToolStripMenuAgricolae.Size = New System.Drawing.Size(122, 22)
-        Me.ToolStripMenuAgricolae.Text = "agricolae"
-        '
-        'cmdRHelpTrend
-        '
-        Me.cmdRHelpTrend.AutoSize = True
-        Me.cmdRHelpTrend.ContextMenuStrip = Me.ContextMenuStripTrend
-        Me.cmdRHelpTrend.Location = New System.Drawing.Point(520, 259)
-        Me.cmdRHelpTrend.Name = "cmdRHelpTrend"
-        Me.cmdRHelpTrend.Size = New System.Drawing.Size(68, 23)
-        Me.cmdRHelpTrend.SplitMenuStrip = Me.ContextMenuStripTrend
-        Me.cmdRHelpTrend.TabIndex = 227
-        Me.cmdRHelpTrend.Text = "R Help"
-        Me.cmdRHelpTrend.UseVisualStyleBackColor = True
-        '
-        'ContextMenuStripTrend
-        '
-        Me.ContextMenuStripTrend.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuTrend})
-        Me.ContextMenuStripTrend.Name = "ContextMenuStrip1"
-        Me.ContextMenuStripTrend.Size = New System.Drawing.Size(103, 26)
-        '
-        'ToolStripMenuTrend
-        '
-        Me.ToolStripMenuTrend.Name = "ToolStripMenuTrend"
-        Me.ToolStripMenuTrend.Size = New System.Drawing.Size(102, 22)
-        Me.ToolStripMenuTrend.Text = "trend"
-        '
-        'cmdRHelpVerification
-        '
-        Me.cmdRHelpVerification.AutoSize = True
-        Me.cmdRHelpVerification.ContextMenuStrip = Me.ContextMenuStripVerification
-        Me.cmdRHelpVerification.Location = New System.Drawing.Point(521, 260)
-        Me.cmdRHelpVerification.Name = "cmdRHelpVerification"
-        Me.cmdRHelpVerification.Size = New System.Drawing.Size(68, 23)
-        Me.cmdRHelpVerification.SplitMenuStrip = Me.ContextMenuStripVerification
-        Me.cmdRHelpVerification.TabIndex = 228
-        Me.cmdRHelpVerification.Text = "R Help"
-        Me.cmdRHelpVerification.UseVisualStyleBackColor = True
-        '
-        'ContextMenuStripVerification
-        '
-        Me.ContextMenuStripVerification.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuVerification})
-        Me.ContextMenuStripVerification.Name = "ContextMenuStrip1"
-        Me.ContextMenuStripVerification.Size = New System.Drawing.Size(134, 26)
-        '
-        'ToolStripMenuVerification
-        '
-        Me.ToolStripMenuVerification.Name = "ToolStripMenuVerification"
-        Me.ToolStripMenuVerification.Size = New System.Drawing.Size(133, 22)
-        Me.ToolStripMenuVerification.Text = "verification"
+        Me.ToolStripMenuStatsr.Name = "ToolStripMenuStatsr"
+        Me.ToolStripMenuStatsr.Size = New System.Drawing.Size(102, 22)
+        Me.ToolStripMenuStatsr.Text = "statsr"
         '
         'dlgHypothesisTestsCalculator
         '
@@ -1740,6 +1805,9 @@ Partial Class dlgHypothesisTestsCalculator
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
         Me.AutoSize = True
         Me.ClientSize = New System.Drawing.Size(643, 485)
+        Me.Controls.Add(Me.cmdRHelpStatsr)
+        Me.Controls.Add(Me.grpBayesianPlus)
+        Me.Controls.Add(Me.grpVerification)
         Me.Controls.Add(Me.cmdRHelpVerification)
         Me.Controls.Add(Me.cmdRHelpTrend)
         Me.Controls.Add(Me.cmdRHelpAgricolae)
@@ -1747,7 +1815,6 @@ Partial Class dlgHypothesisTestsCalculator
         Me.Controls.Add(Me.cmdRHelpStats)
         Me.Controls.Add(Me.grpTrend)
         Me.Controls.Add(Me.grpCoin)
-        Me.Controls.Add(Me.grpVerification)
         Me.Controls.Add(Me.cmdClear)
         Me.Controls.Add(Me.ucrChkDisplayModel)
         Me.Controls.Add(Me.ucrChkSummaryModel)
@@ -1789,6 +1856,8 @@ Partial Class dlgHypothesisTestsCalculator
         Me.ContextMenuStripAgricolae.ResumeLayout(False)
         Me.ContextMenuStripTrend.ResumeLayout(False)
         Me.ContextMenuStripVerification.ResumeLayout(False)
+        Me.grpBayesianPlus.ResumeLayout(False)
+        Me.ContextMenuStatsr.ResumeLayout(False)
         Me.ResumeLayout(False)
         Me.PerformLayout()
 
@@ -1934,4 +2003,10 @@ Partial Class dlgHypothesisTestsCalculator
     Friend WithEvents ToolStripMenuCoin As ToolStripMenuItem
     Friend WithEvents ContextMenuStripTrend As ContextMenuStrip
     Friend WithEvents ToolStripMenuTrend As ToolStripMenuItem
+    Friend WithEvents grpBayesianPlus As GroupBox
+    Friend WithEvents cmdinference As Button
+    Friend WithEvents cmdbayesinference As Button
+    Friend WithEvents cmdRHelpStatsr As ucrSplitButton
+    Friend WithEvents ContextMenuStatsr As ContextMenuStrip
+    Friend WithEvents ToolStripMenuStatsr As ToolStripMenuItem
 End Class

--- a/instat/dlgHypothesisTestsCalculator.resx
+++ b/instat/dlgHypothesisTestsCalculator.resx
@@ -120,19 +120,22 @@
   <metadata name="ttHypothesisTests.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>20, 6</value>
   </metadata>
-  <metadata name="ContextMenuStripVerification.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>569, 11</value>
-  </metadata>
-  <metadata name="ContextMenuStripTrend.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 48</value>
-  </metadata>
-  <metadata name="ContextMenuStripAgricolae.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>373, 10</value>
+  <metadata name="ContextMenuStripStats.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>172, 12</value>
   </metadata>
   <metadata name="ContextMenuStripCoin.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>775, 9</value>
   </metadata>
-  <metadata name="ContextMenuStripStats.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>172, 12</value>
+  <metadata name="ContextMenuStripAgricolae.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>373, 10</value>
+  </metadata>
+  <metadata name="ContextMenuStripTrend.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 48</value>
+  </metadata>
+  <metadata name="ContextMenuStripVerification.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>569, 11</value>
+  </metadata>
+  <metadata name="ContextMenuStatsr.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>199, 48</value>
   </metadata>
 </root>

--- a/instat/dlgHypothesisTestsCalculator.vb
+++ b/instat/dlgHypothesisTestsCalculator.vb
@@ -52,7 +52,7 @@ Public Class dlgHypothesisTestsCalculator
         ucrSaveResult.SetAssignToIfUncheckedValue("Last_Test")
         ucrSaveResult.SetDataFrameSelector(ucrSelectorColumn.ucrAvailableDataFrames)
 
-        ucrInputComboRPackage.SetItems({"Stats1", "Stats2", "Agricolae", "Verification", "Coin", "Trend"})
+        ucrInputComboRPackage.SetItems({"Stats1", "Stats2", "Agricolae", "Verification", "Coin", "Trend", "Statsr"})
         ucrInputComboRPackage.SetDropDownStyleAsNonEditable()
         'Tooltips for conf & and Alt Buttons
         ttHypothesisTests.SetToolTip(cmdConf, "The confidence level can be changed for some tests to 0.9 or 0.99 etc")
@@ -614,11 +614,13 @@ Public Class dlgHypothesisTestsCalculator
                 grpVerification.Visible = False
                 grpCoin.Visible = False
                 grpTrend.Visible = False
+                grpBayesianPlus.Visible = False
                 cmdRHelpStats.Visible = True
                 cmdRHelpAgricolae.Visible = False
                 cmdRHelpCoin.Visible = False
                 cmdRHelpVerification.Visible = False
                 cmdRHelpTrend.Visible = False
+                cmdRHelpStatsr.Visible = False
             Case "Stats2"
                 strPackageName = "stats"
                 grpAgricolae.Visible = False
@@ -627,11 +629,13 @@ Public Class dlgHypothesisTestsCalculator
                 grpVerification.Visible = False
                 grpCoin.Visible = False
                 grpTrend.Visible = False
+                grpBayesianPlus.Visible = False
                 cmdRHelpStats.Visible = True
                 cmdRHelpAgricolae.Visible = False
                 cmdRHelpCoin.Visible = False
                 cmdRHelpVerification.Visible = False
                 cmdRHelpTrend.Visible = False
+                cmdRHelpStatsr.Visible = False
             Case "Agricolae"
                 strPackageName = "agricolae"
                 grpStats1.Visible = False
@@ -640,11 +644,13 @@ Public Class dlgHypothesisTestsCalculator
                 grpVerification.Visible = False
                 grpCoin.Visible = False
                 grpTrend.Visible = False
+                grpBayesianPlus.Visible = False
                 cmdRHelpStats.Visible = False
                 cmdRHelpAgricolae.Visible = True
                 cmdRHelpCoin.Visible = False
                 cmdRHelpVerification.Visible = False
                 cmdRHelpTrend.Visible = False
+                cmdRHelpStatsr.Visible = False
             Case "Verification"
                 strPackageName = "verification"
                 grpStats1.Visible = False
@@ -653,11 +659,13 @@ Public Class dlgHypothesisTestsCalculator
                 grpVerification.Visible = True
                 grpCoin.Visible = False
                 grpTrend.Visible = False
+                grpBayesianPlus.Visible = False
                 cmdRHelpStats.Visible = False
                 cmdRHelpAgricolae.Visible = False
                 cmdRHelpCoin.Visible = False
                 cmdRHelpVerification.Visible = True
                 cmdRHelpTrend.Visible = False
+                cmdRHelpStatsr.Visible = False
             Case "Coin"
                 strPackageName = "coin"
                 grpStats1.Visible = False
@@ -666,11 +674,13 @@ Public Class dlgHypothesisTestsCalculator
                 grpVerification.Visible = False
                 grpCoin.Visible = True
                 grpTrend.Visible = False
+                grpBayesianPlus.Visible = False
                 cmdRHelpStats.Visible = False
                 cmdRHelpAgricolae.Visible = False
                 cmdRHelpCoin.Visible = True
                 cmdRHelpVerification.Visible = False
                 cmdRHelpTrend.Visible = False
+                cmdRHelpStatsr.Visible = False
             Case "Trend"
                 strPackageName = "trend"
                 grpStats1.Visible = False
@@ -679,12 +689,27 @@ Public Class dlgHypothesisTestsCalculator
                 grpVerification.Visible = False
                 grpCoin.Visible = False
                 grpTrend.Visible = True
+                grpBayesianPlus.Visible = False
                 cmdRHelpStats.Visible = False
                 cmdRHelpAgricolae.Visible = False
                 cmdRHelpCoin.Visible = False
                 cmdRHelpVerification.Visible = False
                 cmdRHelpTrend.Visible = True
-
+                cmdRHelpStatsr.Visible = False
+            Case "Statsr"
+                grpBayesianPlus.Visible = True
+                grpStats1.Visible = False
+                grpStats2.Visible = False
+                grpAgricolae.Visible = False
+                grpVerification.Visible = False
+                grpCoin.Visible = False
+                grpTrend.Visible = False
+                cmdRHelpStats.Visible = False
+                cmdRHelpAgricolae.Visible = False
+                cmdRHelpCoin.Visible = False
+                cmdRHelpVerification.Visible = False
+                cmdRHelpTrend.Visible = False
+                cmdRHelpStatsr.Visible = True
         End Select
     End Sub
 
@@ -1072,6 +1097,24 @@ Public Class dlgHypothesisTestsCalculator
         End If
     End Sub
 
+    Private Sub cmdbayesinference_Click(sender As Object, e As EventArgs) Handles cmdbayesinference.Click
+        clear()
+        If ucrChkIncludeArguments.Checked Then
+            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("statsr::bayes_inference(y= ,x = NULL,data=" & ucrSelectorColumn.ucrAvailableDataFrames.cboAvailableDataFrames.Text & " ,type = c(""ci"", ""ht""),statistic = c(""mean"", ""proportion""),method = c(""theoretical"", ""simulation""),success = NULL,cred_level = 0.95,alternative = ""twosided"", prior_family = ""JZS"",mu_0 = 0,rscale = 1,nsim = 10000,show_plot = FALSE)", 246)
+        Else
+            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("statsr::bayes_inference()", 1)
+        End If
+    End Sub
+
+    Private Sub cmdinference_Click(sender As Object, e As EventArgs) Handles cmdinference.Click
+        clear()
+        If ucrChkIncludeArguments.Checked Then
+            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("statsr::inference(y= , x = NULL,data=" & ucrSelectorColumn.ucrAvailableDataFrames.cboAvailableDataFrames.Text & " ,type = c(""ci"", ""ht""),statistic = c(""mean"", ""median"", ""proportion""),success = NULL,method = c(""theoretical"", ""simulation""),null = 0,alternative =""twosided"",sig_level = 0.05,conf_level = 0.95,boot_method = c(""perc"", ""se""),show_eda_plot = FALSE,show_inf_plot = FALSE)", 282)
+        Else
+            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("statsr::inference()", 1)
+        End If
+    End Sub
+
     Private Sub cmdWm_Click(sender As Object, e As EventArgs) Handles cmdWm.Click
         If ucrChkIncludeArguments.Checked Then
             ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("trend::wm.test(x = )", 2)
@@ -1115,6 +1158,13 @@ Public Class dlgHypothesisTestsCalculator
     Private Sub cmdRHelpVerification_Click(sender As Object, e As EventArgs) Handles cmdRHelpVerification.Click, ToolStripMenuVerification.Click
         If ucrInputComboRPackage.GetText = "Verification" Then
             strPackageName = "verification"
+        End If
+        OpenHelpPage()
+    End Sub
+
+    Private Sub cmdRHelpStatsr_Click(sender As Object, e As EventArgs) Handles cmdRHelpStatsr.Click, ToolStripMenuStatsr.Click
+        If ucrInputComboRPackage.GetText = "Statsr" Then
+            strPackageName = "statsr"
         End If
         OpenHelpPage()
     End Sub

--- a/instat/dlgModelling.Designer.vb
+++ b/instat/dlgModelling.Designer.vb
@@ -70,6 +70,24 @@ Partial Class dlgModelling
         Me.cmdlqs = New System.Windows.Forms.Button()
         Me.cmdlda = New System.Windows.Forms.Button()
         Me.lblRpackage = New System.Windows.Forms.Label()
+        Me.ContextMenuStripStats = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.ToolStripMenuStats = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ContextMenuStripExtRemes = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.ToolStripMenuExtRemes = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ContextMenuStripLme4 = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.ToolStripMenuLme4 = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ContextMenuStripMASS = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.ToolStripMenuMASS = New System.Windows.Forms.ToolStripMenuItem()
+        Me.grpRstanarm = New System.Windows.Forms.GroupBox()
+        Me.cmdstanpolr = New System.Windows.Forms.Button()
+        Me.cmdstanglm = New System.Windows.Forms.Button()
+        Me.grpArm = New System.Windows.Forms.GroupBox()
+        Me.cmdbayespolr = New System.Windows.Forms.Button()
+        Me.cmdbayesglm = New System.Windows.Forms.Button()
+        Me.cmdRHelpMASS = New instat.ucrSplitButton()
+        Me.cmdRHelpLme4 = New instat.ucrSplitButton()
+        Me.cmdRHelpExtRemes = New instat.ucrSplitButton()
+        Me.cmdRHelpStats = New instat.ucrSplitButton()
         Me.ucrTryModelling = New instat.ucrTry()
         Me.ucrChkIncludeArguments = New instat.ucrCheck()
         Me.ucrSaveResult = New instat.ucrSave()
@@ -77,18 +95,12 @@ Partial Class dlgModelling
         Me.ucrReceiverForTestColumn = New instat.ucrReceiverExpression()
         Me.ucrSelectorModelling = New instat.ucrSelectorByDataFrameAddRemove()
         Me.ucrBase = New instat.ucrButtons()
-        Me.cmdRHelpStats = New instat.ucrSplitButton()
-        Me.ContextMenuStripStats = New System.Windows.Forms.ContextMenuStrip(Me.components)
-        Me.ToolStripMenuStats = New System.Windows.Forms.ToolStripMenuItem()
-        Me.cmdRHelpExtRemes = New instat.ucrSplitButton()
-        Me.ContextMenuStripExtRemes = New System.Windows.Forms.ContextMenuStrip(Me.components)
-        Me.ToolStripMenuExtRemes = New System.Windows.Forms.ToolStripMenuItem()
-        Me.cmdRHelpLme4 = New instat.ucrSplitButton()
-        Me.ContextMenuStripLme4 = New System.Windows.Forms.ContextMenuStrip(Me.components)
-        Me.ToolStripMenuLme4 = New System.Windows.Forms.ToolStripMenuItem()
-        Me.cmdRHelpMASS = New instat.ucrSplitButton()
-        Me.ContextMenuStripMASS = New System.Windows.Forms.ContextMenuStrip(Me.components)
-        Me.ToolStripMenuMASS = New System.Windows.Forms.ToolStripMenuItem()
+        Me.cmdRHelpRstanam = New instat.ucrSplitButton()
+        Me.ContextMenuStripRstanam = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.ToolStripMenuRstanam = New System.Windows.Forms.ToolStripMenuItem()
+        Me.cmdRHelpArm = New instat.ucrSplitButton()
+        Me.ContextMenuStripArm = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.ToolStripMenuIArm = New System.Windows.Forms.ToolStripMenuItem()
         Me.grpStats.SuspendLayout()
         Me.grpFirstCalc.SuspendLayout()
         Me.grpextRemes.SuspendLayout()
@@ -98,6 +110,10 @@ Partial Class dlgModelling
         Me.ContextMenuStripExtRemes.SuspendLayout()
         Me.ContextMenuStripLme4.SuspendLayout()
         Me.ContextMenuStripMASS.SuspendLayout()
+        Me.grpRstanarm.SuspendLayout()
+        Me.grpArm.SuspendLayout()
+        Me.ContextMenuStripRstanam.SuspendLayout()
+        Me.ContextMenuStripArm.SuspendLayout()
         Me.SuspendLayout()
         '
         'lblModel
@@ -659,6 +675,172 @@ Partial Class dlgModelling
         Me.lblRpackage.TabIndex = 3
         Me.lblRpackage.Text = "R package:"
         '
+        'ContextMenuStripStats
+        '
+        Me.ContextMenuStripStats.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuStats})
+        Me.ContextMenuStripStats.Name = "ContextMenuStrip1"
+        Me.ContextMenuStripStats.Size = New System.Drawing.Size(99, 26)
+        '
+        'ToolStripMenuStats
+        '
+        Me.ToolStripMenuStats.Name = "ToolStripMenuStats"
+        Me.ToolStripMenuStats.Size = New System.Drawing.Size(98, 22)
+        Me.ToolStripMenuStats.Text = "stats"
+        '
+        'ContextMenuStripExtRemes
+        '
+        Me.ContextMenuStripExtRemes.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuExtRemes})
+        Me.ContextMenuStripExtRemes.Name = "ContextMenuStrip1"
+        Me.ContextMenuStripExtRemes.Size = New System.Drawing.Size(126, 26)
+        '
+        'ToolStripMenuExtRemes
+        '
+        Me.ToolStripMenuExtRemes.Name = "ToolStripMenuExtRemes"
+        Me.ToolStripMenuExtRemes.Size = New System.Drawing.Size(125, 22)
+        Me.ToolStripMenuExtRemes.Text = "extRemes"
+        '
+        'ContextMenuStripLme4
+        '
+        Me.ContextMenuStripLme4.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuLme4})
+        Me.ContextMenuStripLme4.Name = "ContextMenuStrip1"
+        Me.ContextMenuStripLme4.Size = New System.Drawing.Size(101, 26)
+        '
+        'ToolStripMenuLme4
+        '
+        Me.ToolStripMenuLme4.Name = "ToolStripMenuLme4"
+        Me.ToolStripMenuLme4.Size = New System.Drawing.Size(100, 22)
+        Me.ToolStripMenuLme4.Text = "lme4"
+        '
+        'ContextMenuStripMASS
+        '
+        Me.ContextMenuStripMASS.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuMASS})
+        Me.ContextMenuStripMASS.Name = "ContextMenuStrip1"
+        Me.ContextMenuStripMASS.Size = New System.Drawing.Size(106, 26)
+        '
+        'ToolStripMenuMASS
+        '
+        Me.ToolStripMenuMASS.Name = "ToolStripMenuMASS"
+        Me.ToolStripMenuMASS.Size = New System.Drawing.Size(105, 22)
+        Me.ToolStripMenuMASS.Text = "MASS"
+        '
+        'grpRstanarm
+        '
+        Me.grpRstanarm.Controls.Add(Me.cmdstanpolr)
+        Me.grpRstanarm.Controls.Add(Me.cmdstanglm)
+        Me.grpRstanarm.Location = New System.Drawing.Point(291, 64)
+        Me.grpRstanarm.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.grpRstanarm.Name = "grpRstanarm"
+        Me.grpRstanarm.Padding = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.grpRstanarm.Size = New System.Drawing.Size(213, 47)
+        Me.grpRstanarm.TabIndex = 154
+        Me.grpRstanarm.TabStop = False
+        Me.grpRstanarm.Text = "Rstanarm"
+        '
+        'cmdstanpolr
+        '
+        Me.cmdstanpolr.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.cmdstanpolr.Location = New System.Drawing.Point(72, 14)
+        Me.cmdstanpolr.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdstanpolr.Name = "cmdstanpolr"
+        Me.cmdstanpolr.Size = New System.Drawing.Size(69, 30)
+        Me.cmdstanpolr.TabIndex = 126
+        Me.cmdstanpolr.Text = "stanpolr"
+        Me.cmdstanpolr.UseVisualStyleBackColor = True
+        '
+        'cmdstanglm
+        '
+        Me.cmdstanglm.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.cmdstanglm.Location = New System.Drawing.Point(4, 14)
+        Me.cmdstanglm.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdstanglm.Name = "cmdstanglm"
+        Me.cmdstanglm.Size = New System.Drawing.Size(69, 30)
+        Me.cmdstanglm.TabIndex = 124
+        Me.cmdstanglm.Text = "stanglm"
+        Me.cmdstanglm.UseVisualStyleBackColor = True
+        '
+        'grpArm
+        '
+        Me.grpArm.Controls.Add(Me.cmdbayespolr)
+        Me.grpArm.Controls.Add(Me.cmdbayesglm)
+        Me.grpArm.Location = New System.Drawing.Point(287, 72)
+        Me.grpArm.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.grpArm.Name = "grpArm"
+        Me.grpArm.Padding = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.grpArm.Size = New System.Drawing.Size(154, 47)
+        Me.grpArm.TabIndex = 154
+        Me.grpArm.TabStop = False
+        Me.grpArm.Text = "arm"
+        '
+        'cmdbayespolr
+        '
+        Me.cmdbayespolr.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.cmdbayespolr.Location = New System.Drawing.Point(72, 14)
+        Me.cmdbayespolr.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdbayespolr.Name = "cmdbayespolr"
+        Me.cmdbayespolr.Size = New System.Drawing.Size(69, 30)
+        Me.cmdbayespolr.TabIndex = 126
+        Me.cmdbayespolr.Text = "bayespolr"
+        Me.cmdbayespolr.UseVisualStyleBackColor = True
+        '
+        'cmdbayesglm
+        '
+        Me.cmdbayesglm.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.cmdbayesglm.Location = New System.Drawing.Point(4, 14)
+        Me.cmdbayesglm.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdbayesglm.Name = "cmdbayesglm"
+        Me.cmdbayesglm.Size = New System.Drawing.Size(69, 30)
+        Me.cmdbayesglm.TabIndex = 124
+        Me.cmdbayesglm.Text = "bayesglm"
+        Me.cmdbayesglm.UseVisualStyleBackColor = True
+        '
+        'cmdRHelpMASS
+        '
+        Me.cmdRHelpMASS.AutoSize = True
+        Me.cmdRHelpMASS.ContextMenuStrip = Me.ContextMenuStripMASS
+        Me.cmdRHelpMASS.Location = New System.Drawing.Point(493, 39)
+        Me.cmdRHelpMASS.Name = "cmdRHelpMASS"
+        Me.cmdRHelpMASS.Size = New System.Drawing.Size(68, 23)
+        Me.cmdRHelpMASS.SplitMenuStrip = Me.ContextMenuStripMASS
+        Me.cmdRHelpMASS.TabIndex = 218
+        Me.cmdRHelpMASS.Text = "R Help"
+        Me.cmdRHelpMASS.UseVisualStyleBackColor = True
+        '
+        'cmdRHelpLme4
+        '
+        Me.cmdRHelpLme4.AutoSize = True
+        Me.cmdRHelpLme4.ContextMenuStrip = Me.ContextMenuStripLme4
+        Me.cmdRHelpLme4.Location = New System.Drawing.Point(493, 39)
+        Me.cmdRHelpLme4.Name = "cmdRHelpLme4"
+        Me.cmdRHelpLme4.Size = New System.Drawing.Size(68, 23)
+        Me.cmdRHelpLme4.SplitMenuStrip = Me.ContextMenuStripLme4
+        Me.cmdRHelpLme4.TabIndex = 217
+        Me.cmdRHelpLme4.Text = "R Help"
+        Me.cmdRHelpLme4.UseVisualStyleBackColor = True
+        '
+        'cmdRHelpExtRemes
+        '
+        Me.cmdRHelpExtRemes.AutoSize = True
+        Me.cmdRHelpExtRemes.ContextMenuStrip = Me.ContextMenuStripExtRemes
+        Me.cmdRHelpExtRemes.Location = New System.Drawing.Point(493, 39)
+        Me.cmdRHelpExtRemes.Name = "cmdRHelpExtRemes"
+        Me.cmdRHelpExtRemes.Size = New System.Drawing.Size(68, 23)
+        Me.cmdRHelpExtRemes.SplitMenuStrip = Me.ContextMenuStripExtRemes
+        Me.cmdRHelpExtRemes.TabIndex = 216
+        Me.cmdRHelpExtRemes.Text = "R Help"
+        Me.cmdRHelpExtRemes.UseVisualStyleBackColor = True
+        '
+        'cmdRHelpStats
+        '
+        Me.cmdRHelpStats.AutoSize = True
+        Me.cmdRHelpStats.ContextMenuStrip = Me.ContextMenuStripStats
+        Me.cmdRHelpStats.Location = New System.Drawing.Point(493, 39)
+        Me.cmdRHelpStats.Name = "cmdRHelpStats"
+        Me.cmdRHelpStats.Size = New System.Drawing.Size(68, 23)
+        Me.cmdRHelpStats.SplitMenuStrip = Me.ContextMenuStripStats
+        Me.cmdRHelpStats.TabIndex = 214
+        Me.cmdRHelpStats.Text = "R Help"
+        Me.cmdRHelpStats.UseVisualStyleBackColor = True
+        '
         'ucrTryModelling
         '
         Me.ucrTryModelling.AutoSize = True
@@ -735,101 +917,53 @@ Partial Class dlgModelling
         Me.ucrBase.Size = New System.Drawing.Size(408, 52)
         Me.ucrBase.TabIndex = 14
         '
-        'cmdRHelpStats
+        'cmdRHelpRstanam
         '
-        Me.cmdRHelpStats.AutoSize = True
-        Me.cmdRHelpStats.ContextMenuStrip = Me.ContextMenuStripStats
-        Me.cmdRHelpStats.Location = New System.Drawing.Point(493, 39)
-        Me.cmdRHelpStats.Name = "cmdRHelpStats"
-        Me.cmdRHelpStats.Size = New System.Drawing.Size(68, 23)
-        Me.cmdRHelpStats.SplitMenuStrip = Me.ContextMenuStripStats
-        Me.cmdRHelpStats.TabIndex = 214
-        Me.cmdRHelpStats.Text = "R Help"
-        Me.cmdRHelpStats.UseVisualStyleBackColor = True
+        Me.cmdRHelpRstanam.AutoSize = True
+        Me.cmdRHelpRstanam.ContextMenuStrip = Me.ContextMenuStripRstanam
+        Me.cmdRHelpRstanam.Location = New System.Drawing.Point(493, 38)
+        Me.cmdRHelpRstanam.Name = "cmdRHelpRstanam"
+        Me.cmdRHelpRstanam.Size = New System.Drawing.Size(68, 23)
+        Me.cmdRHelpRstanam.SplitMenuStrip = Me.ContextMenuStripRstanam
+        Me.cmdRHelpRstanam.TabIndex = 219
+        Me.cmdRHelpRstanam.Text = "R Help"
+        Me.cmdRHelpRstanam.UseVisualStyleBackColor = True
         '
-        'ContextMenuStripStats
+        'ContextMenuStripRstanam
         '
-        Me.ContextMenuStripStats.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuStats})
-        Me.ContextMenuStripStats.Name = "ContextMenuStrip1"
-        Me.ContextMenuStripStats.Size = New System.Drawing.Size(99, 26)
+        Me.ContextMenuStripRstanam.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuRstanam})
+        Me.ContextMenuStripRstanam.Name = "ContextMenuStrip1"
+        Me.ContextMenuStripRstanam.Size = New System.Drawing.Size(181, 48)
         '
-        'ToolStripMenuStats
+        'ToolStripMenuRstanam
         '
-        Me.ToolStripMenuStats.Name = "ToolStripMenuStats"
-        Me.ToolStripMenuStats.Size = New System.Drawing.Size(98, 22)
-        Me.ToolStripMenuStats.Text = "stats"
+        Me.ToolStripMenuRstanam.Name = "ToolStripMenuRstanam"
+        Me.ToolStripMenuRstanam.Size = New System.Drawing.Size(180, 22)
+        Me.ToolStripMenuRstanam.Text = "rstanam"
         '
-        'cmdRHelpExtRemes
+        'cmdRHelpArm
         '
-        Me.cmdRHelpExtRemes.AutoSize = True
-        Me.cmdRHelpExtRemes.ContextMenuStrip = Me.ContextMenuStripExtRemes
-        Me.cmdRHelpExtRemes.Location = New System.Drawing.Point(493, 39)
-        Me.cmdRHelpExtRemes.Name = "cmdRHelpExtRemes"
-        Me.cmdRHelpExtRemes.Size = New System.Drawing.Size(68, 23)
-        Me.cmdRHelpExtRemes.SplitMenuStrip = Me.ContextMenuStripExtRemes
-        Me.cmdRHelpExtRemes.TabIndex = 216
-        Me.cmdRHelpExtRemes.Text = "R Help"
-        Me.cmdRHelpExtRemes.UseVisualStyleBackColor = True
+        Me.cmdRHelpArm.AutoSize = True
+        Me.cmdRHelpArm.ContextMenuStrip = Me.ContextMenuStripArm
+        Me.cmdRHelpArm.Location = New System.Drawing.Point(493, 39)
+        Me.cmdRHelpArm.Name = "cmdRHelpArm"
+        Me.cmdRHelpArm.Size = New System.Drawing.Size(68, 23)
+        Me.cmdRHelpArm.SplitMenuStrip = Me.ContextMenuStripArm
+        Me.cmdRHelpArm.TabIndex = 220
+        Me.cmdRHelpArm.Text = "R Help"
+        Me.cmdRHelpArm.UseVisualStyleBackColor = True
         '
-        'ContextMenuStripExtRemes
+        'ContextMenuStripArm
         '
-        Me.ContextMenuStripExtRemes.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuExtRemes})
-        Me.ContextMenuStripExtRemes.Name = "ContextMenuStrip1"
-        Me.ContextMenuStripExtRemes.Size = New System.Drawing.Size(126, 26)
+        Me.ContextMenuStripArm.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuIArm})
+        Me.ContextMenuStripArm.Name = "ContextMenuStrip1"
+        Me.ContextMenuStripArm.Size = New System.Drawing.Size(96, 26)
         '
-        'ToolStripMenuExtRemes
+        'ToolStripMenuIArm
         '
-        Me.ToolStripMenuExtRemes.Name = "ToolStripMenuExtRemes"
-        Me.ToolStripMenuExtRemes.Size = New System.Drawing.Size(125, 22)
-        Me.ToolStripMenuExtRemes.Text = "extRemes"
-        '
-        'cmdRHelpLme4
-        '
-        Me.cmdRHelpLme4.AutoSize = True
-        Me.cmdRHelpLme4.ContextMenuStrip = Me.ContextMenuStripLme4
-        Me.cmdRHelpLme4.Location = New System.Drawing.Point(493, 39)
-        Me.cmdRHelpLme4.Name = "cmdRHelpLme4"
-        Me.cmdRHelpLme4.Size = New System.Drawing.Size(68, 23)
-        Me.cmdRHelpLme4.SplitMenuStrip = Me.ContextMenuStripLme4
-        Me.cmdRHelpLme4.TabIndex = 217
-        Me.cmdRHelpLme4.Text = "R Help"
-        Me.cmdRHelpLme4.UseVisualStyleBackColor = True
-        '
-        'ContextMenuStripLme4
-        '
-        Me.ContextMenuStripLme4.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuLme4})
-        Me.ContextMenuStripLme4.Name = "ContextMenuStrip1"
-        Me.ContextMenuStripLme4.Size = New System.Drawing.Size(101, 26)
-        '
-        'ToolStripMenuLme4
-        '
-        Me.ToolStripMenuLme4.Name = "ToolStripMenuLme4"
-        Me.ToolStripMenuLme4.Size = New System.Drawing.Size(100, 22)
-        Me.ToolStripMenuLme4.Text = "lme4"
-        '
-        'cmdRHelpMASS
-        '
-        Me.cmdRHelpMASS.AutoSize = True
-        Me.cmdRHelpMASS.ContextMenuStrip = Me.ContextMenuStripMASS
-        Me.cmdRHelpMASS.Location = New System.Drawing.Point(493, 39)
-        Me.cmdRHelpMASS.Name = "cmdRHelpMASS"
-        Me.cmdRHelpMASS.Size = New System.Drawing.Size(68, 23)
-        Me.cmdRHelpMASS.SplitMenuStrip = Me.ContextMenuStripMASS
-        Me.cmdRHelpMASS.TabIndex = 218
-        Me.cmdRHelpMASS.Text = "R Help"
-        Me.cmdRHelpMASS.UseVisualStyleBackColor = True
-        '
-        'ContextMenuStripMASS
-        '
-        Me.ContextMenuStripMASS.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuMASS})
-        Me.ContextMenuStripMASS.Name = "ContextMenuStrip1"
-        Me.ContextMenuStripMASS.Size = New System.Drawing.Size(106, 26)
-        '
-        'ToolStripMenuMASS
-        '
-        Me.ToolStripMenuMASS.Name = "ToolStripMenuMASS"
-        Me.ToolStripMenuMASS.Size = New System.Drawing.Size(105, 22)
-        Me.ToolStripMenuMASS.Text = "MASS"
+        Me.ToolStripMenuIArm.Name = "ToolStripMenuIArm"
+        Me.ToolStripMenuIArm.Size = New System.Drawing.Size(95, 22)
+        Me.ToolStripMenuIArm.Text = "arm"
         '
         'dlgModelling
         '
@@ -837,12 +971,16 @@ Partial Class dlgModelling
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
         Me.AutoSize = True
         Me.ClientSize = New System.Drawing.Size(566, 442)
+        Me.Controls.Add(Me.cmdRHelpArm)
+        Me.Controls.Add(Me.cmdRHelpRstanam)
+        Me.Controls.Add(Me.grpRstanarm)
+        Me.Controls.Add(Me.grpArm)
+        Me.Controls.Add(Me.grplme4)
         Me.Controls.Add(Me.cmdRHelpMASS)
         Me.Controls.Add(Me.cmdRHelpLme4)
         Me.Controls.Add(Me.cmdRHelpExtRemes)
         Me.Controls.Add(Me.cmdRHelpStats)
         Me.Controls.Add(Me.ucrTryModelling)
-        Me.Controls.Add(Me.grplme4)
         Me.Controls.Add(Me.grpMASS)
         Me.Controls.Add(Me.grpextRemes)
         Me.Controls.Add(Me.ucrChkIncludeArguments)
@@ -873,6 +1011,10 @@ Partial Class dlgModelling
         Me.ContextMenuStripExtRemes.ResumeLayout(False)
         Me.ContextMenuStripLme4.ResumeLayout(False)
         Me.ContextMenuStripMASS.ResumeLayout(False)
+        Me.grpRstanarm.ResumeLayout(False)
+        Me.grpArm.ResumeLayout(False)
+        Me.ContextMenuStripRstanam.ResumeLayout(False)
+        Me.ContextMenuStripArm.ResumeLayout(False)
         Me.ResumeLayout(False)
         Me.PerformLayout()
 
@@ -944,4 +1086,16 @@ Partial Class dlgModelling
     Friend WithEvents ToolStripMenuLme4 As ToolStripMenuItem
     Friend WithEvents ContextMenuStripExtRemes As ContextMenuStrip
     Friend WithEvents ToolStripMenuExtRemes As ToolStripMenuItem
+    Friend WithEvents grpArm As GroupBox
+    Friend WithEvents cmdbayespolr As Button
+    Friend WithEvents cmdbayesglm As Button
+    Friend WithEvents grpRstanarm As GroupBox
+    Friend WithEvents cmdstanpolr As Button
+    Friend WithEvents cmdstanglm As Button
+    Friend WithEvents cmdRHelpArm As ucrSplitButton
+    Friend WithEvents cmdRHelpRstanam As ucrSplitButton
+    Friend WithEvents ContextMenuStripArm As ContextMenuStrip
+    Friend WithEvents ToolStripMenuIArm As ToolStripMenuItem
+    Friend WithEvents ContextMenuStripRstanam As ContextMenuStrip
+    Friend WithEvents ToolStripMenuRstanam As ToolStripMenuItem
 End Class

--- a/instat/dlgModelling.resx
+++ b/instat/dlgModelling.resx
@@ -117,16 +117,22 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="ContextMenuStripMASS.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>656, 19</value>
-  </metadata>
-  <metadata name="ContextMenuStripLme4.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>464, 15</value>
+  <metadata name="ContextMenuStripStats.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
   </metadata>
   <metadata name="ContextMenuStripExtRemes.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>229, 15</value>
   </metadata>
-  <metadata name="ContextMenuStripStats.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
+  <metadata name="ContextMenuStripLme4.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>464, 15</value>
+  </metadata>
+  <metadata name="ContextMenuStripMASS.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>656, 19</value>
+  </metadata>
+  <metadata name="ContextMenuStripArm.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>18, 54</value>
+  </metadata>
+  <metadata name="ContextMenuStripRstanam.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>236, 47</value>
   </metadata>
 </root>

--- a/instat/dlgModelling.vb
+++ b/instat/dlgModelling.vb
@@ -31,7 +31,7 @@ Public Class dlgModelling
 
     'Display tab functions
     Public clsFormulaFunction, clsAnovaFunction, clsSummaryFunction, clsConfint As New RFunction
-    Private clsFittedValuesFunction, clsResidualFunction, clsRstandardFunction, clsHatvaluesFunction As New RFunction
+    Private clsFittedValuesFunction, clsResidualFunction, clsRstandardFunction, clsHatvaluesFunction, clsArmAddParameters, clsStanGlmFunction, clsStanPolrFunction As New RFunction
 
     Private bResetDisplayOptions = False
     Private dctPlotFunctions As New Dictionary(Of String, RFunction)
@@ -66,7 +66,7 @@ Public Class dlgModelling
         ucrTryModelling.SetReceiver(ucrReceiverForTestColumn)
         ucrTryModelling.SetIsModel()
 
-        ucrInputComboRPackage.SetItems({"stats", "extRemes", "lme4", "MASS"})
+        ucrInputComboRPackage.SetItems({"stats", "extRemes", "lme4", "MASS", "arm", "rstanarm"})
         ucrInputComboRPackage.SetDropDownStyleAsNonEditable()
 
         bUpdating = False
@@ -85,6 +85,9 @@ Public Class dlgModelling
         clsHatvaluesFunction = New RFunction
         clsResidualFunction = New RFunction
         clsFittedValuesFunction = New RFunction
+        clsArmAddParameters = New RFunction
+        clsStanGlmFunction = New RFunction
+        clsStanPolrFunction = New RFunction
 
         '---------------------------------------------------------
         'todo. what was the purpose of these RFunctions? delete?
@@ -134,6 +137,23 @@ Public Class dlgModelling
         'Model
         clsFormulaFunction = clsRegressionDefaults.clsDefaultFormulaFunction.Clone
         clsFormulaFunction.bExcludeAssignedFunctionOutput = False
+
+        'Bayesian
+        clsArmAddParameters.SetPackageName("arm")
+        clsArmAddParameters.SetRCommand("bayesglm")
+        clsArmAddParameters.iCallType = 2
+
+        clsArmAddParameters.SetPackageName("arm")
+        clsArmAddParameters.SetRCommand("bayespolr")
+        clsArmAddParameters.iCallType = 2
+
+        clsStanGlmFunction.SetPackageName("rstanarm")
+        clsStanGlmFunction.SetRCommand("StanGlm")
+        clsStanGlmFunction.iCallType = 2
+
+        clsStanPolrFunction.SetPackageName("rstanarm")
+        clsStanPolrFunction.SetRCommand("StanPolr")
+        clsStanPolrFunction.iCallType = 2
 
         'Summary
         clsSummaryFunction = clsRegressionDefaults.clsDefaultSummary.Clone
@@ -493,6 +513,42 @@ Public Class dlgModelling
         End If
     End Sub
 
+    Private Sub cmdbayesglm_Click(sender As Object, e As EventArgs) Handles cmdbayesglm.Click
+        Clear()
+        If ucrChkIncludeArguments.Checked Then
+            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("arm::bayesglm(formula =, family = gaussian, data=" & ucrSelectorModelling.ucrAvailableDataFrames.cboAvailableDataFrames.Text & ",weights=, subset=, na.action=,start = NULL, etastart=, mustart= ,offset=, control = list(...),model = TRUE, method = glm.fit, x = FALSE, y = TRUE, contrasts = NULL,drop.unused.levels = TRUE,prior.mean = 0,prior.scale = NULL,prior.df = 1, prior.mean.for.intercept = 0,prior.scale.for.intercept = NULL,prior.df.for.intercept = 1,min.prior.scale=1e-12,scaled = TRUE, keep.order=TRUE,drop.baseline=TRUE,maxit=100, print.unnormalized.log.posterior=FALSE,Warning=TRUE)", 489)
+        Else
+            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("arm::bayesglm()", 1)
+        End If
+    End Sub
+
+    Private Sub cmdbayespolr_Click(sender As Object, e As EventArgs) Handles cmdbayespolr.Click
+        Clear()
+        If ucrChkIncludeArguments.Checked Then
+            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("arm::bayespolr(formula= , data=" & ucrSelectorModelling.ucrAvailableDataFrames.cboAvailableDataFrames.Text & ", weights=, start=, subset=, na.action=, contrasts = NULL,Hess = TRUE, model = TRUE,method = c(logistic, probit,cloglog,cauchit),drop.unused.levels=TRUE,prior.mean = 0,prior.scale = 2.5,prior.df = 1,prior.counts.for.bins = NULL,min.prior.scale=1e-12,scaled = TRUE,maxit = 100,print.unnormalized.log.posterior = FALSE)", 325)
+        Else
+            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("arm::bayespolr()", 1)
+        End If
+    End Sub
+
+    Private Sub cmdstanglm_Click(sender As Object, e As EventArgs) Handles cmdstanglm.Click
+        Clear()
+        If ucrChkIncludeArguments.Checked Then
+            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("rstanarm::stan_glm(formula= ,family= gaussian, data=" & ucrSelectorModelling.ucrAvailableDataFrames.cboAvailableDataFrames.Text & ", weights=, subset= ,na.action = NULL,offset = NULL,model = TRUE, x = FALSE, y = TRUE,contrasts = NULL,prior = default_prior_coef(family),prior_intercept = default_prior_intercept(family),prior_aux = exponential(autoscale = TRUE),prior_PD = FALSE,algorithm = c(sampling, optimizing, meanfield, fullrank),mean_PPD = algorithm != optimizing && !prior_PD,adapt_delta = NULL,QR = FALSE,sparse = FALSE)", 421)
+        Else
+            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("rstanarm::stan_glm()", 1)
+        End If
+    End Sub
+
+    Private Sub cmdstanpolr_Click(sender As Object, e As EventArgs) Handles cmdstanpolr.Click
+        Clear()
+        If ucrChkIncludeArguments.Checked Then
+            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("rstanarm::stan_polr(formula=, data=" & ucrSelectorModelling.ucrAvailableDataFrames.cboAvailableDataFrames.Text & ", weights= ,subset= ,na.action = getOption(na.action, na.omit), contrasts = NULL,model = TRUE,method = c(logistic, probit, loglog, cloglog, cauchit), prior = R2,prior_counts = dirichlet(1),shape = NULL,rate = NULL, prior_PD = FALSE,algorithm = c(sampling, meanfield, fullrank),adapt_delta = NULL,do_residuals = NULL)", 323)
+        Else
+            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("rstanarm::stan_polr()", 1)
+        End If
+    End Sub
+
     Private Sub cmdlda_Click(sender As Object, e As EventArgs) Handles cmdlda.Click
         Clear()
         If ucrChkIncludeArguments.Checked Then
@@ -613,40 +669,84 @@ Public Class dlgModelling
                 grpextRemes.Visible = False
                 grplme4.Visible = False
                 grpMASS.Visible = False
+                grpArm.Visible = False
+                grpRstanarm.Visible = False
                 cmdRHelpStats.Visible = True
                 cmdRHelpExtRemes.Visible = False
                 cmdRHelpLme4.Visible = False
                 cmdRHelpMASS.Visible = False
+                cmdRHelpArm.Visible = False
+                cmdRHelpRstanam.Visible = False
             Case "extRemes"
                 strPackageName = "extRemes"
                 grpStats.Visible = False
                 grpextRemes.Visible = True
                 grplme4.Visible = False
                 grpMASS.Visible = False
+                grpArm.Visible = False
+                grpRstanarm.Visible = False
                 cmdRHelpStats.Visible = False
                 cmdRHelpExtRemes.Visible = True
                 cmdRHelpLme4.Visible = False
                 cmdRHelpMASS.Visible = False
+                cmdRHelpArm.Visible = False
+                cmdRHelpRstanam.Visible = False
             Case "lme4"
                 strPackageName = "lme4"
                 grpStats.Visible = False
                 grpextRemes.Visible = False
                 grplme4.Visible = True
                 grpMASS.Visible = False
+                grpArm.Visible = False
+                grpRstanarm.Visible = False
                 cmdRHelpStats.Visible = False
                 cmdRHelpExtRemes.Visible = False
                 cmdRHelpLme4.Visible = True
                 cmdRHelpMASS.Visible = False
+                cmdRHelpArm.Visible = False
+                cmdRHelpRstanam.Visible = False
             Case "MASS"
                 strPackageName = "MASS"
                 grpStats.Visible = False
                 grpextRemes.Visible = False
                 grplme4.Visible = False
                 grpMASS.Visible = True
+                grpArm.Visible = False
+                grpRstanarm.Visible = False
                 cmdRHelpStats.Visible = False
                 cmdRHelpExtRemes.Visible = False
                 cmdRHelpLme4.Visible = False
                 cmdRHelpMASS.Visible = True
+                cmdRHelpArm.Visible = False
+                cmdRHelpRstanam.Visible = False
+            Case "arm"
+                strPackageName = "arm"
+                grpArm.Visible = True
+                grpRstanarm.Visible = False
+                grpStats.Visible = False
+                grpextRemes.Visible = False
+                grplme4.Visible = False
+                grpMASS.Visible = False
+                cmdRHelpStats.Visible = False
+                cmdRHelpExtRemes.Visible = False
+                cmdRHelpLme4.Visible = False
+                cmdRHelpMASS.Visible = False
+                cmdRHelpArm.Visible = True
+                cmdRHelpRstanam.Visible = False
+            Case "rstanarm"
+                strPackageName = "rstanarm"
+                grpRstanarm.Visible = True
+                grpArm.Visible = False
+                grpStats.Visible = False
+                grpextRemes.Visible = False
+                grplme4.Visible = False
+                grpMASS.Visible = False
+                cmdRHelpStats.Visible = False
+                cmdRHelpExtRemes.Visible = False
+                cmdRHelpLme4.Visible = False
+                cmdRHelpMASS.Visible = False
+                cmdRHelpArm.Visible = False
+                cmdRHelpRstanam.Visible = True
         End Select
     End Sub
 
@@ -673,6 +773,20 @@ Public Class dlgModelling
     Private Sub cmdRHelpMASS_Click(sender As Object, e As EventArgs) Handles cmdRHelpMASS.Click, ToolStripMenuMASS.Click
         If ucrInputComboRPackage.GetText = "MASS" Then
             strPackageName = "MASS"
+        End If
+        OpenHelpPage()
+    End Sub
+
+    Private Sub cmdRHelpArm_Click(sender As Object, e As EventArgs) Handles cmdRHelpArm.Click, ToolStripMenuIArm.Click
+        If ucrInputComboRPackage.GetText = "arm" Then
+            strPackageName = "arm"
+        End If
+        OpenHelpPage()
+    End Sub
+
+    Private Sub cmdRHelpRstanam_Click(sender As Object, e As EventArgs) Handles cmdRHelpRstanam.Click, ToolStripMenuRstanam.Click
+        If ucrInputComboRPackage.GetText = "rstanarm" Then
+            strPackageName = "rstanarm"
         End If
         OpenHelpPage()
     End Sub


### PR DESCRIPTION
fixes #7681 
Replaces #7863 
I have added the `bayesglm` and `bayespolr` functions from the `arm` package, `stanglm` and `stanpolr` keys from the `rstanarm` packages and the `bayes_inference` and `inference` keys from the `statsr` package into the fit model keyboard.

@rdstern  I did not have the `arm`, `rstanarm` and `statsr` packages installed on my machine and i wanted to find out if you had it on yours else i could make i new Pull request for these packages. 
 This PR is ready for review