### PR TITLE
Added new Emmeans keyboard

### DIFF
--- a/instat/dlgUseModel.Designer.vb
+++ b/instat/dlgUseModel.Designer.vb
@@ -76,19 +76,22 @@ Partial Class dlgUseModel
         Me.ContextMenuStripSegmented = New System.Windows.Forms.ContextMenuStrip(Me.components)
         Me.ToolStripMenuSegmented = New System.Windows.Forms.ToolStripMenuItem()
         Me.grpEmmeans = New System.Windows.Forms.GroupBox()
-        Me.Button1 = New System.Windows.Forms.Button()
-        Me.Button15 = New System.Windows.Forms.Button()
-        Me.Button14 = New System.Windows.Forms.Button()
-        Me.Button13 = New System.Windows.Forms.Button()
-        Me.Button4 = New System.Windows.Forms.Button()
-        Me.Button5 = New System.Windows.Forms.Button()
-        Me.Button6 = New System.Windows.Forms.Button()
-        Me.Button7 = New System.Windows.Forms.Button()
-        Me.Button8 = New System.Windows.Forms.Button()
-        Me.Button9 = New System.Windows.Forms.Button()
-        Me.Button10 = New System.Windows.Forms.Button()
-        Me.Button11 = New System.Windows.Forms.Button()
-        Me.Button12 = New System.Windows.Forms.Button()
+        Me.cmdXtable = New System.Windows.Forms.Button()
+        Me.cmdTest = New System.Windows.Forms.Button()
+        Me.cmdPairs = New System.Windows.Forms.Button()
+        Me.cmdRefgrid = New System.Windows.Forms.Button()
+        Me.cmdEmmeansSummary = New System.Windows.Forms.Button()
+        Me.cmdpwpp = New System.Windows.Forms.Button()
+        Me.cmdEmmeansPlot = New System.Windows.Forms.Button()
+        Me.cmdIntplot = New System.Windows.Forms.Button()
+        Me.cmdContrast = New System.Windows.Forms.Button()
+        Me.cmdEmmeanConfint = New System.Windows.Forms.Button()
+        Me.cmdTrends = New System.Windows.Forms.Button()
+        Me.cmdEmmeans = New System.Windows.Forms.Button()
+        Me.cmdJoint = New System.Windows.Forms.Button()
+        Me.ContextMenuStripEmmeans = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.ToolStripMenuEmmeans = New System.Windows.Forms.ToolStripMenuItem()
+        Me.cmdRHelpEmmeans = New instat.ucrSplitButton()
         Me.cmdRHelpSegmented = New instat.ucrSplitButton()
         Me.cmdRHelpExtRemes = New instat.ucrSplitButton()
         Me.cmdRHelpGeneral = New instat.ucrSplitButton()
@@ -101,9 +104,6 @@ Partial Class dlgUseModel
         Me.ucrBase = New instat.ucrButtons()
         Me.ucrReceiverForTestColumn = New instat.ucrReceiverExpression()
         Me.ucrInputComboRPackage = New instat.ucrInputComboBox()
-        Me.cmdRHelpEmmeans = New instat.ucrSplitButton()
-        Me.ContextMenuStripEmmeans = New System.Windows.Forms.ContextMenuStrip(Me.components)
-        Me.ToolStripMenuEmmeans = New System.Windows.Forms.ToolStripMenuItem()
         Me.grpGeneral.SuspendLayout()
         Me.grpPrediction.SuspendLayout()
         Me.grpExtrRemes.SuspendLayout()
@@ -678,19 +678,19 @@ Partial Class dlgUseModel
         '
         'grpEmmeans
         '
-        Me.grpEmmeans.Controls.Add(Me.Button1)
-        Me.grpEmmeans.Controls.Add(Me.Button15)
-        Me.grpEmmeans.Controls.Add(Me.Button14)
-        Me.grpEmmeans.Controls.Add(Me.Button13)
-        Me.grpEmmeans.Controls.Add(Me.Button4)
-        Me.grpEmmeans.Controls.Add(Me.Button5)
-        Me.grpEmmeans.Controls.Add(Me.Button6)
-        Me.grpEmmeans.Controls.Add(Me.Button7)
-        Me.grpEmmeans.Controls.Add(Me.Button8)
-        Me.grpEmmeans.Controls.Add(Me.Button9)
-        Me.grpEmmeans.Controls.Add(Me.Button10)
-        Me.grpEmmeans.Controls.Add(Me.Button11)
-        Me.grpEmmeans.Controls.Add(Me.Button12)
+        Me.grpEmmeans.Controls.Add(Me.cmdXtable)
+        Me.grpEmmeans.Controls.Add(Me.cmdTest)
+        Me.grpEmmeans.Controls.Add(Me.cmdPairs)
+        Me.grpEmmeans.Controls.Add(Me.cmdRefgrid)
+        Me.grpEmmeans.Controls.Add(Me.cmdEmmeansSummary)
+        Me.grpEmmeans.Controls.Add(Me.cmdpwpp)
+        Me.grpEmmeans.Controls.Add(Me.cmdEmmeansPlot)
+        Me.grpEmmeans.Controls.Add(Me.cmdIntplot)
+        Me.grpEmmeans.Controls.Add(Me.cmdContrast)
+        Me.grpEmmeans.Controls.Add(Me.cmdEmmeanConfint)
+        Me.grpEmmeans.Controls.Add(Me.cmdTrends)
+        Me.grpEmmeans.Controls.Add(Me.cmdEmmeans)
+        Me.grpEmmeans.Controls.Add(Me.cmdJoint)
         Me.grpEmmeans.Location = New System.Drawing.Point(260, 106)
         Me.grpEmmeans.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
         Me.grpEmmeans.Name = "grpEmmeans"
@@ -700,148 +700,172 @@ Partial Class dlgUseModel
         Me.grpEmmeans.TabStop = False
         Me.grpEmmeans.Text = "Emmeans"
         '
-        'Button1
+        'cmdXtable
         '
-        Me.Button1.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.Button1.Location = New System.Drawing.Point(3, 99)
-        Me.Button1.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
-        Me.Button1.Name = "Button1"
-        Me.Button1.Size = New System.Drawing.Size(69, 30)
-        Me.Button1.TabIndex = 165
-        Me.Button1.Text = "xtable"
-        Me.Button1.UseVisualStyleBackColor = True
+        Me.cmdXtable.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.cmdXtable.Location = New System.Drawing.Point(3, 99)
+        Me.cmdXtable.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdXtable.Name = "cmdXtable"
+        Me.cmdXtable.Size = New System.Drawing.Size(69, 30)
+        Me.cmdXtable.TabIndex = 165
+        Me.cmdXtable.Text = "xtable"
+        Me.cmdXtable.UseVisualStyleBackColor = True
         '
-        'Button15
+        'cmdTest
         '
-        Me.Button15.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.Button15.Location = New System.Drawing.Point(209, 70)
-        Me.Button15.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
-        Me.Button15.Name = "Button15"
-        Me.Button15.Size = New System.Drawing.Size(69, 30)
-        Me.Button15.TabIndex = 164
-        Me.Button15.Text = "test"
-        Me.Button15.UseVisualStyleBackColor = True
+        Me.cmdTest.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.cmdTest.Location = New System.Drawing.Point(209, 70)
+        Me.cmdTest.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdTest.Name = "cmdTest"
+        Me.cmdTest.Size = New System.Drawing.Size(69, 30)
+        Me.cmdTest.TabIndex = 164
+        Me.cmdTest.Text = "test"
+        Me.cmdTest.UseVisualStyleBackColor = True
         '
-        'Button14
+        'cmdPairs
         '
-        Me.Button14.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.Button14.Location = New System.Drawing.Point(209, 41)
-        Me.Button14.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
-        Me.Button14.Name = "Button14"
-        Me.Button14.Size = New System.Drawing.Size(69, 30)
-        Me.Button14.TabIndex = 163
-        Me.Button14.Text = "pairs"
-        Me.Button14.UseVisualStyleBackColor = True
+        Me.cmdPairs.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.cmdPairs.Location = New System.Drawing.Point(209, 41)
+        Me.cmdPairs.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdPairs.Name = "cmdPairs"
+        Me.cmdPairs.Size = New System.Drawing.Size(69, 30)
+        Me.cmdPairs.TabIndex = 163
+        Me.cmdPairs.Text = "pairs"
+        Me.cmdPairs.UseVisualStyleBackColor = True
         '
-        'Button13
+        'cmdRefgrid
         '
