### PR TITLE
Added the save definitions options to the PICSA Crops dialog

### DIFF
--- a/instat/dlgPICSACrops.Designer.vb
+++ b/instat/dlgPICSACrops.Designer.vb
@@ -71,6 +71,8 @@ Partial Class dlgPICSACrops
         Me.ucrReceiverEnd = New instat.ucrReceiverSingle()
         Me.cmdOptions = New System.Windows.Forms.Button()
         Me.ttPlanting = New System.Windows.Forms.ToolTip(Me.components)
+        Me.ucrSaveDefinitionCrops = New instat.ucrSave()
+        Me.ucrSaveDefinitionProportions = New instat.ucrSave()
         Me.grpCropDefinitions.SuspendLayout()
         Me.grpSeasonReceivers.SuspendLayout()
         Me.SuspendLayout()
@@ -81,41 +83,41 @@ Partial Class dlgPICSACrops
         Me.ucrSelectorSummary.bDropUnusedFilterLevels = False
         Me.ucrSelectorSummary.bShowHiddenColumns = False
         Me.ucrSelectorSummary.bUseCurrentFilter = True
-        Me.ucrSelectorSummary.Location = New System.Drawing.Point(6, 195)
+        Me.ucrSelectorSummary.Location = New System.Drawing.Point(9, 292)
         Me.ucrSelectorSummary.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrSelectorSummary.Name = "ucrSelectorSummary"
-        Me.ucrSelectorSummary.Size = New System.Drawing.Size(213, 183)
+        Me.ucrSelectorSummary.Size = New System.Drawing.Size(320, 274)
         Me.ucrSelectorSummary.TabIndex = 56
         '
         'ucrChkDataProp
         '
         Me.ucrChkDataProp.AutoSize = True
         Me.ucrChkDataProp.Checked = False
-        Me.ucrChkDataProp.Location = New System.Drawing.Point(187, 393)
-        Me.ucrChkDataProp.Margin = New System.Windows.Forms.Padding(6)
+        Me.ucrChkDataProp.Location = New System.Drawing.Point(280, 590)
+        Me.ucrChkDataProp.Margin = New System.Windows.Forms.Padding(9, 9, 9, 9)
         Me.ucrChkDataProp.Name = "ucrChkDataProp"
-        Me.ucrChkDataProp.Size = New System.Drawing.Size(172, 23)
+        Me.ucrChkDataProp.Size = New System.Drawing.Size(258, 34)
         Me.ucrChkDataProp.TabIndex = 53
         '
         'ucrChkDataCrops
         '
         Me.ucrChkDataCrops.AutoSize = True
         Me.ucrChkDataCrops.Checked = False
-        Me.ucrChkDataCrops.Location = New System.Drawing.Point(11, 393)
-        Me.ucrChkDataCrops.Margin = New System.Windows.Forms.Padding(6)
+        Me.ucrChkDataCrops.Location = New System.Drawing.Point(16, 590)
+        Me.ucrChkDataCrops.Margin = New System.Windows.Forms.Padding(9, 9, 9, 9)
         Me.ucrChkDataCrops.Name = "ucrChkDataCrops"
-        Me.ucrChkDataCrops.Size = New System.Drawing.Size(255, 23)
+        Me.ucrChkDataCrops.Size = New System.Drawing.Size(382, 34)
         Me.ucrChkDataCrops.TabIndex = 52
         '
         'ucrReceiverRainfall
         '
         Me.ucrReceiverRainfall.AutoSize = True
         Me.ucrReceiverRainfall.frmParent = Me
-        Me.ucrReceiverRainfall.Location = New System.Drawing.Point(235, 81)
+        Me.ucrReceiverRainfall.Location = New System.Drawing.Point(352, 122)
         Me.ucrReceiverRainfall.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverRainfall.Name = "ucrReceiverRainfall"
         Me.ucrReceiverRainfall.Selector = Nothing
-        Me.ucrReceiverRainfall.Size = New System.Drawing.Size(113, 20)
+        Me.ucrReceiverRainfall.Size = New System.Drawing.Size(170, 30)
         Me.ucrReceiverRainfall.strNcFilePath = ""
         Me.ucrReceiverRainfall.TabIndex = 47
         Me.ucrReceiverRainfall.ucrSelector = Nothing
@@ -124,11 +126,11 @@ Partial Class dlgPICSACrops
         '
         Me.ucrReceiverDay.AutoSize = True
         Me.ucrReceiverDay.frmParent = Me
-        Me.ucrReceiverDay.Location = New System.Drawing.Point(358, 81)
+        Me.ucrReceiverDay.Location = New System.Drawing.Point(537, 122)
         Me.ucrReceiverDay.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverDay.Name = "ucrReceiverDay"
         Me.ucrReceiverDay.Selector = Nothing
