### PR TITLE
Ensured the Identify Key checkbox works correctly in Row Names or Numbers dialog

### DIFF
--- a/instat/dlgRownamesOrNumbers.vb
+++ b/instat/dlgRownamesOrNumbers.vb
@@ -22,7 +22,9 @@ Public Class dlgRowNamesOrNumbers
     Private clsGetRowNamesFunction As New RFunction
     Private clsSetRowNamesFunction As New RFunction
     Private clsAddKeyFunction As New RFunction
-    Private clsAsNumericFunction As New RFunction
+    Private clsAsBaseFunction As New RFunction
+    Private clsAsSapplyFunction As New RFunction
+    Private clsAsRownamesFunction As New RFunction
     Private clsDummyFunction As New RFunction
 
     Private Sub dlgRowNamesOrNumbers_Load(sender As Object, e As EventArgs) Handles MyBase.Load
@@ -33,7 +35,6 @@ Public Class dlgRowNamesOrNumbers
 
         If bReset Then
             SetDefaults()
-            IdentifyKey()
         End If
         SetRCodeForControls(bReset)
         bReset = False
@@ -66,7 +67,7 @@ Public Class dlgRowNamesOrNumbers
         ucrPnlOverallOptions.AddParameterValuesCondition(rdoResetintoPositiveIntegers, "checked_rdo", "reset_row")
         ucrPnlOverallOptions.AddParameterValuesCondition(rdoSortbyRowNames, "checked_rdo", "sort_row")
 