-        Me.Button13.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.Button13.Location = New System.Drawing.Point(209, 12)
-        Me.Button13.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
-        Me.Button13.Name = "Button13"
-        Me.Button13.Size = New System.Drawing.Size(69, 30)
-        Me.Button13.TabIndex = 162
-        Me.Button13.Text = "refgrid"
-        Me.Button13.UseVisualStyleBackColor = True
+        Me.cmdRefgrid.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.cmdRefgrid.Location = New System.Drawing.Point(209, 12)
+        Me.cmdRefgrid.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdRefgrid.Name = "cmdRefgrid"
+        Me.cmdRefgrid.Size = New System.Drawing.Size(69, 30)
+        Me.cmdRefgrid.TabIndex = 162
+        Me.cmdRefgrid.Text = "refgrid"
+        Me.cmdRefgrid.UseVisualStyleBackColor = True
         '
-        'Button4
+        'cmdEmmeansSummary
         '
-        Me.Button4.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.Button4.Location = New System.Drawing.Point(140, 70)
-        Me.Button4.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
-        Me.Button4.Name = "Button4"
-        Me.Button4.Size = New System.Drawing.Size(69, 30)
-        Me.Button4.TabIndex = 159
-        Me.Button4.Text = "summary"
-        Me.Button4.UseVisualStyleBackColor = True
+        Me.cmdEmmeansSummary.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.cmdEmmeansSummary.Location = New System.Drawing.Point(140, 70)
+        Me.cmdEmmeansSummary.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdEmmeansSummary.Name = "cmdEmmeansSummary"
+        Me.cmdEmmeansSummary.Size = New System.Drawing.Size(69, 30)
+        Me.cmdEmmeansSummary.TabIndex = 159
+        Me.cmdEmmeansSummary.Text = "summary"
+        Me.cmdEmmeansSummary.UseVisualStyleBackColor = True
         '
-        'Button5
+        'cmdpwpp
         '
-        Me.Button5.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.Button5.Location = New System.Drawing.Point(72, 70)
-        Me.Button5.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
-        Me.Button5.Name = "Button5"
-        Me.Button5.Size = New System.Drawing.Size(69, 30)
-        Me.Button5.TabIndex = 158
-        Me.Button5.Text = "pwpp"
-        Me.Button5.UseVisualStyleBackColor = True
+        Me.cmdpwpp.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.cmdpwpp.Location = New System.Drawing.Point(72, 70)
+        Me.cmdpwpp.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdpwpp.Name = "cmdpwpp"
+        Me.cmdpwpp.Size = New System.Drawing.Size(69, 30)
+        Me.cmdpwpp.TabIndex = 158
+        Me.cmdpwpp.Text = "pwpp"
+        Me.cmdpwpp.UseVisualStyleBackColor = True
         '
-        'Button6
+        'cmdEmmeansPlot
         '
-        Me.Button6.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.Button6.Location = New System.Drawing.Point(3, 70)
-        Me.Button6.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
-        Me.Button6.Name = "Button6"
-        Me.Button6.Size = New System.Drawing.Size(69, 30)
-        Me.Button6.TabIndex = 157
-        Me.Button6.Text = "plot"
-        Me.Button6.UseVisualStyleBackColor = True
+        Me.cmdEmmeansPlot.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.cmdEmmeansPlot.Location = New System.Drawing.Point(3, 70)
+        Me.cmdEmmeansPlot.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdEmmeansPlot.Name = "cmdEmmeansPlot"
+        Me.cmdEmmeansPlot.Size = New System.Drawing.Size(69, 30)
+        Me.cmdEmmeansPlot.TabIndex = 157
+        Me.cmdEmmeansPlot.Text = "plot"
+        Me.cmdEmmeansPlot.UseVisualStyleBackColor = True
         '
-        'Button7
+        'cmdIntplot
         '
-        Me.Button7.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.Button7.Location = New System.Drawing.Point(140, 41)
-        Me.Button7.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
-        Me.Button7.Name = "Button7"
-        Me.Button7.Size = New System.Drawing.Size(69, 30)
-        Me.Button7.TabIndex = 156
-        Me.Button7.Text = "intplot"
-        Me.Button7.UseVisualStyleBackColor = True
+        Me.cmdIntplot.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.cmdIntplot.Location = New System.Drawing.Point(140, 41)
+        Me.cmdIntplot.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdIntplot.Name = "cmdIntplot"
+        Me.cmdIntplot.Size = New System.Drawing.Size(69, 30)
+        Me.cmdIntplot.TabIndex = 156
+        Me.cmdIntplot.Text = "intplot"
+        Me.cmdIntplot.UseVisualStyleBackColor = True
         '
-        'Button8
+        'cmdContrast
         '
-        Me.Button8.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.Button8.Location = New System.Drawing.Point(72, 41)
-        Me.Button8.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
-        Me.Button8.Name = "Button8"
-        Me.Button8.Size = New System.Drawing.Size(69, 30)
-        Me.Button8.TabIndex = 155
-        Me.Button8.Text = "contrast"
-        Me.Button8.UseVisualStyleBackColor = True
+        Me.cmdContrast.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.cmdContrast.Location = New System.Drawing.Point(72, 41)
+        Me.cmdContrast.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdContrast.Name = "cmdContrast"
+        Me.cmdContrast.Size = New System.Drawing.Size(69, 30)
+        Me.cmdContrast.TabIndex = 155
+        Me.cmdContrast.Text = "contrast"
+        Me.cmdContrast.UseVisualStyleBackColor = True
         '
-        'Button9
+        'cmdEmmeanConfint
         '
-        Me.Button9.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.Button9.Location = New System.Drawing.Point(3, 41)
-        Me.Button9.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
-        Me.Button9.Name = "Button9"
-        Me.Button9.Size = New System.Drawing.Size(69, 30)
-        Me.Button9.TabIndex = 154
-        Me.Button9.Text = "confint"
-        Me.Button9.UseVisualStyleBackColor = True
+        Me.cmdEmmeanConfint.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.cmdEmmeanConfint.Location = New System.Drawing.Point(3, 41)
+        Me.cmdEmmeanConfint.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdEmmeanConfint.Name = "cmdEmmeanConfint"
+        Me.cmdEmmeanConfint.Size = New System.Drawing.Size(69, 30)
+        Me.cmdEmmeanConfint.TabIndex = 154
+        Me.cmdEmmeanConfint.Text = "confint"
+        Me.cmdEmmeanConfint.UseVisualStyleBackColor = True
         '
-        'Button10
+        'cmdTrends
         '
-        Me.Button10.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.Button10.Location = New System.Drawing.Point(72, 12)
-        Me.Button10.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
-        Me.Button10.Name = "Button10"
-        Me.Button10.Size = New System.Drawing.Size(69, 30)
-        Me.Button10.TabIndex = 126
-        Me.Button10.Text = "trends"
-        Me.Button10.UseVisualStyleBackColor = True
+        Me.cmdTrends.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.cmdTrends.Location = New System.Drawing.Point(72, 12)
+        Me.cmdTrends.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdTrends.Name = "cmdTrends"
+        Me.cmdTrends.Size = New System.Drawing.Size(69, 30)
+        Me.cmdTrends.TabIndex = 126
+        Me.cmdTrends.Text = "trends"
+        Me.cmdTrends.UseVisualStyleBackColor = True
         '
-        'Button11
+        'cmdEmmeans
         '
-        Me.Button11.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.Button11.Location = New System.Drawing.Point(3, 12)
-        Me.Button11.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
-        Me.Button11.Name = "Button11"
-        Me.Button11.Size = New System.Drawing.Size(69, 30)
-        Me.Button11.TabIndex = 124
-        Me.Button11.Text = "emmeans"
-        Me.Button11.UseVisualStyleBackColor = True
+        Me.cmdEmmeans.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.cmdEmmeans.Location = New System.Drawing.Point(3, 12)
+        Me.cmdEmmeans.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdEmmeans.Name = "cmdEmmeans"
+        Me.cmdEmmeans.Size = New System.Drawing.Size(69, 30)
+        Me.cmdEmmeans.TabIndex = 124
+        Me.cmdEmmeans.Text = "emmeans"
+        Me.cmdEmmeans.UseVisualStyleBackColor = True
         '
-        'Button12
+        'cmdJoint
         '
