### PR TITLE
Fixed Reset issue in Climatic>Prepare>Start of Rain>Amount  Control

### DIFF
--- a/instat/dlgStartofRains.vb
+++ b/instat/dlgStartofRains.vb
@@ -161,7 +161,7 @@ Public Class dlgStartofRains
         ucrPnlTRCalculateBy.AddParameterPresentCondition(rdoTRPercentile, "tr_perc_sub")
         ucrPnlTRCalculateBy.AddParameterPresentCondition(rdoEvapo, "tr_perc_sub")
         ucrPnlTRCalculateBy.AddToLinkedControls(ucrNudTRPercentile, {rdoTRPercentile}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:=0.8)
-        ucrPnlTRCalculateBy.AddToLinkedControls(ucrNudTRAmount, {rdoTRAmount}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:="20")
+        ucrPnlTRCalculateBy.AddToLinkedControls(ucrNudTRAmount, {rdoTRAmount}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:=20)
         ucrPnlTRCalculateBy.AddToLinkedControls(ucrNudEvapo, {rdoEvapo}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:=0.5)
         ucrPnlTRCalculateBy.AddToLinkedControls(ucrReceiverEvap, {rdoEvapo}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
         ucrPnlTRCalculateBy.SetLinkedDisplayControl(lblTRVal)
@@ -169,7 +169,7 @@ Public Class dlgStartofRains
         ucrPnlTRCalculateBy.AddParameterPresentCondition(rdoTRAmount, "tr_amount")
         ucrPnlTRCalculateBy.AddParameterPresentCondition(rdoEvapo, "evap")
 
-        ucrNudTRAmount.SetParameter(New RParameter("tr_amount", 1, False), False)
+        ucrNudTRAmount.SetParameter(New RParameter("tr_amount", 20, False), False)
         ucrNudTRAmount.SetMinMax(1, Integer.MaxValue)
 
         ucrChkTotalRainfall.SetParameter(New RParameter("tr_sub", clsCalcRainRollingSum, 1, False), False)
@@ -368,6 +368,7 @@ Public Class dlgStartofRains
 
         bResetSubdialog = True
         ucrSelectorForStartofRains.Reset()
+        SetRCodeForControls(True)
         ucrNudTROverDays.SetText("3")
         ucrNudTRAmount.SetText("20")
 


### PR DESCRIPTION
Fixes #10148 
Here is how I tested the changes
1-Import dodoma data then open Start of rain dialog in climatic >prepare menu.
 a- Change the value of Over Days from 3 to 2 and Amount from 20 to 21 then click on reset. The controls are resetting well.
 b- Open the dialogue  and chick ok. The dialog ran without any error.
2-Open the dialog
 a- Change the value of Over Days from 3 to 2 and Amount from 20 to 21 then click Ok. The dialog ran without any error.
 b- Open the dialogue  and chick ok. The result are still the same
 c- Edit the Occurrence, Date, and Day of Year controls. then click Ok. The result are still the same. 
3-Open the dialog
  a- Click on Additional condition control>Add>Number of rainy days then click Return and Ok. The dialog ran without any error.
  b- Open the dialogue edit the Occurrence, Date, and Day of Year controls and click Ok. The result are still the same
  c- Open the dialog Additional condition control>Add>Number of rainy days then change the value of Minimum from 1 to 2 and Out of Days from 2 to 3 then click Return and Ok. The dialog ran without any error.
  d- Reopen the dialog click on reset then  Additional condition control>Add>Number of rainy days the Minimum and Out of Days controls retested correctly.
@berylwaswa @Ag-Derek @lilyclements This PR is Ready for review. Please have a look thank you.