-        Me.ucrReceiverDay.Size = New System.Drawing.Size(115, 20)
+        Me.ucrReceiverDay.Size = New System.Drawing.Size(172, 30)
         Me.ucrReceiverDay.strNcFilePath = ""
         Me.ucrReceiverDay.TabIndex = 46
         Me.ucrReceiverDay.ucrSelector = Nothing
@@ -137,11 +139,11 @@ Partial Class dlgPICSACrops
         '
         Me.ucrReceiverYear.AutoSize = True
         Me.ucrReceiverYear.frmParent = Me
-        Me.ucrReceiverYear.Location = New System.Drawing.Point(358, 37)
+        Me.ucrReceiverYear.Location = New System.Drawing.Point(537, 56)
         Me.ucrReceiverYear.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverYear.Name = "ucrReceiverYear"
         Me.ucrReceiverYear.Selector = Nothing
-        Me.ucrReceiverYear.Size = New System.Drawing.Size(115, 20)
+        Me.ucrReceiverYear.Size = New System.Drawing.Size(172, 30)
         Me.ucrReceiverYear.strNcFilePath = ""
         Me.ucrReceiverYear.TabIndex = 44
         Me.ucrReceiverYear.ucrSelector = Nothing
@@ -150,11 +152,11 @@ Partial Class dlgPICSACrops
         '
         Me.ucrReceiverStation.AutoSize = True
         Me.ucrReceiverStation.frmParent = Me
-        Me.ucrReceiverStation.Location = New System.Drawing.Point(235, 37)
+        Me.ucrReceiverStation.Location = New System.Drawing.Point(352, 56)
         Me.ucrReceiverStation.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverStation.Name = "ucrReceiverStation"
         Me.ucrReceiverStation.Selector = Nothing
-        Me.ucrReceiverStation.Size = New System.Drawing.Size(113, 20)
+        Me.ucrReceiverStation.Size = New System.Drawing.Size(170, 30)
         Me.ucrReceiverStation.strNcFilePath = ""
         Me.ucrReceiverStation.TabIndex = 43
         Me.ucrReceiverStation.ucrSelector = Nothing
@@ -165,18 +167,19 @@ Partial Class dlgPICSACrops
         Me.ucrSelectorForCrops.bDropUnusedFilterLevels = False
         Me.ucrSelectorForCrops.bShowHiddenColumns = False
         Me.ucrSelectorForCrops.bUseCurrentFilter = True
-        Me.ucrSelectorForCrops.Location = New System.Drawing.Point(6, 5)
+        Me.ucrSelectorForCrops.Location = New System.Drawing.Point(9, 8)
         Me.ucrSelectorForCrops.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrSelectorForCrops.Name = "ucrSelectorForCrops"
-        Me.ucrSelectorForCrops.Size = New System.Drawing.Size(213, 183)
+        Me.ucrSelectorForCrops.Size = New System.Drawing.Size(320, 274)
         Me.ucrSelectorForCrops.TabIndex = 42
         '
         'lblStarts
         '
         Me.lblStarts.AutoSize = True
-        Me.lblStarts.Location = New System.Drawing.Point(6, 27)
+        Me.lblStarts.Location = New System.Drawing.Point(9, 40)
+        Me.lblStarts.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblStarts.Name = "lblStarts"
-        Me.lblStarts.Size = New System.Drawing.Size(70, 13)
+        Me.lblStarts.Size = New System.Drawing.Size(104, 20)
         Me.lblStarts.TabIndex = 56
         Me.lblStarts.Text = "Include Start:"
         '
@@ -186,10 +189,10 @@ Partial Class dlgPICSACrops
         Me.ucrInputCropLengths.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.ucrInputCropLengths.GetSetSelectedIndex = -1
         Me.ucrInputCropLengths.IsReadOnly = False
-        Me.ucrInputCropLengths.Location = New System.Drawing.Point(94, 129)
-        Me.ucrInputCropLengths.Margin = New System.Windows.Forms.Padding(6)
+        Me.ucrInputCropLengths.Location = New System.Drawing.Point(141, 194)
+        Me.ucrInputCropLengths.Margin = New System.Windows.Forms.Padding(9, 9, 9, 9)
         Me.ucrInputCropLengths.Name = "ucrInputCropLengths"
-        Me.ucrInputCropLengths.Size = New System.Drawing.Size(139, 21)
+        Me.ucrInputCropLengths.Size = New System.Drawing.Size(208, 32)
         Me.ucrInputCropLengths.TabIndex = 55
         '
         'ucrInputWaterAmounts
@@ -198,10 +201,10 @@ Partial Class dlgPICSACrops
         Me.ucrInputWaterAmounts.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.ucrInputWaterAmounts.GetSetSelectedIndex = -1
         Me.ucrInputWaterAmounts.IsReadOnly = False
