### PR TITLE
Bug fix when wrapping or unwrapping a list column

### DIFF
--- a/instat/UserControls/DataGrid/ReoGrid/ucrDataViewReoGrid.vb
+++ b/instat/UserControls/DataGrid/ReoGrid/ucrDataViewReoGrid.vb
@@ -76,7 +76,8 @@ Public Class ucrDataViewReoGrid
         For i = 0 To grdData.CurrentWorksheet.Rows - 1
             For j = 0 To grdData.CurrentWorksheet.Columns - 1
                 Dim strData As String = dataFrame.DisplayedData(i, j)
-                If grdData.CurrentWorksheet.ColumnHeaders.Item(j).Text.Contains("(LT)") Then
+                If grdData.CurrentWorksheet.ColumnHeaders.Item(j).Text.Contains("(LT)") AndAlso
+                    strData IsNot Nothing Then
                     strData = GetInnerBracketedString(strData)
                     strData = If(strData.Contains(":"), strData.Replace(":", ", "), strData)
                 End If
@@ -130,6 +131,8 @@ Public Class ucrDataViewReoGrid
         Dim intLastLeftBracket As Integer = InStrRev(strData, "(")
         If intFirstRightBracket = 0 Or intLastLeftBracket = 0 Then
             Return strData
+        ElseIf strData = "numeric(0)" Then
+            Return String.Empty
         Else
             Dim strOutput As String = Mid(strData, intLastLeftBracket + 1, intFirstRightBracket - intLastLeftBracket - 1)
             Return strOutput

--- a/instat/UserControls/DataGrid/ReoGrid/ucrDataViewReoGrid.vb
+++ b/instat/UserControls/DataGrid/ReoGrid/ucrDataViewReoGrid.vb
@@ -78,7 +78,7 @@ Public Class ucrDataViewReoGrid
                 Dim strData As String = dataFrame.DisplayedData(i, j)
                 If grdData.CurrentWorksheet.ColumnHeaders.Item(j).Text.Contains("(LT)") Then
                     strData = GetInnerBracketedString(strData)
-                    strData = If(strData.Contains(":"), strData.Replace(":", " ,"), strData)
+                    strData = If(strData.Contains(":"), strData.Replace(":", ", "), strData)
                 End If
                 grdData.CurrentWorksheet(row:=i, col:=j) = strData
             Next

--- a/instat/UserControls/DataGrid/ReoGrid/ucrDataViewReoGrid.vb
+++ b/instat/UserControls/DataGrid/ReoGrid/ucrDataViewReoGrid.vb
@@ -78,6 +78,7 @@ Public Class ucrDataViewReoGrid
                 Dim strData As String = dataFrame.DisplayedData(i, j)
                 If grdData.CurrentWorksheet.ColumnHeaders.Item(j).Text.Contains("(LT)") Then
                     strData = GetInnerBracketedString(strData)
+                    strData = If(strData.Contains(":"), strData.Replace(":", " ,"), strData)
                 End If
                 grdData.CurrentWorksheet(row:=i, col:=j) = strData
             Next

