### PR TITLE
Made improvements to the Climatic Boxplot dialog

### DIFF
--- a/instat/dlgClimaticBoxPlot.vb
+++ b/instat/dlgClimaticBoxPlot.vb
@@ -487,10 +487,9 @@ Public Class dlgClimaticBoxPlot
         ucrReceiverElement.AddAdditionalCodeParameterPair(clsFilterElementOperator, New RParameter("left", 0, bNewIncludeArgumentName:=False), iAdditionalPairNo:=1)
         ucrReceiverElement.AddAdditionalCodeParameterPair(clsBoxplotStat2Function, New RParameter("x", 0, bNewIncludeArgumentName:=False), iAdditionalPairNo:=2)
         ucrReceiverElement.AddAdditionalCodeParameterPair(clsInOperator, New RParameter("x", 0, bNewIncludeArgumentName:=False), iAdditionalPairNo:=3)
-        ucrReceiverWithinYear.AddAdditionalCodeParameterPair(clsGroupbyFunction, New RParameter("x", 0, bNewIncludeArgumentName:=False), iAdditionalPairNo:=1)
         ucrReceiverWithinYear.AddAdditionalCodeParameterPair(clsRaesFunction, New RParameter("fill", 25, bNewIncludeArgumentName:=True), iAdditionalPairNo:=1)
 
-        ucrReceiverWithinYear.SetRCode(clsAsFactor2Function)
+        ucrReceiverWithinYear.SetRCode(clsAsFactor2Function, bReset)
         ucrReceiverLabelOutliers.SetRCode(clsRaes2Function, bReset)
         ucrSavePlot.SetRCode(clsBaseOperator, bReset)
         ucrSelectorClimaticBoxPlot.SetRCode(clsFilteredDataOperator, bReset)
@@ -868,6 +867,20 @@ Public Class dlgClimaticBoxPlot
     End Sub
     Private Sub ucrReceiverStation_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverStation.ControlValueChanged, ucrReceiverWithinYear.ControlValueChanged, ucrReceiverYear.ControlValueChanged
         AddRemoveFacets()
+
+        If clsGroupbyFunction IsNot Nothing Then
+            If Not ucrReceiverStation.IsEmpty Then
+                clsGroupbyFunction.AddParameter("x", ucrReceiverStation.GetVariableNames(bWithQuotes:=False), iPosition:=0, bIncludeArgumentName:=False)
+            Else
+                clsGroupbyFunction.RemoveParameterByName("x")
+            End If
+
+            If Not ucrReceiverWithinYear.IsEmpty Then
+                clsGroupbyFunction.AddParameter("y", ucrReceiverWithinYear.GetVariableNames(bWithQuotes:=False), iPosition:=1, bIncludeArgumentName:=False)
+            Else
+                clsGroupbyFunction.RemoveParameterByName("y")
+            End If
+        End If
     End Sub
 
     Private Sub ucrReceiverWithinYear_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverWithinYear.ControlValueChanged
@@ -886,6 +899,12 @@ Public Class dlgClimaticBoxPlot
                 End If
             End If
         End If
+
+        'If Not ucrReceiverWithinYear.IsEmpty Then
+        '    clsGroupbyFunction.AddParameter("y", ucrReceiverWithinYear.GetVariableNames(bWithQuotes:=False), bIncludeArgumentName:=False, iPosition:=1)
+        'Else
+        '    clsGroupbyFunction.RemoveParameterByName("y")
+        'End If
     End Sub
 
     Private Sub ucrNudOutlierCoefficient_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrNudOutlierCoefficient.ControlValueChanged, ucrChkLabel.ControlValueChanged


### PR DESCRIPTION
Fixes #10198
@rdstern @berylwaswa @AmsaleEjigu 

This PR implements the changes requested by @rdstern.
@rdstern For the autofilling functionality for the month, I've implemented it, but the receiver that gets the month (`Within Year:`) only accepts `factor` variables, and as a result, you'd first have to convert the `month` column to `factor` datatype before the opening the `Climatic Boxplot`, in which case the autofill functionality works as expected. Now, my question is, are you okay with this behaviour? I assume there was a reason why that receiver was made to accept only factor variables, hence the reason I didn't change that, but if you want me to change it to accept all data types, then I'll do that.

Also, for your third and fourth points (`c` and `d`), I've made it such that the month variable is always used as the fill and the legend position is always set to `none`, unless explicitly changed. I believe that's what you wanted.

### Before asking for review
Please confirm that you have:

- Completed the developer testing checklist below (ticking items as you go)
- Responded to all AI/bot comments (either fixed or explained)
- Added a short note in the PR describing how you tested these changes
- Noted which issue(s) this PR relates to

**Developer Testing Checklist**
- [x] Runs without errors  
- [x] OK disabled when dialog is incomplete or invalid  
- [x] OK enabled only when required inputs are valid
- [x] Reset returns dialog to its default/sensible state
- [x] Invalid inputs are handled cleanly (e.g. negative, too-large, empty, impossible combos)
- [x] Running twice with different settings behaves consistently (e.g., open → run → close → reopen → change options checked → run again)
- [x] All AI/bot comments addressed (fixed, intentionally ignored with explanation, or queried)
