### PR TITLE
Added the reset function to the sections in the tricot define dialog

### DIFF
--- a/instat/dlgDefineTricotData.vb
+++ b/instat/dlgDefineTricotData.vb
@@ -149,6 +149,8 @@ Public Class dlgDefineTricotData
         ' resetting ucrChks
         ucrChkDefineIDLevel.Checked = False
         ucrChkDefineVarietyLevel.Checked = False
+        ucrSelectorIDLevelData.Reset()
+        ucrSelectorVarietyLevelData.Reset()
 
         ucrReceiverIDVarietyLevelID.SetMeAsReceiver()
         ucrReceiverLevelID.SetMeAsReceiver()


### PR DESCRIPTION
Fixes partly #9667
@lilyclements @rdstern @rachelkg @Ag-Derek
I realized that the reset works for the single receivers but because of the autofill functionality, they are filled again after a reset. However, the multiple receivers were not being reset. I have done that now. Hence, after clicking the reset button, the single receivers are auto-filled, and the multiple receivers are cleared. I'd like to believe that's how it's expected to work else kindly prompt me to redo it. Thank you. 