### PR TITLE
Change "rename_column_in_data" function to use curr_col_name not col_name

### DIFF
--- a/instat/static/InstatObject/R/data_object_R6.R
+++ b/instat/static/InstatObject/R/data_object_R6.R
@@ -771,7 +771,7 @@ DataSheet$set("public", "rename_column_in_data", function(curr_col_name = "", ne
           warning("Multiple columns have name: '", curr_col_name, "'. All such columns will be renamed.")
         }
         # remove key
-        get_key <- self$get_variables_metadata() %>% dplyr::filter(Name == col_name)
+        get_key <- self$get_variables_metadata() %>% dplyr::filter(Name == curr_col_name)
         if (!is.null(get_key$Is_Key)){
           if (!is.na(get_key$Is_Key) && get_key$Is_Key){
             active_keys <- self$get_keys()


### PR DESCRIPTION
fixes #8413

@africanmathsinitiative/developers this is ready to review

The issue before was that renaming columns would pull an error. This should resolve this. The issue occurred because the code was calling `col_name` not `curr_col_name`. This came from a copy-paste issue by me when putting similar code in the `"rename_column_in_data"` function that is in the `"remove_cols_from_data"` function. 