### PR TITLE
Reordered getPass Package Installation to Ensure Dependencies Are Installed First

### DIFF
--- a/instat/static/InstatObject/R/InstallPackages.R
+++ b/instat/static/InstatObject/R/InstallPackages.R
@@ -3,7 +3,6 @@ Sys.setlocale("LC_TIME", "C")
 
 #Install packages from CRAN archive
 install.packages("http://cran.r-project.org/src/contrib/Archive/signmedian.test/signmedian.test_1.5.1.tar.gz", repos=NULL, type="source")
-install.packages("https://cran.r-project.org/src/contrib/Archive/getPass/getPass_0.2-2.tar.gz", repos=NULL, type="source")
 
 #Install packages from win.binary
 install.packages("stringi", dependencies = FALSE,  repos='https://cloud.r-project.org', type = "win.binary")
@@ -115,6 +114,8 @@ packs <- c("abind", "agricolae", "agridat", "agriTutorial",
            "zoo", "Zseq", "zyp")
 
 install.packages(packs, dependencies = FALSE, repos='https://cloud.r-project.org', type="win.binary")
+
+install.packages("https://cran.r-project.org/src/contrib/Archive/getPass/getPass_0.2-2.tar.gz", repos=NULL, type="source")
 
 # Only use internal library
 if (length(.libPaths()) >= 2){


### PR DESCRIPTION
@ChrisMarsh82 this is ready now. It requires rstudioapi which will be installed first.