-        Me.Button12.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.Button12.Location = New System.Drawing.Point(140, 12)
-        Me.Button12.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
-        Me.Button12.Name = "Button12"
-        Me.Button12.Size = New System.Drawing.Size(69, 30)
-        Me.Button12.TabIndex = 153
-        Me.Button12.Text = "joint"
-        Me.Button12.UseVisualStyleBackColor = True
+        Me.cmdJoint.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.cmdJoint.Location = New System.Drawing.Point(140, 12)
+        Me.cmdJoint.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.cmdJoint.Name = "cmdJoint"
+        Me.cmdJoint.Size = New System.Drawing.Size(69, 30)
+        Me.cmdJoint.TabIndex = 153
+        Me.cmdJoint.Text = "joint"
+        Me.cmdJoint.UseVisualStyleBackColor = True
+        '
+        'ContextMenuStripEmmeans
+        '
+        Me.ContextMenuStripEmmeans.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuEmmeans})
+        Me.ContextMenuStripEmmeans.Name = "ContextMenuStrip1"
+        Me.ContextMenuStripEmmeans.Size = New System.Drawing.Size(127, 26)
+        '
+        'ToolStripMenuEmmeans
+        '
+        Me.ToolStripMenuEmmeans.Name = "ToolStripMenuEmmeans"
+        Me.ToolStripMenuEmmeans.Size = New System.Drawing.Size(126, 22)
+        Me.ToolStripMenuEmmeans.Text = "emmeans"
+        '
+        'cmdRHelpEmmeans
+        '
+        Me.cmdRHelpEmmeans.AutoSize = True
+        Me.cmdRHelpEmmeans.ContextMenuStrip = Me.ContextMenuStripEmmeans
+        Me.cmdRHelpEmmeans.Location = New System.Drawing.Point(460, 79)
+        Me.cmdRHelpEmmeans.Name = "cmdRHelpEmmeans"
+        Me.cmdRHelpEmmeans.Size = New System.Drawing.Size(68, 23)
+        Me.cmdRHelpEmmeans.SplitMenuStrip = Me.ContextMenuStripEmmeans
+        Me.cmdRHelpEmmeans.TabIndex = 223
+        Me.cmdRHelpEmmeans.Text = "R Help"
+        Me.cmdRHelpEmmeans.UseVisualStyleBackColor = True
         '
         'cmdRHelpSegmented
         '
@@ -979,30 +1003,6 @@ Partial Class dlgUseModel
         Me.ucrInputComboRPackage.Size = New System.Drawing.Size(122, 21)
         Me.ucrInputComboRPackage.TabIndex = 5
         '
-        'cmdRHelpEmmeans
-        '
-        Me.cmdRHelpEmmeans.AutoSize = True
-        Me.cmdRHelpEmmeans.ContextMenuStrip = Me.ContextMenuStripEmmeans
-        Me.cmdRHelpEmmeans.Location = New System.Drawing.Point(460, 79)
-        Me.cmdRHelpEmmeans.Name = "cmdRHelpEmmeans"
-        Me.cmdRHelpEmmeans.Size = New System.Drawing.Size(68, 23)
-        Me.cmdRHelpEmmeans.SplitMenuStrip = Me.ContextMenuStripEmmeans
-        Me.cmdRHelpEmmeans.TabIndex = 223
-        Me.cmdRHelpEmmeans.Text = "R Help"
-        Me.cmdRHelpEmmeans.UseVisualStyleBackColor = True
-        '
-        'ContextMenuStripEmmeans
-        '
-        Me.ContextMenuStripEmmeans.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuEmmeans})
-        Me.ContextMenuStripEmmeans.Name = "ContextMenuStrip1"
-        Me.ContextMenuStripEmmeans.Size = New System.Drawing.Size(127, 26)
-        '
-        'ToolStripMenuEmmeans
-        '
-        Me.ToolStripMenuEmmeans.Name = "ToolStripMenuEmmeans"
-        Me.ToolStripMenuEmmeans.Size = New System.Drawing.Size(126, 22)
-        Me.ToolStripMenuEmmeans.Text = "emmeans"
-        '
         'dlgUseModel
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
@@ -1010,6 +1010,7 @@ Partial Class dlgUseModel
         Me.AutoSize = True
         Me.ClientSize = New System.Drawing.Size(582, 423)
         Me.Controls.Add(Me.grpEmmeans)
+        Me.Controls.Add(Me.grpSegmented)
         Me.Controls.Add(Me.cmdRHelpEmmeans)
         Me.Controls.Add(Me.cmdRHelpSegmented)
         Me.Controls.Add(Me.cmdRHelpExtRemes)
@@ -1020,7 +1021,6 @@ Partial Class dlgUseModel
         Me.Controls.Add(Me.lblRpackage)
         Me.Controls.Add(Me.ucrSaveResult)
         Me.Controls.Add(Me.ucrChkIncludeArguments)
-        Me.Controls.Add(Me.grpSegmented)
         Me.Controls.Add(Me.cmdClear)
         Me.Controls.Add(Me.grpExtrRemes)
         Me.Controls.Add(Me.ucrInputModels)
@@ -1118,19 +1118,19 @@ Partial Class dlgUseModel
     Friend WithEvents ContextMenuStripSegmented As ContextMenuStrip
     Friend WithEvents ToolStripMenuSegmented As ToolStripMenuItem
     Friend WithEvents grpEmmeans As GroupBox
-    Friend WithEvents Button4 As Button
-    Friend WithEvents Button5 As Button
-    Friend WithEvents Button6 As Button
-    Friend WithEvents Button7 As Button
-    Friend WithEvents Button8 As Button
-    Friend WithEvents Button9 As Button
-    Friend WithEvents Button10 As Button
-    Friend WithEvents Button11 As Button
-    Friend WithEvents Button12 As Button
-    Friend WithEvents Button1 As Button
-    Friend WithEvents Button15 As Button
-    Friend WithEvents Button14 As Button
-    Friend WithEvents Button13 As Button
+    Friend WithEvents cmdEmmeansSummary As Button
+    Friend WithEvents cmdpwpp As Button
+    Friend WithEvents cmdEmmeansPlot As Button
+    Friend WithEvents cmdIntplot As Button
+    Friend WithEvents cmdContrast As Button
+    Friend WithEvents cmdEmmeanConfint As Button
+    Friend WithEvents cmdTrends As Button
+    Friend WithEvents cmdEmmeans As Button
+    Friend WithEvents cmdJoint As Button
+    Friend WithEvents cmdXtable As Button
+    Friend WithEvents cmdTest As Button
+    Friend WithEvents cmdPairs As Button
+    Friend WithEvents cmdRefgrid As Button
     Friend WithEvents cmdRHelpEmmeans As ucrSplitButton
     Friend WithEvents ContextMenuStripEmmeans As ContextMenuStrip
     Friend WithEvents ToolStripMenuEmmeans As ToolStripMenuItem

--- a/instat/dlgUseModel.Designer.vb
+++ b/instat/dlgUseModel.Designer.vb
@@ -51,8 +51,6 @@ Partial Class dlgUseModel
         Me.cmdErlevd = New System.Windows.Forms.Button()
         Me.cmdClear = New System.Windows.Forms.Button()
         Me.lblRpackage = New System.Windows.Forms.Label()
-        Me.ucrSaveResult = New instat.ucrSave()
-        Me.ucrChkIncludeArguments = New instat.ucrCheck()
         Me.grpSegmented = New System.Windows.Forms.GroupBox()
         Me.cmdSlope = New System.Windows.Forms.Button()
         Me.cmdPscore = New System.Windows.Forms.Button()
@@ -68,25 +66,44 @@ Partial Class dlgUseModel
         Me.cmdAapc = New System.Windows.Forms.Button()
         Me.cmdSegmented = New System.Windows.Forms.Button()
         Me.cmdSegmentedPrint = New System.Windows.Forms.Button()
+        Me.ContextMenuStripPrediction = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.ToolStripMenuPrediction = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ContextMenuStripGeneral = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.ToolStripMenuStats = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ToolStripMenuCar = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ContextMenuStripExtRemes = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.ToolStripMenuExtRemes = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ContextMenuStripSegmented = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.ToolStripMenuSegmented = New System.Windows.Forms.ToolStripMenuItem()
+        Me.grpEmmeans = New System.Windows.Forms.GroupBox()
+        Me.Button1 = New System.Windows.Forms.Button()
+        Me.Button15 = New System.Windows.Forms.Button()
+        Me.Button14 = New System.Windows.Forms.Button()
+        Me.Button13 = New System.Windows.Forms.Button()
+        Me.Button4 = New System.Windows.Forms.Button()
+        Me.Button5 = New System.Windows.Forms.Button()
+        Me.Button6 = New System.Windows.Forms.Button()
+        Me.Button7 = New System.Windows.Forms.Button()
+        Me.Button8 = New System.Windows.Forms.Button()
+        Me.Button9 = New System.Windows.Forms.Button()
+        Me.Button10 = New System.Windows.Forms.Button()
+        Me.Button11 = New System.Windows.Forms.Button()
+        Me.Button12 = New System.Windows.Forms.Button()
+        Me.cmdRHelpSegmented = New instat.ucrSplitButton()
+        Me.cmdRHelpExtRemes = New instat.ucrSplitButton()
+        Me.cmdRHelpGeneral = New instat.ucrSplitButton()
+        Me.cmdRHelpPrediction = New instat.ucrSplitButton()
+        Me.ucrTryModelling = New instat.ucrTry()
+        Me.ucrSaveResult = New instat.ucrSave()
+        Me.ucrChkIncludeArguments = New instat.ucrCheck()
         Me.ucrInputModels = New instat.ucrInputTextBox()
         Me.ucrSelectorUseModel = New instat.ucrSelectorByDataFrameAddRemove()
         Me.ucrBase = New instat.ucrButtons()
         Me.ucrReceiverForTestColumn = New instat.ucrReceiverExpression()
         Me.ucrInputComboRPackage = New instat.ucrInputComboBox()
