### PR TITLE
Ensured that Import Dataset dialog does not hang when opened in French

### DIFF
--- a/instat/dlgImportDataset.vb
+++ b/instat/dlgImportDataset.vb
@@ -919,14 +919,12 @@ Public Class dlgImportDataset
         TryTextPreview()
         TryGridPreview()
         TestOkEnabled()
-        autoTranslate(Me)
     End Sub
 
     Private Sub cmdRefreshPreview_Click(sender As Object, e As EventArgs) Handles cmdRefreshPreview.Click
         TryTextPreview()
         TryGridPreview()
         TestOkEnabled()
-        autoTranslate(Me)
     End Sub
 
     Private Sub HideDropEmptyCheckBox()
@@ -947,7 +945,6 @@ Public Class dlgImportDataset
         TryGridPreview()
         TestOkEnabled()
         HideDropEmptyCheckBox()
-        autoTranslate(Me)
     End Sub
 
     Private Sub MissingValuesInputControls_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrInputMissingValueStringText.ControlContentsChanged, ucrInputMissingValueStringCSV.ControlContentsChanged, ucrInputMissingValueStringExcel.ControlContentsChanged
@@ -975,7 +972,6 @@ Public Class dlgImportDataset
         End If
         TryGridPreview()
         TestOkEnabled()
-        autoTranslate(Me)
     End Sub
 
     'todo. This event could be changed to UcrPanelFixedWidthText_ControlValueChanged
@@ -1005,7 +1001,6 @@ Public Class dlgImportDataset
         TryGridPreview()
         RemoveMissingValues()
         TestOkEnabled()
-        autoTranslate(Me)
     End Sub
 
     Private Sub clbSheets_ItemCheck(sender As Object, e As ItemCheckEventArgs) Handles clbSheets.ItemCheck
@@ -1050,7 +1045,6 @@ Public Class dlgImportDataset
         TryGridPreview()
         RemoveMissingValues()
         TestOkEnabled()
-        autoTranslate(Me)
     End Sub
 
     Private Sub ucrSaveFile_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrSaveFile.ControlContentsChanged
@@ -1109,7 +1103,6 @@ Public Class dlgImportDataset
         End If
         TryGridPreview()
         TestOkEnabled()
-        autoTranslate(Me)
     End Sub
 
     Private Function GetCorrectSeparatorInPath() As String


### PR DESCRIPTION
@rdstern When you tested R-Instat 0.7.12 you reported that if the user tries to open the Import Dataset dialog in French, then the dialog does not open and R-Instat hangs. This PR fixes this. Please could you test?
thanks

Notes:
- This PR fixes some regression inadvertently introduced by PR #8319
- This PR does not fix the issue with the apostrophe in the Import Dataset comment field. This will be fixed in a separate PR.