-        ucrPnlOverallOptions.AddToLinkedControls({ucrNewColumnName, ucrChkMakeColumnIntoKey}, {rdoCopyRowNamesIntoFirstColumn}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
+        ucrPnlOverallOptions.AddToLinkedControls({ucrNewColumnName, ucrChkMakeColumnIntoKey}, {rdoCopyRowNamesIntoFirstColumn}, bNewLinkedHideIfParameterMissing:=True)
         ucrPnlOverallOptions.AddToLinkedControls(ucrReceiverRowNames, {rdoSetRowNamesFromColumn}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
         ucrPnlOverallOptions.AddToLinkedControls(ucrPnlSortOptions, {rdoSortbyRowNames}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
         ucrPnlOverallOptions.AddToLinkedControls(ucrChkAsNumeric, {rdoSortbyRowNames}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
@@ -92,7 +93,7 @@ Public Class dlgRowNamesOrNumbers
         ucrChkMakeColumnIntoKey.SetText("Make the Column a Key for the Data Frame")
         ucrChkMakeColumnIntoKey.AddParameterValuesCondition(True, "add_key", "TRUE")
         ucrChkMakeColumnIntoKey.AddParameterValuesCondition(False, "add_key", "FALSE")
-        IdentifyKey()
+
         'ucrNewColumnName
         ucrNewColumnName.SetIsComboBox()
         ucrNewColumnName.SetPrefix("row")
@@ -106,25 +107,34 @@ Public Class dlgRowNamesOrNumbers
         clsAddKeyFunction = New RFunction
         clsDummyFunction = New RFunction
         clsSetRowNamesFunction = New RFunction
-        clsAsNumericFunction = New RFunction
+        clsAsBaseFunction = New RFunction
+        clsAsSapplyFunction = New RFunction
+        clsAsRownamesFunction = New RFunction
 
         ucrNewColumnName.Reset()
         ucrSelectorRowNames.Reset()
         ucrBase.clsRsyntax.lstAfterCodes.Clear()
 
         clsDummyFunction.AddParameter("checked_rdo", "copy_row", iPosition:=1)
-        clsDummyFunction.AddParameter("add_key", "FALSE", iPosition:=2)
+        clsDummyFunction.AddParameter("add_key", "TRUE", iPosition:=2)
+
+        clsAsRownamesFunction.SetRCommand("rownames")
+        clsAsRownamesFunction.AddParameter("data", ucrSelectorRowNames.ucrAvailableDataFrames.cboAvailableDataFrames.Text, bIncludeArgumentName:=False)
+
+        clsAsSapplyFunction.SetRCommand("sapply")
+        clsAsSapplyFunction.AddParameter("x", clsRFunctionParameter:=clsAsRownamesFunction, bIncludeArgumentName:=False, iPosition:=0)
+        clsAsSapplyFunction.AddParameter("numeric", "is.numeric", bIncludeArgumentName:=False, iPosition:=1)
+
+        clsAsBaseFunction.SetRCommand("all")
+        clsAsBaseFunction.AddParameter("all", clsRFunctionParameter:=clsAsSapplyFunction, bIncludeArgumentName:=False, iPosition:=0)
 
         clsAddKeyFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$add_key")
-
-        clsAsNumericFunction.SetRCommand("as.numeric")
-        clsAsNumericFunction.AddParameter("x", clsRFunctionParameter:=clsGetRowNamesFunction, iPosition:=0)
 
         clsGetRowNamesFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_row_names")
         clsGetRowNamesFunction.SetAssignTo(strTemp:=ucrNewColumnName.GetText(), strTempDataframe:=ucrSelectorRowNames.ucrAvailableDataFrames.cboAvailableDataFrames.Text, strTempColumn:=ucrNewColumnName.GetText())
 
         clsSetRowNamesFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$set_row_names")
-
+        ucrBase.clsRsyntax.AddToBeforeCodes(clsAsBaseFunction)
         ucrBase.clsRsyntax.SetBaseRFunction(clsGetRowNamesFunction)
     End Sub
 
@@ -137,9 +147,9 @@ Public Class dlgRowNamesOrNumbers
         ucrChkMakeColumnIntoKey.SetRCode(clsDummyFunction, bReset)
         ucrPnlOverallOptions.SetRCode(clsDummyFunction, bReset)
         ucrNewColumnName.AddAdditionalRCode(clsGetRowNamesFunction, bReset)
-        ucrNewColumnName.SetRCode(clsAsNumericFunction, bReset)
+        ucrNewColumnName.SetRCode(clsGetRowNamesFunction, bReset)
         ucrChkAsNumeric.SetRCode(ucrBase.clsRsyntax.clsBaseFunction, bReset)
-        IdentifyKey()
+
     End Sub
 
     Private Sub TestOKEnabled()
@@ -165,7 +175,7 @@ Public Class dlgRowNamesOrNumbers
         Else
             ucrSelectorRowNames.SetVariablesVisible(False)
             If rdoCopyRowNamesIntoFirstColumn.Checked Then
-                ucrBase.clsRsyntax.SetBaseRFunction(clsAsNumericFunction)
+                ucrBase.clsRsyntax.SetBaseRFunction(clsGetRowNamesFunction)
                 clsDummyFunction.AddParameter("checked_rdo", "copy_row", iPosition:=1)
             ElseIf rdoResetintoPositiveIntegers.Checked Then
                 ucrBase.clsRsyntax.SetBaseRFunction(clsSetRowNamesFunction)
@@ -190,13 +200,8 @@ Public Class dlgRowNamesOrNumbers
         End If
     End Sub
 
-    Private Sub IdentifyKey()
-        ucrChkMakeColumnIntoKey.Checked = Not frmMain.clsRLink.IsVariablesMetadata(ucrSelectorRowNames.ucrAvailableDataFrames.cboAvailableDataFrames.Text, "Is_Key")
-    End Sub
-
     Private Sub ucrChkMakeColumnIntoKey_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrChkMakeColumnIntoKey.ControlValueChanged
         AddRemoveKeyFromAfterCodes()
-        IdentifyKey()
     End Sub
 
     Private Sub ucrNewColumnName_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrNewColumnName.ControlValueChanged
@@ -210,6 +215,5 @@ Public Class dlgRowNamesOrNumbers
     End Sub
 
     Private Sub ucrSelectorRowNames_DataFrameChanged() Handles ucrSelectorRowNames.DataFrameChanged
-        IdentifyKey()
     End Sub
 End Class

--- a/instat/dlgRownamesOrNumbers.vb
+++ b/instat/dlgRownamesOrNumbers.vb
@@ -23,6 +23,9 @@ Public Class dlgRowNamesOrNumbers
     Private clsSetRowNamesFunction As New RFunction
     Private clsAddKeyFunction As New RFunction
     Private clsDummyFunction As New RFunction
+    Private clsGetVectorFunction As New RFunction
+    Private clsHmiscFunction As New RFunction
+
 
     Private Sub dlgRowNamesOrNumbers_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         If bFirstLoad Then
@@ -104,6 +107,9 @@ Public Class dlgRowNamesOrNumbers
         clsAddKeyFunction = New RFunction
         clsDummyFunction = New RFunction
         clsSetRowNamesFunction = New RFunction
+        clsGetVectorFunction = New RFunction
+        clsHmiscFunction = New RFunction
+
 
         ucrNewColumnName.Reset()
         ucrSelectorRowNames.Reset()
@@ -113,6 +119,14 @@ Public Class dlgRowNamesOrNumbers
         clsDummyFunction.AddParameter("add_key", "TRUE", iPosition:=2)
 
         clsAddKeyFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$add_key")
+
+        clsGetVectorFunction.SetRCommand("what=c")
+        clsGetVectorFunction.AddParameter("vector", Chr(34) & "vector" & Chr(34), bIncludeArgumentName:=False)
+
+        clsHmiscFunction.SetPackageName("Hmisc")
+        clsHmiscFunction.SetRCommand("all.is.numeric")
+        clsHmiscFunction.AddParameter("row", clsRFunctionParameter:=clsGetRowNamesFunction, bIncludeArgumentName:=False, iPosition:=0)
+        clsHmiscFunction.AddParameter("vector", clsRFunctionParameter:=clsGetVectorFunction, bIncludeArgumentName:=False, iPosition:=1)
 
         clsGetRowNamesFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_row_names")
         clsGetRowNamesFunction.SetAssignTo(strTemp:=ucrNewColumnName.GetText(), strTempDataframe:=ucrSelectorRowNames.ucrAvailableDataFrames.cboAvailableDataFrames.Text, strTempColumn:=ucrNewColumnName.GetText())
@@ -130,7 +144,7 @@ Public Class dlgRowNamesOrNumbers
         ucrChkMakeColumnIntoKey.SetRCode(clsDummyFunction, bReset)
         ucrPnlOverallOptions.SetRCode(clsDummyFunction, bReset)
         ucrNewColumnName.AddAdditionalRCode(clsGetRowNamesFunction, bReset)
-        ucrNewColumnName.SetRCode(clsGetRowNamesFunction, bReset)
+        ucrNewColumnName.SetRCode(clsHmiscFunction, bReset)
         ucrChkAsNumeric.SetRCode(ucrBase.clsRsyntax.clsBaseFunction, bReset)
 
     End Sub
@@ -158,7 +172,7 @@ Public Class dlgRowNamesOrNumbers
         Else
             ucrSelectorRowNames.SetVariablesVisible(False)
             If rdoCopyRowNamesIntoFirstColumn.Checked Then
-                ucrBase.clsRsyntax.SetBaseRFunction(clsGetRowNamesFunction)
+                ucrBase.clsRsyntax.SetBaseRFunction(clsHmiscFunction)
                 clsDummyFunction.AddParameter("checked_rdo", "copy_row", iPosition:=1)
             ElseIf rdoResetintoPositiveIntegers.Checked Then
                 ucrBase.clsRsyntax.SetBaseRFunction(clsSetRowNamesFunction)

--- a/instat/dlgRownamesOrNumbers.vb
+++ b/instat/dlgRownamesOrNumbers.vb
@@ -22,9 +22,6 @@ Public Class dlgRowNamesOrNumbers
     Private clsGetRowNamesFunction As New RFunction
     Private clsSetRowNamesFunction As New RFunction
     Private clsAddKeyFunction As New RFunction
-    Private clsAsBaseFunction As New RFunction
-    Private clsAsSapplyFunction As New RFunction
-    Private clsAsRownamesFunction As New RFunction
     Private clsDummyFunction As New RFunction
 
     Private Sub dlgRowNamesOrNumbers_Load(sender As Object, e As EventArgs) Handles MyBase.Load
@@ -107,9 +104,6 @@ Public Class dlgRowNamesOrNumbers
         clsAddKeyFunction = New RFunction
         clsDummyFunction = New RFunction
         clsSetRowNamesFunction = New RFunction
-        clsAsBaseFunction = New RFunction
-        clsAsSapplyFunction = New RFunction
-        clsAsRownamesFunction = New RFunction
 
         ucrNewColumnName.Reset()
         ucrSelectorRowNames.Reset()
@@ -118,23 +112,12 @@ Public Class dlgRowNamesOrNumbers
         clsDummyFunction.AddParameter("checked_rdo", "copy_row", iPosition:=1)
         clsDummyFunction.AddParameter("add_key", "TRUE", iPosition:=2)
 
-        clsAsRownamesFunction.SetRCommand("rownames")
-        clsAsRownamesFunction.AddParameter("data", ucrSelectorRowNames.ucrAvailableDataFrames.cboAvailableDataFrames.Text, bIncludeArgumentName:=False)
-
-        clsAsSapplyFunction.SetRCommand("sapply")
-        clsAsSapplyFunction.AddParameter("x", clsRFunctionParameter:=clsAsRownamesFunction, bIncludeArgumentName:=False, iPosition:=0)
-        clsAsSapplyFunction.AddParameter("numeric", "is.numeric", bIncludeArgumentName:=False, iPosition:=1)
-
-        clsAsBaseFunction.SetRCommand("all")
-        clsAsBaseFunction.AddParameter("all", clsRFunctionParameter:=clsAsSapplyFunction, bIncludeArgumentName:=False, iPosition:=0)
-
         clsAddKeyFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$add_key")
 
         clsGetRowNamesFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_row_names")
         clsGetRowNamesFunction.SetAssignTo(strTemp:=ucrNewColumnName.GetText(), strTempDataframe:=ucrSelectorRowNames.ucrAvailableDataFrames.cboAvailableDataFrames.Text, strTempColumn:=ucrNewColumnName.GetText())
 
         clsSetRowNamesFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$set_row_names")
-        ucrBase.clsRsyntax.AddToBeforeCodes(clsAsBaseFunction)
         ucrBase.clsRsyntax.SetBaseRFunction(clsGetRowNamesFunction)
     End Sub
 


### PR DESCRIPTION
fixes #8510
The changes are; 

a) Delete the second set of lines. 
b) To permit the key variable checkbox to be unchecked while still being checked by default.
c) added the function  `all(sapply(rownames(data), is.numeric))`

@N-thony , @rdstern this PR is ready for review

Thanks