-        Me.ucrTryModelling = New instat.ucrTry()
-        Me.cmdRHelpPrediction = New instat.ucrSplitButton()
-        Me.ContextMenuStripPrediction = New System.Windows.Forms.ContextMenuStrip(Me.components)
-        Me.ToolStripMenuPrediction = New System.Windows.Forms.ToolStripMenuItem()
-        Me.cmdRHelpGeneral = New instat.ucrSplitButton()
-        Me.ContextMenuStripGeneral = New System.Windows.Forms.ContextMenuStrip(Me.components)
-        Me.ToolStripMenuStats = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ToolStripMenuCar = New System.Windows.Forms.ToolStripMenuItem()
-        Me.cmdRHelpExtRemes = New instat.ucrSplitButton()
-        Me.ContextMenuStripExtRemes = New System.Windows.Forms.ContextMenuStrip(Me.components)
-        Me.ToolStripMenuExtRemes = New System.Windows.Forms.ToolStripMenuItem()
-        Me.cmdRHelpSegmented = New instat.ucrSplitButton()
-        Me.ContextMenuStripSegmented = New System.Windows.Forms.ContextMenuStrip(Me.components)
-        Me.ToolStripMenuSegmented = New System.Windows.Forms.ToolStripMenuItem()
+        Me.cmdRHelpEmmeans = New instat.ucrSplitButton()
+        Me.ContextMenuStripEmmeans = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.ToolStripMenuEmmeans = New System.Windows.Forms.ToolStripMenuItem()
         Me.grpGeneral.SuspendLayout()
         Me.grpPrediction.SuspendLayout()
         Me.grpExtrRemes.SuspendLayout()
@@ -95,6 +112,8 @@ Partial Class dlgUseModel
         Me.ContextMenuStripGeneral.SuspendLayout()
         Me.ContextMenuStripExtRemes.SuspendLayout()
         Me.ContextMenuStripSegmented.SuspendLayout()
+        Me.grpEmmeans.SuspendLayout()
+        Me.ContextMenuStripEmmeans.SuspendLayout()
         Me.SuspendLayout()
         '
         'lblModel
@@ -424,25 +443,6 @@ Partial Class dlgUseModel
         Me.lblRpackage.TabIndex = 36
         Me.lblRpackage.Text = "R package:"
         '
-        'ucrSaveResult
-        '
-        Me.ucrSaveResult.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrSaveResult.Location = New System.Drawing.Point(10, 319)
-        Me.ucrSaveResult.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
-        Me.ucrSaveResult.Name = "ucrSaveResult"
-        Me.ucrSaveResult.Size = New System.Drawing.Size(277, 24)
-        Me.ucrSaveResult.TabIndex = 35
-        '
-        'ucrChkIncludeArguments
-        '
-        Me.ucrChkIncludeArguments.AutoSize = True
-        Me.ucrChkIncludeArguments.Checked = False
-        Me.ucrChkIncludeArguments.Location = New System.Drawing.Point(445, 12)
-        Me.ucrChkIncludeArguments.Margin = New System.Windows.Forms.Padding(5)
-        Me.ucrChkIncludeArguments.Name = "ucrChkIncludeArguments"
-        Me.ucrChkIncludeArguments.Size = New System.Drawing.Size(130, 23)
-        Me.ucrChkIncludeArguments.TabIndex = 32
-        '
         'grpSegmented
         '
         Me.grpSegmented.Controls.Add(Me.cmdSlope)
@@ -622,6 +622,304 @@ Partial Class dlgUseModel
         Me.cmdSegmentedPrint.Text = "print"
         Me.cmdSegmentedPrint.UseVisualStyleBackColor = True
         '
