### PR TITLE
Fixes a bug in Import dialog when Empty columns are deleted 

### DIFF
--- a/instat/dlgImportDataset.vb
+++ b/instat/dlgImportDataset.vb
@@ -866,7 +866,6 @@ Public Class dlgImportDataset
             Dim clsPipeClone As ROperator = clsPipeOperator.Clone()
             clsPipeClone.RemoveAssignTo()
 
-            clsPipeClone.RemoveParameterByName("y")
             clsPipeClone.AddParameter("y", clsRFunctionParameter:=clsTempImport, iPosition:=0)
 
             clsAsCharacterFunc.AddParameter("data", clsPipeClone.ToScript())
@@ -896,7 +895,6 @@ Public Class dlgImportDataset
         If clsTempImport.ContainsParameter("n_max") Then
             clsTempImport.RemoveParameterByName("n_max")
         End If
-        clsPipeOperator.AddParameter("y", clsRFunctionParameter:=clsTempImport, iPosition:=0)
 
     End Sub
 


### PR DESCRIPTION
Fixes #10202 
@rdstern @lilyclements , Ensures full dataset is imported after droping missing rows/columns