-        Me.ucrInputWaterAmounts.Location = New System.Drawing.Point(94, 92)
-        Me.ucrInputWaterAmounts.Margin = New System.Windows.Forms.Padding(9)
+        Me.ucrInputWaterAmounts.Location = New System.Drawing.Point(141, 138)
+        Me.ucrInputWaterAmounts.Margin = New System.Windows.Forms.Padding(14, 14, 14, 14)
         Me.ucrInputWaterAmounts.Name = "ucrInputWaterAmounts"
-        Me.ucrInputWaterAmounts.Size = New System.Drawing.Size(139, 21)
+        Me.ucrInputWaterAmounts.Size = New System.Drawing.Size(208, 32)
         Me.ucrInputWaterAmounts.TabIndex = 40
         '
         'ucrInputPlantingDates
@@ -210,18 +213,19 @@ Partial Class dlgPICSACrops
         Me.ucrInputPlantingDates.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.ucrInputPlantingDates.GetSetSelectedIndex = -1
         Me.ucrInputPlantingDates.IsReadOnly = False
-        Me.ucrInputPlantingDates.Location = New System.Drawing.Point(94, 58)
-        Me.ucrInputPlantingDates.Margin = New System.Windows.Forms.Padding(9)
+        Me.ucrInputPlantingDates.Location = New System.Drawing.Point(141, 87)
+        Me.ucrInputPlantingDates.Margin = New System.Windows.Forms.Padding(14, 14, 14, 14)
         Me.ucrInputPlantingDates.Name = "ucrInputPlantingDates"
-        Me.ucrInputPlantingDates.Size = New System.Drawing.Size(139, 21)
+        Me.ucrInputPlantingDates.Size = New System.Drawing.Size(208, 32)
         Me.ucrInputPlantingDates.TabIndex = 53
         '
         'Label3
         '
         Me.Label3.AutoSize = True
-        Me.Label3.Location = New System.Drawing.Point(355, 66)
+        Me.Label3.Location = New System.Drawing.Point(532, 99)
+        Me.Label3.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.Label3.Name = "Label3"
-        Me.Label3.Size = New System.Drawing.Size(65, 13)
+        Me.Label3.Size = New System.Drawing.Size(95, 20)
         Me.Label3.TabIndex = 49
         Me.Label3.Tag = ""
         Me.Label3.Text = "Day in Year:"
@@ -229,9 +233,10 @@ Partial Class dlgPICSACrops
         'Label2
         '
         Me.Label2.AutoSize = True
-        Me.Label2.Location = New System.Drawing.Point(355, 21)
+        Me.Label2.Location = New System.Drawing.Point(532, 32)
+        Me.Label2.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.Label2.Name = "Label2"
-        Me.Label2.Size = New System.Drawing.Size(32, 13)
+        Me.Label2.Size = New System.Drawing.Size(47, 20)
         Me.Label2.TabIndex = 48
         Me.Label2.Tag = ""
         Me.Label2.Text = "Year:"
@@ -239,9 +244,10 @@ Partial Class dlgPICSACrops
         'lblSelectedSet
         '
         Me.lblSelectedSet.AutoSize = True
-        Me.lblSelectedSet.Location = New System.Drawing.Point(231, 21)
+        Me.lblSelectedSet.Location = New System.Drawing.Point(346, 32)
+        Me.lblSelectedSet.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblSelectedSet.Name = "lblSelectedSet"
-        Me.lblSelectedSet.Size = New System.Drawing.Size(43, 13)
+        Me.lblSelectedSet.Size = New System.Drawing.Size(64, 20)
         Me.lblSelectedSet.TabIndex = 45
         Me.lblSelectedSet.Tag = ""
         Me.lblSelectedSet.Text = "Station:"
@@ -250,19 +256,18 @@ Partial Class dlgPICSACrops
         '
         Me.ucrBase.AutoSize = True
         Me.ucrBase.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrBase.Location = New System.Drawing.Point(10, 426)
-        Me.ucrBase.Margin = New System.Windows.Forms.Padding(4)
+        Me.ucrBase.Location = New System.Drawing.Point(15, 744)
+        Me.ucrBase.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
         Me.ucrBase.Name = "ucrBase"
-        Me.ucrBase.Size = New System.Drawing.Size(408, 52)
+        Me.ucrBase.Size = New System.Drawing.Size(611, 77)
         Me.ucrBase.TabIndex = 41
         '
         'rdoBoth
         '
         Me.rdoBoth.AutoSize = True
-        Me.rdoBoth.Location = New System.Drawing.Point(176, 25)
-        Me.rdoBoth.Margin = New System.Windows.Forms.Padding(2)
+        Me.rdoBoth.Location = New System.Drawing.Point(264, 38)
         Me.rdoBoth.Name = "rdoBoth"
-        Me.rdoBoth.Size = New System.Drawing.Size(47, 17)
+        Me.rdoBoth.Size = New System.Drawing.Size(68, 24)
         Me.rdoBoth.TabIndex = 44
         Me.rdoBoth.TabStop = True
         Me.rdoBoth.Text = "Both"