+        'ContextMenuStripPrediction
+        '
+        Me.ContextMenuStripPrediction.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuPrediction})
+        Me.ContextMenuStripPrediction.Name = "ContextMenuStrip1"
+        Me.ContextMenuStripPrediction.Size = New System.Drawing.Size(129, 26)
+        '
+        'ToolStripMenuPrediction
+        '
+        Me.ToolStripMenuPrediction.Name = "ToolStripMenuPrediction"
+        Me.ToolStripMenuPrediction.Size = New System.Drawing.Size(128, 22)
+        Me.ToolStripMenuPrediction.Text = "prediction"
+        '
+        'ContextMenuStripGeneral
+        '
+        Me.ContextMenuStripGeneral.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuStats, Me.ToolStripMenuCar})
+        Me.ContextMenuStripGeneral.Name = "ContextMenuStrip1"
+        Me.ContextMenuStripGeneral.Size = New System.Drawing.Size(99, 48)
+        '
+        'ToolStripMenuStats
+        '
+        Me.ToolStripMenuStats.Name = "ToolStripMenuStats"
+        Me.ToolStripMenuStats.Size = New System.Drawing.Size(98, 22)
+        Me.ToolStripMenuStats.Text = "stats"
+        '
+        'ToolStripMenuCar
+        '
+        Me.ToolStripMenuCar.Name = "ToolStripMenuCar"
+        Me.ToolStripMenuCar.Size = New System.Drawing.Size(98, 22)
+        Me.ToolStripMenuCar.Text = "car"
+        '
+        'ContextMenuStripExtRemes
+        '
+        Me.ContextMenuStripExtRemes.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuExtRemes})
+        Me.ContextMenuStripExtRemes.Name = "ContextMenuStrip1"
+        Me.ContextMenuStripExtRemes.Size = New System.Drawing.Size(126, 26)
+        '
+        'ToolStripMenuExtRemes
+        '
+        Me.ToolStripMenuExtRemes.Name = "ToolStripMenuExtRemes"
+        Me.ToolStripMenuExtRemes.Size = New System.Drawing.Size(125, 22)
+        Me.ToolStripMenuExtRemes.Text = "extRemes"
+        '
+        'ContextMenuStripSegmented
+        '
+        Me.ContextMenuStripSegmented.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuSegmented})
+        Me.ContextMenuStripSegmented.Name = "ContextMenuStrip1"
+        Me.ContextMenuStripSegmented.Size = New System.Drawing.Size(134, 26)
+        '
+        'ToolStripMenuSegmented
+        '
+        Me.ToolStripMenuSegmented.Name = "ToolStripMenuSegmented"
+        Me.ToolStripMenuSegmented.Size = New System.Drawing.Size(133, 22)
+        Me.ToolStripMenuSegmented.Text = "segmented"
+        '
+        'grpEmmeans
+        '
+        Me.grpEmmeans.Controls.Add(Me.Button1)
+        Me.grpEmmeans.Controls.Add(Me.Button15)
+        Me.grpEmmeans.Controls.Add(Me.Button14)
+        Me.grpEmmeans.Controls.Add(Me.Button13)
+        Me.grpEmmeans.Controls.Add(Me.Button4)
+        Me.grpEmmeans.Controls.Add(Me.Button5)
+        Me.grpEmmeans.Controls.Add(Me.Button6)
+        Me.grpEmmeans.Controls.Add(Me.Button7)
+        Me.grpEmmeans.Controls.Add(Me.Button8)
+        Me.grpEmmeans.Controls.Add(Me.Button9)
+        Me.grpEmmeans.Controls.Add(Me.Button10)
+        Me.grpEmmeans.Controls.Add(Me.Button11)
+        Me.grpEmmeans.Controls.Add(Me.Button12)
+        Me.grpEmmeans.Location = New System.Drawing.Point(260, 106)
+        Me.grpEmmeans.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.grpEmmeans.Name = "grpEmmeans"
+        Me.grpEmmeans.Padding = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.grpEmmeans.Size = New System.Drawing.Size(282, 142)
+        Me.grpEmmeans.TabIndex = 162
+        Me.grpEmmeans.TabStop = False
+        Me.grpEmmeans.Text = "Emmeans"
+        '
+        'Button1
+        '
+        Me.Button1.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.Button1.Location = New System.Drawing.Point(3, 99)
+        Me.Button1.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.Button1.Name = "Button1"
+        Me.Button1.Size = New System.Drawing.Size(69, 30)
+        Me.Button1.TabIndex = 165
+        Me.Button1.Text = "xtable"
+        Me.Button1.UseVisualStyleBackColor = True
+        '
+        'Button15
+        '
+        Me.Button15.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.Button15.Location = New System.Drawing.Point(209, 70)
+        Me.Button15.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.Button15.Name = "Button15"
+        Me.Button15.Size = New System.Drawing.Size(69, 30)
+        Me.Button15.TabIndex = 164
+        Me.Button15.Text = "test"
+        Me.Button15.UseVisualStyleBackColor = True
+        '
+        'Button14
+        '
+        Me.Button14.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.Button14.Location = New System.Drawing.Point(209, 41)
+        Me.Button14.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.Button14.Name = "Button14"
+        Me.Button14.Size = New System.Drawing.Size(69, 30)
+        Me.Button14.TabIndex = 163
+        Me.Button14.Text = "pairs"
+        Me.Button14.UseVisualStyleBackColor = True
+        '
+        'Button13
+        '
+        Me.Button13.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.Button13.Location = New System.Drawing.Point(209, 12)
+        Me.Button13.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.Button13.Name = "Button13"
+        Me.Button13.Size = New System.Drawing.Size(69, 30)
+        Me.Button13.TabIndex = 162
+        Me.Button13.Text = "refgrid"
+        Me.Button13.UseVisualStyleBackColor = True
+        '
+        'Button4
+        '
+        Me.Button4.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.Button4.Location = New System.Drawing.Point(140, 70)
+        Me.Button4.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.Button4.Name = "Button4"
+        Me.Button4.Size = New System.Drawing.Size(69, 30)
+        Me.Button4.TabIndex = 159
+        Me.Button4.Text = "summary"
+        Me.Button4.UseVisualStyleBackColor = True
+        '
+        'Button5
+        '
+        Me.Button5.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.Button5.Location = New System.Drawing.Point(72, 70)
+        Me.Button5.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.Button5.Name = "Button5"
+        Me.Button5.Size = New System.Drawing.Size(69, 30)
+        Me.Button5.TabIndex = 158
+        Me.Button5.Text = "pwpp"
+        Me.Button5.UseVisualStyleBackColor = True
+        '
+        'Button6
+        '
+        Me.Button6.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.Button6.Location = New System.Drawing.Point(3, 70)
+        Me.Button6.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.Button6.Name = "Button6"
+        Me.Button6.Size = New System.Drawing.Size(69, 30)
+        Me.Button6.TabIndex = 157
+        Me.Button6.Text = "plot"
+        Me.Button6.UseVisualStyleBackColor = True
+        '
+        'Button7
+        '
+        Me.Button7.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.Button7.Location = New System.Drawing.Point(140, 41)
+        Me.Button7.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.Button7.Name = "Button7"
+        Me.Button7.Size = New System.Drawing.Size(69, 30)
+        Me.Button7.TabIndex = 156
+        Me.Button7.Text = "intplot"
+        Me.Button7.UseVisualStyleBackColor = True
+        '
+        'Button8
+        '
+        Me.Button8.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.Button8.Location = New System.Drawing.Point(72, 41)
+        Me.Button8.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.Button8.Name = "Button8"
+        Me.Button8.Size = New System.Drawing.Size(69, 30)
+        Me.Button8.TabIndex = 155
+        Me.Button8.Text = "contrast"
+        Me.Button8.UseVisualStyleBackColor = True
+        '
+        'Button9
+        '
+        Me.Button9.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.Button9.Location = New System.Drawing.Point(3, 41)
+        Me.Button9.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.Button9.Name = "Button9"
+        Me.Button9.Size = New System.Drawing.Size(69, 30)
+        Me.Button9.TabIndex = 154
+        Me.Button9.Text = "confint"
+        Me.Button9.UseVisualStyleBackColor = True
+        '
+        'Button10
+        '
+        Me.Button10.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.Button10.Location = New System.Drawing.Point(72, 12)
+        Me.Button10.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.Button10.Name = "Button10"
+        Me.Button10.Size = New System.Drawing.Size(69, 30)
+        Me.Button10.TabIndex = 126
+        Me.Button10.Text = "trends"
+        Me.Button10.UseVisualStyleBackColor = True
+        '
+        'Button11
+        '
+        Me.Button11.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.Button11.Location = New System.Drawing.Point(3, 12)
+        Me.Button11.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.Button11.Name = "Button11"
+        Me.Button11.Size = New System.Drawing.Size(69, 30)
+        Me.Button11.TabIndex = 124
+        Me.Button11.Text = "emmeans"
+        Me.Button11.UseVisualStyleBackColor = True
+        '
+        'Button12
+        '
+        Me.Button12.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.Button12.Location = New System.Drawing.Point(140, 12)
+        Me.Button12.Margin = New System.Windows.Forms.Padding(2, 3, 2, 3)
+        Me.Button12.Name = "Button12"
+        Me.Button12.Size = New System.Drawing.Size(69, 30)
+        Me.Button12.TabIndex = 153
+        Me.Button12.Text = "joint"
+        Me.Button12.UseVisualStyleBackColor = True
+        '
+        'cmdRHelpSegmented
+        '
+        Me.cmdRHelpSegmented.AutoSize = True
+        Me.cmdRHelpSegmented.ContextMenuStrip = Me.ContextMenuStripSegmented
+        Me.cmdRHelpSegmented.Location = New System.Drawing.Point(460, 80)
+        Me.cmdRHelpSegmented.Name = "cmdRHelpSegmented"
+        Me.cmdRHelpSegmented.Size = New System.Drawing.Size(68, 23)
+        Me.cmdRHelpSegmented.SplitMenuStrip = Me.ContextMenuStripSegmented
+        Me.cmdRHelpSegmented.TabIndex = 222
+        Me.cmdRHelpSegmented.Text = "R Help"
+        Me.cmdRHelpSegmented.UseVisualStyleBackColor = True
+        '
+        'cmdRHelpExtRemes
+        '
+        Me.cmdRHelpExtRemes.AutoSize = True
+        Me.cmdRHelpExtRemes.ContextMenuStrip = Me.ContextMenuStripExtRemes
+        Me.cmdRHelpExtRemes.Location = New System.Drawing.Point(461, 79)
+        Me.cmdRHelpExtRemes.Name = "cmdRHelpExtRemes"
+        Me.cmdRHelpExtRemes.Size = New System.Drawing.Size(68, 23)
+        Me.cmdRHelpExtRemes.SplitMenuStrip = Me.ContextMenuStripExtRemes
+        Me.cmdRHelpExtRemes.TabIndex = 221
+        Me.cmdRHelpExtRemes.Text = "R Help"
+        Me.cmdRHelpExtRemes.UseVisualStyleBackColor = True
+        '
+        'cmdRHelpGeneral
+        '
+        Me.cmdRHelpGeneral.AutoSize = True
+        Me.cmdRHelpGeneral.ContextMenuStrip = Me.ContextMenuStripGeneral
+        Me.cmdRHelpGeneral.Location = New System.Drawing.Point(460, 80)
+        Me.cmdRHelpGeneral.Name = "cmdRHelpGeneral"
+        Me.cmdRHelpGeneral.Size = New System.Drawing.Size(68, 23)
+        Me.cmdRHelpGeneral.SplitMenuStrip = Me.ContextMenuStripGeneral
+        Me.cmdRHelpGeneral.TabIndex = 220
+        Me.cmdRHelpGeneral.Text = "R Help"
+        Me.cmdRHelpGeneral.UseVisualStyleBackColor = True
+        '
+        'cmdRHelpPrediction
+        '
+        Me.cmdRHelpPrediction.AutoSize = True
+        Me.cmdRHelpPrediction.ContextMenuStrip = Me.ContextMenuStripPrediction
+        Me.cmdRHelpPrediction.Location = New System.Drawing.Point(460, 79)
+        Me.cmdRHelpPrediction.Name = "cmdRHelpPrediction"
+        Me.cmdRHelpPrediction.Size = New System.Drawing.Size(68, 23)
+        Me.cmdRHelpPrediction.SplitMenuStrip = Me.ContextMenuStripPrediction
+        Me.cmdRHelpPrediction.TabIndex = 219
+        Me.cmdRHelpPrediction.Text = "R Help"
+        Me.cmdRHelpPrediction.UseVisualStyleBackColor = True
+        '
+        'ucrTryModelling
+        '
+        Me.ucrTryModelling.AutoSize = True
+        Me.ucrTryModelling.Location = New System.Drawing.Point(2, 285)
+        Me.ucrTryModelling.Margin = New System.Windows.Forms.Padding(4)
+        Me.ucrTryModelling.Name = "ucrTryModelling"
+        Me.ucrTryModelling.RunCommandAsMultipleLines = False
+        Me.ucrTryModelling.Size = New System.Drawing.Size(480, 37)
+        Me.ucrTryModelling.TabIndex = 163
+        '
+        'ucrSaveResult
+        '
+        Me.ucrSaveResult.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrSaveResult.Location = New System.Drawing.Point(10, 319)
+        Me.ucrSaveResult.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
+        Me.ucrSaveResult.Name = "ucrSaveResult"
+        Me.ucrSaveResult.Size = New System.Drawing.Size(277, 24)
+        Me.ucrSaveResult.TabIndex = 35
+        '
+        'ucrChkIncludeArguments
+        '
+        Me.ucrChkIncludeArguments.AutoSize = True
+        Me.ucrChkIncludeArguments.Checked = False
+        Me.ucrChkIncludeArguments.Location = New System.Drawing.Point(445, 12)
+        Me.ucrChkIncludeArguments.Margin = New System.Windows.Forms.Padding(5)
+        Me.ucrChkIncludeArguments.Name = "ucrChkIncludeArguments"
+        Me.ucrChkIncludeArguments.Size = New System.Drawing.Size(130, 23)
+        Me.ucrChkIncludeArguments.TabIndex = 32
+        '
         'ucrInputModels
         '
         Me.ucrInputModels.AddQuotesIfUnrecognised = True
