### PR TITLE
Ensured logical layout and correct toggling of Script, Metadata, Data and Output windows

### DIFF
--- a/instat/frmMain.vb
+++ b/instat/frmMain.vb
@@ -80,6 +80,10 @@ Public Class frmMain
         InitializeComponent()
 
         ' Add any initialization after the InitializeComponent() call.
+
+        'set controls layout
+        SetupInitialLayout()
+
         clsOutputLogger = New clsOutputLogger
         clsRLink = New RLink(clsOutputLogger)
         If RuntimeInformation.IsOSPlatform(OSPlatform.Windows) Then
@@ -127,8 +131,6 @@ Public Class frmMain
         ucrDataFrameMeta.DataBook = clsDataBook
 
         ucrOutput.SetLogger(clsOutputLogger)
-
-        SetToDefaultLayout()
 
         '---------------------------------------
         'set up R-Instat options (settings)
@@ -216,6 +218,114 @@ Public Class frmMain
         '---------------------------------------
 
         isMaximised = True 'Need to get the windowstate when the application is loaded
+    End Sub
+
+    Private Sub SetupInitialLayout()
+        'splOverall has 2 panels
+        'splOverall.Panel1 contains splExtraWindows
+        'splOverall.Panel2 contains splDataOutput
+
+        'splExtraWindows has 2 panels
+        'splExtraWindows.Panel1 contains splMetadata
+        'splExtraWindows.Panel2 contains script window
+
+        'splMetadata has 2 panels
+        'splMetadata.Panel1 contains data frame
+        'splMetadata.Panel2 contains column metadata
+
+        'splDataOutput has 2 panels
+        'splDataOutput.Panel1 contains data viewer window
+        'splDataOutput.Panel2 contains output window
+
+        'collaspe all the panels initially (on application startup)
+        splOverall.Panel1Collapsed = True
+        splOverall.Panel2Collapsed = True
+
+        splExtraWindows.Panel1Collapsed = True
+        splExtraWindows.Panel2Collapsed = True
+
+        splMetadata.Panel1Collapsed = True
+        splMetadata.Panel2Collapsed = True
+
+        splDataOutput.Panel1Collapsed = True
+        splDataOutput.Panel2Collapsed = True
+
+        SetToDefaultLayout()
+    End Sub
+
+    Private Sub SetToDefaultLayout()
+        splOverall.SplitterDistance = splOverall.Height / 4
+        splDataOutput.SplitterDistance = splDataOutput.Width / 2
+        splExtraWindows.SplitterDistance = splExtraWindows.Width / 2
+        splMetadata.SplitterDistance = splMetadata.Width / 2
+
+        mnuViewDataView.Checked = True
+        mnuViewOutput.Checked = True
+        mnuViewDataFrameMetadata.Checked = False
+        mnuViewColumnMetadata.Checked = False
+        mnuViewLogScript.Checked = False
+        mnuViewSwapDataAndMetadata.Checked = False
+        mnuColumnMetadat.Checked = False
+        mnuDataFrameMetadat.Checked = False
+
+        mnuTbDataView.Checked = True
+        mnuOutputWindow.Checked = True
+        mnuLogScript.Checked = False
+        UpdateLayout()
+    End Sub
+
+    Public Sub UpdateLayout()
+
+        If Not mnuViewDataView.Checked _
+                AndAlso Not mnuViewOutput.Checked _
+                AndAlso Not mnuViewColumnMetadata.Checked _
+                AndAlso Not mnuViewDataFrameMetadata.Checked _
+                AndAlso Not mnuViewLogScript.Checked _
+                AndAlso Not mnuViewSwapDataAndMetadata.Checked Then
+            splOverall.Hide()
+        Else
+            splOverall.Show()
+
+            'determine splOverall contents visibility 
+
+            '-------------------------------
+            'determine splOverall.Panel1 and it's contents visibility
+
+            If mnuViewColumnMetadata.Checked OrElse mnuViewDataFrameMetadata.Checked OrElse mnuViewLogScript.Checked Then
+                'expand panel 1
+                splOverall.Panel1Collapsed = False
+                'change splOverall.Panel1Collapsed contents visibilty
+                If mnuViewColumnMetadata.Checked OrElse mnuViewDataFrameMetadata.Checked Then
+                    splMetadata.Panel1Collapsed = Not mnuViewColumnMetadata.Checked
+                    splMetadata.Panel2Collapsed = Not mnuViewDataFrameMetadata.Checked
+                    splExtraWindows.Panel1Collapsed = False
+                Else
+                    splExtraWindows.Panel1Collapsed = True
+                End If
+                'expand panel 2 based on log script menu item checked status
+                splExtraWindows.Panel2Collapsed = Not mnuViewLogScript.Checked
+            Else
+                splOverall.Panel1Collapsed = True
+            End If
+            '-------------------------------
+
+            '-------------------------------
+            'determine splOverall.Panel2 and it's contents visibility
+
+            If mnuViewDataView.Checked OrElse mnuViewOutput.Checked Then
+                splDataOutput.Panel1Collapsed = Not mnuViewDataView.Checked
+                splDataOutput.Panel2Collapsed = Not mnuViewOutput.Checked
+                splOverall.Panel2Collapsed = False
+            Else
+                splOverall.Panel2Collapsed = True
+            End If
+            '-------------------------------
+
+
+        End If
+        mnuTbDataView.Checked = mnuViewDataView.Checked
+        mnuOutputWindow.Checked = mnuViewOutput.Checked
+        mnuLogScript.Checked = mnuViewLogScript.Checked
     End Sub
 
     Private Function GetSavedRInstatOptions() As InstatOptions
