### PR TITLE
Added missing themes for ggplot2 graphs

### DIFF
--- a/instat/clsGgplotDefaults.vb
+++ b/instat/clsGgplotDefaults.vb
@@ -67,7 +67,7 @@ Public Class GgplotDefaults
         Get
             Dim strTemp As String()
             'TODO need to make proper functions and set package names
-            strTemp = {"theme_bw", "theme_linedraw", "theme_light", "theme_minimal", "theme_classic", "theme_dark", "theme_void", "theme_base", "theme_calc", "theme_economist", "theme_few", "theme_fivethirtyeight", "theme_foundation", "theme_grey", "theme_gdocs", "theme_igray", "theme_map", "theme_par", "theme_solarized", "theme_hc", "theme_pander", "theme_solid", "theme_stata", "theme_tufte", "theme_wsj", "theme_excel", "theme_excel_new", "theme_economist_white", "theme_solarized_2", "theme_get", "theme_replace", "theme_test", "theme_set", "theme_update", "reset_theme_settings"}
+            strTemp = {"theme_bw", "theme_linedraw", "theme_light", "theme_minimal", "theme_classic", "theme_dark", "theme_void", "theme_base", "theme_calc", "theme_economist", "theme_few", "theme_fivethirtyeight", "theme_foundation", "theme_grey", "theme_gdocs", "theme_igray", "theme_map", "theme_par", "theme_solarized", "theme_hc", "theme_pander", "theme_solid", "theme_stata", "theme_tufte", "theme_wsj", "theme_excel", "theme_excel_new", "theme_economist_white", "theme_solarized_2", "reset_theme_settings"}
             System.Array.Sort(Of String)(strTemp)
             Return strTemp
         End Get


### PR DESCRIPTION
Fixes #9332 

@rdstern @N-thony , added `theme_excel` and `theme_excel_new` for excel themes, `theme_solarized_2`for the Solarized  palette, `theme_economist_white` which approximates the style of the 'Economist' and theme Settings Functions; `theme_update, theme_replace, theme_get, theme_test` and `reset_theme_settings`