@@ -681,117 +979,29 @@ Partial Class dlgUseModel
         Me.ucrInputComboRPackage.Size = New System.Drawing.Size(122, 21)
         Me.ucrInputComboRPackage.TabIndex = 5
         '
-        'ucrTryModelling
+        'cmdRHelpEmmeans
         '
-        Me.ucrTryModelling.AutoSize = True
-        Me.ucrTryModelling.Location = New System.Drawing.Point(2, 285)
-        Me.ucrTryModelling.Margin = New System.Windows.Forms.Padding(4)
-        Me.ucrTryModelling.Name = "ucrTryModelling"
-        Me.ucrTryModelling.RunCommandAsMultipleLines = False
-        Me.ucrTryModelling.Size = New System.Drawing.Size(480, 37)
-        Me.ucrTryModelling.TabIndex = 163
+        Me.cmdRHelpEmmeans.AutoSize = True
+        Me.cmdRHelpEmmeans.ContextMenuStrip = Me.ContextMenuStripEmmeans
+        Me.cmdRHelpEmmeans.Location = New System.Drawing.Point(460, 79)
+        Me.cmdRHelpEmmeans.Name = "cmdRHelpEmmeans"
+        Me.cmdRHelpEmmeans.Size = New System.Drawing.Size(68, 23)
+        Me.cmdRHelpEmmeans.SplitMenuStrip = Me.ContextMenuStripEmmeans
+        Me.cmdRHelpEmmeans.TabIndex = 223
+        Me.cmdRHelpEmmeans.Text = "R Help"
+        Me.cmdRHelpEmmeans.UseVisualStyleBackColor = True
         '
-        'cmdRHelpPrediction
+        'ContextMenuStripEmmeans
         '
-        Me.cmdRHelpPrediction.AutoSize = True
-        Me.cmdRHelpPrediction.ContextMenuStrip = Me.ContextMenuStripPrediction
-        Me.cmdRHelpPrediction.Location = New System.Drawing.Point(460, 79)
-        Me.cmdRHelpPrediction.Name = "cmdRHelpPrediction"
-        Me.cmdRHelpPrediction.Size = New System.Drawing.Size(68, 23)
-        Me.cmdRHelpPrediction.SplitMenuStrip = Me.ContextMenuStripPrediction
-        Me.cmdRHelpPrediction.TabIndex = 219
-        Me.cmdRHelpPrediction.Text = "R Help"
-        Me.cmdRHelpPrediction.UseVisualStyleBackColor = True
+        Me.ContextMenuStripEmmeans.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuEmmeans})
+        Me.ContextMenuStripEmmeans.Name = "ContextMenuStrip1"
+        Me.ContextMenuStripEmmeans.Size = New System.Drawing.Size(127, 26)
         '
-        'ContextMenuStripPrediction
+        'ToolStripMenuEmmeans
         '
-        Me.ContextMenuStripPrediction.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuPrediction})
-        Me.ContextMenuStripPrediction.Name = "ContextMenuStrip1"
-        Me.ContextMenuStripPrediction.Size = New System.Drawing.Size(129, 26)
-        '
-        'ToolStripMenuPrediction
-        '
-        Me.ToolStripMenuPrediction.Name = "ToolStripMenuPrediction"
-        Me.ToolStripMenuPrediction.Size = New System.Drawing.Size(128, 22)
-        Me.ToolStripMenuPrediction.Text = "prediction"
-        '
-        'cmdRHelpGeneral
-        '
-        Me.cmdRHelpGeneral.AutoSize = True
-        Me.cmdRHelpGeneral.ContextMenuStrip = Me.ContextMenuStripGeneral
-        Me.cmdRHelpGeneral.Location = New System.Drawing.Point(460, 80)
-        Me.cmdRHelpGeneral.Name = "cmdRHelpGeneral"
-        Me.cmdRHelpGeneral.Size = New System.Drawing.Size(68, 23)
-        Me.cmdRHelpGeneral.SplitMenuStrip = Me.ContextMenuStripGeneral
-        Me.cmdRHelpGeneral.TabIndex = 220
-        Me.cmdRHelpGeneral.Text = "R Help"
-        Me.cmdRHelpGeneral.UseVisualStyleBackColor = True
-        '
-        'ContextMenuStripGeneral
-        '
-        Me.ContextMenuStripGeneral.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuStats, Me.ToolStripMenuCar})
-        Me.ContextMenuStripGeneral.Name = "ContextMenuStrip1"
-        Me.ContextMenuStripGeneral.Size = New System.Drawing.Size(99, 48)
-        '
-        'ToolStripMenuStats
-        '
-        Me.ToolStripMenuStats.Name = "ToolStripMenuStats"
-        Me.ToolStripMenuStats.Size = New System.Drawing.Size(98, 22)
-        Me.ToolStripMenuStats.Text = "stats"
-        '
-        'ToolStripMenuCar
-        '
-        Me.ToolStripMenuCar.Name = "ToolStripMenuCar"
-        Me.ToolStripMenuCar.Size = New System.Drawing.Size(98, 22)
-        Me.ToolStripMenuCar.Text = "car"
-        '
-        'cmdRHelpExtRemes
-        '
-        Me.cmdRHelpExtRemes.AutoSize = True
-        Me.cmdRHelpExtRemes.ContextMenuStrip = Me.ContextMenuStripExtRemes
-        Me.cmdRHelpExtRemes.Location = New System.Drawing.Point(461, 79)
-        Me.cmdRHelpExtRemes.Name = "cmdRHelpExtRemes"
-        Me.cmdRHelpExtRemes.Size = New System.Drawing.Size(68, 23)
-        Me.cmdRHelpExtRemes.SplitMenuStrip = Me.ContextMenuStripExtRemes
-        Me.cmdRHelpExtRemes.TabIndex = 221
-        Me.cmdRHelpExtRemes.Text = "R Help"
-        Me.cmdRHelpExtRemes.UseVisualStyleBackColor = True
-        '
-        'ContextMenuStripExtRemes
-        '
-        Me.ContextMenuStripExtRemes.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuExtRemes})
-        Me.ContextMenuStripExtRemes.Name = "ContextMenuStrip1"
-        Me.ContextMenuStripExtRemes.Size = New System.Drawing.Size(126, 26)
-        '
-        'ToolStripMenuExtRemes
-        '
-        Me.ToolStripMenuExtRemes.Name = "ToolStripMenuExtRemes"
-        Me.ToolStripMenuExtRemes.Size = New System.Drawing.Size(125, 22)
-        Me.ToolStripMenuExtRemes.Text = "extRemes"
-        '
-        'cmdRHelpSegmented
-        '
-        Me.cmdRHelpSegmented.AutoSize = True
-        Me.cmdRHelpSegmented.ContextMenuStrip = Me.ContextMenuStripSegmented
-        Me.cmdRHelpSegmented.Location = New System.Drawing.Point(460, 80)
-        Me.cmdRHelpSegmented.Name = "cmdRHelpSegmented"
-        Me.cmdRHelpSegmented.Size = New System.Drawing.Size(68, 23)
-        Me.cmdRHelpSegmented.SplitMenuStrip = Me.ContextMenuStripSegmented
-        Me.cmdRHelpSegmented.TabIndex = 222
-        Me.cmdRHelpSegmented.Text = "R Help"
-        Me.cmdRHelpSegmented.UseVisualStyleBackColor = True
-        '
-        'ContextMenuStripSegmented
-        '
-        Me.ContextMenuStripSegmented.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuSegmented})
-        Me.ContextMenuStripSegmented.Name = "ContextMenuStrip1"
-        Me.ContextMenuStripSegmented.Size = New System.Drawing.Size(134, 26)
-        '
-        'ToolStripMenuSegmented
-        '
-        Me.ToolStripMenuSegmented.Name = "ToolStripMenuSegmented"
-        Me.ToolStripMenuSegmented.Size = New System.Drawing.Size(133, 22)
-        Me.ToolStripMenuSegmented.Text = "segmented"
+        Me.ToolStripMenuEmmeans.Name = "ToolStripMenuEmmeans"
+        Me.ToolStripMenuEmmeans.Size = New System.Drawing.Size(126, 22)
+        Me.ToolStripMenuEmmeans.Text = "emmeans"
         '
         'dlgUseModel
         '
