### PR TITLE
Additional library for R-Instat

### DIFF
--- a/instat/static/InstatObject/R/InstallPackages.R
+++ b/instat/static/InstatObject/R/InstallPackages.R
@@ -1,6 +1,13 @@
 Sys.setenv(TZ='GMT')
 Sys.setlocale("LC_TIME", "C")
 
+# Define the custom package library path (in AppData, no admin rights needed)
+app_data_lib <- file.path(Sys.getenv("APPDATA"), "R-Instat", "library")
+dir.create(app_data_lib, recursive = TRUE, showWarnings = FALSE)
+
+# Add the custom library path to .libPaths() for installing user-level packages
+.libPaths(c(app_data_lib, .libPaths()))
+
 #Install packages from CRAN archive
 install.packages("http://cran.r-project.org/src/contrib/Archive/signmedian.test/signmedian.test_1.5.1.tar.gz", repos=NULL, type="source")
 
@@ -157,7 +164,10 @@ packs <- c("abind", "agricolae", "agridat",
 install.packages(packs, dependencies = FALSE, repos='https://cloud.r-project.org', type="win.binary")
 
 # Only use internal library
-if (length(.libPaths()) == 2) .libPaths(.libPaths()[2])
+if (length(.libPaths()) >= 2){
+  current_paths <- .libPaths()
+  current_paths[c(1, 2) <= length(current_paths)]
+}
 
 #install development packages not on CRAN
 devtools::install_github("ianmoran11/mmtable2")


### PR DESCRIPTION
Fixes #7064
@ChrisMarsh82 As discussed yesterday,, I added an additional package directory to R-Instat where no administrator privilege will be required. The directory will be located in something like `C:\Users\Antoine\AppData\Roaming\R-Instat\library`.
@rdstern @ChrisMarsh82 this will need a new release to be able to test. I also made sure that R-Instat looks for package in the two libraries i.e the one in something like `C:\Program Files\R-Instat\0.7.9\static\R\library` and `C:\Users\Antoine\AppData\Roaming\R-Instat\library`.