### PR TITLE
Fixed QC Rainfall - Issue if Month is not a factor

### DIFF
--- a/instat/sdgSelectMonth.vb
+++ b/instat/sdgSelectMonth.vb
@@ -55,7 +55,8 @@ Public Class sdgSelectMonth
 
                 ' Show popup message instead
                 MsgBox(GetTranslation("Month variable is numeric and has no month labels." & vbCrLf &
-                                  "Convert Month to a factor (e.g., via Climatic > Dates > Use Date)."),
+                                  "Convert Month to a factor (e.g., via Climatic > Dates > Use Date)." & vbCrLf & vbCrLf &
+                                  "Tip: If you converted a column type before running this, click Reset first."),
                    MsgBoxStyle.Exclamation,
                    GetTranslation("Variable Type Warning"))
             End If


### PR DESCRIPTION
Fixes #10036 
I have added the display helper text which will display when the Month column is not a factor in the omit button of the QC rainfall dialog
@berylwaswa @lilyclements this is ready for review