### PR TITLE
Updating position for After Codes in Start of Rains dialog

### DIFF
--- a/instat/dlgStartofRains.vb
+++ b/instat/dlgStartofRains.vb
@@ -913,7 +913,7 @@ Public Class dlgStartofRains
         ucrBase.clsRsyntax.AddToBeforeCodes(clsConvertColumnTypeFunction, iPosition:=1)
         ucrBase.clsRsyntax.AddToBeforeCodes(clsConvertLinkedVariablesFunction, iPosition:=4)
         ucrBase.clsRsyntax.AddToAfterCodes(clsConvertColumnType1Function, iPosition:=6)
-        ucrBase.clsRsyntax.AddToAfterCodes(clsConvertssndLinkedVariableFunction, iPosition:=9)
+        ucrBase.clsRsyntax.AddToAfterCodes(clsConvertssndLinkedVariableFunction, iPosition:=8)
         SetReceiver()
         ChangeDSValue()
         AdditionalCondition()
@@ -1067,7 +1067,7 @@ Public Class dlgStartofRains
             clsConvertColumnType2Function.AddParameter("col_names", ucrReceiverStation.GetVariableNames(), iPosition:=1)
             ucrBase.clsRsyntax.AddToBeforeCodes(clsStationTypeFunction, iPosition:=2)
             ucrBase.clsRsyntax.AddToBeforeCodes(clsConvertStationtypeFunction, iPosition:=3)
-            ucrBase.clsRsyntax.AddToAfterCodes(clsDeleteunusedrowFunction, iPosition:=8)
+            ucrBase.clsRsyntax.AddToAfterCodes(clsDeleteunusedrowFunction, iPosition:=9)
         Else
             ucrBase.clsRsyntax.RemoveFromAfterCodes(clsDeleteunusedrowFunction)
             ucrBase.clsRsyntax.RemoveFromBeforeCodes(clsStationTypeFunction)
@@ -1454,4 +1454,5 @@ Public Class dlgStartofRains
         clsDefineAsClimatic.AddParameter("types", clsRFunctionParameter:=clsVectorConcat2Function, iPosition:=2)
     End Sub
 End Class
+
 


### PR DESCRIPTION
This is related to `databook` amendments in [182](https://github.com/IDEMSInternational/databook/issues/182)

I have switched the order of the after codes - this means that we now convert to a factor before removing additional levels that were created by the `.drop  = FALSE` portion of the code.

Removing additional levels runs the `calculate_summary` function to check the `n()` for each combination, and filter out the relevant rows that did not exist in the prior data frame. This was causing an error if we had not converted our key variables on the two data frames to be the same type (e.g., factor and factor)

**Developer Testing Checklist**
- [x] Runs without errors  
- [x] OK disabled when dialog is incomplete or invalid  
- [x] OK enabled only when required inputs are valid
- [x] Reset returns dialog to its default/sensible state
- [x] Invalid inputs are handled cleanly (e.g. negative, too-large, empty, impossible combos)
- [x] Running twice with different settings behaves consistently (e.g., open → run → close → reopen → change options checked → run again)
- [x] All AI/bot comments addressed (fixed, intentionally ignored with explanation, or queried)