@@ -799,6 +1009,8 @@ Partial Class dlgUseModel
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
         Me.AutoSize = True
         Me.ClientSize = New System.Drawing.Size(582, 423)
+        Me.Controls.Add(Me.grpEmmeans)
+        Me.Controls.Add(Me.cmdRHelpEmmeans)
         Me.Controls.Add(Me.cmdRHelpSegmented)
         Me.Controls.Add(Me.cmdRHelpExtRemes)
         Me.Controls.Add(Me.cmdRHelpGeneral)
@@ -832,6 +1044,8 @@ Partial Class dlgUseModel
         Me.ContextMenuStripGeneral.ResumeLayout(False)
         Me.ContextMenuStripExtRemes.ResumeLayout(False)
         Me.ContextMenuStripSegmented.ResumeLayout(False)
+        Me.grpEmmeans.ResumeLayout(False)
+        Me.ContextMenuStripEmmeans.ResumeLayout(False)
         Me.ResumeLayout(False)
         Me.PerformLayout()
 
@@ -903,4 +1117,21 @@ Partial Class dlgUseModel
     Friend WithEvents ToolStripMenuExtRemes As ToolStripMenuItem
     Friend WithEvents ContextMenuStripSegmented As ContextMenuStrip
     Friend WithEvents ToolStripMenuSegmented As ToolStripMenuItem
+    Friend WithEvents grpEmmeans As GroupBox
+    Friend WithEvents Button4 As Button
+    Friend WithEvents Button5 As Button
+    Friend WithEvents Button6 As Button
+    Friend WithEvents Button7 As Button
+    Friend WithEvents Button8 As Button
+    Friend WithEvents Button9 As Button
+    Friend WithEvents Button10 As Button
+    Friend WithEvents Button11 As Button
+    Friend WithEvents Button12 As Button
+    Friend WithEvents Button1 As Button
+    Friend WithEvents Button15 As Button
+    Friend WithEvents Button14 As Button
+    Friend WithEvents Button13 As Button
+    Friend WithEvents cmdRHelpEmmeans As ucrSplitButton
+    Friend WithEvents ContextMenuStripEmmeans As ContextMenuStrip
+    Friend WithEvents ToolStripMenuEmmeans As ToolStripMenuItem
 End Class

--- a/instat/dlgUseModel.resx
+++ b/instat/dlgUseModel.resx
@@ -117,16 +117,19 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="ContextMenuStripSegmented.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>656, 17</value>
-  </metadata>
-  <metadata name="ContextMenuStripExtRemes.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>444, 17</value>
+  <metadata name="ContextMenuStripPrediction.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>229, 18</value>
   </metadata>
   <metadata name="ContextMenuStripGeneral.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <metadata name="ContextMenuStripPrediction.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>229, 18</value>
+  <metadata name="ContextMenuStripExtRemes.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>444, 17</value>
+  </metadata>
+  <metadata name="ContextMenuStripSegmented.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>671, 19</value>
+  </metadata>
+  <metadata name="ContextMenuStripEmmeans.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>29, 49</value>
   </metadata>
 </root>

--- a/instat/dlgUseModel.vb
+++ b/instat/dlgUseModel.vb
@@ -532,4 +532,103 @@ Public Class dlgUseModel
         OpenHelpPage()
     End Sub
 
+    Private Sub cmdEmmeans_Click(sender As Object, e As EventArgs) Handles cmdEmmeans.Click
+        Clear()
+        If ucrChkIncludeArguments.Checked Then
+            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("emmeans::emmeans(obj= , specs =~ , by = NULL )", 23)
+        Else
+            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("emmeans::emmeans( , specs =~ )", 11)
+        End If
+    End Sub
+
+    Private Sub cmdJoint_Click(sender As Object, e As EventArgs) Handles cmdJoint.Click
+        Clear()
+        If ucrChkIncludeArguments.Checked Then
+            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("emmeans::joint_tests(obj= , by = NULL, show0df = FALSE, showconf=TRUE, cov.reduce=make.meanint(1))", 70)
+        Else
+            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("emmeans::joint_tests( )", 1)
+        End If
+    End Sub
+
+    Private Sub cmdRefgrid_Click(sender As Object, e As EventArgs) Handles cmdRefgrid.Click
+        Clear()
+        If ucrChkIncludeArguments.Checked Then
+            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("emmeans::ref_grid(obj= , cov.reduce = mean)", 20)
+        Else
+            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("emmeans::ref_grid( )", 1)
+        End If
+    End Sub
+
+    Private Sub cmdEmmeanConfint_Click(sender As Object, e As EventArgs) Handles cmdEmmeanConfint.Click
+        Clear()
+        If ucrChkIncludeArguments.Checked Then
+            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("confint(obj= , level = 0.95)", 15)
+        Else
+            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("confint( )", 1)
+        End If
+    End Sub
+
+    Private Sub cmdContrast_Click(sender As Object, e As EventArgs) Handles cmdContrast.Click
+        Clear()
+        If ucrChkIncludeArguments.Checked Then
+            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("emmeans::contrast(obj= )", 1)
+        Else
+            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("emmeans::contrast( )", 1)
+        End If
+    End Sub
+
+    Private Sub cmdIntplot_Click(sender As Object, e As EventArgs) Handles cmdIntplot.Click
+        Clear()
+        If ucrChkIncludeArguments.Checked Then
+            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("emmeans::emmip(obj= , formula = ~ , CIs = FALSE, PIs = TRUE, plotit = TRUE)", 55)
+        Else
+            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("emmeans::emmip( , formula = ~ )", 15)
+        End If
+    End Sub
+
+    Private Sub cmdPairs_Click(sender As Object, e As EventArgs) Handles cmdPairs.Click
+        Clear()
+        If ucrChkIncludeArguments.Checked Then
+            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("pairs(obj= )", 1)
+        Else
+            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("pairs( )", 1)
+        End If
+    End Sub
+
+    Private Sub cmdEmmeansPlot_Click(sender As Object, e As EventArgs) Handles cmdEmmeansPlot.Click
+        Clear()
+        If ucrChkIncludeArguments.Checked Then
+            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("emmeans::plot(obj= , by=NULL, comparisons = TRUE, horizontal = FALSE, colors = ""darkgreen"")", 73)
+        Else
+            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("emmeans::plot( )", 1)
+        End If
+    End Sub
+
+    Private Sub cmdpwpp_Click(sender As Object, e As EventArgs) Handles cmdpwpp.Click
+        Clear()
+        If ucrChkIncludeArguments.Checked Then
+            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("emmeans::plot(obj= , method = ""trt.vs.ctrll"", type = ""response"", method = "">"")", 65)
+        Else
+            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("emmeans::pwpp( )", 1)
+        End If
+    End Sub
+
+    Private Sub cmdEmmeansSummary_Click(sender As Object, e As EventArgs) Handles cmdEmmeansSummary.Click
+        Clear()
+        If ucrChkIncludeArguments.Checked Then
+            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("emmeans::summary(obj= , infer = c(TRUE, TRUE ), adjust = ""scheffe"")", 47)
+        Else
+            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("emmeans::summary( )", 1)
+        End If
+    End Sub
+
+    Private Sub cmdTest_Click(sender As Object, e As EventArgs) Handles cmdTest.Click
+        Clear()
+        If ucrChkIncludeArguments.Checked Then
+            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("emmeans::plot(obj= , joint = TRUE, verbose = TRUE)", 47)
+        Else
+            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("emmeans::test( )", 1)
+        End If
+    End Sub
+
 End Class

