### PR TITLE
Fixed Error with Heatmaps dialog When Using Factor in Fill receiver and Viridis button Checked

### DIFF
--- a/instat/dlgHeatMapPlot.vb
+++ b/instat/dlgHeatMapPlot.vb
@@ -766,6 +766,7 @@ Public Class dlgHeatMapPlot
         AddRemoveGeomParameter()
         ChangePalette()
         Visibility()
+        AddDiscrete()
     End Sub
 
     Private Sub AutoFacetStation()
@@ -1001,9 +1002,21 @@ Public Class dlgHeatMapPlot
             End If
         End If
     End Sub
+    Private Sub AddDiscrete()
+        If rdoViridis.Checked Then
+            If Not ucrReceiverFill.IsEmpty Then
+                If ucrReceiverFill.strCurrDataType = "factor" OrElse ucrReceiverFill.strCurrDataType = "Character" Then
+                    clsColourPaletteFunction.AddParameter("discrete", "TRUE")
+                Else
+                    clsColourPaletteFunction.RemoveParameterByName("discrete")
+                End If
+            End If
+        End If
+    End Sub
 
     Private Sub ucrPnlColour_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrPnlColour.ControlValueChanged, ucrInputPalette.ControlValueChanged, ucrInputColourPalette.ControlValueChanged, ucrInputValue.ControlValueChanged, ucrColourFrom.ControlValueChanged, ucrColourTo.ControlValueChanged
         ChangePalette()
         Visibility()
+        AddDiscrete()
     End Sub
 End Class


### PR DESCRIPTION
Fixes #10228
This fixes the error found by @MeSophie in the Heatmap dialog when using a factor in the fill reciever. the dataset used was the experimental survey data. this can be checked after PR #10227 is merged.
@berylwaswa , @lilyclements @MeSophie kindly review after #10227 has been merged.
Thanks 

**Developer Testing Checklist**
- [x] Runs without errors  
- [x] OK disabled when dialog is incomplete or invalid  
- [x] OK enabled only when required inputs are valid
- [x] Reset returns dialog to its default/sensible state
- [x] Invalid inputs are handled cleanly (e.g. negative, too-large, empty, impossible combos)
- [x] Running twice with different settings behaves consistently (e.g., open → run → close → reopen → change options checked → run again)
- [x] All AI/bot comments addressed (fixed, intentionally ignored with explanation, or queried)
