### PR TITLE
Ensured that the Change of the Data Frame Works correctly in the Pivot Table dialog in Climatic Menu 

### DIFF
--- a/instat/dlgThreeVariablePivotTable.vb
+++ b/instat/dlgThreeVariablePivotTable.vb
@@ -331,7 +331,8 @@ Public Class dlgThreeVariablePivotTable
                     ucrReceiverFactorLevels.Add(strMonthCol, strDataFrame)
                     ucrReceiverInitialColumnFactor.Add(strMonthCol, strDataFrame)
                 End If
-                If ucrSelectorPivot.lstAvailableVariable.Items.Count > 0 Then
+                If ucrSelectorPivot.lstAvailableVariable.Items.Count > 0 AndAlso
+                   Not String.IsNullOrEmpty(strYearCol) AndAlso Not String.IsNullOrEmpty(strDayCol) Then
                     Dim lstItems(1) As KeyValuePair(Of String, String)
                     lstItems(0) = New KeyValuePair(Of String, String)(strDataFrame, strYearCol)
                     lstItems(1) = New KeyValuePair(Of String, String)(strDataFrame, strDayCol)


### PR DESCRIPTION
@rdstern, @lloyddewit  base on this comment

>  @MeSophie and @lloyddewit of course I checked something slightly different this time, and found another problem with the new pivot table. I hope it might be easy to fix?
> 
> To see the problem:
> 
> a) open (say) Domoma from the library, or any of the climatic sets you have been using to check yourself.
> b) Then open a second data frame - I used the usual survey.
> c) Then go into your climatic pivot table with the wrong data frame.
> d) Then try to change to the correct data frame. I found it was impossible. It insists on the original data frame. Even going to the correct data frame and pressing Reset does no good. It insists on sticking with the wrong data frame.

 in PR #8431
 I corrected the bug when trying to change data frame in Pivot table. Please have a look. 