--- a/instat/dlgUseModel.vb
+++ b/instat/dlgUseModel.vb
@@ -52,7 +52,7 @@ Public Class dlgUseModel
         ucrReceiverForTestColumn.Selector = ucrSelectorUseModel
         ucrReceiverForTestColumn.SetMeAsReceiver()
 
-        ucrInputComboRPackage.SetItems({"General", "Prediction", "extRemes", "segmented"})
+        ucrInputComboRPackage.SetItems({"General", "Prediction", "extRemes", "segmented", "emmeans"})
         ucrInputComboRPackage.SetDropDownStyleAsNonEditable()
 
         ucrTryModelling.SetReceiver(ucrReceiverForTestColumn)
@@ -198,6 +198,7 @@ Public Class dlgUseModel
         grpPrediction.Visible = False
         grpExtrRemes.Visible = False
         grpSegmented.Visible = False
+        grpEmmeans.Visible = False
         Select Case ucrInputComboRPackage.GetText
             Case "General"
                 grpGeneral.Visible = True
@@ -205,24 +206,35 @@ Public Class dlgUseModel
                 cmdRHelpExtRemes.Visible = False
                 cmdRHelpPrediction.Visible = False
                 cmdRHelpSegmented.Visible = False
+                cmdRHelpEmmeans.Visible = False
             Case "Prediction"
                 grpPrediction.Visible = True
                 cmdRHelpGeneral.Visible = False
                 cmdRHelpExtRemes.Visible = False
                 cmdRHelpPrediction.Visible = True
                 cmdRHelpSegmented.Visible = False
+                cmdRHelpEmmeans.Visible = False
             Case "extRemes"
                 grpExtrRemes.Visible = True
                 cmdRHelpGeneral.Visible = False
                 cmdRHelpExtRemes.Visible = True
                 cmdRHelpPrediction.Visible = False
                 cmdRHelpSegmented.Visible = False
+                cmdRHelpEmmeans.Visible = False
             Case "segmented"
                 grpSegmented.Visible = True
                 cmdRHelpGeneral.Visible = False
                 cmdRHelpExtRemes.Visible = False
                 cmdRHelpPrediction.Visible = False
                 cmdRHelpSegmented.Visible = True
+                cmdRHelpEmmeans.Visible = False
+            Case "emmeans"
+                grpEmmeans.Visible = True
+                cmdRHelpEmmeans.Visible = True
+                cmdRHelpGeneral.Visible = False
+                cmdRHelpExtRemes.Visible = False
+                cmdRHelpPrediction.Visible = False
+                cmdRHelpSegmented.Visible = False
         End Select
     End Sub
 
@@ -398,7 +410,7 @@ Public Class dlgUseModel
         End If
     End Sub
 
-        Private Sub OpenHelpPage()
+    Private Sub OpenHelpPage()
         If Not String.IsNullOrEmpty(strPackageName) Then
             frmMaximiseOutput.Show(strFileName:=clsFileUrlUtilities.GetHelpFileURL(strPackageName:=strPackageName), bReplace:=False)
         End If
@@ -512,4 +524,12 @@ Public Class dlgUseModel
         End If
         OpenHelpPage()
     End Sub
+
+    Private Sub cmdRHelpEmmeans_Click(sender As Object, e As EventArgs) Handles cmdRHelpEmmeans.Click, ToolStripMenuEmmeans.Click
+        If ucrInputComboRPackage.GetText = "emmeans" Then
+            strPackageName = "emmeans"
+        End If
+        OpenHelpPage()
+    End Sub
+
 End Class

--- a/instat/dlgUseModel.vb
+++ b/instat/dlgUseModel.vb
@@ -535,16 +535,25 @@ Public Class dlgUseModel
     Private Sub cmdEmmeans_Click(sender As Object, e As EventArgs) Handles cmdEmmeans.Click
         Clear()
         If ucrChkIncludeArguments.Checked Then
-            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("emmeans::emmeans(obj= , specs =~ , by = NULL )", 23)
+            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("emmeans::emmeans(obj= , specs =~ , by = NULL )", 24)
         Else
-            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("emmeans::emmeans( , specs =~ )", 11)
+            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("emmeans::emmeans( , specs =~ )", 12)
+        End If
+    End Sub
+
+    Private Sub cmdTrends_Click(sender As Object, e As EventArgs) Handles cmdTrends.Click
+        Clear()
+        If ucrChkIncludeArguments.Checked Then
+            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("emmeans::emmeans(obj= , var = )", 9)
+        Else
+            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("emmeans::emtrends( , var = )", 9)
         End If
     End Sub
 
     Private Sub cmdJoint_Click(sender As Object, e As EventArgs) Handles cmdJoint.Click
         Clear()
         If ucrChkIncludeArguments.Checked Then
-            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("emmeans::joint_tests(obj= , by = NULL, show0df = FALSE, showconf=TRUE, cov.reduce=make.meanint(1))", 70)
+            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("emmeans::joint_tests(obj= , by = NULL, show0df = FALSE, showconf=TRUE, cov.reduce=make.meanint(1))", 72)
         Else
             ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("emmeans::joint_tests( )", 1)
         End If
@@ -598,16 +607,16 @@ Public Class dlgUseModel
     Private Sub cmdEmmeansPlot_Click(sender As Object, e As EventArgs) Handles cmdEmmeansPlot.Click
         Clear()
         If ucrChkIncludeArguments.Checked Then
-            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("emmeans::plot(obj= , by=NULL, comparisons = TRUE, horizontal = FALSE, colors = ""darkgreen"")", 73)
+            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("plot(obj= , by=NULL, comparisons = TRUE, horizontal = FALSE, colors = ""darkgreen"")", 73)
         Else
-            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("emmeans::plot( )", 1)
+            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("plot( )", 1)
         End If
     End Sub
 
     Private Sub cmdpwpp_Click(sender As Object, e As EventArgs) Handles cmdpwpp.Click
         Clear()
         If ucrChkIncludeArguments.Checked Then
-            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("emmeans::plot(obj= , method = ""trt.vs.ctrll"", type = ""response"", method = "">"")", 65)
+            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("emmeans::plot(obj= , method = ""trt.vs.ctrll"", type = ""response"", method = "">"")", 60)
         Else
             ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("emmeans::pwpp( )", 1)
         End If
@@ -616,18 +625,27 @@ Public Class dlgUseModel
     Private Sub cmdEmmeansSummary_Click(sender As Object, e As EventArgs) Handles cmdEmmeansSummary.Click
         Clear()
         If ucrChkIncludeArguments.Checked Then
-            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("emmeans::summary(obj= , infer = c(TRUE, TRUE ), adjust = ""scheffe"")", 47)
+            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("summary(obj= , infer = c(TRUE, TRUE ), adjust = ""scheffe"")", 45)
         Else
-            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("emmeans::summary( )", 1)
+            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("summary( )", 1)
         End If
     End Sub
 
     Private Sub cmdTest_Click(sender As Object, e As EventArgs) Handles cmdTest.Click
         Clear()
         If ucrChkIncludeArguments.Checked Then
-            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("emmeans::plot(obj= , joint = TRUE, verbose = TRUE)", 47)
+            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("emmeans::test(obj= , joint = TRUE, verbose = TRUE)", 32)
         Else
             ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("emmeans::test( )", 1)
+        End If
+    End Sub
+
+    Private Sub cmdXtable_Click(sender As Object, e As EventArgs) Handles cmdXtable.Click
+        Clear()
+        If ucrChkIncludeArguments.Checked Then
+            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("xtable::xtable(obj = , caption = NULL, label = NULL, align = NULL,digits = 4, display = NULL, auto = FALSE)", 85)
+        Else
+            ucrReceiverForTestColumn.AddToReceiverAtCursorPosition("xtable::xtable( )", 1)
         End If
     End Sub
 


### PR DESCRIPTION
fixes partly #8546 
This PR is ready for review. 

The emmeans keyboard can be found in Model > use Model > use Model Keyboard
the keys added are;
emmeans,  trends, joint, refgrid
confint, contrast, intplot, pairs
plot, pwpp, summary, test, xTable in that particular order. 
dataset to be used for this keyboard must be `.lm`, `.emm`, `.glm`
@rdstern would it be ok to add tooltips to this keyboard? 
@lilyclements can you review this
Thanks 