@@ -426,28 +536,20 @@ Public Class frmMain
         End If
     End Sub
 
-
-
-    Private Sub SetToDefaultLayout()
-        splOverall.SplitterDistance = splOverall.Height / 4
-        splDataOutput.SplitterDistance = splDataOutput.Width / 2
-        splExtraWindows.SplitterDistance = splExtraWindows.Width / 2
-        splMetadata.SplitterDistance = splMetadata.Width / 2
-
-        mnuViewDataView.Checked = True
-        mnuViewOutput.Checked = True
-        mnuViewDataFrameMetadata.Checked = False
-        mnuViewColumnMetadata.Checked = False
-        mnuViewLogScript.Checked = False
-        mnuViewSwapDataAndMetadata.Checked = False
-        mnuColumnMetadat.Checked = False
-        mnuDataFrameMetadat.Checked = False
-
-        mnuTbDataView.Checked = True
-        mnuOutputWindow.Checked = True
-        mnuLogScript.Checked = False
-        UpdateLayout()
+    Private Sub UpdateSwapDataAndMetadata()
+        If mnuViewSwapDataAndMetadata.Checked Then
+            splDataOutput.Panel1.Controls.Add(ucrColumnMeta)
+            splMetadata.Panel1.Controls.Add(ucrDataViewer)
+            mnuViewColumnMetadata.Text = "Data View"
+            mnuViewDataView.Text = "Column Metadata"
+        Else
+            splDataOutput.Panel1.Controls.Add(ucrDataViewer)
+            splMetadata.Panel1.Controls.Add(ucrColumnMeta)
+            mnuViewColumnMetadata.Text = "Column Metadata"
+            mnuViewDataView.Text = "Data View"
+        End If
     End Sub
+
 
     Public Sub SaveInstatOptions(strFilePath As String)
         Dim serializer As New BinaryFormatter()
@@ -548,85 +650,6 @@ Public Class frmMain
 
     Private Sub mnuPrepareDataRename_Click(sender As Object, e As EventArgs) Handles mnuPrepareDataFrameRenameColumn.Click
         dlgName.ShowDialog()