--- a/instat/static/InstatObject/R/data_object_R6.R
+++ b/instat/static/InstatObject/R/data_object_R6.R
@@ -335,15 +335,20 @@ DataSheet$set("public", "get_data_frame", function(convert_to_character = FALSE,
     
     # If a filter has been done, some column attributes are lost.
     # This ensures they are present in the returned data.
-    if(retain_attr) {
-      for(col_name in names(out)) {
-        for(attr_name in names(attributes(private$data[[col_name]]))) {
-          if(!attr_name %in% c("class", "levels")) {
-            attr(out[[col_name]], attr_name) <- attr(private$data[[col_name]][1:nrow(out)], attr_name)
+    if (retain_attr) {
+      for (col_name in names(out)) {
+        private_attr_names <- names(attributes(private$data[[col_name]]))
+        for (attr_name in private_attr_names) {
+          if (!attr_name %in% c("class", "names")) {
+            private_attr <- attr(private$data[[col_name]], attr_name)
+            if (!is.null(private_attr)) {
+              attr(out[[col_name]], attr_name) <- private_attr
+            }
           }
         }
       }
     }
+    
     # If there is a start column, return columns from start onwards
     if (!missing(start_col) && start_col <= ncol(out)) #out <- out[start_col:max_cols]
     {

--- a/instat/static/InstatObject/R/instat_object_R6.R
+++ b/instat/static/InstatObject/R/instat_object_R6.R
@@ -2733,16 +2733,17 @@ DataBook$set("public","wrap_or_unwrap_data", function(data_name, col_name, colum
     if (!is.null(width) && wrap) {
       column_data <- stringr::str_wrap(column_data, width = width)
     }
-    
+    curr_data <- self$get_data_frame(data_name=data_name, retain_attr = TRUE)
     # Convert back to the original data type if necessary
     if (original_type != class(column_data)) {
       if (original_type %in% c("factor", "ordered_factor")){
         column_data <- make_factor(column_data)
       }else if(original_type == "list"){
-        column_data <- lapply(column_data, convert_to_list)
+        result <- curr_data %>%
+          dplyr::mutate(list_column = lapply(column_data, convert_to_list))
+        column_data <- result$list_column
       }else{ column_data <- as(column_data, original_type) }
     }
-    curr_data <- self$get_data_frame(data_name=data_name, retain_attr = TRUE)
     # retain the attributes of the column after wrapping or unwrapping
     attributes(column_data) <- attributes(curr_data[[col_name]])
     self$add_columns_to_data(data_name=data_name, col_name=col_name, col_data=column_data, before=FALSE)

--- a/instat/static/InstatObject/R/instat_object_R6.R
+++ b/instat/static/InstatObject/R/instat_object_R6.R
@@ -2738,8 +2738,13 @@ DataBook$set("public","wrap_or_unwrap_data", function(data_name, col_name, colum
     if (original_type != class(column_data)) {
       if (original_type %in% c("factor", "ordered_factor")){
         column_data <- make_factor(column_data)
+      }else if(original_type == "list"){
+        column_data <- lapply(column_data, convert_to_list)
       }else{ column_data <- as(column_data, original_type) }
     }
+    curr_data <- self$get_data_frame(data_name=data_name, retain_attr = TRUE)
+    # retain the attributes of the column after wrapping or unwrapping
+    attributes(column_data) <- attributes(curr_data[[col_name]])
     self$add_columns_to_data(data_name=data_name, col_name=col_name, col_data=column_data, before=FALSE)
   }
 }

--- a/instat/static/InstatObject/R/stand_alone_functions.R
+++ b/instat/static/InstatObject/R/stand_alone_functions.R
@@ -2948,17 +2948,15 @@ getRowHeadersWithText <- function(data, column, searchText, ignore_case, use_reg
   return(rowHeaders)
 }
 
-# Function to convert character strings to lists
+# Custom function to convert character to list of numeric vector
 convert_to_list <- function(x) {
-  if (startsWith(x, "c(") && endsWith(x, ")")) {
-    x <- substring(x, 3, nchar(x) - 1) # Remove the 'c(' and ')' characters
-    return(as.list(as.numeric(unlist(strsplit(x, ", ")))))
-  } else if (grepl(":", x)){
+  if (grepl("^c\\(", x)) {
+    x <- gsub("^c\\(|\\)$", "", x)  # Remove 'c(' and ')'
+    return(as.numeric(unlist(strsplit(x, ","))))
+  } else if (grepl(":", x)) {
     x <- gsub(":", ",", x, fixed = TRUE)  # Replace ':' with ','
-    return(as.list(as.numeric(unlist(strsplit(x, "[, ]+")))))
-  } else if (x == "numeric(0)") {
-    return(list())
+    return(as.numeric(unlist(strsplit(x, ","))))
   } else {
-    return(as.list(as.numeric(x)))
+    return(as.numeric(x))
   }
 }

--- a/instat/static/InstatObject/R/stand_alone_functions.R
+++ b/instat/static/InstatObject/R/stand_alone_functions.R
@@ -2947,3 +2947,18 @@ getRowHeadersWithText <- function(data, column, searchText, ignore_case, use_reg
   # Return the row headers
   return(rowHeaders)
 }
+
+# Function to convert character strings to lists
+convert_to_list <- function(x) {
+  if (startsWith(x, "c(") && endsWith(x, ")")) {
+    x <- substring(x, 3, nchar(x) - 1) # Remove the 'c(' and ')' characters
+    return(as.list(as.numeric(unlist(strsplit(x, ", ")))))
+  } else if (grepl(":", x)){
+    x <- gsub(":", ",", x, fixed = TRUE)  # Replace ':' with ','
+    return(as.list(as.numeric(unlist(strsplit(x, "[, ]+")))))
+  } else if (x == "numeric(0)") {
+    return(list())
+  } else {
+    return(as.list(as.numeric(x)))
+  }
+}


### PR DESCRIPTION
Fixes partially #8443 
Fixes #8475
@rdstern this fixes the bug when wrapping/unwrapping a column to not lose the `meta data` and also correct the display of `2:1` to `2, 1`