### PR TITLE
Fixed double imports of data when using script window

### DIFF
--- a/instat/clsRLink.vb
+++ b/instat/clsRLink.vb
@@ -824,15 +824,8 @@ Public Class RLink
                     End If
                 ElseIf iCallType = 5 Then
                     'else if script comes from script window
-                    Dim bSuccess As Boolean = Evaluate(strScript, bSilent:=bSilent, bSeparateThread:=bSeparateThread, bShowWaitDialogOverride:=bShowWaitDialogOverride)
-
-                    'if not an assignment operation, then capture the output
-                    If Not strScript.Contains("<-") AndAlso bSuccess Then
-                        Dim strScriptAsSingleLine As String = strScript.Replace(vbCrLf, String.Empty)
-                        strScriptAsSingleLine = strScriptAsSingleLine.Replace(vbCr, String.Empty)
-                        strScriptAsSingleLine = strScriptAsSingleLine.Replace(vbLf, String.Empty)
-                        strOutput = GetFileOutput("view_object_data(object = " & strScriptAsSingleLine & " , object_format = 'text' )", bSilent, bSeparateThread, bShowWaitDialogOverride)
-                    End If
+                    'wrap command inside view_object_data just incase there is an output object
+                    strOutput = GetFileOutput("view_object_data(object = " & strScript & " , object_format = 'text' )", bSilent, bSeparateThread, bShowWaitDialogOverride)
                 Else
                     'else if script output should not be ignored or not stored as an object or variable
 
@@ -883,7 +876,8 @@ Public Class RLink
         Dim expTemp As RDotNet.SymbolicExpression
         Dim strNewAssignedToScript As String = ConstructAssignTo(strTempAssignTo, strScript)
         Evaluate(strNewAssignedToScript, bSilent:=bSilent, bSeparateThread:=bSeparateThread, bShowWaitDialogOverride:=bShowWaitDialogOverride)
-        expTemp = GetSymbol(strTempAssignTo, bSilent:=bSilent)
+        'get file path. If not found then silently return nothing
+        expTemp = GetSymbol(strTempAssignTo, bSilent:=False)
         Evaluate("rm(" & strTempAssignTo & ")", bSilent:=True)
         If expTemp IsNot Nothing Then
             'get the file path name, check if it exists and whether it has contents

--- a/instat/clsRLink.vb
+++ b/instat/clsRLink.vb
@@ -912,17 +912,8 @@ Public Class RLink
     Public Function RunScriptFromWindow(strNewScript As String, strNewComment As String) As String
         Dim strScriptCmd As String = ""
 
-
         'for each line in script
         For Each strScriptLine As String In strNewScript.Split(Environment.NewLine)
-            'remove any comments (character '#' and anything after)
-            Dim iCommentPos As Integer = strScriptLine.IndexOf("#")
-            Select Case iCommentPos
-                Case 0      'a normal comment line (starts with '#')
-                    Continue For
-                Case Is > 0 ' a line with an appended comment (e.g. 'x <- 1 # generate data' converted to 'x <- 1 ')
-                    strScriptLine = strScriptLine.Substring(0, iCommentPos - 1)
-            End Select
 
             'if line is empty or only whitespace then ignore line
             Dim strTrimmedLine As String = strScriptLine.Trim(vbLf).Trim()

--- a/instat/clsRLink.vb
+++ b/instat/clsRLink.vb
@@ -877,7 +877,7 @@ Public Class RLink
         Dim strNewAssignedToScript As String = ConstructAssignTo(strTempAssignTo, strScript)
         Evaluate(strNewAssignedToScript, bSilent:=bSilent, bSeparateThread:=bSeparateThread, bShowWaitDialogOverride:=bShowWaitDialogOverride)
         'get file path. If not found then silently return nothing
-        expTemp = GetSymbol(strTempAssignTo, bSilent:=False)
+        expTemp = GetSymbol(strTempAssignTo, bSilent:=True)
         Evaluate("rm(" & strTempAssignTo & ")", bSilent:=True)
         If expTemp IsNot Nothing Then
             'get the file path name, check if it exists and whether it has contents
@@ -914,6 +914,14 @@ Public Class RLink
 
         'for each line in script
         For Each strScriptLine As String In strNewScript.Split(Environment.NewLine)
+            'remove any comments (character '#' and anything after)
+            Dim iCommentPos As Integer = strScriptLine.IndexOf("#")
+            Select Case iCommentPos
+                Case 0      'a normal comment line (starts with '#')
+                    Continue For
+                Case Is > 0 ' a line with an appended comment (e.g. 'x <- 1 # generate data' converted to 'x <- 1 ')
+                    strScriptLine = strScriptLine.Substring(0, iCommentPos - 1)
+            End Select
 
             'if line is empty or only whitespace then ignore line
             Dim strTrimmedLine As String = strScriptLine.Trim(vbLf).Trim()

--- a/instat/clsRLink.vb
+++ b/instat/clsRLink.vb
@@ -912,6 +912,7 @@ Public Class RLink
     Public Function RunScriptFromWindow(strNewScript As String, strNewComment As String) As String
         Dim strScriptCmd As String = ""
 
+
         'for each line in script
         For Each strScriptLine As String In strNewScript.Split(Environment.NewLine)
             'remove any comments (character '#' and anything after)


### PR DESCRIPTION
Fixes double imports of data as outlined in issue #8509.
This PR also fixes optimises running of commands through the script window.

@africanmathsinitiative/developers this is ready for review.

@rdstern I'll keep this updated with the master branch. 
If possible, kindly do all possible tests on this branch in your daily operations. I'm particularly keen on which dialog scripts would fail when run through the script window.

@lloyddewit as mentioned to me by @rdstern you may be working on this as well.