-    End Sub
-
-    Public Sub UpdateLayout()
-        'splOverall has 2 panels
-        'splDataOutput.Panel1 contains splExtraWindows
-        'splDataOutput.Panel2 contains splDataOutput
-
-        'splExtraWindows has 2 panels
-        'splExtraWindows.Panel1 contains splMetadata which contains data frame and column metadata windows
-        'splExtraWindows.Panel2 contains script window
-
-        'splDataOutput has 2 panels
-        'splDataOutput.Panel1 contains data viewer window
-        'splDataOutput.Panel2 contains output window
-
-        If Not mnuViewDataView.Checked _
-                AndAlso Not mnuViewOutput.Checked _
-                AndAlso Not mnuViewColumnMetadata.Checked _
-                AndAlso Not mnuViewDataFrameMetadata.Checked _
-                AndAlso Not mnuViewLogScript.Checked _
-                AndAlso Not mnuViewSwapDataAndMetadata.Checked Then
-            splOverall.Hide()
-        Else
-            splOverall.Show()
-
-            'determine splOverall contents visibility 
-
-            '-------------------------------
-            'determine splOverall.Panel1 and it's contents visibility
-
-            If mnuViewColumnMetadata.Checked OrElse mnuViewDataFrameMetadata.Checked OrElse mnuViewLogScript.Checked Then
-                'change splOverall.Panel1Collapsed contents visibilty
-                If mnuViewColumnMetadata.Checked OrElse mnuViewDataFrameMetadata.Checked Then
-                    splMetadata.Panel1Collapsed = Not mnuViewColumnMetadata.Checked
-                    splMetadata.Panel2Collapsed = Not mnuViewDataFrameMetadata.Checked
-                    splExtraWindows.Panel1Collapsed = False
-                Else
-                    splExtraWindows.Panel1Collapsed = True
-                End If
-                'expand panel 1
-                splOverall.Panel1Collapsed = False
-                'expand panel 2 based on log script menu item checked status
-                splExtraWindows.Panel2Collapsed = Not mnuViewLogScript.Checked
-            Else
-                splOverall.Panel1Collapsed = True
-            End If
-            '-------------------------------
-
-            '-------------------------------
-            'determine splOverall.Panel2 and it's contents visibility
-
-            If mnuViewDataView.Checked OrElse mnuViewOutput.Checked Then
-                splDataOutput.Panel1Collapsed = Not mnuViewDataView.Checked
-                splDataOutput.Panel2Collapsed = Not mnuViewOutput.Checked
-                splOverall.Panel2Collapsed = False
-            Else
-                splOverall.Panel2Collapsed = True
-            End If
-            '-------------------------------
-
-
-        End If
-        mnuTbDataView.Checked = mnuViewDataView.Checked
-        mnuOutputWindow.Checked = mnuViewOutput.Checked
-        mnuLogScript.Checked = mnuViewLogScript.Checked
-    End Sub
-
-    Private Sub UpdateSwapDataAndMetadata()
-        If mnuViewSwapDataAndMetadata.Checked Then
-            splDataOutput.Panel1.Controls.Add(ucrColumnMeta)
-            splMetadata.Panel1.Controls.Add(ucrDataViewer)
-            mnuViewColumnMetadata.Text = "Data View"
-            mnuViewDataView.Text = "Column Metadata"
-        Else
-            splDataOutput.Panel1.Controls.Add(ucrDataViewer)
-            splMetadata.Panel1.Controls.Add(ucrColumnMeta)
-            mnuViewColumnMetadata.Text = "Column Metadata"
-            mnuViewDataView.Text = "Data View"
-        End If
     End Sub
 
     Private Sub mnuWindowDataFrame_Click(sender As Object, e As EventArgs) Handles mnuViewDataFrameMetadata.Click

--- a/instat/frmMain.vb
+++ b/instat/frmMain.vb
@@ -551,6 +551,18 @@ Public Class frmMain
     End Sub
 
     Public Sub UpdateLayout()
+        'splOverall has 2 panels
+        'splDataOutput.Panel1 contains splExtraWindows
+        'splDataOutput.Panel2 contains splDataOutput
+
+        'splExtraWindows has 2 panels
+        'splExtraWindows.Panel1 contains splMetadata which contains data frame and column metadata windows
+        'splExtraWindows.Panel2 contains script window
+
+        'splDataOutput has 2 panels
+        'splDataOutput.Panel1 contains data viewer window
+        'splDataOutput.Panel2 contains output window
+
         If Not mnuViewDataView.Checked _
                 AndAlso Not mnuViewOutput.Checked _
                 AndAlso Not mnuViewColumnMetadata.Checked _
@@ -560,32 +572,43 @@ Public Class frmMain
             splOverall.Hide()
         Else
             splOverall.Show()