@@ -271,10 +276,9 @@ Partial Class dlgPICSACrops
         'rdoNo
         '
         Me.rdoNo.AutoSize = True
-        Me.rdoNo.Location = New System.Drawing.Point(128, 25)
-        Me.rdoNo.Margin = New System.Windows.Forms.Padding(2)
+        Me.rdoNo.Location = New System.Drawing.Point(192, 38)
         Me.rdoNo.Name = "rdoNo"
-        Me.rdoNo.Size = New System.Drawing.Size(39, 17)
+        Me.rdoNo.Size = New System.Drawing.Size(54, 24)
         Me.rdoNo.TabIndex = 45
         Me.rdoNo.TabStop = True
         Me.rdoNo.Text = "No"
@@ -283,10 +287,9 @@ Partial Class dlgPICSACrops
         'rdoYes
         '
         Me.rdoYes.AutoSize = True
-        Me.rdoYes.Location = New System.Drawing.Point(81, 25)
-        Me.rdoYes.Margin = New System.Windows.Forms.Padding(2)
+        Me.rdoYes.Location = New System.Drawing.Point(122, 38)
         Me.rdoYes.Name = "rdoYes"
-        Me.rdoYes.Size = New System.Drawing.Size(43, 17)
+        Me.rdoYes.Size = New System.Drawing.Size(62, 24)
         Me.rdoYes.TabIndex = 43
         Me.rdoYes.TabStop = True
         Me.rdoYes.Text = "Yes"
@@ -294,26 +297,29 @@ Partial Class dlgPICSACrops
         '
         'lblPlantingDays
         '
-        Me.lblPlantingDays.Location = New System.Drawing.Point(3, 60)
+        Me.lblPlantingDays.Location = New System.Drawing.Point(4, 90)
+        Me.lblPlantingDays.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblPlantingDays.Name = "lblPlantingDays"
-        Me.lblPlantingDays.Size = New System.Drawing.Size(73, 19)
+        Me.lblPlantingDays.Size = New System.Drawing.Size(110, 28)
         Me.lblPlantingDays.TabIndex = 42
         Me.lblPlantingDays.Text = "Planting:"
         '
         'lblCropLengthDays
         '
-        Me.lblCropLengthDays.Location = New System.Drawing.Point(5, 133)
+        Me.lblCropLengthDays.Location = New System.Drawing.Point(8, 200)
+        Me.lblCropLengthDays.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblCropLengthDays.Name = "lblCropLengthDays"
-        Me.lblCropLengthDays.Size = New System.Drawing.Size(71, 17)
+        Me.lblCropLengthDays.Size = New System.Drawing.Size(106, 26)
         Me.lblCropLengthDays.TabIndex = 41
         Me.lblCropLengthDays.Text = "Length:"
         '
         'lblRain
         '
         Me.lblRain.AutoSize = True
-        Me.lblRain.Location = New System.Drawing.Point(231, 66)
+        Me.lblRain.Location = New System.Drawing.Point(346, 99)
+        Me.lblRain.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblRain.Name = "lblRain"
-        Me.lblRain.Size = New System.Drawing.Size(32, 13)
+        Me.lblRain.Size = New System.Drawing.Size(46, 20)
         Me.lblRain.TabIndex = 50
         Me.lblRain.Tag = ""
         Me.lblRain.Text = "Rain:"
@@ -321,28 +327,30 @@ Partial Class dlgPICSACrops
         'Label5
         '
         Me.Label5.AutoSize = True
-        Me.Label5.Location = New System.Drawing.Point(6, 19)
+        Me.Label5.Location = New System.Drawing.Point(9, 28)
+        Me.Label5.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.Label5.Name = "Label5"
-        Me.Label5.Size = New System.Drawing.Size(32, 13)
+        Me.Label5.Size = New System.Drawing.Size(48, 20)
         Me.Label5.TabIndex = 24
         Me.Label5.Tag = ""
         Me.Label5.Text = "Start:"
         '
         'lblWaterAmounts
         '
-        Me.lblWaterAmounts.Location = New System.Drawing.Point(5, 95)
+        Me.lblWaterAmounts.Location = New System.Drawing.Point(8, 142)
+        Me.lblWaterAmounts.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblWaterAmounts.Name = "lblWaterAmounts"
-        Me.lblWaterAmounts.Size = New System.Drawing.Size(71, 18)
+        Me.lblWaterAmounts.Size = New System.Drawing.Size(106, 27)
         Me.lblWaterAmounts.TabIndex = 40
         Me.lblWaterAmounts.Text = "Water:"
         '
         'ucrPnlStartCheck
         '
         Me.ucrPnlStartCheck.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrPnlStartCheck.Location = New System.Drawing.Point(75, 14)
-        Me.ucrPnlStartCheck.Margin = New System.Windows.Forms.Padding(6)
+        Me.ucrPnlStartCheck.Location = New System.Drawing.Point(112, 21)
+        Me.ucrPnlStartCheck.Margin = New System.Windows.Forms.Padding(9, 9, 9, 9)
         Me.ucrPnlStartCheck.Name = "ucrPnlStartCheck"
