### PR TITLE
Restores 'add to' and 'save' output window features

### DIFF
--- a/instat/Model/Output/clsOutputLogger.vb
+++ b/instat/Model/Output/clsOutputLogger.vb
@@ -77,36 +77,47 @@ Public Class clsOutputLogger
             Exit Sub
         End If
 
-        Dim outputType As OutputType
-        If String.IsNullOrEmpty(strOutput) Then
-            outputType = OutputType.Script
-        ElseIf Not bAsFile Then
-            outputType = OutputType.TextOutput
-        Else
-            Dim strFileExtension As String = Path.GetExtension(strOutput).ToLower
-            Select Case strFileExtension
-                Case ".png"
-                    outputType = OutputType.ImageOutput
-                Case ".html"
-                    outputType = OutputType.HtmlOutput
-                Case ".txt"
-                    outputType = OutputType.TextOutput
-                Case Else
-                    MessageBox.Show("The file type to be added is currently not suported",
-                                "Developer Error",
-                                MessageBoxButtons.OK,
-                                MessageBoxIcon.Error)
-                    Exit Sub
-            End Select
+        'add the R script as an output element
+        Dim rScriptElement As New clsOutputElement
+        rScriptElement.SetContent(strScript, OutputType.Script, "")
+        _outputElements.Add(rScriptElement)
+        'raise event for output pages
+        RaiseEvent NewOutputAdded(rScriptElement, False)
+
+
+        If Not String.IsNullOrEmpty(strOutput) Then
+            Dim outputElement As New clsOutputElement
+            Dim outputType As OutputType
+            If bAsFile Then
+                Dim strFileExtension As String = Path.GetExtension(strOutput).ToLower
+                Select Case strFileExtension
+                    Case ".png"
+                        outputType = OutputType.ImageOutput
+                    Case ".html"
+                        outputType = OutputType.HtmlOutput
+                    Case ".txt"
+                        outputType = OutputType.TextOutput
+                    Case Else
+                        MessageBox.Show("The file type to be added is currently not suported",
+                                    "Developer Error",
+                                    MessageBoxButtons.OK,
+                                    MessageBoxIcon.Error)
+                        Exit Sub
+                End Select
+            Else
+                outputType = OutputType.TextOutput
+            End If
+
+            'add the output with it's R script as another output element
+            outputElement.SetContent("", outputType, strOutput)
+            '_outputElements.Add(outputElement)
+            'raise event for output pages
+            RaiseEvent NewOutputAdded(outputElement, bDisplayOutputInExternalViewer)
+
         End If
 
-        Dim outputElement As New clsOutputElement
-        outputElement.SetContent(strScript, outputType, strOutput)
 
-        _outputElements.Add(outputElement)
 
-        'raise event for output pages
-        RaiseEvent NewOutputAdded(outputElement, bDisplayOutputInExternalViewer)
     End Sub
 
     ''' <summary>

--- a/instat/UserControl/ucrOutputPage.vb
+++ b/instat/UserControl/ucrOutputPage.vb
@@ -420,8 +420,15 @@ Public Class ucrOutputPage
             Case OutputType.Script
                 FillRichTextWithRScriptBasedOnSettings(richText, element.FormattedRScript)
             Case OutputType.TextOutput
-                'todo. check if output is file or not. if file, read the contents of the file
-                AddFormatedTextToRichTextBox(richText, element.Output, OutputFont.ROutputFont, OutputFont.ROutputColour)
+                Dim strOutput As String = ""
+                If element.IsFile Then
+                    For Each strLine As String In IO.File.ReadLines(element.Output)
+                        strOutput = strOutput & strLine & Environment.NewLine
+                    Next strLine
+                Else
+                    strOutput = element.Output
+                End If
+                AddFormatedTextToRichTextBox(richText, strOutput, OutputFont.ROutputFont, OutputFont.ROutputColour)
             Case OutputType.ImageOutput
                 Clipboard.Clear()
                 'todo. instead of copy paste, add image to rtf directly from file?

--- a/instat/UserControl/ucrOutputPage.vb
+++ b/instat/UserControl/ucrOutputPage.vb
@@ -418,7 +418,7 @@ Public Class ucrOutputPage
     Private Sub AddElementToRichTextBox(element As clsOutputElement, richText As RichTextBox)
         Select Case element.OutputType
             Case OutputType.Script
-                FillRichTextBoxWithFormatedRScript(richText, element.FormattedRScript)
+                FillRichTextWithRScriptBasedOnSettings(richText, element.FormattedRScript)
             Case OutputType.TextOutput
                 'todo. check if output is file or not. if file, read the contents of the file
                 AddFormatedTextToRichTextBox(richText, element.Output, OutputFont.ROutputFont, OutputFont.ROutputColour)

--- a/instat/UserControl/ucrOutputPages.vb
+++ b/instat/UserControl/ucrOutputPages.vb
@@ -24,6 +24,7 @@ Public Class ucrOutputPages
     Private _clsInstatOptions As InstatOptions
     Private _outputLogger As clsOutputLogger
     Private _selectedOutputPage As ucrOutputPage
+    Private _strSaveDirectory As String
     Public Sub New()
 
         ' This call is required by the designer.
@@ -57,10 +58,11 @@ Public Class ucrOutputPages
             dlgSaveFile.Title = "Save Output Window"
             dlgSaveFile.Filter = "Rich Text Format (*.rtf)|*.rtf"
             dlgSaveFile.FileName = Path.GetFileName(SelectedTab)
-            dlgSaveFile.InitialDirectory = _clsInstatOptions.strWorkingDirectory
+            dlgSaveFile.InitialDirectory = If(String.IsNullOrEmpty(_strSaveDirectory), _clsInstatOptions.strWorkingDirectory, _strSaveDirectory)
             If DialogResult.OK = dlgSaveFile.ShowDialog() Then
                 Try
                     _selectedOutputPage.Save(dlgSaveFile.FileName)
+                    _strSaveDirectory = Path.GetDirectoryName(dlgSaveFile.FileName)
                 Catch
                     MsgBox("Could not save the output window." & Environment.NewLine & "The file may be in use by another program or you may not have access to write to the specified location.", MsgBoxStyle.Critical)
                 End Try


### PR DESCRIPTION
Fixes partly #8408

@africanmathsinitiative/developers this is ready for review.
This is a temporary solution. It restore previously regressed features in a way that it was previously implemented.
Html outputs will still not be saved.