-            If mnuViewDataView.Checked OrElse mnuViewOutput.Checked Then
-                splOverall.Panel2Collapsed = False
-                splDataOutput.Panel1Collapsed = Not mnuViewDataView.Checked
-                splDataOutput.Panel2Collapsed = Not mnuViewOutput.Checked
-            Else
-                splOverall.Panel2Collapsed = True
-            End If
-            If mnuViewColumnMetadata.Checked _
-                    OrElse mnuViewDataFrameMetadata.Checked _
-                    OrElse mnuViewLogScript.Checked Then
-                splOverall.Panel1Collapsed = False
+
+            'determine splOverall contents visibility 
+
+            '-------------------------------
+            'determine splOverall.Panel1 and it's contents visibility
+
+            If mnuViewColumnMetadata.Checked OrElse mnuViewDataFrameMetadata.Checked OrElse mnuViewLogScript.Checked Then
+                'change splOverall.Panel1Collapsed contents visibilty
                 If mnuViewColumnMetadata.Checked OrElse mnuViewDataFrameMetadata.Checked Then
-                    splExtraWindows.Panel1Collapsed = False
                     splMetadata.Panel1Collapsed = Not mnuViewColumnMetadata.Checked
                     splMetadata.Panel2Collapsed = Not mnuViewDataFrameMetadata.Checked
+                    splExtraWindows.Panel1Collapsed = False
                 Else
                     splExtraWindows.Panel1Collapsed = True
                 End If
-                If mnuViewLogScript.Checked Then
-                    splExtraWindows.Panel2Collapsed = False
-                Else
-                    splExtraWindows.Panel2Collapsed = True
-                End If
+                'expand panel 1
+                splOverall.Panel1Collapsed = False
+                'expand panel 2 based on log script menu item checked status
+                splExtraWindows.Panel2Collapsed = Not mnuViewLogScript.Checked
             Else
                 splOverall.Panel1Collapsed = True
             End If
+            '-------------------------------
+
+            '-------------------------------
+            'determine splOverall.Panel2 and it's contents visibility
+
+            If mnuViewDataView.Checked OrElse mnuViewOutput.Checked Then
+                splDataOutput.Panel1Collapsed = Not mnuViewDataView.Checked
+                splDataOutput.Panel2Collapsed = Not mnuViewOutput.Checked
+                splOverall.Panel2Collapsed = False
+            Else
+                splOverall.Panel2Collapsed = True
+            End If
+            '-------------------------------
+
+
         End If
         mnuTbDataView.Checked = mnuViewDataView.Checked
         mnuOutputWindow.Checked = mnuViewOutput.Checked
@@ -640,7 +663,7 @@ Public Class frmMain
     End Sub
 
     Private Sub mnuPrepareSheetColumnMetadata_Click(sender As Object, e As EventArgs) Handles mnuViewColumnMetadata.Click
-        mnuViewColumnMetadata.Checked = True
+        mnuViewColumnMetadata.Checked = Not mnuViewColumnMetadata.Checked
         UpdateLayout()
     End Sub
 

--- a/instat/ucrColumnMetadata.vb
+++ b/instat/ucrColumnMetadata.vb
@@ -33,17 +33,19 @@ Public Class ucrColumnMetadata
     Private strLabelsScientific As String = "Scientific"
     Private _Refreshed As Boolean = False
 
-    Public WriteOnly Property DataBook() As clsDataBook
-        Set(ByVal value As clsDataBook)
-            _clsDataBook = value
-            _grid.DataBook = value
-        End Set
-    End Property
+    Public Sub New()
 
-    Private Sub frmVariables_Load(sender As Object, e As EventArgs) Handles Me.Load
-        loadForm()
+        ' This call is required by the designer.
+        InitializeComponent()
+
+        ' Add any initialization after the InitializeComponent() call.
+        SetupInitialLayoutAndGrid()
+    End Sub
+
+    Private Sub ucrColumnMetadata_Load(sender As Object, e As EventArgs) Handles Me.Load
         mnuInsertColsAfter.Visible = False
         mnuInsertColsBefore.Visible = False