-        Me.ucrPnlStartCheck.Size = New System.Drawing.Size(165, 37)
+        Me.ucrPnlStartCheck.Size = New System.Drawing.Size(248, 56)
         Me.ucrPnlStartCheck.TabIndex = 46
         '
         'grpCropDefinitions
@@ -358,9 +366,11 @@ Partial Class dlgPICSACrops
         Me.grpCropDefinitions.Controls.Add(Me.lblCropLengthDays)
         Me.grpCropDefinitions.Controls.Add(Me.lblWaterAmounts)
         Me.grpCropDefinitions.Controls.Add(Me.ucrPnlStartCheck)
-        Me.grpCropDefinitions.Location = New System.Drawing.Point(230, 209)
+        Me.grpCropDefinitions.Location = New System.Drawing.Point(345, 314)
+        Me.grpCropDefinitions.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
         Me.grpCropDefinitions.Name = "grpCropDefinitions"
-        Me.grpCropDefinitions.Size = New System.Drawing.Size(249, 158)
+        Me.grpCropDefinitions.Padding = New System.Windows.Forms.Padding(4, 4, 4, 4)
+        Me.grpCropDefinitions.Size = New System.Drawing.Size(374, 237)
         Me.grpCropDefinitions.TabIndex = 55
         Me.grpCropDefinitions.TabStop = False
         Me.grpCropDefinitions.Text = "Crop Definitions"
@@ -371,9 +381,11 @@ Partial Class dlgPICSACrops
         Me.grpSeasonReceivers.Controls.Add(Me.ucrReceiverStart)
         Me.grpSeasonReceivers.Controls.Add(Me.Label6)
         Me.grpSeasonReceivers.Controls.Add(Me.ucrReceiverEnd)
-        Me.grpSeasonReceivers.Location = New System.Drawing.Point(225, 111)
+        Me.grpSeasonReceivers.Location = New System.Drawing.Point(338, 166)
+        Me.grpSeasonReceivers.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
         Me.grpSeasonReceivers.Name = "grpSeasonReceivers"
-        Me.grpSeasonReceivers.Size = New System.Drawing.Size(254, 66)
+        Me.grpSeasonReceivers.Padding = New System.Windows.Forms.Padding(4, 4, 4, 4)
+        Me.grpSeasonReceivers.Size = New System.Drawing.Size(381, 99)
         Me.grpSeasonReceivers.TabIndex = 54
         Me.grpSeasonReceivers.TabStop = False
         Me.grpSeasonReceivers.Text = "Season Dates"
@@ -382,11 +394,11 @@ Partial Class dlgPICSACrops
         '
         Me.ucrReceiverStart.AutoSize = True
         Me.ucrReceiverStart.frmParent = Me
-        Me.ucrReceiverStart.Location = New System.Drawing.Point(9, 32)
+        Me.ucrReceiverStart.Location = New System.Drawing.Point(14, 48)
         Me.ucrReceiverStart.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverStart.Name = "ucrReceiverStart"
         Me.ucrReceiverStart.Selector = Nothing
-        Me.ucrReceiverStart.Size = New System.Drawing.Size(113, 20)
+        Me.ucrReceiverStart.Size = New System.Drawing.Size(170, 30)
         Me.ucrReceiverStart.strNcFilePath = ""
         Me.ucrReceiverStart.TabIndex = 19
         Me.ucrReceiverStart.ucrSelector = Nothing
@@ -394,9 +406,10 @@ Partial Class dlgPICSACrops
         'Label6
         '
         Me.Label6.AutoSize = True
-        Me.Label6.Location = New System.Drawing.Point(130, 19)
+        Me.Label6.Location = New System.Drawing.Point(195, 28)
+        Me.Label6.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.Label6.Name = "Label6"
-        Me.Label6.Size = New System.Drawing.Size(32, 13)
+        Me.Label6.Size = New System.Drawing.Size(46, 20)
         Me.Label6.TabIndex = 25
         Me.Label6.Tag = ""
         Me.Label6.Text = "End :"
@@ -405,11 +418,11 @@ Partial Class dlgPICSACrops
         '
         Me.ucrReceiverEnd.AutoSize = True
         Me.ucrReceiverEnd.frmParent = Me
-        Me.ucrReceiverEnd.Location = New System.Drawing.Point(133, 32)
+        Me.ucrReceiverEnd.Location = New System.Drawing.Point(200, 48)
         Me.ucrReceiverEnd.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverEnd.Name = "ucrReceiverEnd"
         Me.ucrReceiverEnd.Selector = Nothing
-        Me.ucrReceiverEnd.Size = New System.Drawing.Size(115, 22)
+        Me.ucrReceiverEnd.Size = New System.Drawing.Size(172, 33)
         Me.ucrReceiverEnd.strNcFilePath = ""
         Me.ucrReceiverEnd.TabIndex = 26
         Me.ucrReceiverEnd.ucrSelector = Nothing
