### PR TITLE
Made Column metadata consistent with Data View when selection is applied

### DIFF
--- a/instat/static/InstatObject/R/data_object_R6.R
+++ b/instat/static/InstatObject/R/data_object_R6.R
@@ -463,8 +463,8 @@ DataSheet$set("public", "get_variables_metadata", function(data_type = "all", co
       if(self$column_selection_applied()) cols <- self$current_column_selection
       curr_data <- private$data[column]
     }
-    for(c in cols) {
-      col <- curr_data[[c]]
+    for (i in seq_along(cols)) {
+      col <- curr_data[[cols[i]]]
       ind <- which(names(attributes(col)) == "levels")
       if(length(ind) > 0) col_attributes <- attributes(col)[-ind]
       else col_attributes <- attributes(col)
@@ -487,7 +487,7 @@ DataSheet$set("public", "get_variables_metadata", function(data_type = "all", co
       #  col_attributes <- data.frame(class = NA)
       #}
       col_attributes <- data.frame(col_attributes, stringsAsFactors = FALSE)
-      out[[c]] <- col_attributes
+      out[[i]] <- col_attributes
     }
     #RLink crashes with bind_rows for some data frames with ~50+ columns
     #rbind.fill safer alternative currently


### PR DESCRIPTION
@rdstern I'm not sure about the issue number this PR fixes, but I made the change as discussed on Skype so that the Metadata grid will reflect on the Data View when the selection is applied. Have a look.
![image](https://github.com/africanmathsinitiative/R-Instat/assets/68591383/3277807d-5816-4754-bc1e-9d71a1f8bb21)
