### PR TITLE
In Script window, added support for question mark operator

### DIFF
--- a/instat/instat.vbproj
+++ b/instat/instat.vbproj
@@ -155,8 +155,8 @@
     <Reference Include="RDotNet, Version=1.8.2.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\R.NET.1.8.2\lib\netstandard2.0\RDotNet.dll</HintPath>
     </Reference>
-    <Reference Include="RScript, Version=0.1.0.8, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\RScript.1.0.9\lib\net461\RScript.dll</HintPath>
+    <Reference Include="RScript, Version=0.1.0.9, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\RScript.1.0.10\lib\net461\RScript.dll</HintPath>
     </Reference>
     <Reference Include="ScintillaNET, Version=3.6.3.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\jacobslusser.ScintillaNET.3.6.3\lib\net40\ScintillaNET.dll</HintPath>

--- a/instat/packages.config
+++ b/instat/packages.config
@@ -11,7 +11,7 @@
   <package id="Microsoft.Win32.Registry" version="4.5.0" targetFramework="net461" />
   <package id="NLog" version="5.1.0" targetFramework="net461" />
   <package id="R.NET" version="1.8.2" targetFramework="net461" />
-  <package id="RScript" version="1.0.9" targetFramework="net461" />
+  <package id="RScript" version="1.0.10" targetFramework="net461" />
   <package id="Stub.System.Data.SQLite.Core.NetFramework" version="1.0.113.3" targetFramework="net461" />
   <package id="System.Collections.Specialized" version="4.3.0" targetFramework="net461" />
   <package id="System.Data.SQLite.Core" version="1.0.113.7" targetFramework="net461" />


### PR DESCRIPTION
Fixes #8508 
(Also see lloyddewit/rscript#17 and lloyddewit/rscript#21)

In the Script window, added support for question mark operator and also ensured that unary plus/minus operators behave correctly across line breaks.

I tested with:
```
# lloyddewit/rscript#21
x<-1
+5

# lloyddewit/rscript#17
# africanmathsinitiative/r-instat#8508
library(agridat)
?agridat
?log
library(bayesplot)
?bayesplot
```

@rdstern Please could you test? thanks

Note: During testing, R-Instat once threw an exception in its thread handling. I could not recreate and I don't think this PR was the root cause.
If you experience something similar during your testing, then please let me know.