@@ -417,20 +430,41 @@ Partial Class dlgPICSACrops
         'cmdOptions
         '
         Me.cmdOptions.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdOptions.Location = New System.Drawing.Point(355, 392)
+        Me.cmdOptions.Location = New System.Drawing.Point(532, 588)
+        Me.cmdOptions.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
         Me.cmdOptions.Name = "cmdOptions"
-        Me.cmdOptions.Size = New System.Drawing.Size(120, 25)
+        Me.cmdOptions.Size = New System.Drawing.Size(180, 38)
         Me.cmdOptions.TabIndex = 51
         Me.cmdOptions.Tag = "Options"
         Me.cmdOptions.Text = "Options"
         Me.cmdOptions.UseVisualStyleBackColor = True
         '
+        'ucrSaveDefinitionCrops
+        '
+        Me.ucrSaveDefinitionCrops.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrSaveDefinitionCrops.Location = New System.Drawing.Point(15, 641)
+        Me.ucrSaveDefinitionCrops.Margin = New System.Windows.Forms.Padding(6, 8, 6, 8)
+        Me.ucrSaveDefinitionCrops.Name = "ucrSaveDefinitionCrops"
+        Me.ucrSaveDefinitionCrops.Size = New System.Drawing.Size(480, 36)
+        Me.ucrSaveDefinitionCrops.TabIndex = 57
+        '
+        'ucrSaveDefinitionProportions
+        '
+        Me.ucrSaveDefinitionProportions.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrSaveDefinitionProportions.Location = New System.Drawing.Point(16, 693)
+        Me.ucrSaveDefinitionProportions.Margin = New System.Windows.Forms.Padding(6, 8, 6, 8)
+        Me.ucrSaveDefinitionProportions.Name = "ucrSaveDefinitionProportions"
+        Me.ucrSaveDefinitionProportions.Size = New System.Drawing.Size(480, 36)
+        Me.ucrSaveDefinitionProportions.TabIndex = 58
+        '
         'dlgPICSACrops
         '
