### PR TITLE
Corrected the Autofilling in the Fill Date Gaps Dialog

### DIFF
--- a/instat/dlgInfill.vb
+++ b/instat/dlgInfill.vb
@@ -42,7 +42,6 @@ Public Class dlgInfill
         SetHelpOptions()
         bReset = False
         autoTranslate(Me)
-        AutoFillStation()
     End Sub
 
     Private Sub InitialiseDialog()


### PR DESCRIPTION
Fixes #9271
@rdstern I Fixed the auto-filling issue with the station receiver but unfortunately i can say what was the cause of this issue. I tried to create a date column to check if the error was linked to the metadata. Unfortunately I couldn't go through with it because when I went back to the Fill Gaps dialog it crashed my machine. Maybe because of this notification that appears and disappears as it pleases or because the data isn't daily? In short, I haven't been able to determine the cause of the error.  

![image](https://github.com/user-attachments/assets/8f5a0329-13d7-40b7-883c-47c0f7b95929)
