### PR TITLE
Fixed bug found in the Restore Backup dialog

### DIFF
--- a/instat/dlgRestoreBackup.vb
+++ b/instat/dlgRestoreBackup.vb
@@ -207,13 +207,13 @@ Public Class dlgRestoreBackup
     End Function
 
     Private Sub ucrInputSavedPathData_Leave(sender As Object, e As EventArgs) Handles ucrInputSavedPathData.Leave
-        If Not ucrInputSavedPathData.IsEmpty AndAlso Not String.IsNullOrEmpty(ucrInputSavedPathData.FilePath) Then
+        If Not ucrInputSavedPathData.IsEmpty Then
             frmMain.clsRecentItems.addToMenu(ucrInputSavedPathData.FilePath.Replace("\", "/"))
         End If
     End Sub
 
     Private Sub ucrInputSavedPathLog_Leave(sender As Object, e As EventArgs) Handles ucrInputSavedPathLog.Leave
-        If Not ucrInputSavedPathLog.IsEmpty AndAlso Not String.IsNullOrEmpty(ucrInputSavedPathLog.FilePath) Then
+        If Not ucrInputSavedPathLog.IsEmpty Then
             frmMain.clsRecentItems.addToMenu(ucrInputSavedPathLog.FilePath.Replace("\", "/"))
         End If
     End Sub


### PR DESCRIPTION
Fixes partly #10117
The PR fixes the bug found by @N-thony, when you open the `Restore Backup` dialog and click on browse for the `backup log file` checkbox return but to the dialog without selecting any file and unchecking the `Backup Log file` checkbox which gives an error
see the link below for more details 
https://github.com/IDEMSInternational/R-Instat/issues/10117#issuecomment-3588569490

@N-thony and @rdstern this PR is ready for Review