-        Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(144.0!, 144.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
         Me.AutoSize = True
-        Me.ClientSize = New System.Drawing.Size(482, 482)
+        Me.ClientSize = New System.Drawing.Size(723, 825)
+        Me.Controls.Add(Me.ucrSaveDefinitionProportions)
+        Me.Controls.Add(Me.ucrSaveDefinitionCrops)
         Me.Controls.Add(Me.ucrSelectorSummary)
         Me.Controls.Add(Me.ucrChkDataProp)
         Me.Controls.Add(Me.ucrChkDataCrops)
@@ -448,6 +482,7 @@ Partial Class dlgPICSACrops
         Me.Controls.Add(Me.grpSeasonReceivers)
         Me.Controls.Add(Me.cmdOptions)
         Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow
+        Me.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
         Me.MaximizeBox = False
         Me.MinimizeBox = False
         Me.Name = "dlgPICSACrops"
@@ -494,4 +529,6 @@ Partial Class dlgPICSACrops
     Friend WithEvents ucrReceiverEnd As ucrReceiverSingle
     Friend WithEvents cmdOptions As Button
     Friend WithEvents ttPlanting As ToolTip
+    Friend WithEvents ucrSaveDefinitionProportions As ucrSave
+    Friend WithEvents ucrSaveDefinitionCrops As ucrSave
 End Class

--- a/instat/dlgPICSACrops.vb
+++ b/instat/dlgPICSACrops.vb
@@ -387,12 +387,12 @@ Public Class dlgPICSACrops
     End Sub
 
     Private Sub TestOkEnabled()
-        Dim bOkEnabled = True
-        If Not ucrReceiverYear.IsEmpty AndAlso Not ucrReceiverRainfall.IsEmpty AndAlso Not ucrReceiverStart.IsEmpty AndAlso Not ucrReceiverDay.IsEmpty AndAlso Not ucrReceiverEnd.IsEmpty AndAlso Not ucrInputPlantingDates.IsEmpty AndAlso Not ucrInputCropLengths.IsEmpty AndAlso Not ucrInputWaterAmounts.IsEmpty AndAlso (ucrChkDataCrops.Checked OrElse ucrChkDataProp.Checked) Then
-            bOkEnabled = True
-        Else
-            bOkEnabled = False
-        End If
+        Dim bOkEnabled = (Not ucrReceiverYear.IsEmpty AndAlso Not ucrReceiverRainfall.IsEmpty AndAlso Not ucrReceiverStart.IsEmpty AndAlso Not ucrReceiverDay.IsEmpty AndAlso Not ucrReceiverEnd.IsEmpty AndAlso Not ucrInputPlantingDates.IsEmpty AndAlso Not ucrInputCropLengths.IsEmpty AndAlso Not ucrInputWaterAmounts.IsEmpty AndAlso (ucrChkDataCrops.Checked OrElse ucrChkDataProp.Checked))
+        'If Not ucrReceiverYear.IsEmpty AndAlso Not ucrReceiverRainfall.IsEmpty AndAlso Not ucrReceiverStart.IsEmpty AndAlso Not ucrReceiverDay.IsEmpty AndAlso Not ucrReceiverEnd.IsEmpty AndAlso Not ucrInputPlantingDates.IsEmpty AndAlso Not ucrInputCropLengths.IsEmpty AndAlso Not ucrInputWaterAmounts.IsEmpty AndAlso (ucrChkDataCrops.Checked OrElse ucrChkDataProp.Checked) Then
+        '    bOkEnabled = True
+        'Else
+        '    bOkEnabled = False
+        'End If
 
         If ucrSaveDefinitionCrops.ucrChkSave.Checked AndAlso Not ucrSaveDefinitionCrops.IsComplete Then
             bOkEnabled = False

--- a/instat/dlgPICSACrops.vb
+++ b/instat/dlgPICSACrops.vb
@@ -23,7 +23,7 @@ Public Class dlgPICSACrops
     Private clsDummyFunction As New RFunction
     Private clsSequenceFunction, clsSequencewaterFunction, clsSequencePlantingFunction As New RFunction
     Private clsGetDataNamesFunction, clsSetDiffFunction, clsUpdatedDataNamesFunction, clsStartsWithFunction,
-            clsGetDataFrameFunction, clsGetCropDefinitionFunction, clsGetSeasonStartDefinitionFunction,
+            clsGetDataFrameFunction, clsGetCropDefinitionFunction, clsGetCropDefinitionPropsFunction,
             clsStartsWithPropsFunction, clsGetDataFramePropsFunction As New RFunction
 
     Private clsFirstBracketOperator, clsEmptySpaceOperator, clsEmptySpacePropsOperator As New ROperator
@@ -253,7 +253,7 @@ Public Class dlgPICSACrops
         clsStartsWithFunction = New RFunction
         clsGetDataFrameFunction = New RFunction
         clsGetCropDefinitionFunction = New RFunction
-        clsGetSeasonStartDefinitionFunction = New RFunction
+        clsGetCropDefinitionPropsFunction = New RFunction
         clsStartsWithPropsFunction = New RFunction
         clsGetDataFramePropsFunction = New RFunction
 
@@ -290,12 +290,13 @@ Public Class dlgPICSACrops
         clsSetDiffFunction.SetRCommand("setdiff")
         clsSetDiffFunction.AddParameter("x", clsRFunctionParameter:=clsUpdatedDataNamesFunction, iPosition:=0, bIncludeArgumentName:=False)
         clsSetDiffFunction.AddParameter("y", "existing_dfs", iPosition:=1, bIncludeArgumentName:=False)
+        clsSetDiffFunction.SetAssignTo("new_df_name")
 
-        clsFirstBracketOperator.SetOperation("[")
-        clsFirstBracketOperator.AddParameter("x", clsRFunctionParameter:=clsSetDiffFunction, iPosition:=0, bIncludeArgumentName:=False)
-        clsFirstBracketOperator.AddParameter("y", "1]", iPosition:=1, bIncludeArgumentName:=False)
-        clsFirstBracketOperator.SetAssignTo("new_df_name")
-        clsFirstBracketOperator.bSpaceAroundOperation = False
+        'clsFirstBracketOperator.SetOperation("[")
+        'clsFirstBracketOperator.AddParameter("x", clsRFunctionParameter:=clsSetDiffFunction, iPosition:=0, bIncludeArgumentName:=False)
+        'clsFirstBracketOperator.AddParameter("y", "1]", iPosition:=1, bIncludeArgumentName:=False)
+        'clsFirstBracketOperator.SetAssignTo("new_df_name")
+        'clsFirstBracketOperator.bSpaceAroundOperation = False
 
         clsStartsWithFunction.SetRCommand("startsWith")
         clsStartsWithFunction.AddParameter("x", "new_df_name", iPosition:=0, bIncludeArgumentName:=False)
@@ -332,8 +333,8 @@ Public Class dlgPICSACrops
         clsGetCropDefinitionFunction.SetRCommand("get_crop_definition")
         clsGetCropDefinitionFunction.AddParameter("x", clsRFunctionParameter:=clsGetDataFrameFunction, iPosition:=0, bIncludeArgumentName:=False)
 
-        clsGetSeasonStartDefinitionFunction.SetRCommand("get_season_start_definition")
-        clsGetSeasonStartDefinitionFunction.AddParameter("x", clsRFunctionParameter:=clsGetDataFramePropsFunction, iPosition:=0, bIncludeArgumentName:=False)
+        clsGetCropDefinitionPropsFunction.SetRCommand("get_crop_definition")
+        clsGetCropDefinitionPropsFunction.AddParameter("x", clsRFunctionParameter:=clsGetDataFramePropsFunction, iPosition:=0, bIncludeArgumentName:=False)
 
         ucrInputPlantingDates.SetName("160")
         ucrInputCropLengths.SetName("120")
@@ -369,7 +370,7 @@ Public Class dlgPICSACrops
         ucrChkDataProp.SetRCode(clsCropsFunction, bReset)
         ucrChkDataCrops.SetRCode(clsCropsFunction, bReset)
         ucrSaveDefinitionCrops.SetRCode(clsGetCropDefinitionFunction, bReset)
-        ucrSaveDefinitionProportions.SetRCode(clsGetSeasonStartDefinitionFunction, bReset)
+        ucrSaveDefinitionProportions.SetRCode(clsGetCropDefinitionPropsFunction, bReset)
         If bReset Then
             ucrPnlStartCheck.SetRCode(clsDummyFunction, bReset)
         End If
@@ -431,9 +432,9 @@ Public Class dlgPICSACrops
         End If
 
         If ucrChkDataProp.Checked AndAlso ucrSaveDefinitionProportions.ucrChkSave.Checked Then
-            ucrBase.clsRsyntax.AddToAfterCodes(clsGetSeasonStartDefinitionFunction, iPosition:=3)
+            ucrBase.clsRsyntax.AddToAfterCodes(clsGetCropDefinitionPropsFunction, iPosition:=3)
         Else
-            ucrBase.clsRsyntax.RemoveFromAfterCodes(clsGetSeasonStartDefinitionFunction)
+            ucrBase.clsRsyntax.RemoveFromAfterCodes(clsGetCropDefinitionPropsFunction)
         End If
         AddDataNames()
     End Sub
@@ -441,10 +442,10 @@ Public Class dlgPICSACrops
     Private Sub AddDataNames()
         If ucrSaveDefinitionProportions.ucrChkSave.Checked OrElse ucrSaveDefinitionCrops.ucrChkSave.Checked Then
             ucrBase.clsRsyntax.AddToBeforeCodes(clsGetDataNamesFunction, iPosition:=1)
-            ucrBase.clsRsyntax.AddToAfterCodes(clsFirstBracketOperator, iPosition:=1)
+            ucrBase.clsRsyntax.AddToAfterCodes(clsSetDiffFunction, iPosition:=1)
         Else
             ucrBase.clsRsyntax.RemoveFromBeforeCodes(clsGetDataNamesFunction)
-            ucrBase.clsRsyntax.RemoveFromAfterCodes(clsFirstBracketOperator)
+            ucrBase.clsRsyntax.RemoveFromAfterCodes(clsSetDiffFunction)
         End If
     End Sub
 

--- a/instat/dlgPICSACrops.vb
+++ b/instat/dlgPICSACrops.vb
@@ -226,14 +226,12 @@ Public Class dlgPICSACrops
         ucrSaveDefinitionCrops.SetSaveType(strRObjectType:=RObjectTypeLabel.StructureLabel, strRObjectFormat:=RObjectFormat.Text)
         ucrSaveDefinitionCrops.SetIsComboBox()
         ucrSaveDefinitionCrops.SetCheckBoxText("Store Crops Data Definitions")
-        ucrSaveDefinitionCrops.SetAssignToBooleans(bTempAssignToIsPrefix:=True)
         ucrSaveDefinitionCrops.SetDataFrameSelector(ucrSelectorForCrops.ucrAvailableDataFrames)
 
         ucrSaveDefinitionProportions.SetPrefix("crops_proportion_definition")
         ucrSaveDefinitionProportions.SetSaveType(strRObjectType:=RObjectTypeLabel.StructureLabel, strRObjectFormat:=RObjectFormat.Text)
         ucrSaveDefinitionProportions.SetIsComboBox()
         ucrSaveDefinitionProportions.SetCheckBoxText("Store Proportion Definitions")
-        ucrSaveDefinitionProportions.SetAssignToBooleans(bTempAssignToIsPrefix:=True)
         ucrSaveDefinitionProportions.SetDataFrameSelector(ucrSelectorForCrops.ucrAvailableDataFrames)
 
         'Linking of controls


### PR DESCRIPTION
Fixes Partly #10041
@lilyclements @rdstern @berylwaswa 

I've added the save definitions options to the `PICSA Crops` dialog.

I used the `guinea_two_stations` dataset from the library to test this PR.

**Developer Testing Checklist**
- [x] Runs without errors  
- [x] OK disabled when dialog is incomplete or invalid  
- [x] OK enabled only when required inputs are valid
- [x] Reset returns dialog to its default/sensible state
- [x] Invalid inputs are handled cleanly (e.g. negative, too-large, empty, impossible combos)
- [x] Running twice with different settings behaves consistently (e.g., open → run → close → reopen → change options checked → run again)
- [x] All AI/bot comments addressed (fixed, intentionally ignored with explanation, or queried)
