### PR TITLE
Update help topic ID in dlgAddLink to 515

### DIFF
--- a/instat/dlgAddLink.vb
+++ b/instat/dlgAddLink.vb
@@ -37,7 +37,7 @@ Public Class dlgAddLink
     End Sub
 
     Private Sub InitialiseDialog()
-        ucrBase.iHelpTopicID = 506
+        ucrBase.iHelpTopicID = 515
         ucrBase.clsRsyntax.iCallType = 2
         cmdSpecifyLink.Enabled = False ' temporarily disabled
 


### PR DESCRIPTION
@lilyclements and @rdstern @rachelkg @berylwaswa while testing the new version of R-Instat I faced an issue with the Add Link dialog help file and Changed ucrBase.iHelpTopicID from 506 to 515 in InitialiseDialog to reference the correct or updated help documentation for this dialog. No other functionality was modified.

### Before asking for review
Please confirm that you have:

- Completed the developer testing checklist below (ticking items as you go)
- Responded to all AI/bot comments (either fixed or explained)
- Added a short note in the PR describing how you tested these changes
- Noted which issue(s) this PR relates to

**Developer Testing Checklist**
- [x] Runs without errors  
- [ ] OK disabled when dialog is incomplete or invalid  
- [ ] OK enabled only when required inputs are valid
- [ ] Reset returns dialog to its default/sensible state
- [ ] Invalid inputs are handled cleanly (e.g. negative, too-large, empty, impossible combos)
- [ ] Running twice with different settings behaves consistently (e.g., open → run → close → reopen → change options checked → run again)
- [ ] All AI/bot comments addressed (fixed, intentionally ignored with explanation, or queried)