+        autoTranslate(Me)
     End Sub
 
     Private Sub ucrColumnMetadata_VisibleChanged(sender As Object, e As EventArgs) Handles Me.VisibleChanged
@@ -52,6 +54,37 @@ Public Class ucrColumnMetadata
         'once 'paging' feature is implemented, this block can be removed.
         RefreshGridData()
     End Sub
+
+    Private Sub SetupInitialLayoutAndGrid()
+        lstNonEditableColumns.AddRange({"class", "labels", "Is_Hidden", "Is_Key", "Is_Calculated", "Has_Dependants", "Dependent_Columns", "Calculated_By", "Dependencies", "Colour"})
+
+        'DEBUG
+        ' If True Then
+        If RuntimeInformation.IsOSPlatform(OSPlatform.Linux) Then
+            _grid = ucrLinuxGrid
+            tlpTableContainer.ColumnStyles(0).SizeType = SizeType.Percent
+            tlpTableContainer.ColumnStyles(0).Width = 100
+            tlpTableContainer.ColumnStyles(1).SizeType = SizeType.Absolute
+            tlpTableContainer.ColumnStyles(1).Width = 0
+        Else
+            _grid = ucrReoGrid
+            tlpTableContainer.ColumnStyles(0).SizeType = SizeType.Absolute
+            tlpTableContainer.ColumnStyles(0).Width = 0
+            tlpTableContainer.ColumnStyles(1).SizeType = SizeType.Percent
+            tlpTableContainer.ColumnStyles(1).Width = 100
+        End If
+        _grid.SetNonEditableColumns(lstNonEditableColumns)
+        _grid.SetContextmenuStrips(Nothing, cellContextMenuStrip, columnContextMenuStrip, statusColumnMenu)
+        AddHandler _grid.EditValue, AddressOf EditValue
+        AddHandler _grid.DeleteLabels, AddressOf DeleteLables
+    End Sub
+
+    Public WriteOnly Property DataBook() As clsDataBook
+        Set(ByVal value As clsDataBook)
+            _clsDataBook = value
+            _grid.DataBook = value
+        End Set
+    End Property
 
     Private Function GetCurrentDataFrameFocus() As clsDataFrame
         Return _clsDataBook.GetDataFrame(_grid.CurrentWorksheet.Name)
@@ -111,31 +144,6 @@ Public Class ucrColumnMetadata
             AddAndUpdateWorksheets()
             _grid.bVisible = _clsDataBook.DataFrames.Count > 0
         End If
-    End Sub
-
-    Private Sub loadForm()
-        lstNonEditableColumns.AddRange({"class", "labels", "Is_Hidden", "Is_Key", "Is_Calculated", "Has_Dependants", "Dependent_Columns", "Calculated_By", "Dependencies", "Colour"})
-
-        'DEBUG
-        ' If True Then
-        If RuntimeInformation.IsOSPlatform(OSPlatform.Linux) Then
-            _grid = ucrLinuxGrid
-            tlpTableContainer.ColumnStyles(0).SizeType = SizeType.Percent
-            tlpTableContainer.ColumnStyles(0).Width = 100
-            tlpTableContainer.ColumnStyles(1).SizeType = SizeType.Absolute
-            tlpTableContainer.ColumnStyles(1).Width = 0
-        Else
-            _grid = ucrReoGrid
-            tlpTableContainer.ColumnStyles(0).SizeType = SizeType.Absolute
-            tlpTableContainer.ColumnStyles(0).Width = 0
-            tlpTableContainer.ColumnStyles(1).SizeType = SizeType.Percent
-            tlpTableContainer.ColumnStyles(1).Width = 100
-        End If
-        _grid.SetNonEditableColumns(lstNonEditableColumns)
-        _grid.SetContextmenuStrips(Nothing, cellContextMenuStrip, columnContextMenuStrip, statusColumnMenu)
-        AddHandler _grid.EditValue, AddressOf EditValue
-        AddHandler _grid.DeleteLabels, AddressOf DeleteLables
-        autoTranslate(Me)
     End Sub
 
     Public Sub SetCurrentDataFrame(strDataName As String)

