### PR TITLE
Improving the additional libPaths

### DIFF
--- a/instat/frmMain.vb
+++ b/instat/frmMain.vb
@@ -414,18 +414,15 @@ Public Class frmMain
                 Directory.CreateDirectory(strLibraryPath)
             End If
 
+
             'To ensure this part of the code only runs when the application Is Not in the Debug mode (i.e., in Release mode)
 #If Not DEBUG Then
-            ' Add the custom library path to R's .libPaths for user-level package installation
-            Dim strScript As String = $".libPaths(c('{strLibraryPath.Replace("\", "/")}', .libPaths()))" & Environment.NewLine &
-                   "if (length(.libPaths()) > 2) {
-                         current_paths <- .libPaths()
-                         valid_indices <- c(1, 3)[c(1, 3) <= length(current_paths)]
-                         .libPaths(current_paths[valid_indices])
-                   }"
+                     Dim clsSetLibPathsFunction As New RFunction
+            clsSetLibPathsFunction.SetRCommand("set_library_paths")
+            clsSetLibPathsFunction.AddParameter("library_path", Chr(34) & strLibraryPath.Replace("\", "/") & Chr(34))
 
             ' Execute the R script to update the library paths
-            clsRLink.RunScript(strScript:=strScript, bSeparateThread:=False, bSilent:=False)
+            clsRLink.RunScript(strScript:=clsSetLibPathsFunction.ToScript, bSeparateThread:=False, bSilent:=False)
 #End If
         Catch ex As Exception
             ' Handle potential errors (e.g., directory creation failure)

--- a/instat/static/InstatObject/R/stand_alone_functions.R
+++ b/instat/static/InstatObject/R/stand_alone_functions.R
@@ -3430,3 +3430,20 @@ time_operation <- function(expr) {
   timing <- system.time(expr)
   print(timing)
 }
+
+set_library_paths <- function(library_path) {
+  # Update the library paths
+  .libPaths(c(library_path, .libPaths()))
+  
+  # Check if there are more than 2 library paths
+  if (length(.libPaths()) > 2) {
+    # Get the current library paths
+    current_paths <- .libPaths()
+    
+    # Select valid indices (1 and 3) only if they exist
+    valid_indices <- c(1, 3)[c(1, 3) <= length(current_paths)]
+    
+    # Set the library paths to the valid ones
+    .libPaths(current_paths[valid_indices])
+  }
+}


### PR DESCRIPTION
Fixes partially #9314
@rdstern @ChrisMarsh82, as pointed by @rdstern in the issue, when you install/update new packages they go to the user library i.e. `C:/Users/rdste/AppData/Roaming/R-Instat/library`. Packages here persist across updates of R-Instat unless explicitly removed by deleting the folder.
This PR ensures that a separate directory is created for each version of R-Instat in the Roaming folder `(e.g., C:/Users/rdste/AppData/Roaming/R-Instat/0.8.0b/library)`, also that packages from previous versions don't interfere with the new ones. When updating R-Instat, you would then install new packages in the corresponding version-specific library, keeping older versions isolated.