### PR TITLE
Fixing the issue on where R-Instat looks for packages

### DIFF
--- a/instat/static/InstatObject/R/InstallPackages.R
+++ b/instat/static/InstatObject/R/InstallPackages.R
@@ -156,6 +156,9 @@ packs <- c("abind", "agricolae", "agridat",
 
 install.packages(packs, dependencies = FALSE, repos='https://cloud.r-project.org', type="win.binary")
 
+# Only use internal library
+if (length(.libPaths()) == 2) .libPaths(.libPaths()[2])
+
 #install development packages not on CRAN
 devtools::install_github("ianmoran11/mmtable2")
 devtools::install_github("michael-franke/aida-package")


### PR DESCRIPTION
@rdstern @ChrisMarsh82 this PR is attempting to fix the issue #9109 on where R-Instat looks for package. I have added
`if (length(.libPaths()) == 2) .libPaths(.libPaths()[2])` in the `installPackages.R` to specify the library after installation of R-Instat to looks for it packages by default. This can be tested only after creating a test release and I'm planning to do that once this PR is merged.