### PR TITLE
Updating Facet_grid arguments in Scatter Plot

### DIFF
--- a/instat/dlgScatterPlot.vb
+++ b/instat/dlgScatterPlot.vb
@@ -768,14 +768,6 @@ Public Class dlgScatterPlot
                 Select Case ucrInputStation.GetText()
                     Case strFacetWrap
                         GetParameterValue(clsFacetVariablesOperator)
-                    Case strFacetCol, strFacetColAll, strFacetRow, strFacetRowAll
-                        Dim i As Integer = clsGroupByFunction.iParameterCount
-                        For Each clsTempParam As RParameter In clsVarsFunction.clsParameters
-                            If clsTempParam.strArgumentValue <> "" AndAlso clsTempParam.strArgumentValue <> "." Then
-                                clsGroupByFunction.AddParameter(i, clsTempParam.strArgumentValue, bIncludeArgumentName:=False, iPosition:=i)
-                                i = i + 1
-                            End If
-                        Next
                 End Select
             End If
 


### PR DESCRIPTION
Fixes partially #10031

@ARMSTRONGOPONDO you can have a look at how I updated the functions here. This doesn't interfere with the subdialog linking.

@lilyclements how are the new arguments supposed to treat the second variable when a user fills it in the subdialog? At the moment, it gets ignored not unless using facet_wrap