### PR TITLE
Added a comma to the rep function

### DIFF
--- a/instat/dlgEnter.vb
+++ b/instat/dlgEnter.vb
@@ -224,7 +224,7 @@ Public Class dlgEnter
     Private Sub cmdRepelicationFunction_Click_1(sender As Object, e As EventArgs) Handles cmdRepelicationFunction.Click
         If chkShowEnterArguments.Checked Then
             ucrReceiverForEnterCalculation.AddToReceiverAtCursorPosition("rep(x = , times = , length = , each = )", 32)
-        Else ucrReceiverForEnterCalculation.AddToReceiverAtCursorPosition("rep( )", 2)
+        Else ucrReceiverForEnterCalculation.AddToReceiverAtCursorPosition("rep( , )", 4)
         End If
         TestOKEnabled()
     End Sub


### PR DESCRIPTION
@rdstern and @lilyclements 

As noted last week, I have added a comma in the Prepare > Column::Numeric > Enter dialog rep function, to make the function user friendly.