--- a/instat/ucrDataFrameMetadata.vb
+++ b/instat/ucrDataFrameMetadata.vb
@@ -30,6 +30,20 @@ Public Class ucrDataFrameMetadata
     Private clsViewDataFrame As New RFunction
     Private clsGetDataFrame As New RFunction
 
+    Public Sub New()
+        ' This call is required by the designer.
+        InitializeComponent()
+
+        ' Add any initialization after the InitializeComponent() call.
+        SetupInitialLayoutAndGrid()
+    End Sub
+    Private Sub ucrDataFrameMetadata_Load(sender As Object, e As EventArgs) Handles Me.Load
+        clsViewDataFrame.SetRCommand("View")
+        clsGetDataFrame.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_data_frame")
+        clsHideDataFrame.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$append_to_dataframe_metadata")
+    End Sub
+
+
     Public WriteOnly Property DataBook() As clsDataBook
         Set(ByVal value As clsDataBook)
             _clsDataBook = value
@@ -37,14 +51,7 @@ Public Class ucrDataFrameMetadata
         End Set
     End Property
 
-    Private Sub frmMetaData_Load(sender As Object, e As EventArgs) Handles Me.Load
-        LoadForm()
-        clsViewDataFrame.SetRCommand("View")
-        clsGetDataFrame.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_data_frame")
-        clsHideDataFrame.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$append_to_dataframe_metadata")
-    End Sub
-
-    Private Sub LoadForm()
+    Private Sub SetupInitialLayoutAndGrid()
         lstNonEditableColumns.AddRange({"class", "Is_Hidden", "Row_Count", "Column_Count", "Is_Linkable", "Is_Calculated"})
 
         'Debug

--- a/instat/ucrScript.vb
+++ b/instat/ucrScript.vb
@@ -29,6 +29,56 @@ Public Class ucrScript
     Friend WithEvents clsScriptActive As Scintilla
     Friend WithEvents clsScriptLog As Scintilla
 
