### PR TITLE
Minor change in the ShortenString Function for consistency in multiple receivers

### DIFF
--- a/instat/ucrReceiverMultiple.vb
+++ b/instat/ucrReceiverMultiple.vb
@@ -199,10 +199,10 @@ Public Class ucrReceiverMultiple
 
         If strText.Length > maxLength Then
             ' Trim the string to the specified length and add ellipsis
-            strText = strText.Substring(0, maxLength) & "..."
+            Return strText.Substring(0, maxLength) & "..."
         End If
 
-        Return strText & ":"
+        Return strText
     End Function
 
     Public Overrides Function IsEmpty() As Boolean


### PR DESCRIPTION
…
Fixes #10259 
This fixes the issue of the Receiver Headers not being consistent, I use the survey dataset and another dataset with a longer name to check for both cases.
@rdstern and @berylwaswa this is ready for review

**Developer Testing Checklist**
- [x] Runs without errors  
- [x] OK disabled when dialog is incomplete or invalid  
- [x] OK enabled only when required inputs are valid
- [x] Reset returns dialog to its default/sensible state
- [x] Invalid inputs are handled cleanly (e.g. negative, too-large, empty, impossible combos)
- [x] Running twice with different settings behaves consistently (e.g., open → run → close → reopen → change options checked → run again)
- [x] All AI/bot comments addressed (fixed, intentionally ignored with explanation, or queried)
