### PR TITLE
Modify error message for GitHub package retrieval

### DIFF
--- a/instat/dlgRPackages.vb
+++ b/instat/dlgRPackages.vb
@@ -182,7 +182,7 @@ Public Class dlgInstallRPackage
                     ucrInputMessage.SetText("Package exists and not currently installed.")
                     ucrInputMessage.txtInput.BackColor = Color.LightGreen
                 ElseIf rdoRPackage.Checked Then
-                    ucrInputMessage.SetText("Unable to retrieve from GitHub. Check internet connection? OK is enabled, but package may not install. Try to change to a different internet if it fails again.")
+                    ucrInputMessage.SetText("Unable to retrieve from GitHub. Check internet connection? OK is enabled, but package may not install. Try to change to a different internet if installation fails.")
                     ucrInputMessage.txtInput.BackColor = Color.Gold
                     bUniqueChecked = True
                 End If


### PR DESCRIPTION
Updated message for GitHub retrieval error to indicate that the package may not install even if OK is enabled.

Fixes #10023