+    Public Sub New()
+        ' This call is required by the designer.
+        InitializeComponent()
+
+
+        ' Add any initialization after the InitializeComponent() call.
+        SetupInitialLayout()
+
+    End Sub
+
+    Private Sub ucrScript_Load(sender As Object, e As EventArgs) Handles Me.Load
+
+        toolTipScriptWindow.SetToolTip(cmdRunLineSelection, "Run the current line or selection. (Ctrl+Enter)")
+        toolTipScriptWindow.SetToolTip(cmdRunAll, "Run all the text in the tab. (Ctrl+Alt+R)")
+        toolTipScriptWindow.SetToolTip(cmdLoadScript, "Load a script from file into the current tab.")
+        toolTipScriptWindow.SetToolTip(cmdSave, "Save the script in the current tab to a file.")
+        toolTipScriptWindow.SetToolTip(cmdAddTab, "Add a new tab.")
+        toolTipScriptWindow.SetToolTip(cmdRemoveTab, "Delete the current tab.")
+        toolTipScriptWindow.SetToolTip(cmdClear, "Clear the contents of the current tab. (Ctrl+L)")
+        toolTipScriptWindow.SetToolTip(cmdHelp, "Display the Script Window help information.")
+
+        mnuUndo.ToolTipText = "Undo the last change. (Ctrl+Z)"
+        mnuRedo.ToolTipText = "Redo the last change. (Ctrl+Y)"
+        mnuCut.ToolTipText = "Copy the selected text to the clipboard, then delete the text. (Ctrl+X)"
+        mnuCopy.ToolTipText = "Copy the selected text to the clipboard. (Ctrl+C)"
+        mnuPaste.ToolTipText = "Paste the contents of the clipboard into the current tab. (Ctrl+V)"
+        mnuSelectAll.ToolTipText = "Select all the contents of the current tab. (Ctrl+A)"
+        mnuClear.ToolTipText = "Clear the contents of the current tab. (Ctrl+L)"
+        mnuRunCurrentLineSelection.ToolTipText = "Run the current line or selection. (Ctrl+Enter)"
+        mnuRunAllText.ToolTipText = "Run all the text in the tab. (Ctrl+Alt+R)"
+        mnuOpenScriptasFile.ToolTipText = "Save file to log folder and open file in external editor."
+        mnuLoadScriptFromFile.ToolTipText = "Load script from file into the current tab."
+        mnuSaveScript.ToolTipText = "Save the script in the current tab to a file."
+        mnuHelp.ToolTipText = "Display the Script Window help information."
+
+        'normally we would do this in the designer, but designer doesn't allow enter key as shortcut
+        mnuRunCurrentLineSelection.ShortcutKeys = Keys.Enter Or Keys.Control
+
+        'Make the log tab the selected tab
+        TabControl.SelectTab(iTabIndexLog)
+    End Sub
+
+    Private Sub SetupInitialLayout()
+        'Create log tab
+        AddTab(bIsLogTab:=True)
+
+        'Create script tab
+        AddTab()
+    End Sub
+
     ''' <summary>
     '''     The current text in the active tab. 
     ''' </summary>
@@ -821,44 +871,6 @@ Public Class ucrScript
         If IsNothing(clsScriptActive) Then
             MsgBox("Developer error: could not find editor winfow in tab.")
         End If
-    End Sub
-
-    Private Sub ucrScript_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-
-        toolTipScriptWindow.SetToolTip(cmdRunLineSelection, "Run the current line or selection. (Ctrl+Enter)")
-        toolTipScriptWindow.SetToolTip(cmdRunAll, "Run all the text in the tab. (Ctrl+Alt+R)")
-        toolTipScriptWindow.SetToolTip(cmdLoadScript, "Load a script from file into the current tab.")
-        toolTipScriptWindow.SetToolTip(cmdSave, "Save the script in the current tab to a file.")
-        toolTipScriptWindow.SetToolTip(cmdAddTab, "Add a new tab.")
-        toolTipScriptWindow.SetToolTip(cmdRemoveTab, "Delete the current tab.")
-        toolTipScriptWindow.SetToolTip(cmdClear, "Clear the contents of the current tab. (Ctrl+L)")
-        toolTipScriptWindow.SetToolTip(cmdHelp, "Display the Script Window help information.")
-
-        mnuUndo.ToolTipText = "Undo the last change. (Ctrl+Z)"
-        mnuRedo.ToolTipText = "Redo the last change. (Ctrl+Y)"
-        mnuCut.ToolTipText = "Copy the selected text to the clipboard, then delete the text. (Ctrl+X)"
-        mnuCopy.ToolTipText = "Copy the selected text to the clipboard. (Ctrl+C)"
-        mnuPaste.ToolTipText = "Paste the contents of the clipboard into the current tab. (Ctrl+V)"
-        mnuSelectAll.ToolTipText = "Select all the contents of the current tab. (Ctrl+A)"
-        mnuClear.ToolTipText = "Clear the contents of the current tab. (Ctrl+L)"
-        mnuRunCurrentLineSelection.ToolTipText = "Run the current line or selection. (Ctrl+Enter)"
-        mnuRunAllText.ToolTipText = "Run all the text in the tab. (Ctrl+Alt+R)"
-        mnuOpenScriptasFile.ToolTipText = "Save file to log folder and open file in external editor."
-        mnuLoadScriptFromFile.ToolTipText = "Load script from file into the current tab."
-        mnuSaveScript.ToolTipText = "Save the script in the current tab to a file."
-        mnuHelp.ToolTipText = "Display the Script Window help information."
-
-        'normally we would do this in the designer, but designer doesn't allow enter key as shortcut
-        mnuRunCurrentLineSelection.ShortcutKeys = Keys.Enter Or Keys.Control
-
-        'Create log tab
-        AddTab(bIsLogTab:=True)
-
-        'Create script tab
-        AddTab()
-
-        'Make the log tab the selected tab
-        TabControl.SelectTab(iTabIndexLog)
     End Sub
 
 End Class


### PR DESCRIPTION
When you start R-Instat, there is a layout oddity as shown in the image below. 
This PR fixes the oddity and also comment https://github.com/africanmathsinitiative/R-Instat/pull/8465#pullrequestreview-1588370215 
@africanmathsinitiative/developers this is ready for review.

Layout oddity screenshot
<img width="935" alt="1" src="https://github.com/africanmathsinitiative/R-Instat/assets/21179007/972a06e2-3557-46a5-b69e-fb84f344a02e">

 
