### PR TITLE
Ensured that Climatic > Check Data > Display Daily Data dialog works in non-English languages

### DIFF
--- a/instat/translations/translateIgnore.txt
+++ b/instat/translations/translateIgnore.txt
@@ -94,3 +94,8 @@ dlgClimaticBoxPlot_ucrInputWithinYear%
 # In the 'InventoryPlot' dialog, the selected 'Facet' should not be translated
 # Partially fixes issue #6989, related to PR #7070
 dlgInventoryPlot_ucrInputFacetBy%
+
+# In any dialog, input text should not be translated
+# Fixes issue #8275
+# TODO If by 2024, this line has not caused any problems, then delete ucrInput controls specified above (already covered by this pattern)
+%_ucrInput%


### PR DESCRIPTION
Fixes #8275
Fixes #8298

@rdstern 
I was only able to recreate the #8275 error intermittently. I think it's fixed but please test thoroughly.

This PR fixes the above issues by setting all input fields (including combo boxes), in all dialogs, to 'do not translate'. My rationale is that these controls contain values to be used literally in the R code. Does this make sense? Please could you do a sanity check on a few other dialogs with input fields to see if the translations are still as expected.

Thanks for your help