### PR TITLE
Fixed Regression on the PICSA Temperature Graph

### DIFF
--- a/instat/dlgPICSARainfall.Designer.vb
+++ b/instat/dlgPICSARainfall.Designer.vb
@@ -252,7 +252,7 @@ Partial Class dlgPICSARainfall
         '
         Me.ucrChkLineofBestFit.AutoSize = True
         Me.ucrChkLineofBestFit.Checked = False
-        Me.ucrChkLineofBestFit.Location = New System.Drawing.Point(18, 375)
+        Me.ucrChkLineofBestFit.Location = New System.Drawing.Point(14, 375)
         Me.ucrChkLineofBestFit.Margin = New System.Windows.Forms.Padding(9)
         Me.ucrChkLineofBestFit.Name = "ucrChkLineofBestFit"
         Me.ucrChkLineofBestFit.Size = New System.Drawing.Size(332, 34)

--- a/instat/dlgPICSARainfall.Designer.vb
+++ b/instat/dlgPICSARainfall.Designer.vb
@@ -368,11 +368,11 @@ Partial Class dlgPICSARainfall
         '
         Me.ucrVariablesAsFactorForPicsa.AutoSize = True
         Me.ucrVariablesAsFactorForPicsa.frmParent = Me
-        Me.ucrVariablesAsFactorForPicsa.Location = New System.Drawing.Point(377, 63)
+        Me.ucrVariablesAsFactorForPicsa.Location = New System.Drawing.Point(372, 73)
         Me.ucrVariablesAsFactorForPicsa.Margin = New System.Windows.Forms.Padding(9)
         Me.ucrVariablesAsFactorForPicsa.Name = "ucrVariablesAsFactorForPicsa"
         Me.ucrVariablesAsFactorForPicsa.Selector = Nothing
-        Me.ucrVariablesAsFactorForPicsa.Size = New System.Drawing.Size(188, 212)
+        Me.ucrVariablesAsFactorForPicsa.Size = New System.Drawing.Size(202, 195)
         Me.ucrVariablesAsFactorForPicsa.strNcFilePath = ""
         Me.ucrVariablesAsFactorForPicsa.TabIndex = 23
         Me.ucrVariablesAsFactorForPicsa.ucrSelector = Nothing
@@ -384,10 +384,10 @@ Partial Class dlgPICSARainfall
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
         Me.AutoSize = True
         Me.ClientSize = New System.Drawing.Size(694, 724)
-        Me.Controls.Add(Me.lblSecondYVar)
         Me.Controls.Add(Me.ucrReceiverSecondYVar)
-        Me.Controls.Add(Me.lblYVar)
+        Me.Controls.Add(Me.lblSecondYVar)
         Me.Controls.Add(Me.ucrReceiverForPICSA)
+        Me.Controls.Add(Me.lblYVar)
         Me.Controls.Add(Me.ucrVariablesAsFactorForPicsa)
         Me.Controls.Add(Me.ucrChkIncludeStatus)
         Me.Controls.Add(Me.ucrReceiverIncludeStatus)

--- a/instat/dlgPICSARainfall.Designer.vb
+++ b/instat/dlgPICSARainfall.Designer.vb
@@ -66,6 +66,7 @@ Partial Class dlgPICSARainfall
         Me.ucrSelectorPICSARainfall = New instat.ucrSelectorByDataFrameAddRemove()
         Me.ucrBase = New instat.ucrButtons()
         Me.ucrReceiverColourBy = New instat.ucrReceiverSingle()
+        Me.ucrVariablesAsFactorForPicsa = New instat.ucrVariablesAsFactor()
         Me.contextMenuStripOptions.SuspendLayout()
         Me.SuspendLayout()
         '
@@ -73,7 +74,7 @@ Partial Class dlgPICSARainfall
         '
         Me.lblFactorOptional.AutoSize = True
         Me.lblFactorOptional.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblFactorOptional.Location = New System.Drawing.Point(372, 266)
+        Me.lblFactorOptional.Location = New System.Drawing.Point(372, 347)
         Me.lblFactorOptional.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblFactorOptional.Name = "lblFactorOptional"
         Me.lblFactorOptional.Size = New System.Drawing.Size(154, 20)
@@ -85,7 +86,7 @@ Partial Class dlgPICSARainfall
         '
         Me.lblXVariable.AutoSize = True
         Me.lblXVariable.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblXVariable.Location = New System.Drawing.Point(372, 203)
+        Me.lblXVariable.Location = New System.Drawing.Point(372, 284)
         Me.lblXVariable.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblXVariable.Name = "lblXVariable"
         Me.lblXVariable.Size = New System.Drawing.Size(86, 20)
@@ -119,7 +120,7 @@ Partial Class dlgPICSARainfall
         '
         Me.lblFacetBy.AutoSize = True
         Me.lblFacetBy.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblFacetBy.Location = New System.Drawing.Point(372, 337)
+        Me.lblFacetBy.Location = New System.Drawing.Point(372, 418)
         Me.lblFacetBy.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblFacetBy.Name = "lblFacetBy"
         Me.lblFacetBy.Size = New System.Drawing.Size(149, 20)
@@ -277,7 +278,7 @@ Partial Class dlgPICSARainfall
         Me.ucrInputStation.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.ucrInputStation.GetSetSelectedIndex = -1
         Me.ucrInputStation.IsReadOnly = False
-        Me.ucrInputStation.Location = New System.Drawing.Point(562, 357)
+        Me.ucrInputStation.Location = New System.Drawing.Point(562, 438)
         Me.ucrInputStation.Margin = New System.Windows.Forms.Padding(14)
         Me.ucrInputStation.Name = "ucrInputStation"
         Me.ucrInputStation.Size = New System.Drawing.Size(123, 32)
@@ -287,7 +288,7 @@ Partial Class dlgPICSARainfall
         '
         Me.ucrReceiverFacetBy.AutoSize = True
         Me.ucrReceiverFacetBy.frmParent = Me
-        Me.ucrReceiverFacetBy.Location = New System.Drawing.Point(372, 357)
+        Me.ucrReceiverFacetBy.Location = New System.Drawing.Point(372, 438)
         Me.ucrReceiverFacetBy.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverFacetBy.Name = "ucrReceiverFacetBy"
         Me.ucrReceiverFacetBy.Selector = Nothing
@@ -300,7 +301,7 @@ Partial Class dlgPICSARainfall
         '
         Me.ucrReceiverX.AutoSize = True
         Me.ucrReceiverX.frmParent = Me
-        Me.ucrReceiverX.Location = New System.Drawing.Point(372, 225)
+        Me.ucrReceiverX.Location = New System.Drawing.Point(372, 306)
         Me.ucrReceiverX.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverX.Name = "ucrReceiverX"
         Me.ucrReceiverX.Selector = Nothing
@@ -354,7 +355,7 @@ Partial Class dlgPICSARainfall
         '
         Me.ucrReceiverColourBy.AutoSize = True
         Me.ucrReceiverColourBy.frmParent = Me
-        Me.ucrReceiverColourBy.Location = New System.Drawing.Point(372, 293)
+        Me.ucrReceiverColourBy.Location = New System.Drawing.Point(372, 374)
         Me.ucrReceiverColourBy.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverColourBy.Name = "ucrReceiverColourBy"
         Me.ucrReceiverColourBy.Selector = Nothing
@@ -362,6 +363,20 @@ Partial Class dlgPICSARainfall
         Me.ucrReceiverColourBy.strNcFilePath = ""
         Me.ucrReceiverColourBy.TabIndex = 10
         Me.ucrReceiverColourBy.ucrSelector = Nothing
+        '
+        'ucrVariablesAsFactorForPicsa
+        '
+        Me.ucrVariablesAsFactorForPicsa.AutoSize = True
+        Me.ucrVariablesAsFactorForPicsa.frmParent = Me
+        Me.ucrVariablesAsFactorForPicsa.Location = New System.Drawing.Point(377, 63)
+        Me.ucrVariablesAsFactorForPicsa.Margin = New System.Windows.Forms.Padding(9)
+        Me.ucrVariablesAsFactorForPicsa.Name = "ucrVariablesAsFactorForPicsa"
+        Me.ucrVariablesAsFactorForPicsa.Selector = Nothing
+        Me.ucrVariablesAsFactorForPicsa.Size = New System.Drawing.Size(188, 212)
+        Me.ucrVariablesAsFactorForPicsa.strNcFilePath = ""
+        Me.ucrVariablesAsFactorForPicsa.TabIndex = 23
+        Me.ucrVariablesAsFactorForPicsa.ucrSelector = Nothing
+        Me.ucrVariablesAsFactorForPicsa.ucrVariableSelector = Nothing
         '
         'dlgPICSARainfall
         '
@@ -373,6 +388,7 @@ Partial Class dlgPICSARainfall
         Me.Controls.Add(Me.ucrReceiverSecondYVar)
         Me.Controls.Add(Me.lblYVar)
         Me.Controls.Add(Me.ucrReceiverForPICSA)
+        Me.Controls.Add(Me.ucrVariablesAsFactorForPicsa)
         Me.Controls.Add(Me.ucrChkIncludeStatus)
         Me.Controls.Add(Me.ucrReceiverIncludeStatus)
         Me.Controls.Add(Me.lblIncludeStatus)
@@ -432,4 +448,5 @@ Partial Class dlgPICSARainfall
     Friend WithEvents ucrReceiverForPICSA As ucrReceiverSingle
     Friend WithEvents lblSecondYVar As Label
     Friend WithEvents ucrReceiverSecondYVar As ucrReceiverSingle
+    Friend WithEvents ucrVariablesAsFactorForPicsa As ucrVariablesAsFactor
 End Class

--- a/instat/dlgPICSARainfall.vb
+++ b/instat/dlgPICSARainfall.vb
@@ -57,7 +57,7 @@ Public Class dlgPICSARainfall
     Private clsSegmentAesFunction As New RFunction
     Private clsGeomPoint2Function As New RFunction
     Private clsPoint2AesFunction As New RFunction
-
+    Private clsAsNumeric As New RFunction
     Private clsDatePeriodOperator As New ROperator
 
     Private clsAsFactorFunction As New RFunction
@@ -299,7 +299,7 @@ Public Class dlgPICSARainfall
         clsUpperTercileFunction = New RFunction
         clsRoundUpperTercileY = New RFunction
         clsAsDateUpperTercileY = New RFunction
-
+        clsAsNumeric = New RFunction
         clsStatRegEquationFunction = New RFunction
         clsStatsCorFunction = New RFunction
         clsGeomSmoothFunction = New RFunction
@@ -728,6 +728,7 @@ Public Class dlgPICSARainfall
 
         clsAsNumericX.SetRCommand("as.numeric")
         clsAsNumericY.SetRCommand("as.numeric")
+        clsAsNumeric.SetRCommand("as.numeric")
 
         clsVarsFunction.SetPackageName("ggplot2")
         clsVarsFunction.SetRCommand("vars")
@@ -775,7 +776,7 @@ Public Class dlgPICSARainfall
 
         If bReset Then
             AutoFacetStation()
-            ucrVariablesAsFactorForPicsa.SetRCode(clsAsNumericX, bReset)
+            ucrVariablesAsFactorForPicsa.SetRCode(clsAsNumeric, bReset)
             ucrReceiverForPICSA.SetRCode(clsRaesFunction, bReset)
             ucrReceiverSecondYVar.SetRCode(clsSegmentAesFunction, bReset)
         End If
@@ -1016,7 +1017,7 @@ Public Class dlgPICSARainfall
                 ucrVariablesAsFactorForPicsa.Visible = False
                 Me.Text = "PICSA Rainfall Graphs"
             Case PICSAMode.Temperature
-                clsRaesFunction.AddParameter("y", clsRFunctionParameter:=clsAsNumericX, iPosition:=1)
+                clsRaesFunction.AddParameter("y", clsRFunctionParameter:=clsAsNumeric, iPosition:=1)
                 clsRaesFunction.AddParameter("x", ucrReceiverX.GetVariableNames(bWithQuotes:=False), iPosition:=2)
                 ucrVariablesAsFactorForPicsa.Visible = True
                 ucrVariablesAsFactorForPicsa.SetMeAsReceiver()

--- a/instat/dlgPICSARainfall.vb
+++ b/instat/dlgPICSARainfall.vb
@@ -732,10 +732,6 @@ Public Class dlgPICSARainfall
         clsVarsFunction.SetPackageName("ggplot2")
         clsVarsFunction.SetRCommand("vars")
 
-        clsRaesFunction.AddParameter("x", clsRFunctionParameter:=clsAsNumericX, iPosition:=0)
-        clsRaesFunction.AddParameter("y", ucrReceiverForPICSA.GetVariableNames, iPosition:=1)
-        clsRaesFunction.AddParameter("y", clsRFunctionParameter:=clsAsNumericX, iPosition:=1)
-        clsRaesFunction.AddParameter("x", ucrReceiverX.GetVariableNames(bWithQuotes:=False), iPosition:=2)
         clsCoordPolarStartOperator = GgplotDefaults.clsCoordPolarStartOperator.Clone()
         clsCoordPolarFunction = GgplotDefaults.clsCoordPolarFunction.Clone()
         clsXScaleDateFunction = GgplotDefaults.clsXScaleDateFunction.Clone()
@@ -997,23 +993,31 @@ Public Class dlgPICSARainfall
     Private Sub OpeningMode()
         Select Case enumPICSAMode
             Case PICSAMode.General
+                clsRaesFunction.AddParameter("x", clsRFunctionParameter:=clsAsNumericX, iPosition:=0)
+                clsRaesFunction.AddParameter("y", ucrReceiverForPICSA.GetVariableNames, iPosition:=1)
                 ucrChkLineofBestFit.Visible = True
                 ucrChkWithSE.Visible = True
                 ucrVariablesAsFactorForPicsa.Visible = False
                 Me.Text = "PICSA General Graphs"
                 ucrBase.iHelpTopicID = 521
             Case PICSAMode.Trend
+                clsRaesFunction.AddParameter("x", clsRFunctionParameter:=clsAsNumericX, iPosition:=0)
+                clsRaesFunction.AddParameter("y", ucrReceiverForPICSA.GetVariableNames, iPosition:=1)
                 ucrChkLineofBestFit.Visible = True
                 ucrChkWithSE.Visible = True
                 ucrVariablesAsFactorForPicsa.Visible = False
                 Me.Text = "Climatic Trend Graph"
                 ucrSave.SetPrefix("climatic_trend_graph")
             Case PICSAMode.Rainfall
+                clsRaesFunction.AddParameter("x", clsRFunctionParameter:=clsAsNumericX, iPosition:=0)
+                clsRaesFunction.AddParameter("y", ucrReceiverForPICSA.GetVariableNames, iPosition:=1)
                 ucrChkLineofBestFit.Visible = False
                 ucrChkWithSE.Visible = False
                 ucrVariablesAsFactorForPicsa.Visible = False
                 Me.Text = "PICSA Rainfall Graphs"
             Case PICSAMode.Temperature
+                clsRaesFunction.AddParameter("y", clsRFunctionParameter:=clsAsNumericX, iPosition:=1)
+                clsRaesFunction.AddParameter("x", ucrReceiverX.GetVariableNames(bWithQuotes:=False), iPosition:=2)
                 ucrVariablesAsFactorForPicsa.Visible = True
                 ucrVariablesAsFactorForPicsa.SetMeAsReceiver()
                 ucrReceiverForPICSA.Visible = False

--- a/instat/dlgPICSARainfall.vb
+++ b/instat/dlgPICSARainfall.vb
@@ -782,20 +782,18 @@ Public Class dlgPICSARainfall
     End Sub
 
     Private Sub TestOkEnabled()
+        Dim bEnable As Boolean = False
+
         Select Case enumPICSAMode
-            Case PICSAMode.Rainfall OrElse PICSAMode.General OrElse PICSAMode.Trend
-                If (ucrReceiverForPICSA.IsEmpty OrElse ucrReceiverX.IsEmpty) OrElse (ucrChkIncludeStatus.Checked AndAlso ucrReceiverIncludeStatus.IsEmpty) OrElse Not ucrSave.IsComplete Then
-                    ucrBase.OKEnabled(False)
-                Else
-                    ucrBase.OKEnabled(True)
-                End If
+            Case PICSAMode.Rainfall, PICSAMode.General, PICSAMode.Trend
+                bEnable = Not (ucrReceiverForPICSA.IsEmpty OrElse ucrReceiverX.IsEmpty OrElse
+                (ucrChkIncludeStatus.Checked AndAlso ucrReceiverIncludeStatus.IsEmpty) OrElse
+                Not ucrSave.IsComplete)
             Case PICSAMode.Temperature
-                If (ucrVariablesAsFactorForPicsa.IsEmpty OrElse ucrReceiverX.IsEmpty) OrElse (ucrChkIncludeStatus.Checked AndAlso ucrReceiverIncludeStatus.IsEmpty) OrElse Not ucrSave.IsComplete Then
-                    ucrBase.OKEnabled(False)
-                Else
-                    ucrBase.OKEnabled(True)
-                End If
+                bEnable = Not (ucrVariablesAsFactorForPicsa.IsEmpty OrElse ucrReceiverX.IsEmpty OrElse Not ucrSave.IsComplete)
         End Select
+
+        ucrBase.OKEnabled(bEnable)
     End Sub
 
     Private Sub ucrBase_ClickReset(sender As Object, e As EventArgs) Handles ucrBase.ClickReset
@@ -941,7 +939,7 @@ Public Class dlgPICSARainfall
         bResetSubdialog = False
     End Sub
 
-    Private Sub AllControl_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrSave.ControlContentsChanged, ucrReceiverX.ControlContentsChanged, ucrReceiverForPICSA.ControlContentsChanged, ucrChkIncludeStatus.ControlContentsChanged, ucrReceiverIncludeStatus.ControlContentsChanged
+    Private Sub AllControl_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrSave.ControlContentsChanged, ucrReceiverX.ControlContentsChanged, ucrReceiverForPICSA.ControlContentsChanged, ucrChkIncludeStatus.ControlContentsChanged, ucrReceiverIncludeStatus.ControlContentsChanged, ucrVariablesAsFactorForPicsa.ControlContentsChanged
         TestOkEnabled()
     End Sub
 
@@ -1042,6 +1040,7 @@ Public Class dlgPICSARainfall
                 Me.Text = "PICSA Temperature Graphs"
                 ucrBase.iHelpTopicID = 479
         End Select
+        TestOkEnabled()
     End Sub
 
     Private Sub YAxisDataTypeCheckPISCATemp()

--- a/instat/dlgPICSARainfall.vb
+++ b/instat/dlgPICSARainfall.vb
@@ -370,7 +370,6 @@ Public Class dlgPICSARainfall
         clsLocalRaesFunction = GgplotDefaults.clsAesFunction.Clone()
         dctThemeFunctions = New Dictionary(Of String, RFunction)(GgplotDefaults.dctThemeFunctions)
 
-        'ucrVariablesAsFactorForPicsa.Visible = False
         ucrSelectorPICSARainfall.Reset()
         ucrSelectorPICSARainfall.SetGgplotFunction(clsBaseOperator)
         ucrSave.Reset()

--- a/instat/dlgPICSARainfall.vb
+++ b/instat/dlgPICSARainfall.vb
@@ -169,6 +169,14 @@ Public Class dlgPICSARainfall
         ucrReceiverForPICSA.SetParameterIsString()
         ucrReceiverForPICSA.bWithQuotes = False
 
+        ucrVariablesAsFactorForPicsa.SetParameter(New RParameter("x", 0))
+        ucrVariablesAsFactorForPicsa.SetFactorReceiver(ucrReceiverColourBy)
+        ucrVariablesAsFactorForPicsa.Selector = ucrSelectorPICSARainfall
+        ucrVariablesAsFactorForPicsa.SetIncludedDataTypes({"numeric"}, True)
+        ucrVariablesAsFactorForPicsa.SetSelectorHeading("Numerics")
+        ucrVariablesAsFactorForPicsa.SetParameterIsString()
+        ucrVariablesAsFactorForPicsa.bWithQuotes = False
+
         ucrReceiverSecondYVar.SetParameter(New RParameter("yend"))
         ucrReceiverSecondYVar.Selector = ucrSelectorPICSARainfall
         ucrReceiverSecondYVar.SetIncludedDataTypes({"numeric"}, True)
@@ -362,6 +370,7 @@ Public Class dlgPICSARainfall
         clsLocalRaesFunction = GgplotDefaults.clsAesFunction.Clone()
         dctThemeFunctions = New Dictionary(Of String, RFunction)(GgplotDefaults.dctThemeFunctions)
 
+        ucrVariablesAsFactorForPicsa.Visible = False
         ucrSelectorPICSARainfall.Reset()
         ucrSelectorPICSARainfall.SetGgplotFunction(clsBaseOperator)
         ucrSave.Reset()
@@ -725,6 +734,8 @@ Public Class dlgPICSARainfall
 
         clsRaesFunction.AddParameter("x", clsRFunctionParameter:=clsAsNumericX, iPosition:=0)
         clsRaesFunction.AddParameter("y", ucrReceiverForPICSA.GetVariableNames, iPosition:=1)
+        clsRaesFunction.AddParameter("y", clsRFunctionParameter:=clsAsNumericX, iPosition:=1)
+        clsRaesFunction.AddParameter("x", ucrReceiverX.GetVariableNames(bWithQuotes:=False), iPosition:=2)
         clsCoordPolarStartOperator = GgplotDefaults.clsCoordPolarStartOperator.Clone()
         clsCoordPolarFunction = GgplotDefaults.clsCoordPolarFunction.Clone()
         clsXScaleDateFunction = GgplotDefaults.clsXScaleDateFunction.Clone()
@@ -744,6 +755,14 @@ Public Class dlgPICSARainfall
         ucrReceiverForPICSA.AddAdditionalCodeParameterPair(clsSegmentAesFunction, New RParameter("y", 1), iAdditionalPairNo:=6)
         ucrReceiverForPICSA.AddAdditionalCodeParameterPair(clsAsNumericY, New RParameter("y", 0, bNewIncludeArgumentName:=False), iAdditionalPairNo:=7)
 
+        ucrVariablesAsFactorForPicsa.AddAdditionalCodeParameterPair(clsAsDate, New RParameter("x", 0), iAdditionalPairNo:=1)
+        ucrVariablesAsFactorForPicsa.AddAdditionalCodeParameterPair(clsMeanFunction, New RParameter("x", 0), iAdditionalPairNo:=2)
+        ucrVariablesAsFactorForPicsa.AddAdditionalCodeParameterPair(clsMedianFunction, New RParameter("x", 0), iAdditionalPairNo:=3)
+        ucrVariablesAsFactorForPicsa.AddAdditionalCodeParameterPair(clsLowerTercileFunction, New RParameter("x", 0), iAdditionalPairNo:=4)
+        ucrVariablesAsFactorForPicsa.AddAdditionalCodeParameterPair(clsUpperTercileFunction, New RParameter("x", 0), iAdditionalPairNo:=5)
+        ucrVariablesAsFactorForPicsa.AddAdditionalCodeParameterPair(clsSegmentAesFunction, New RParameter("y", 1), iAdditionalPairNo:=6)
+        ucrVariablesAsFactorForPicsa.AddAdditionalCodeParameterPair(clsAsNumericY, New RParameter("y", 0, bNewIncludeArgumentName:=False), iAdditionalPairNo:=7)
+
         ucrReceiverSecondYVar.AddAdditionalCodeParameterPair(clsPoint2AesFunction, New RParameter("y", 1), iAdditionalPairNo:=1)
         ucrReceiverSecondYVar.AddAdditionalCodeParameterPair(clsAsDateYendFunction, New RParameter("x", 0), iAdditionalPairNo:=2)
 
@@ -760,17 +779,27 @@ Public Class dlgPICSARainfall
 
         If bReset Then
             AutoFacetStation()
+            ucrVariablesAsFactorForPicsa.SetRCode(clsAsNumericX, bReset)
             ucrReceiverForPICSA.SetRCode(clsRaesFunction, bReset)
             ucrReceiverSecondYVar.SetRCode(clsSegmentAesFunction, bReset)
         End If
     End Sub
 
     Private Sub TestOkEnabled()
-        If (ucrReceiverForPICSA.IsEmpty OrElse ucrReceiverX.IsEmpty) OrElse (ucrChkIncludeStatus.Checked AndAlso ucrReceiverIncludeStatus.IsEmpty) OrElse Not ucrSave.IsComplete Then
-            ucrBase.OKEnabled(False)
-        Else
-            ucrBase.OKEnabled(True)
-        End If
+        Select Case enumPICSAMode
+            Case PICSAMode.Rainfall OrElse PICSAMode.General OrElse PICSAMode.Trend
+                If (ucrReceiverForPICSA.IsEmpty OrElse ucrReceiverX.IsEmpty) OrElse (ucrChkIncludeStatus.Checked AndAlso ucrReceiverIncludeStatus.IsEmpty) OrElse Not ucrSave.IsComplete Then
+                    ucrBase.OKEnabled(False)
+                Else
+                    ucrBase.OKEnabled(True)
+                End If
+            Case PICSAMode.Temperature
+                If (ucrVariablesAsFactorForPicsa.IsEmpty OrElse ucrReceiverX.IsEmpty) OrElse (ucrChkIncludeStatus.Checked AndAlso ucrReceiverIncludeStatus.IsEmpty) OrElse Not ucrSave.IsComplete Then
+                    ucrBase.OKEnabled(False)
+                Else
+                    ucrBase.OKEnabled(True)
+                End If
+        End Select
     End Sub
 
     Private Sub ucrBase_ClickReset(sender As Object, e As EventArgs) Handles ucrBase.ClickReset
@@ -916,7 +945,7 @@ Public Class dlgPICSARainfall
         bResetSubdialog = False
     End Sub
 
-    Private Sub AllControl_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrSave.ControlContentsChanged, ucrReceiverX.ControlContentsChanged, ucrReceiverForPICSA.ControlContentsChanged, ucrChkIncludeStatus.ControlContentsChanged, ucrReceiverIncludeStatus.ControlContentsChanged
+    Private Sub AllControl_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrSave.ControlContentsChanged, ucrReceiverX.ControlContentsChanged, ucrReceiverForPICSA.ControlContentsChanged, ucrVariablesAsFactorForPicsa.ControlContentsChanged, ucrChkIncludeStatus.ControlContentsChanged, ucrReceiverIncludeStatus.ControlContentsChanged
         TestOkEnabled()
     End Sub
 
@@ -970,18 +999,27 @@ Public Class dlgPICSARainfall
             Case PICSAMode.General
                 ucrChkLineofBestFit.Visible = True
                 ucrChkWithSE.Visible = True
+                ucrVariablesAsFactorForPicsa.Visible = False
                 Me.Text = "PICSA General Graphs"
                 ucrBase.iHelpTopicID = 521
             Case PICSAMode.Trend
                 ucrChkLineofBestFit.Visible = True
                 ucrChkWithSE.Visible = True
+                ucrVariablesAsFactorForPicsa.Visible = False
                 Me.Text = "Climatic Trend Graph"
                 ucrSave.SetPrefix("climatic_trend_graph")
             Case PICSAMode.Rainfall
                 ucrChkLineofBestFit.Visible = False
                 ucrChkWithSE.Visible = False
+                ucrVariablesAsFactorForPicsa.Visible = False
                 Me.Text = "PICSA Rainfall Graphs"
             Case PICSAMode.Temperature
+                ucrVariablesAsFactorForPicsa.Visible = True
+                ucrVariablesAsFactorForPicsa.SetMeAsReceiver()
+                ucrReceiverForPICSA.Visible = False
+                lblSecondYVar.Visible = False
+                lblYVar.Visible = False
+                ucrReceiverSecondYVar.Visible = False
                 ucrChkLineofBestFit.Visible = True
                 ucrChkWithSE.Visible = True
                 Me.Text = "PICSA Temperature Graphs"
@@ -989,6 +1027,13 @@ Public Class dlgPICSARainfall
         End Select
     End Sub
 
+    Private Sub YAxisDataTypeCheckPISCATemp()
+        If Not ucrVariablesAsFactorForPicsa.IsEmpty Then
+            clsGeomLine.AddParameter("group", 0)
+        Else
+            clsGeomLine.RemoveParameterByName("group")
+        End If
+    End Sub
 
     Private Sub YAxisDataTypeCheck()
         If Not ucrReceiverForPICSA.IsEmpty Then
@@ -1018,6 +1063,10 @@ Public Class dlgPICSARainfall
 
     Private Sub ucrReceiverForPICSA_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverForPICSA.ControlValueChanged
         YAxisDataTypeCheck()
+    End Sub
+
+    Private Sub ucrVariablesAsFactorForPicsa_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrVariablesAsFactorForPicsa.ControlValueChanged
+        YAxisDataTypeCheckPISCATemp()
     End Sub
 
     Private Sub ucrSelectorPICSARainfall_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrSelectorPICSARainfall.ControlValueChanged
@@ -1111,6 +1160,11 @@ Public Class dlgPICSARainfall
                     ucrReceiverForPICSA.Clear()
                 Else
                     ucrReceiverForPICSA.Add(clsParam.strArgumentValue)
+                End If
+                If clsParam.strArgumentValue = (Chr(34) & Chr(34)) Then
+                    ucrVariablesAsFactorForPicsa.Clear()
+                Else
+                    ucrVariablesAsFactorForPicsa.Add(clsParam.strArgumentValue)
                 End If
             ElseIf clsParam.strArgumentName = "colour" Then
                 ucrReceiverColourBy.Add(clsParam.strArgumentValue)

--- a/instat/dlgPICSARainfall.vb
+++ b/instat/dlgPICSARainfall.vb
@@ -941,7 +941,7 @@ Public Class dlgPICSARainfall
         bResetSubdialog = False
     End Sub
 
-    Private Sub AllControl_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrSave.ControlContentsChanged, ucrReceiverX.ControlContentsChanged, ucrReceiverForPICSA.ControlContentsChanged, ucrVariablesAsFactorForPicsa.ControlContentsChanged, ucrChkIncludeStatus.ControlContentsChanged, ucrReceiverIncludeStatus.ControlContentsChanged
+    Private Sub AllControl_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrSave.ControlContentsChanged, ucrReceiverX.ControlContentsChanged, ucrReceiverForPICSA.ControlContentsChanged, ucrChkIncludeStatus.ControlContentsChanged, ucrReceiverIncludeStatus.ControlContentsChanged
         TestOkEnabled()
     End Sub
 
@@ -997,6 +997,10 @@ Public Class dlgPICSARainfall
                 clsRaesFunction.AddParameter("y", ucrReceiverForPICSA.GetVariableNames, iPosition:=1)
                 ucrChkLineofBestFit.Visible = True
                 ucrChkWithSE.Visible = True
+                ucrReceiverForPICSA.Visible = True
+                lblYVar.Visible = True
+                lblSecondYVar.Visible = True
+                ucrReceiverSecondYVar.Visible = True
                 ucrVariablesAsFactorForPicsa.Visible = False
                 Me.Text = "PICSA General Graphs"
                 ucrBase.iHelpTopicID = 521
@@ -1005,6 +1009,10 @@ Public Class dlgPICSARainfall
                 clsRaesFunction.AddParameter("y", ucrReceiverForPICSA.GetVariableNames, iPosition:=1)
                 ucrChkLineofBestFit.Visible = True
                 ucrChkWithSE.Visible = True
+                ucrReceiverForPICSA.Visible = True
+                lblYVar.Visible = True
+                lblSecondYVar.Visible = True
+                ucrReceiverSecondYVar.Visible = True
                 ucrVariablesAsFactorForPicsa.Visible = False
                 Me.Text = "Climatic Trend Graph"
                 ucrSave.SetPrefix("climatic_trend_graph")
@@ -1013,6 +1021,10 @@ Public Class dlgPICSARainfall
                 clsRaesFunction.AddParameter("y", ucrReceiverForPICSA.GetVariableNames, iPosition:=1)
                 ucrChkLineofBestFit.Visible = False
                 ucrChkWithSE.Visible = False
+                ucrReceiverForPICSA.Visible = True
+                lblYVar.Visible = True
+                lblSecondYVar.Visible = True
+                ucrReceiverSecondYVar.Visible = True
                 ucrVariablesAsFactorForPicsa.Visible = False
                 Me.Text = "PICSA Rainfall Graphs"
             Case PICSAMode.Temperature
@@ -1026,6 +1038,7 @@ Public Class dlgPICSARainfall
                 ucrReceiverSecondYVar.Visible = False
                 ucrChkLineofBestFit.Visible = True
                 ucrChkWithSE.Visible = True
+                ucrChkIncludeStatus.Visible = False
                 Me.Text = "PICSA Temperature Graphs"
                 ucrBase.iHelpTopicID = 479
         End Select
@@ -1069,7 +1082,7 @@ Public Class dlgPICSARainfall
         YAxisDataTypeCheck()
     End Sub
 
-    Private Sub ucrVariablesAsFactorForPicsa_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrVariablesAsFactorForPicsa.ControlValueChanged
+    Private Sub ucrVariablesAsFactorForPicsa_ControlValueChanged(ucrChangedControl As ucrCore)
         YAxisDataTypeCheckPISCATemp()
     End Sub
 

--- a/instat/dlgPICSARainfall.vb
+++ b/instat/dlgPICSARainfall.vb
@@ -370,7 +370,7 @@ Public Class dlgPICSARainfall
         clsLocalRaesFunction = GgplotDefaults.clsAesFunction.Clone()
         dctThemeFunctions = New Dictionary(Of String, RFunction)(GgplotDefaults.dctThemeFunctions)
 
-        ucrVariablesAsFactorForPicsa.Visible = False
+        'ucrVariablesAsFactorForPicsa.Visible = False
         ucrSelectorPICSARainfall.Reset()
         ucrSelectorPICSARainfall.SetGgplotFunction(clsBaseOperator)
         ucrSave.Reset()

--- a/instat/dlgPICSATemperature.Designer.vb
+++ b/instat/dlgPICSATemperature.Designer.vb
@@ -38,35 +38,296 @@ Partial Class dlgPICSATemperature
     'Do not modify it using the code editor.
     <System.Diagnostics.DebuggerStepThrough()> _
     Private Sub InitializeComponent()
+        Me.components = New System.ComponentModel.Container()
         Me.ucrBase = New instat.ucrButtons()
+        Me.ucrSelectorPICSATemperature = New instat.ucrSelectorByDataFrameAddRemove()
+        Me.ucrInputStation = New instat.ucrInputComboBox()
+        Me.ucrReceiverFacetBy = New instat.ucrReceiverSingle()
+        Me.lblFacetBy = New System.Windows.Forms.Label()
+        Me.ucrReceiverX = New instat.ucrReceiverSingle()
+        Me.ucrReceiverColourBy = New instat.ucrReceiverSingle()
+        Me.lblFactorOptional = New System.Windows.Forms.Label()
+        Me.lblXVariable = New System.Windows.Forms.Label()
+        Me.ucrChkWithSE = New instat.ucrCheck()
+        Me.ucrChkLineofBestFit = New instat.ucrCheck()
+        Me.ucrChkPoints = New instat.ucrCheck()
+        Me.ucrSave = New instat.ucrSave()
+        Me.cmdOptions = New instat.ucrSplitButton()
+        Me.contextMenuStripOptions = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.PlotOptionsToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.toolStripMenuItemLineOptions = New System.Windows.Forms.ToolStripMenuItem()
+        Me.toolStripMenuItemPointOption = New System.Windows.Forms.ToolStripMenuItem()
+        Me.cmdPICSAOptions = New System.Windows.Forms.Button()
+        Me.ucrReceiverPICSA = New instat.ucrVariablesAsFactor()
+        Me.contextMenuStripOptions.SuspendLayout()
         Me.SuspendLayout()
         '
         'ucrBase
         '
         Me.ucrBase.AutoSize = True
         Me.ucrBase.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrBase.Location = New System.Drawing.Point(7, 203)
+        Me.ucrBase.Location = New System.Drawing.Point(20, 587)
+        Me.ucrBase.Margin = New System.Windows.Forms.Padding(9)
         Me.ucrBase.Name = "ucrBase"
-        Me.ucrBase.Size = New System.Drawing.Size(405, 52)
+        Me.ucrBase.Size = New System.Drawing.Size(611, 77)
         Me.ucrBase.TabIndex = 0
+        '
+        'ucrSelectorPICSATemperature
+        '
+        Me.ucrSelectorPICSATemperature.AutoSize = True
+        Me.ucrSelectorPICSATemperature.bDropUnusedFilterLevels = False
+        Me.ucrSelectorPICSATemperature.bShowHiddenColumns = False
+        Me.ucrSelectorPICSATemperature.bUseCurrentFilter = True
+        Me.ucrSelectorPICSATemperature.Location = New System.Drawing.Point(6, 39)
+        Me.ucrSelectorPICSATemperature.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrSelectorPICSATemperature.Name = "ucrSelectorPICSATemperature"
+        Me.ucrSelectorPICSATemperature.Size = New System.Drawing.Size(332, 284)
+        Me.ucrSelectorPICSATemperature.TabIndex = 2
+        '
+        'ucrInputStation
+        '
+        Me.ucrInputStation.AddQuotesIfUnrecognised = True
+        Me.ucrInputStation.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrInputStation.GetSetSelectedIndex = -1
+        Me.ucrInputStation.IsReadOnly = False
+        Me.ucrInputStation.Location = New System.Drawing.Point(553, 430)
+        Me.ucrInputStation.Margin = New System.Windows.Forms.Padding(14)
+        Me.ucrInputStation.Name = "ucrInputStation"
+        Me.ucrInputStation.Size = New System.Drawing.Size(123, 32)
+        Me.ucrInputStation.TabIndex = 31
+        '
+        'ucrReceiverFacetBy
+        '
+        Me.ucrReceiverFacetBy.AutoSize = True
+        Me.ucrReceiverFacetBy.frmParent = Me
+        Me.ucrReceiverFacetBy.Location = New System.Drawing.Point(363, 430)
+        Me.ucrReceiverFacetBy.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrReceiverFacetBy.Name = "ucrReceiverFacetBy"
+        Me.ucrReceiverFacetBy.Selector = Nothing
+        Me.ucrReceiverFacetBy.Size = New System.Drawing.Size(188, 39)
+        Me.ucrReceiverFacetBy.strNcFilePath = ""
+        Me.ucrReceiverFacetBy.TabIndex = 30
+        Me.ucrReceiverFacetBy.ucrSelector = Nothing
+        '
+        'lblFacetBy
+        '
+        Me.lblFacetBy.AutoSize = True
+        Me.lblFacetBy.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.lblFacetBy.Location = New System.Drawing.Point(363, 410)
+        Me.lblFacetBy.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
+        Me.lblFacetBy.Name = "lblFacetBy"
+        Me.lblFacetBy.Size = New System.Drawing.Size(149, 20)
+        Me.lblFacetBy.TabIndex = 29
+        Me.lblFacetBy.Tag = ""
+        Me.lblFacetBy.Text = "Facet By (Optional):"
+        '
+        'ucrReceiverX
+        '
+        Me.ucrReceiverX.AutoSize = True
+        Me.ucrReceiverX.frmParent = Me
+        Me.ucrReceiverX.Location = New System.Drawing.Point(363, 298)
+        Me.ucrReceiverX.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrReceiverX.Name = "ucrReceiverX"
+        Me.ucrReceiverX.Selector = Nothing
+        Me.ucrReceiverX.Size = New System.Drawing.Size(218, 39)
+        Me.ucrReceiverX.strNcFilePath = ""
+        Me.ucrReceiverX.TabIndex = 26
+        Me.ucrReceiverX.ucrSelector = Nothing
+        '
+        'ucrReceiverColourBy
+        '
+        Me.ucrReceiverColourBy.AutoSize = True
+        Me.ucrReceiverColourBy.frmParent = Me
+        Me.ucrReceiverColourBy.Location = New System.Drawing.Point(363, 366)
+        Me.ucrReceiverColourBy.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrReceiverColourBy.Name = "ucrReceiverColourBy"
+        Me.ucrReceiverColourBy.Selector = Nothing
+        Me.ucrReceiverColourBy.Size = New System.Drawing.Size(218, 39)
+        Me.ucrReceiverColourBy.strNcFilePath = ""
+        Me.ucrReceiverColourBy.TabIndex = 28
+        Me.ucrReceiverColourBy.ucrSelector = Nothing
+        '
+        'lblFactorOptional
+        '
+        Me.lblFactorOptional.AutoSize = True
+        Me.lblFactorOptional.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.lblFactorOptional.Location = New System.Drawing.Point(363, 339)
+        Me.lblFactorOptional.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
+        Me.lblFactorOptional.Name = "lblFactorOptional"
+        Me.lblFactorOptional.Size = New System.Drawing.Size(154, 20)
+        Me.lblFactorOptional.TabIndex = 27
+        Me.lblFactorOptional.Tag = "Factor_Optional:"
+        Me.lblFactorOptional.Text = "Colour By (Optional):"
+        '
+        'lblXVariable
+        '
+        Me.lblXVariable.AutoSize = True
+        Me.lblXVariable.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.lblXVariable.Location = New System.Drawing.Point(363, 276)
+        Me.lblXVariable.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
+        Me.lblXVariable.Name = "lblXVariable"
+        Me.lblXVariable.Size = New System.Drawing.Size(86, 20)
+        Me.lblXVariable.TabIndex = 25
+        Me.lblXVariable.Tag = "X_Variable:"
+        Me.lblXVariable.Text = "X Variable:"
+        '
+        'ucrChkWithSE
+        '
+        Me.ucrChkWithSE.AutoSize = True
+        Me.ucrChkWithSE.Checked = False
+        Me.ucrChkWithSE.Location = New System.Drawing.Point(6, 449)
+        Me.ucrChkWithSE.Margin = New System.Windows.Forms.Padding(9)
+        Me.ucrChkWithSE.Name = "ucrChkWithSE"
+        Me.ucrChkWithSE.Size = New System.Drawing.Size(332, 34)
+        Me.ucrChkWithSE.TabIndex = 33
+        '
+        'ucrChkLineofBestFit
+        '
+        Me.ucrChkLineofBestFit.AutoSize = True
+        Me.ucrChkLineofBestFit.Checked = False
+        Me.ucrChkLineofBestFit.Location = New System.Drawing.Point(6, 398)
+        Me.ucrChkLineofBestFit.Margin = New System.Windows.Forms.Padding(9)
+        Me.ucrChkLineofBestFit.Name = "ucrChkLineofBestFit"
+        Me.ucrChkLineofBestFit.Size = New System.Drawing.Size(332, 34)
+        Me.ucrChkLineofBestFit.TabIndex = 32
+        '
+        'ucrChkPoints
+        '
+        Me.ucrChkPoints.AutoSize = True
+        Me.ucrChkPoints.Checked = False
+        Me.ucrChkPoints.Location = New System.Drawing.Point(6, 486)
+        Me.ucrChkPoints.Margin = New System.Windows.Forms.Padding(9)
+        Me.ucrChkPoints.Name = "ucrChkPoints"
+        Me.ucrChkPoints.Size = New System.Drawing.Size(332, 36)
+        Me.ucrChkPoints.TabIndex = 34
+        '
+        'ucrSave
+        '
+        Me.ucrSave.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrSave.Location = New System.Drawing.Point(6, 536)
+        Me.ucrSave.Margin = New System.Windows.Forms.Padding(6, 8, 6, 8)
+        Me.ucrSave.Name = "ucrSave"
+        Me.ucrSave.Size = New System.Drawing.Size(480, 36)
+        Me.ucrSave.TabIndex = 35
+        '
+        'cmdOptions
+        '
+        Me.cmdOptions.AutoSize = True
+        Me.cmdOptions.ContextMenuStrip = Me.contextMenuStripOptions
+        Me.cmdOptions.Location = New System.Drawing.Point(6, 347)
+        Me.cmdOptions.Margin = New System.Windows.Forms.Padding(4)
+        Me.cmdOptions.Name = "cmdOptions"
+        Me.cmdOptions.Size = New System.Drawing.Size(226, 34)
+        Me.cmdOptions.SplitMenuStrip = Me.contextMenuStripOptions
+        Me.cmdOptions.TabIndex = 37
+        Me.cmdOptions.Tag = "Plot Options"
+        Me.cmdOptions.Text = "Plot Options"
+        Me.cmdOptions.UseVisualStyleBackColor = True
+        '
+        'contextMenuStripOptions
+        '
+        Me.contextMenuStripOptions.ImageScalingSize = New System.Drawing.Size(24, 24)
+        Me.contextMenuStripOptions.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.PlotOptionsToolStripMenuItem, Me.toolStripMenuItemLineOptions, Me.toolStripMenuItemPointOption})
+        Me.contextMenuStripOptions.Name = "contextMenuStripOk"
+        Me.contextMenuStripOptions.Size = New System.Drawing.Size(194, 100)
+        '
+        'PlotOptionsToolStripMenuItem
+        '
+        Me.PlotOptionsToolStripMenuItem.Name = "PlotOptionsToolStripMenuItem"
+        Me.PlotOptionsToolStripMenuItem.Size = New System.Drawing.Size(193, 32)
+        Me.PlotOptionsToolStripMenuItem.Text = "Plot Options"
+        '
+        'toolStripMenuItemLineOptions
+        '
+        Me.toolStripMenuItemLineOptions.Name = "toolStripMenuItemLineOptions"
+        Me.toolStripMenuItemLineOptions.Size = New System.Drawing.Size(193, 32)
+        Me.toolStripMenuItemLineOptions.Text = "Line Options"
+        '
+        'toolStripMenuItemPointOption
+        '
+        Me.toolStripMenuItemPointOption.Name = "toolStripMenuItemPointOption"
+        Me.toolStripMenuItemPointOption.Size = New System.Drawing.Size(193, 32)
+        Me.toolStripMenuItemPointOption.Text = "Point Options"
+        '
+        'cmdPICSAOptions
+        '
+        Me.cmdPICSAOptions.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.cmdPICSAOptions.Location = New System.Drawing.Point(6, 311)
+        Me.cmdPICSAOptions.Margin = New System.Windows.Forms.Padding(4)
+        Me.cmdPICSAOptions.Name = "cmdPICSAOptions"
+        Me.cmdPICSAOptions.Size = New System.Drawing.Size(226, 34)
+        Me.cmdPICSAOptions.TabIndex = 36
+        Me.cmdPICSAOptions.Tag = ""
+        Me.cmdPICSAOptions.Text = "PICSA Options"
+        Me.cmdPICSAOptions.UseVisualStyleBackColor = True
+        '
+        'ucrReceiverPICSA
+        '
+        Me.ucrReceiverPICSA.AutoSize = True
+        Me.ucrReceiverPICSA.frmParent = Me
+        Me.ucrReceiverPICSA.Location = New System.Drawing.Point(363, 27)
+        Me.ucrReceiverPICSA.Margin = New System.Windows.Forms.Padding(9)
+        Me.ucrReceiverPICSA.Name = "ucrReceiverPICSA"
+        Me.ucrReceiverPICSA.Selector = Nothing
+        Me.ucrReceiverPICSA.Size = New System.Drawing.Size(180, 207)
+        Me.ucrReceiverPICSA.strNcFilePath = ""
+        Me.ucrReceiverPICSA.TabIndex = 38
+        Me.ucrReceiverPICSA.ucrSelector = Nothing
+        Me.ucrReceiverPICSA.ucrVariableSelector = Nothing
         '
         'dlgPICSATemperature
         '
-        Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(144.0!, 144.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
         Me.AutoSize = True
-        Me.ClientSize = New System.Drawing.Size(412, 261)
+        Me.ClientSize = New System.Drawing.Size(693, 671)
+        Me.Controls.Add(Me.ucrReceiverPICSA)
+        Me.Controls.Add(Me.cmdOptions)
+        Me.Controls.Add(Me.cmdPICSAOptions)
+        Me.Controls.Add(Me.ucrChkWithSE)
+        Me.Controls.Add(Me.ucrChkLineofBestFit)
+        Me.Controls.Add(Me.ucrChkPoints)
+        Me.Controls.Add(Me.ucrSave)
+        Me.Controls.Add(Me.ucrInputStation)
+        Me.Controls.Add(Me.ucrReceiverFacetBy)
+        Me.Controls.Add(Me.lblFacetBy)
+        Me.Controls.Add(Me.ucrReceiverX)
+        Me.Controls.Add(Me.ucrReceiverColourBy)
+        Me.Controls.Add(Me.lblFactorOptional)
+        Me.Controls.Add(Me.lblXVariable)
+        Me.Controls.Add(Me.ucrSelectorPICSATemperature)
         Me.Controls.Add(Me.ucrBase)
         Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow
+        Me.Margin = New System.Windows.Forms.Padding(4)
         Me.MaximizeBox = False
         Me.MinimizeBox = False
         Me.Name = "dlgPICSATemperature"
         Me.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen
         Me.Text = "PICSA Temperature"
+        Me.contextMenuStripOptions.ResumeLayout(False)
         Me.ResumeLayout(False)
         Me.PerformLayout()
 
     End Sub
 
     Friend WithEvents ucrBase As ucrButtons
+    Friend WithEvents ucrSelectorPICSATemperature As ucrSelectorByDataFrameAddRemove
+    Friend WithEvents ucrInputStation As ucrInputComboBox
+    Friend WithEvents ucrReceiverFacetBy As ucrReceiverSingle
+    Friend WithEvents lblFacetBy As Label
+    Friend WithEvents ucrReceiverX As ucrReceiverSingle
+    Friend WithEvents ucrReceiverColourBy As ucrReceiverSingle
+    Friend WithEvents lblFactorOptional As Label
+    Friend WithEvents lblXVariable As Label
+    Friend WithEvents ucrChkWithSE As ucrCheck
+    Friend WithEvents ucrChkLineofBestFit As ucrCheck
+    Friend WithEvents ucrChkPoints As ucrCheck
+    Friend WithEvents ucrSave As ucrSave
+    Friend WithEvents cmdOptions As ucrSplitButton
+    Friend WithEvents cmdPICSAOptions As Button
+    Friend WithEvents contextMenuStripOptions As ContextMenuStrip
+    Friend WithEvents PlotOptionsToolStripMenuItem As ToolStripMenuItem
+    Friend WithEvents toolStripMenuItemLineOptions As ToolStripMenuItem
+    Friend WithEvents toolStripMenuItemPointOption As ToolStripMenuItem
+    Friend WithEvents ucrReceiverPICSA As ucrVariablesAsFactor
 End Class

--- a/instat/dlgPICSATemperature.resx
+++ b/instat/dlgPICSATemperature.resx
@@ -117,4 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="contextMenuStripOptions.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>

--- a/instat/dlgPICSATemperature.vb
+++ b/instat/dlgPICSATemperature.vb
@@ -17,24 +17,1082 @@
 Imports instat.Translations
 Public Class dlgPICSATemperature
     Public bFirstLoad As Boolean = True
+    Private clsBaseOperator As New ROperator
+    Private clsGroupByFunction As New RFunction
+    Private clsMutateFunction As New RFunction
+
+    Private clsRggplotFunction As New RFunction
+    Private clsGeomLine As New RFunction
+    Private clsRaesFunction As New RFunction
+    Private clsPipeOperator As New ROperator
+    Private bReset As Boolean = True
+    Private clsXScalecontinuousFunction As New RFunction
+    Private clsYScalecontinuousFunction As New RFunction
+    Private clsCLimitsYContinuous As New RFunction
+    Private clsXScaleDateFunction As New RFunction
+    Private clsYScaleDateFunction As New RFunction
+    Private clsCLimitsYDate As New RFunction
+    Private clsFacetFunction As New RFunction
+    Private clsRowVarsFunction, clsColVarsFunction As New RFunction
+    Private clsThemeFunction As New RFunction
+    Private dctThemeFunctions As New Dictionary(Of String, RFunction)
+    Private bResetSubdialog As Boolean = True
+    Private bResetLineLayerSubdialog As Boolean = True
+    Private clsLocalRaesFunction As New RFunction
+    Private clsPointsFunc As New RFunction
+    Private clsYLabsFunction, clsXLabsFunction, clsLabsFunction As RFunction
+    Private clsFactorLevels As New RFunction
+    Private clsGeomRugFunction As New RFunction
+    Private clsFilterFunction As New RFunction
+    Private clsEqualToOperator As New ROperator
+    Private clsGeomSegmentFunction As New RFunction
+    Private clsSegmentAesFunction As New RFunction
+    Private clsGeomPoint2Function As New RFunction
+    Private clsPoint2AesFunction As New RFunction
+    Private clsAsNumeric As New RFunction
+    Private clsDatePeriodOperator As New ROperator
+
+    Private clsAsFactorFunction As New RFunction
+
+    Private clsMeanFunction As New RFunction
+    Private clsRoundMeanY As New RFunction
+    Private clsAsDateMeanY As New RFunction
+    Private clsMedianFunction As New RFunction
+    Private clsRoundMedianY As New RFunction
+    Private clsAsDateMedianY As New RFunction
+    Private clsLowerTercileFunction As New RFunction
+    Private clsRoundLowerTercileY As New RFunction
+    Private clsAsDateLowerTercileY As New RFunction
+    Private clsUpperTercileFunction As New RFunction
+    Private clsRoundUpperTercileY As New RFunction
+    Private clsAsDateUpperTercileY As New RFunction
+    Private clsScaleFillViridisFunction As New RFunction
+    Private clsScaleColourViridisFunction As New RFunction
+    Private clsAnnotateFunction As New RFunction
+    Private clsGeomSmoothFunction As New RFunction
+    Private clsStatRegEquationFunction As New RFunction
+    Private clsStatsCorFunction As New RFunction
+
+    Private strMeanName As String = ".mean_y"
+    Private strMedianName As String = ".median_y"
+    Private strLowerTercileName As String = ".lower_ter_y"
+    Private strUpperTercileName As String = ".upper_ter_y"
+
+    Private clsDummyFunction As New RFunction
+
+    Private clsAsDateYLimit As New RFunction
+    Private clsGeomHlineMean As New RFunction
+    Private clsGeomHlineMedian As New RFunction
+    Private clsGeomHlineLowerTercile As New RFunction
+    Private clsGeomHlineUpperTercile As New RFunction
+
+    Private clsGeomHlineAesMean As New RFunction
+    Private clsGeomHlineAesMedian As New RFunction
+    Private clsGeomHlineAesLowerTercile As New RFunction
+    Private clsGeomHlineAesUpperTercile As New RFunction
+
+    Private ReadOnly strFacetWrap As String = "Facet Wrap"
+    Private ReadOnly strFacetRow As String = "Facet Row"
+    Private ReadOnly strFacetCol As String = "Facet Column"
+    Private ReadOnly strFacetRowAll As String = "Facet Row + O"
+    Private ReadOnly strFacetColAll As String = "Facet Col + O"
+    Private ReadOnly strFacetRowAndCol As String = "Facet Row & Col"
+    Private ReadOnly strFacetRowAndColAll As String = "Facet Row & Col + O"
+    Private ReadOnly strNone As String = "None"
+
+    Private bNotSubdialogue As Boolean = False
+    Private bUpdateComboOptions As Boolean = True
+    Private bUpdatingParameters As Boolean = False
+
+    Private clsGeomTextLabelMeanLine As New RFunction
+    Private clsAesGeomTextLabelMeanLine As New RFunction
+    Private clsPasteMeanY As New RFunction
+    Private clsFormatMeanY As New RFunction
+    Private clsGeomTextLabelMedianLine As New RFunction
+    Private clsAesGeomTextLabelMedianLine As New RFunction
+    Private clsPasteMedianY As New RFunction
+    Private clsFormatMedianY As New RFunction
+    Private clsGeomTextLabelLowerTercileLine As New RFunction
+    Private clsAesGeomTextLabelLowerTercileLine As New RFunction
+    Private clsPasteLowerTercileY As New RFunction
+    Private clsFormatLowerTercileY As New RFunction
+    Private clsGeomTextLabelUpperTercileLine As New RFunction
+    Private clsAesGeomTextLabelUpperTercileLine As New RFunction
+    Private clsPasteUpperTercileY As New RFunction
+    Private clsFormatUpperTercileY As New RFunction
+    Private clsVarsFunction As New RFunction
+
+    Private clsAsDate As New RFunction
+    Private clsAsDateYendFunction As New RFunction
+    Private clsAsNumericX As New RFunction
+    Private clsAsNumericY As New RFunction
+    Private clsCoordPolarFunction As New RFunction
+    Private clsCoordPolarStartOperator As New ROperator
     Private Sub dlgPICSATemperature_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         If bFirstLoad Then
             InitialiseDialog()
             SetDefaults()
             bFirstLoad = False
         End If
-        TestOKEnabled()
+        SetRCodeForControls(bReset)
+        bReset = False
+        XAxisDataTypeCheck()
+        TestOkEnabled()
         autoTranslate(Me)
     End Sub
     Private Sub InitialiseDialog()
         ucrBase.iHelpTopicID = 479
-    End Sub
+        ucrBase.clsRsyntax.bExcludeAssignedFunctionOutput = False
+        ucrBase.clsRsyntax.iCallType = 3
 
-    Private Sub TestOKEnabled()
+        ucrSelectorPICSATemperature.SetParameter(New RParameter("data", 0))
+        ucrSelectorPICSATemperature.SetParameterIsrfunction()
 
+        ucrReceiverPICSA.SetParameter(New RParameter("x", 0))
+        ucrReceiverPICSA.SetFactorReceiver(ucrReceiverColourBy)
+        ucrReceiverPICSA.Selector = ucrSelectorPICSATemperature
+        ucrReceiverPICSA.SetIncludedDataTypes({"numeric"}, True)
+        ucrReceiverPICSA.SetSelectorHeading("Numerics")
+        ucrReceiverPICSA.SetParameterIsString()
+        ucrReceiverPICSA.bWithQuotes = False
+
+        ucrReceiverX.SetParameter(New RParameter("x", 1, bNewIncludeArgumentName:=False))
+        ucrReceiverX.SetParameterIsString()
+        ucrReceiverX.Selector = ucrSelectorPICSATemperature
+        ucrReceiverX.SetClimaticType("year")
+        ucrReceiverX.bAutoFill = True
+        ucrReceiverX.bWithQuotes = False
+        ucrReceiverX.SetIncludedDataTypes({"numeric", "factor"})
+        ucrReceiverX.bAddParameterIfEmpty = True
+
+        ucrReceiverColourBy.SetParameter(New RParameter("colour", 2))
+        ucrReceiverColourBy.Selector = ucrSelectorPICSATemperature
+        ucrReceiverColourBy.SetIncludedDataTypes({"factor"})
+        ucrReceiverColourBy.strSelectorHeading = "Factors"
+        ucrReceiverColourBy.bWithQuotes = False
+        ucrReceiverColourBy.SetParameterIsString()
+
+        ucrReceiverFacetBy.SetParameter(New RParameter("rows", bNewIncludeArgumentName:=False))
+        ucrReceiverFacetBy.Selector = ucrSelectorPICSATemperature
+        ucrReceiverFacetBy.SetIncludedDataTypes({"factor"})
+        ucrReceiverFacetBy.strSelectorHeading = "Factors"
+        ucrReceiverFacetBy.bWithQuotes = False
+        ucrReceiverFacetBy.SetParameterIsString()
+        ucrReceiverFacetBy.SetValuesToIgnore({"."})
+        ucrReceiverFacetBy.SetParameterPosition(0)
+
+        ucrChkPoints.SetText("Add Points")
+        ucrChkPoints.AddParameterPresentCondition(True, "geom_point")
+        ucrChkPoints.AddParameterPresentCondition(False, "geom_point", False)
+
+        ucrChkLineofBestFit.SetText("Add Line of Best Fit")
+        ucrChkLineofBestFit.AddParameterPresentCondition(True, "geom_smooth")
+        ucrChkLineofBestFit.AddParameterPresentCondition(False, "geom_smooth", False)
+        ucrChkLineofBestFit.AddToLinkedControls(ucrChkWithSE, {True}, bNewLinkedHideIfParameterMissing:=True)
+
+        ucrChkWithSE.SetText("With Standard Error")
+        ucrChkWithSE.SetParameter(New RParameter("se"), bNewAddRemoveParameter:=False, bNewChangeParameterValue:=True)
+        ucrChkWithSE.SetValuesCheckedAndUnchecked("TRUE", "FALSE")
+        ucrChkWithSE.SetRDefault("TRUE")
+
+        ucrInputStation.SetItems({strFacetWrap, strFacetRow, strFacetCol, strFacetRowAll, strFacetColAll, strFacetRowAndCol, strFacetRowAndColAll, strNone})
+        ucrInputStation.SetDropDownStyleAsNonEditable()
+
+        ucrSave.SetPrefix("picsa_temperature_graph")
+        ucrSave.SetIsComboBox()
+        ucrSave.SetSaveTypeAsGraph()
+        ucrSave.SetCheckBoxText("Store Graph")
+        ucrSave.SetDataFrameSelector(ucrSelectorPICSATemperature.ucrAvailableDataFrames)
+        ucrSave.SetAssignToIfUncheckedValue("last_graph")
     End Sub
 
     Private Sub SetDefaults()
-        TestOKEnabled()
+        Dim clsPanelBackgroundElementRect As New RFunction
+        Dim clsXElementLabels As New RFunction
+        Dim clsXElementTitle As New RFunction
+        Dim clsYElementTitle As New RFunction
+        Dim clsYElementLabels As New RFunction
+        Dim clsPanelGridMajorElementLine As New RFunction
+        Dim clsPanelGridMinorElementLine As New RFunction
+        Dim clsPanelBorderElementRect As New RFunction
+        Dim clsPlotElementTitle As New RFunction
+        Dim clsPlotElementSubTitle As New RFunction
+        Dim clsPlotElementCaption As New RFunction
+
+        clsBaseOperator = New ROperator
+        clsGroupByFunction = New RFunction
+        clsMutateFunction = New RFunction
+        clsDummyFunction = New RFunction
+
+        clsRggplotFunction = New RFunction
+        clsGeomLine = New RFunction
+        clsRaesFunction = New RFunction
+        clsPipeOperator = New ROperator
+        clsFactorLevels = New RFunction
+
+        clsVarsFunction = New RFunction
+        clsCLimitsYContinuous = New RFunction
+        clsCLimitsYDate = New RFunction
+        clsFacetFunction = New RFunction
+        clsRowVarsFunction = New RFunction
+        clsColVarsFunction = New RFunction
+        clsAsDateYLimit = New RFunction
+        clsGeomHlineMean = New RFunction
+        clsGeomHlineAesMean = New RFunction
+        clsMeanFunction = New RFunction
+        clsRoundMeanY = New RFunction
+        clsAsDateMeanY = New RFunction
+        clsGeomHlineMedian = New RFunction
+        clsGeomHlineAesMedian = New RFunction
+        clsMedianFunction = New RFunction
+        clsRoundMedianY = New RFunction
+        clsAsDateMedianY = New RFunction
+        clsGeomHlineLowerTercile = New RFunction
+        clsGeomHlineAesLowerTercile = New RFunction
+        clsLowerTercileFunction = New RFunction
+        clsRoundLowerTercileY = New RFunction
+        clsAsDateLowerTercileY = New RFunction
+        clsGeomHlineUpperTercile = New RFunction
+        clsGeomHlineAesUpperTercile = New RFunction
+        clsUpperTercileFunction = New RFunction
+        clsRoundUpperTercileY = New RFunction
+        clsAsDateUpperTercileY = New RFunction
+        clsAsNumeric = New RFunction
+        clsStatRegEquationFunction = New RFunction
+        clsStatsCorFunction = New RFunction
+        clsGeomSmoothFunction = New RFunction
+        clsPointsFunc = New RFunction
+        clsGeomTextLabelMeanLine = New RFunction
+        clsPasteMeanY = New RFunction
+        clsFormatMeanY = New RFunction
+        clsGeomTextLabelMedianLine = New RFunction
+        clsPasteMedianY = New RFunction
+        clsFormatMedianY = New RFunction
+        clsGeomTextLabelLowerTercileLine = New RFunction
+        clsPasteLowerTercileY = New RFunction
+        clsFormatLowerTercileY = New RFunction
+        clsGeomTextLabelUpperTercileLine = New RFunction
+        clsPasteUpperTercileY = New RFunction
+        clsFormatUpperTercileY = New RFunction
+        clsGeomRugFunction = New RFunction
+        clsFilterFunction = New RFunction
+        clsEqualToOperator = New ROperator
+        clsGeomSegmentFunction = New RFunction
+        clsSegmentAesFunction = New RFunction
+        clsGeomPoint2Function = New RFunction
+        clsPoint2AesFunction = New RFunction
+        clsAsDateYendFunction = New RFunction
+
+        ucrInputStation.SetName(strFacetWrap)
+        ucrInputStation.bUpdateRCodeFromControl = True
+        ucrSelectorPICSATemperature.Reset()
+        ucrSelectorPICSATemperature.SetGgplotFunction(clsBaseOperator)
+        ucrSave.Reset()
+        ucrReceiverPICSA.SetMeAsReceiver()
+        bResetSubdialog = True
+        bResetLineLayerSubdialog = True
+
+        clsDatePeriodOperator = New ROperator
+
+        clsAsDate = New RFunction
+        clsAsNumericX = New RFunction
+        clsAsNumericY = New RFunction
+
+        clsXLabsFunction = GgplotDefaults.clsXlabTitleFunction.Clone()
+        clsYLabsFunction = GgplotDefaults.clsYlabTitleFunction.Clone()
+        clsLabsFunction = GgplotDefaults.clsDefaultLabs.Clone()
+        clsXScalecontinuousFunction = GgplotDefaults.clsXScalecontinuousFunction.Clone()
+        clsYScalecontinuousFunction = GgplotDefaults.clsYScalecontinuousFunction.Clone()
+        clsScaleFillViridisFunction = GgplotDefaults.clsScaleFillViridisFunction
+        clsScaleColourViridisFunction = GgplotDefaults.clsScaleColorViridisFunction
+        clsAnnotateFunction = GgplotDefaults.clsAnnotateFunction
+
+        clsDummyFunction.AddParameter("upper_limit", "FALSE", iPosition:=0)
+        clsDummyFunction.AddParameter("lower_limit", "FALSE", iPosition:=1)
+        clsDummyFunction.AddParameter("rdo_checked", "numeric", iPosition:=2)
+
+        clsYScalecontinuousFunction.AddParameter("limits", clsRFunctionParameter:=clsCLimitsYContinuous, iPosition:=3)
+        clsCLimitsYContinuous.SetRCommand("c")
+        clsCLimitsYContinuous.AddParameter("lowerlimit", "NA", bIncludeArgumentName:=False, iPosition:=0)
+        clsCLimitsYContinuous.AddParameter("upperlimit", "NA", bIncludeArgumentName:=False, iPosition:=1)
+
+        clsYScaleDateFunction = GgplotDefaults.clsYScaleDateFunction.Clone()
+        clsYScaleDateFunction.AddParameter("date_labels", Chr(34) & "%d %b" & Chr(34), iPosition:=0)
+        clsYScaleDateFunction.AddParameter("limits", clsRFunctionParameter:=clsCLimitsYDate, iPosition:=3)
+        clsAsDateYLimit.SetRCommand("as.Date")
+        clsAsDateYLimit.AddParameter("x", clsRFunctionParameter:=clsCLimitsYDate, iPosition:=0)
+        clsAsDateYLimit.AddParameter("format", Chr(34) & "%Y/%B/%d" & Chr(34), iPosition:=1)
+
+        clsCLimitsYDate.SetRCommand("c")
+        clsCLimitsYDate.AddParameter("lowerlimit", "NA", bIncludeArgumentName:=False, iPosition:=0)
+        clsCLimitsYDate.AddParameter("upperlimit", "NA", bIncludeArgumentName:=False, iPosition:=1)
+
+        'TODO Not yet implemented so do not add
+        'clsYScaleDateFunction.AddParameter("limits", clsRFunctionParameter:=clsCLimitsYDate, iPosition:=8)
+
+        clsThemeFunction = GgplotDefaults.clsDefaultThemeFunction
+        clsLocalRaesFunction = GgplotDefaults.clsAesFunction.Clone()
+        dctThemeFunctions = New Dictionary(Of String, RFunction)(GgplotDefaults.dctThemeFunctions)
+
+        clsPipeOperator.SetOperation("%>%")
+        SetPipeAssignTo()
+
+        clsGroupByFunction.SetPackageName("dplyr")
+        clsGroupByFunction.SetRCommand("group_by")
+
+        clsMutateFunction.SetPackageName("dplyr")
+        clsMutateFunction.SetRCommand("mutate")
+
+        clsBaseOperator.SetOperation("+")
+        clsBaseOperator.AddParameter("ggplot", clsRFunctionParameter:=clsRggplotFunction, iPosition:=0)
+        clsBaseOperator.AddParameter("lineplot", clsRFunctionParameter:=clsGeomLine, iPosition:=3)
+
+        clsRggplotFunction.SetPackageName("ggplot2")
+        clsRggplotFunction.SetRCommand("ggplot")
+        clsRggplotFunction.AddParameter("data", clsROperatorParameter:=clsPipeOperator, iPosition:=0)
+        clsRggplotFunction.AddParameter("mapping", clsRFunctionParameter:=clsRaesFunction, iPosition:=1)
+
+        clsAsFactorFunction = New RFunction
+
+        clsRaesFunction.SetPackageName("ggplot2")
+        clsRaesFunction.SetRCommand("aes")
+
+        clsAsFactorFunction.SetRCommand("as.factor")
+
+        clsGeomLine.SetPackageName("ggplot2")
+        clsGeomLine.SetRCommand("geom_line")
+        clsGeomLine.AddParameter("colour", Chr(34) & "blue" & Chr(34))
+        clsGeomLine.AddParameter("size", "0.8")
+
+        clsGeomSmoothFunction.SetPackageName("ggplot2")
+        clsGeomSmoothFunction.SetRCommand("geom_smooth")
+        clsGeomSmoothFunction.AddParameter("method", Chr(34) & "lm" & Chr(34), iPosition:=0)
+        clsGeomSmoothFunction.AddParameter("se", "FALSE", iPosition:=1)
+
+        clsPointsFunc.SetPackageName("ggplot2")
+        clsPointsFunc.SetRCommand("geom_point")
+        clsPointsFunc.AddParameter("size", "2")
+        clsPointsFunc.AddParameter("colour", Chr(34) & "red" & Chr(34))
+
+        clsFacetFunction.SetPackageName("ggplot2")
+        clsFacetFunction.AddParameter("facets", clsRFunctionParameter:=clsRowVarsFunction, iPosition:=0)
+
+        clsRowVarsFunction.SetPackageName("ggplot2")
+        clsRowVarsFunction.SetRCommand("vars")
+
+        clsColVarsFunction.SetPackageName("ggplot2")
+        clsColVarsFunction.SetRCommand("vars")
+
+        clsFilterFunction.SetPackageName("dplyr")
+        clsFilterFunction.SetRCommand("filter")
+        clsFilterFunction.AddParameter("data", clsROperatorParameter:=clsPipeOperator, iPosition:=0, bIncludeArgumentName:=False)
+        clsFilterFunction.AddParameter("var", clsROperatorParameter:=clsEqualToOperator, iPosition:=1, bIncludeArgumentName:=False)
+
+        clsEqualToOperator.SetOperation("==")
+        clsEqualToOperator.AddParameter("right", "FALSE", iPosition:=1, bIncludeArgumentName:=False)
+
+        clsGeomRugFunction.SetPackageName("ggplot2")
+        clsGeomRugFunction.SetRCommand("geom_rug")
+        clsGeomRugFunction.AddParameter("data", clsRFunctionParameter:=clsFilterFunction, iPosition:=0)
+        clsGeomRugFunction.AddParameter("sides", Chr(34) & "t" & Chr(34), iPosition:=1)
+        clsGeomRugFunction.AddParameter("alpha", "0.8", iPosition:=2)
+        clsGeomRugFunction.AddParameter("linewidth", "1", iPosition:=3)
+        clsGeomRugFunction.AddParameter("colour", Chr(34) & "blue" & Chr(34), iPosition:=4)
+
+        clsGeomSegmentFunction.SetPackageName("ggplot2")
+        clsGeomSegmentFunction.SetRCommand("geom_segment")
+        clsGeomSegmentFunction.AddParameter("x", clsRFunctionParameter:=clsSegmentAesFunction, iPosition:=0, bIncludeArgumentName:=False)
+        clsGeomSegmentFunction.AddParameter("linewidth", "0.8", iPosition:=1)
+        clsGeomSegmentFunction.AddParameter("lty", "2", iPosition:=2)
+
+        clsSegmentAesFunction.SetRCommand("aes")
+        clsSegmentAesFunction.AddParameter("x", clsRFunctionParameter:=clsAsNumericX, iPosition:=0)
+
+        clsGeomPoint2Function.SetPackageName("ggplot2")
+        clsGeomPoint2Function.SetRCommand("geom_point")
+        clsGeomPoint2Function.AddParameter("data", clsROperatorParameter:=clsPipeOperator, iPosition:=0)
+        clsGeomPoint2Function.AddParameter("mapping", clsRFunctionParameter:=clsPoint2AesFunction, iPosition:=1)
+        clsGeomPoint2Function.AddParameter("size", "2", iPosition:=2)
+        clsGeomPoint2Function.AddParameter("colour", Chr(34) & "darkgreen" & Chr(34), iPosition:=3)
+        clsGeomPoint2Function.AddParameter("shape", "17", iPosition:=4)
+
+        clsPoint2AesFunction.SetRCommand("aes")
+        clsPoint2AesFunction.AddParameter("x", clsRFunctionParameter:=clsAsNumericX, iPosition:=0)
+
+        'Mean Line
+        clsGeomHlineMean.SetPackageName("ggplot2")
+        clsGeomHlineMean.SetRCommand("geom_hline")
+        clsGeomHlineMean.AddParameter("mapping", clsRFunctionParameter:=clsGeomHlineAesMean, iPosition:=0)
+        clsGeomHlineMean.AddParameter("size", "1.5", iPosition:=2)
+
+        clsGeomHlineAesMean.SetPackageName("ggplot2")
+        clsGeomHlineAesMean.SetRCommand("aes")
+        clsGeomHlineAesMean.AddParameter("yintercept", strMeanName, iPosition:=3)
+
+        clsMeanFunction.SetRCommand("mean")
+        clsMeanFunction.AddParameter("x", "value")
+        clsMeanFunction.AddParameter("na.rm", "TRUE")
+
+        clsRoundMeanY.SetRCommand("round")
+
+        clsAsDateMeanY.SetRCommand("as.Date")
+        clsAsDateMeanY.AddParameter("x", clsRFunctionParameter:=clsRoundMeanY, iPosition:=0)
+        clsAsDateMeanY.AddParameter("origin", Chr(34) & "2015-12-31" & Chr(34), iPosition:=1)
+
+        'Regression Equation line
+        clsStatRegEquationFunction.SetPackageName("ggpubr")
+        clsStatRegEquationFunction.SetRCommand("stat_regline_equation")
+        clsStatRegEquationFunction.AddParameter("label.x.npc", Chr(34) & "left" & Chr(34), iPosition:=0)
+        clsStatRegEquationFunction.AddParameter("label.y.npc", Chr(34) & "bottom" & Chr(34), iPosition:=1)
+
+        'Significance level
+        clsStatsCorFunction.SetPackageName("ggpubr")
+        clsStatsCorFunction.SetRCommand("stat_cor")
+        clsStatsCorFunction.AddParameter("label.x.npc", Chr(34) & "left" & Chr(34), iPosition:=0)
+        clsStatsCorFunction.AddParameter("label.y.npc", Chr(34) & "top" & Chr(34), iPosition:=1)
+
+        ' Mean Line Label
+        clsGeomTextLabelMeanLine.SetPackageName("ggplot2")
+        clsGeomTextLabelMeanLine.SetRCommand("geom_label")
+        clsGeomTextLabelMeanLine.AddParameter("mapping", clsRFunctionParameter:=clsAesGeomTextLabelMeanLine, iPosition:=0)
+        clsGeomTextLabelMeanLine.AddParameter("hjust", "0", iPosition:=9)
+        clsGeomTextLabelMeanLine.AddParameter("vjust", "-0.3", iPosition:=10)
+
+        clsAesGeomTextLabelMeanLine.SetPackageName("ggplot2")
+        clsAesGeomTextLabelMeanLine.SetRCommand("aes")
+        clsAesGeomTextLabelMeanLine.AddParameter("x", "-Inf", iPosition:=1)
+        clsAesGeomTextLabelMeanLine.AddParameter("y", strMeanName, iPosition:=2)
+        clsAesGeomTextLabelMeanLine.AddParameter("label", clsRFunctionParameter:=clsPasteMeanY, iPosition:=3)
+
+        clsPasteMeanY.SetRCommand("paste")
+        clsPasteMeanY.AddParameter("0", Chr(34) & "Mean:" & Chr(34), bIncludeArgumentName:=False, iPosition:=0)
+        clsPasteMeanY.AddParameter("1", clsRFunctionParameter:=clsRoundMeanY, bIncludeArgumentName:=False, iPosition:=1)
+
+        clsFormatMeanY.SetRCommand("format")
+        clsFormatMeanY.AddParameter("x", strMeanName, iPosition:=0)
+        clsFormatMeanY.AddParameter("format", Chr(34) & "%d %b" & Chr(34), iPosition:=1)
+
+        'Median Line
+        clsGeomHlineMedian.SetPackageName("ggplot2")
+        clsGeomHlineMedian.SetRCommand("geom_hline")
+        clsGeomHlineMedian.AddParameter("mapping", clsRFunctionParameter:=clsGeomHlineAesMedian, iPosition:=0)
+        clsGeomHlineMedian.AddParameter("size", "1.5", iPosition:=2)
+
+        clsGeomHlineAesMedian.SetPackageName("ggplot2")
+        clsGeomHlineAesMedian.SetRCommand("aes")
+        clsGeomHlineAesMedian.AddParameter("yintercept", strMedianName, iPosition:=3)
+
+        clsMedianFunction.SetRCommand("median")
+        clsMedianFunction.AddParameter("x", "value")
+        clsMedianFunction.AddParameter("na.rm", "TRUE")
+
+        clsRoundMedianY.SetRCommand("round")
+
+        clsAsDateMedianY.SetRCommand("as.Date")
+        clsAsDateMedianY.AddParameter("x", clsRFunctionParameter:=clsRoundMedianY, iPosition:=0)
+        clsAsDateMedianY.AddParameter("origin", Chr(34) & "2015-12-31" & Chr(34), iPosition:=1)
+
+        ' Median Line Label
+        clsGeomTextLabelMedianLine.SetPackageName("ggplot2")
+        clsGeomTextLabelMedianLine.SetRCommand("geom_label")
+        clsGeomTextLabelMedianLine.AddParameter("mapping", clsRFunctionParameter:=clsAesGeomTextLabelMedianLine, iPosition:=0)
+        clsGeomTextLabelMedianLine.AddParameter("hjust", "0", iPosition:=9)
+        clsGeomTextLabelMedianLine.AddParameter("vjust", "-0.3", iPosition:=10)
+
+        clsAesGeomTextLabelMedianLine.SetPackageName("ggplot2")
+        clsAesGeomTextLabelMedianLine.SetRCommand("aes")
+        clsAesGeomTextLabelMedianLine.AddParameter("x", "-Inf", iPosition:=1)
+        clsAesGeomTextLabelMedianLine.AddParameter("y", strMedianName, iPosition:=2)
+        clsAesGeomTextLabelMedianLine.AddParameter("label", clsRFunctionParameter:=clsPasteMedianY, iPosition:=3)
+
+        clsPasteMedianY.SetRCommand("paste")
+        clsPasteMedianY.AddParameter("0", Chr(34) & "Median:" & Chr(34), bIncludeArgumentName:=False, iPosition:=0)
+        clsPasteMedianY.AddParameter("1", clsRFunctionParameter:=clsRoundMedianY, bIncludeArgumentName:=False, iPosition:=1)
+
+        clsFormatMedianY.SetRCommand("format")
+        clsFormatMedianY.AddParameter("x", strMedianName, iPosition:=0)
+        clsFormatMedianY.AddParameter("format", Chr(34) & "%d %b" & Chr(34), iPosition:=1)
+
+        'Lower Tercile Line
+        clsGeomHlineLowerTercile.SetPackageName("ggplot2")
+        clsGeomHlineLowerTercile.SetRCommand("geom_hline")
+        clsGeomHlineLowerTercile.AddParameter("mapping", clsRFunctionParameter:=clsGeomHlineAesLowerTercile, iPosition:=0)
+        clsGeomHlineLowerTercile.AddParameter("size", "1.5", iPosition:=2)
+
+        clsGeomHlineAesLowerTercile.SetPackageName("ggplot2")
+        clsGeomHlineAesLowerTercile.SetRCommand("aes")
+        clsGeomHlineAesLowerTercile.AddParameter("yintercept", strLowerTercileName, iPosition:=3)
+
+        clsLowerTercileFunction.SetRCommand("quantile")
+        clsLowerTercileFunction.AddParameter("x", "value", iPosition:=0)
+        clsLowerTercileFunction.AddParameter("probs", "1/3", iPosition:=1)
+        clsLowerTercileFunction.AddParameter("na.rm", "TRUE", iPosition:=2)
+
+        clsRoundLowerTercileY.SetRCommand("round")
+
+        clsAsDateLowerTercileY.SetRCommand("as.Date")
+        clsAsDateLowerTercileY.AddParameter("x", clsRFunctionParameter:=clsRoundLowerTercileY, iPosition:=0)
+        clsAsDateLowerTercileY.AddParameter("origin", Chr(34) & "2015-12-31" & Chr(34), iPosition:=1)
+
+        ' Lower Tercile Line Label
+        clsGeomTextLabelLowerTercileLine.SetPackageName("ggplot2")
+        clsGeomTextLabelLowerTercileLine.SetRCommand("geom_label")
+        clsGeomTextLabelLowerTercileLine.AddParameter("mapping", clsRFunctionParameter:=clsAesGeomTextLabelLowerTercileLine, iPosition:=0)
+        clsGeomTextLabelLowerTercileLine.AddParameter("hjust", "0", iPosition:=9)
+        clsGeomTextLabelLowerTercileLine.AddParameter("vjust", "1.2", iPosition:=10)
+
+        clsAesGeomTextLabelLowerTercileLine.SetPackageName("ggplot2")
+        clsAesGeomTextLabelLowerTercileLine.SetRCommand("aes")
+        clsAesGeomTextLabelLowerTercileLine.AddParameter("x", "-Inf", iPosition:=1)
+        clsAesGeomTextLabelLowerTercileLine.AddParameter("y", strLowerTercileName, iPosition:=2)
+        clsAesGeomTextLabelLowerTercileLine.AddParameter("label", clsRFunctionParameter:=clsPasteLowerTercileY, iPosition:=3)
+
+        clsPasteLowerTercileY.SetRCommand("paste")
+        clsPasteLowerTercileY.AddParameter("0", Chr(34) & "33%:" & Chr(34), bIncludeArgumentName:=False, iPosition:=0)
+        clsPasteLowerTercileY.AddParameter("1", clsRFunctionParameter:=clsRoundLowerTercileY, bIncludeArgumentName:=False, iPosition:=1)
+
+        clsFormatLowerTercileY.SetRCommand("format")
+        clsFormatLowerTercileY.AddParameter("x", strLowerTercileName, iPosition:=0)
+        clsFormatLowerTercileY.AddParameter("format", Chr(34) & "%d %b" & Chr(34), iPosition:=1)
+
+        'Upper Tercile Line
+        clsGeomHlineUpperTercile.SetPackageName("ggplot2")
+        clsGeomHlineUpperTercile.SetRCommand("geom_hline")
+        clsGeomHlineUpperTercile.AddParameter("mapping", clsRFunctionParameter:=clsGeomHlineAesUpperTercile, iPosition:=0)
+        clsGeomHlineUpperTercile.AddParameter("size", "1.5", iPosition:=2)
+
+        clsGeomHlineAesUpperTercile.SetPackageName("ggplot2")
+        clsGeomHlineAesUpperTercile.SetRCommand("aes")
+        clsGeomHlineAesUpperTercile.AddParameter("yintercept", strUpperTercileName, iPosition:=3)
+
+        clsUpperTercileFunction.SetRCommand("quantile")
+        clsUpperTercileFunction.AddParameter("x", "value", iPosition:=0)
+        clsUpperTercileFunction.AddParameter("probs", "2/3", iPosition:=1)
+        clsUpperTercileFunction.AddParameter("na.rm", "TRUE", iPosition:=2)
+
+        clsRoundUpperTercileY.SetRCommand("round")
+
+        clsAsDateUpperTercileY.SetRCommand("as.Date")
+        clsAsDateUpperTercileY.AddParameter("x", clsRFunctionParameter:=clsRoundUpperTercileY, iPosition:=0)
+        clsAsDateUpperTercileY.AddParameter("origin", Chr(34) & "2015-12-31" & Chr(34), iPosition:=1)
+
+        'Upper Tercile Line Label
+        clsGeomTextLabelUpperTercileLine.SetPackageName("ggplot2")
+        clsGeomTextLabelUpperTercileLine.SetRCommand("geom_label")
+        clsGeomTextLabelUpperTercileLine.AddParameter("mapping", clsRFunctionParameter:=clsAesGeomTextLabelUpperTercileLine, iPosition:=0)
+        clsGeomTextLabelUpperTercileLine.AddParameter("hjust", "0", iPosition:=9)
+        clsGeomTextLabelUpperTercileLine.AddParameter("vjust", "-0.3", iPosition:=10)
+
+        clsAesGeomTextLabelUpperTercileLine.SetPackageName("ggplot2")
+        clsAesGeomTextLabelUpperTercileLine.SetRCommand("aes")
+        clsAesGeomTextLabelUpperTercileLine.AddParameter("x", "-Inf", iPosition:=1)
+        clsAesGeomTextLabelUpperTercileLine.AddParameter("y", strUpperTercileName, iPosition:=2)
+        clsAesGeomTextLabelUpperTercileLine.AddParameter("label", clsRFunctionParameter:=clsPasteUpperTercileY, iPosition:=3)
+
+        clsPasteUpperTercileY.SetRCommand("paste")
+        clsPasteUpperTercileY.AddParameter("0", Chr(34) & "67%:" & Chr(34), bIncludeArgumentName:=False, iPosition:=0)
+        clsPasteUpperTercileY.AddParameter("1", clsRFunctionParameter:=clsRoundUpperTercileY, bIncludeArgumentName:=False, iPosition:=1)
+
+        clsFormatUpperTercileY.SetRCommand("format")
+        clsFormatUpperTercileY.AddParameter("x", strUpperTercileName, iPosition:=0)
+        clsFormatUpperTercileY.AddParameter("format", Chr(34) & "%d %b" & Chr(34), iPosition:=1)
+
+        If dctThemeFunctions.TryGetValue("panel.background", clsPanelBackgroundElementRect) Then
+            clsPanelBackgroundElementRect.AddParameter("colour", Chr(34) & "white" & Chr(34))
+            clsPanelBackgroundElementRect.AddParameter("fill", Chr(34) & "white" & Chr(34))
+            clsPanelBackgroundElementRect.AddParameter("size", "0.5")
+            clsPanelBackgroundElementRect.AddParameter("linetype", Chr(34) & "solid" & Chr(34))
+            clsThemeFunction.AddParameter("panel.background", clsRFunctionParameter:=clsPanelBackgroundElementRect)
+        End If
+
+        If dctThemeFunctions.TryGetValue("panel.grid.major", clsPanelGridMajorElementLine) Then
+            clsPanelGridMajorElementLine.AddParameter("colour", Chr(34) & "lightblue" & Chr(34))
+            clsPanelGridMajorElementLine.AddParameter("linetype", Chr(34) & "longdash" & Chr(34))
+            clsPanelGridMajorElementLine.AddParameter("size", 1)
+            clsThemeFunction.AddParameter("panel.grid.major", clsRFunctionParameter:=clsPanelGridMajorElementLine)
+        End If
+
+        If dctThemeFunctions.TryGetValue("panel.grid.minor", clsPanelGridMinorElementLine) Then
+            clsPanelGridMinorElementLine.AddParameter("colour", Chr(34) & "lightblue" & Chr(34))
+            clsPanelGridMinorElementLine.AddParameter("linetype", Chr(34) & "longdash" & Chr(34))
+            clsPanelGridMinorElementLine.AddParameter("size", 1)
+            clsThemeFunction.AddParameter("panel.grid.minor", clsRFunctionParameter:=clsPanelGridMinorElementLine)
+        End If
+
+        If dctThemeFunctions.TryGetValue("panel.border", clsPanelBorderElementRect) Then
+            clsPanelBorderElementRect.AddParameter("colour", Chr(34) & "black" & Chr(34))
+            clsPanelBorderElementRect.AddParameter("fill", Chr(34) & "NA" & Chr(34))
+            clsThemeFunction.AddParameter("panel.border", clsRFunctionParameter:=clsPanelBorderElementRect)
+        End If
+
+        If dctThemeFunctions.TryGetValue("axis.text.x", clsXElementLabels) Then
+            clsXElementLabels.AddParameter("angle", "90")
+            clsXElementLabels.AddParameter("vjust", "0.4")
+            clsXElementLabels.AddParameter("size", "12")
+            clsThemeFunction.AddParameter("axis.text.x", clsRFunctionParameter:=clsXElementLabels)
+        End If
+
+        If dctThemeFunctions.TryGetValue("axis.title.x", clsXElementTitle) Then
+            clsXElementTitle.AddParameter("size", 14)
+            clsThemeFunction.AddParameter("axis.title.x", clsRFunctionParameter:=clsXElementTitle)
+        End If
+
+        If dctThemeFunctions.TryGetValue("axis.text.y", clsYElementLabels) Then
+            clsYElementLabels.AddParameter("size", "12")
+            clsThemeFunction.AddParameter("axis.text.y", clsRFunctionParameter:=clsYElementLabels)
+        End If
+
+        If dctThemeFunctions.TryGetValue("axis.title.y", clsYElementTitle) Then
+            clsYElementTitle.AddParameter("size", 14)
+            clsThemeFunction.AddParameter("axis.title.y", clsRFunctionParameter:=clsYElementTitle)
+        End If
+
+        If dctThemeFunctions.TryGetValue("title", clsPlotElementTitle) Then
+            clsPlotElementTitle.AddParameter("size", 20)
+            clsThemeFunction.AddParameter("title", clsRFunctionParameter:=clsPlotElementTitle)
+        End If
+
+        If dctThemeFunctions.TryGetValue("sub.title", clsPlotElementSubTitle) Then
+            clsPlotElementSubTitle.AddParameter("size", 15)
+            clsThemeFunction.AddParameter("plot.subtitle", clsRFunctionParameter:=clsPlotElementSubTitle)
+        End If
+
+        If dctThemeFunctions.TryGetValue("caption", clsPlotElementCaption) Then
+            clsPlotElementCaption.AddParameter("size", 8)
+            clsThemeFunction.AddParameter("plot.caption", clsRFunctionParameter:=clsPlotElementCaption)
+        End If
+
+        clsFactorLevels.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_column_factor_levels")
+
+        clsBaseOperator.AddParameter("xlab", clsRFunctionParameter:=clsXLabsFunction)
+        clsXLabsFunction.AddParameter("label", Chr(34) & Chr(34))
+
+        clsBaseOperator.AddParameter("ylab", clsRFunctionParameter:=clsYLabsFunction)
+        clsYLabsFunction.AddParameter("label", Chr(34) & Chr(34))
+
+        clsAsDate.SetRCommand("as.Date")
+        clsAsDate.AddParameter("origin", Chr(34) & "2015-12-31" & Chr(34), iPosition:=1)
+
+        clsAsDateYendFunction.SetRCommand("as.Date")
+        clsAsDateYendFunction.AddParameter("origin", Chr(34) & "2015-12-31" & Chr(34), iPosition:=1)
+
+        clsDatePeriodOperator.SetOperation(" ")
+        clsDatePeriodOperator.AddParameter("left", "1", iPosition:=0)
+        clsDatePeriodOperator.AddParameter("right", "months", iPosition:=1)
+        clsDatePeriodOperator.bSpaceAroundOperation = False
+        clsDatePeriodOperator.bToScriptAsRString = True
+
+        clsAsNumericX.SetRCommand("as.numeric")
+        clsAsNumericY.SetRCommand("as.numeric")
+        clsAsNumeric.SetRCommand("as.numeric")
+
+        clsVarsFunction.SetPackageName("ggplot2")
+        clsVarsFunction.SetRCommand("vars")
+        clsRggplotFunction.AddParameter("data", clsRFunctionParameter:=ucrSelectorPICSATemperature.ucrAvailableDataFrames.clsCurrDataFrame, iPosition:=0)
+        clsRaesFunction.AddParameter("y", clsRFunctionParameter:=clsAsNumeric, iPosition:=1)
+        clsRaesFunction.AddParameter("x", ucrReceiverX.GetVariableNames(bWithQuotes:=False), iPosition:=2)
+        clsCoordPolarStartOperator = GgplotDefaults.clsCoordPolarStartOperator.Clone()
+        clsCoordPolarFunction = GgplotDefaults.clsCoordPolarFunction.Clone()
+        clsXScaleDateFunction = GgplotDefaults.clsXScaleDateFunction.Clone()
+        clsBaseOperator.AddParameter("theme", clsRFunctionParameter:=clsThemeFunction, iPosition:=100)
+        clsBaseOperator.AddParameter("geom_point", clsRFunctionParameter:=clsPointsFunc, iPosition:=4)
+        clsBaseOperator.SetAssignTo("last_graph", strTempDataframe:=ucrSelectorPICSATemperature.ucrAvailableDataFrames.cboAvailableDataFrames.Text, strTempGraph:="last_graph")
+        ucrBase.clsRsyntax.SetBaseROperator(clsBaseOperator)
+
+
+        TestOkEnabled()
     End Sub
+
+    Public Sub SetRCodeForControls(bReset As Boolean)
+        ucrReceiverPICSA.AddAdditionalCodeParameterPair(clsAsDate, New RParameter("x", 0), iAdditionalPairNo:=1)
+        ucrReceiverPICSA.AddAdditionalCodeParameterPair(clsMeanFunction, New RParameter("x", 0), iAdditionalPairNo:=2)
+        ucrReceiverPICSA.AddAdditionalCodeParameterPair(clsMedianFunction, New RParameter("x", 0), iAdditionalPairNo:=3)
+        ucrReceiverPICSA.AddAdditionalCodeParameterPair(clsLowerTercileFunction, New RParameter("x", 0), iAdditionalPairNo:=4)
+        ucrReceiverPICSA.AddAdditionalCodeParameterPair(clsUpperTercileFunction, New RParameter("x", 0), iAdditionalPairNo:=5)
+        ucrReceiverPICSA.AddAdditionalCodeParameterPair(clsSegmentAesFunction, New RParameter("y", 1), iAdditionalPairNo:=6)
+        ucrReceiverPICSA.AddAdditionalCodeParameterPair(clsAsNumericY, New RParameter("y", 0, bNewIncludeArgumentName:=False), iAdditionalPairNo:=7)
+
+        ucrSelectorPICSATemperature.SetRCode(clsPipeOperator, bReset)
+        ucrReceiverColourBy.SetRCode(clsRaesFunction, bReset)
+        ucrSave.SetRCode(clsBaseOperator, bReset)
+        ucrChkPoints.SetRCode(clsBaseOperator, bReset)
+        ucrReceiverX.SetRCode(clsAsNumericX, bReset)
+        ucrChkLineofBestFit.SetRCode(clsBaseOperator, bReset)
+        ucrChkWithSE.SetRCode(clsGeomSmoothFunction, bReset)
+        ucrReceiverFacetBy.SetRCode(clsRowVarsFunction, bReset)
+
+        If bReset Then
+            AutoFacetStation()
+            ucrReceiverPICSA.SetRCode(clsAsNumeric, bReset)
+        End If
+
+    End Sub
+
+    Private Sub TestOkEnabled()
+        Dim bEnable As Boolean = False
+        bEnable = Not (ucrReceiverPICSA.IsEmpty OrElse ucrReceiverX.IsEmpty OrElse Not ucrSave.IsComplete)
+        ucrBase.OKEnabled(bEnable)
+    End Sub
+
+    Private Sub ucrBase_ClickReset(sender As Object, e As EventArgs) Handles ucrBase.ClickReset
+        SetDefaults()
+        SetRCodeForControls(True)
+        UpdateParameters()
+        TestOkEnabled()
+    End Sub
+
+    Private Sub ucrInput_ControlValueChanged(ucrChangedControl As ucrInputComboBox) Handles ucrInputStation.ControlValueChanged
+        If Not bUpdateComboOptions Then
+            Exit Sub
+        End If
+        Dim strChangedText As String = ucrChangedControl.GetText()
+        If strChangedText <> strNone Then
+            If Not (strChangedText = strFacetCol OrElse strChangedText = strFacetColAll _
+            OrElse strChangedText = strFacetRow OrElse strChangedText = strFacetRowAll OrElse strChangedText = strFacetRowAndCol OrElse strChangedText = strFacetRowAndColAll) _
+            AndAlso Not ucrInputStation.Equals(ucrChangedControl) _
+            AndAlso ucrInputStation.GetText() = strChangedText Then
+
+                bUpdateComboOptions = False
+                ucrInputStation.SetName(strNone)
+                bUpdateComboOptions = True
+            End If
+            If (strChangedText = strFacetWrap AndAlso
+            (ucrInputStation.GetText = strFacetRow OrElse ucrInputStation.GetText = strFacetRowAll _
+            OrElse ucrInputStation.GetText = strFacetCol OrElse ucrInputStation.GetText = strFacetColAll _
+            OrElse ucrInputStation.GetText = strFacetRowAndCol OrElse ucrInputStation.GetText = strFacetRowAndColAll)) _
+        OrElse ((strChangedText = strFacetRow OrElse strChangedText = strFacetRowAll) _
+            AndAlso ucrInputStation.GetText = strFacetWrap) _
+        OrElse ((strChangedText = strFacetCol OrElse strChangedText = strFacetColAll) _
+            AndAlso ucrInputStation.GetText = strFacetWrap) _
+            OrElse ((strChangedText = strFacetRowAndCol OrElse strChangedText = strFacetRowAndColAll) _
+             AndAlso ucrInputStation.GetText = strFacetWrap) Then
+
+                ucrInputStation.SetName(strNone)
+            End If
+        End If
+        UpdateParameters()
+        AddRemoveFacets()
+        AddRemoveGroupBy()
+    End Sub
+
+    Private Sub UpdateParameters()
+        clsBaseOperator.RemoveParameterByName("facets")
+        bUpdatingParameters = True
+        ucrReceiverFacetBy.SetRCode(clsRowVarsFunction, bReset)
+
+        If Not clsRaesFunction.ContainsParameter("x") Then
+            clsRaesFunction.AddParameter("x", Chr(34) & Chr(34))
+        End If
+        If bNotSubdialogue Then
+            clsFacetFunction.ClearParameters()
+        End If
+        bUpdatingParameters = False
+    End Sub
+
+    Private Sub AddRemoveFacets()
+        Dim bWrap As Boolean = False
+        Dim bCol As Boolean = False
+        Dim bRow As Boolean = False
+        Dim bColAll As Boolean = False
+        Dim bRowAll As Boolean = False
+        Dim bRowsAndCols As Boolean = False
+        Dim bRowsAndColsAll As Boolean = False
+
+        If bUpdatingParameters Then
+            Exit Sub
+        End If
+        clsBaseOperator.RemoveParameterByName("facets")
+
+        If Not ucrReceiverFacetBy.IsEmpty Then
+            Select Case ucrInputStation.GetText()
+                Case strFacetWrap
+                    bWrap = True
+                Case strFacetCol
+                    bCol = True
+                Case strFacetRow
+                    bRow = True
+                Case strFacetColAll
+                    bColAll = True
+                Case strFacetRowAll
+                    bRowAll = True
+                Case strFacetRowAndCol
+                    bRowsAndCols = True
+                Case strFacetRowAndColAll
+                    bRowsAndColsAll = True
+            End Select
+        End If
+        If bWrap OrElse bRow OrElse bCol OrElse bColAll OrElse bRowAll OrElse bRowsAndCols OrElse bRowsAndColsAll Then
+            clsBaseOperator.AddParameter("facets", clsRFunctionParameter:=clsFacetFunction)
+        End If
+
+        If bWrap Then
+            clsFacetFunction.SetRCommand("facet_wrap")
+            clsFacetFunction.AddParameter("facets", clsRFunctionParameter:=clsRowVarsFunction, iPosition:=0)
+            clsFacetFunction.RemoveParameterByName("rows")
+            clsFacetFunction.RemoveParameterByName("cols")
+        Else
+            clsFacetFunction.RemoveParameterByName("facets")
+        End If
+
+        If bRow OrElse bCol OrElse bRowAll OrElse bColAll OrElse bRowsAndCols OrElse bRowsAndColsAll Then
+            clsFacetFunction.SetRCommand("facet_grid")
+            clsFacetFunction.RemoveParameterByName("facets")
+        End If
+
+        If bRowAll OrElse bColAll OrElse bRowsAndColsAll Then
+            clsFacetFunction.AddParameter("margins", "TRUE")
+        Else
+            clsFacetFunction.RemoveParameterByName("margins")
+        End If
+
+        If bRowsAndCols OrElse bRowsAndColsAll Then
+            clsFacetFunction.AddParameter("rows", clsRFunctionParameter:=clsRowVarsFunction, iPosition:=0)
+            clsFacetFunction.AddParameter("cols", clsRFunctionParameter:=clsColVarsFunction, iPosition:=1)
+        ElseIf bRow OrElse bRowAll Then
+            clsFacetFunction.AddParameter("rows", clsRFunctionParameter:=clsRowVarsFunction, iPosition:=0)
+            clsFacetFunction.RemoveParameterByName("cols")
+        ElseIf bCol OrElse bColAll Then
+            clsFacetFunction.AddParameter("cols", clsRFunctionParameter:=clsRowVarsFunction, iPosition:=0)
+            clsFacetFunction.RemoveParameterByName("rows")
+        End If
+    End Sub
+
+    'add more functions 
+    Private Sub cmdPICSAOptions_Click(sender As Object, e As EventArgs) Handles cmdPICSAOptions.Click
+        sdgPICSARainfallGraph.SetRCode(clsNewOperator:=ucrBase.clsRsyntax.clsBaseOperator, clsNewPipeOperator:=clsPipeOperator, clsNewStatRegEquation:=clsStatRegEquationFunction, clsNewStatsCorFunction:=clsStatsCorFunction,
+                                      dctNewThemeFunctions:=dctThemeFunctions, clsNewLabsFunction:=clsLabsFunction, clsNewThemeFunction:=clsThemeFunction, clsNewDummyFunction:=clsDummyFunction,
+                                      clsNewXScaleContinuousFunction:=clsXScalecontinuousFunction, clsNewYScaleContinuousFunction:=clsYScalecontinuousFunction,
+                                      clsNewGeomhlineMean:=clsGeomHlineMean, clsNewGeomhlineMedian:=clsGeomHlineMedian, clsNewGeomhlineLowerTercile:=clsGeomHlineLowerTercile,
+                                      clsNewGeomhlineUpperTercile:=clsGeomHlineUpperTercile, clsNewXLabsFunction:=clsXLabsFunction, clsNewYLabsFunction:=clsYLabsFunction, clsNewAsNumericY:=clsAsNumericY,
+                                      clsNewRaesFunction:=clsRaesFunction, clsNewAsDate:=clsAsDate, clsNewAsDateYLimit:=clsAsDateYLimit, clsNewAsNumericX:=clsAsNumericX, clsNewYScaleDateFunction:=clsYScaleDateFunction,
+                                      clsNewDatePeriodOperator:=clsDatePeriodOperator, clsNewGeomTextLabelMeanLine:=clsGeomTextLabelMeanLine, clsNewRoundMeanY:=clsRoundMeanY, clsNewPasteMeanY:=clsPasteMeanY,
+                                      clsNewGeomTextLabelMedianLine:=clsGeomTextLabelMedianLine, clsNewRoundMedianY:=clsRoundMedianY, clsNewPasteMedianY:=clsPasteMedianY, clsNewGeomTextLabelLowerTercileLine:=clsGeomTextLabelLowerTercileLine,
+                                      clsNewRoundLowerTercileY:=clsRoundLowerTercileY, clsNewPasteLowerTercileY:=clsPasteLowerTercileY, clsNewGeomTextLabelUpperTercileLine:=clsGeomTextLabelUpperTercileLine, clsNewRoundUpperTercileY:=clsRoundUpperTercileY,
+                                      clsNewPasteUpperTercileY:=clsPasteUpperTercileY, strXAxisType:=ucrReceiverX.strCurrDataType, clsNewMutateFunction:=clsMutateFunction, clsNewMeanFunction:=clsMeanFunction, clsNewMedianFunction:=clsMedianFunction,
+                                      clsNewLowerTercileFunction:=clsLowerTercileFunction, clsNewUpperTercileFunction:=clsUpperTercileFunction, clsNewAsDateMeanY:=clsAsDateMeanY, clsNewAsDateMedianY:=clsAsDateMedianY, clsNewAsDateLowerTercileY:=clsAsDateLowerTercileY,
+                                      clsNewAsDateUpperTercileY:=clsAsDateUpperTercileY, clsNewFormatMeanY:=clsFormatMeanY, clsNewFormatMedianY:=clsFormatMedianY, clsNewFormatLowerTercileY:=clsFormatLowerTercileY, clsNewFormatUpperTercileY:=clsFormatUpperTercileY,
+                                      clsNewPoint2AesFunction:=clsPoint2AesFunction, clsNewSegmentAes:=clsSegmentAesFunction, clsNewAsDateYend:=clsAsDateYendFunction, bReset:=bResetSubdialog)
+        sdgPICSARainfallGraph.ShowDialog()
+        AddRemoveGroupBy()
+        bResetSubdialog = False
+    End Sub
+
+    Private Sub AllControl_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrSave.ControlContentsChanged, ucrReceiverX.ControlContentsChanged
+        TestOkEnabled()
+    End Sub
+
+    Private Sub ucrFactorOptionalReceiver_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverColourBy.ControlValueChanged
+        'TODO this should run when levels of factor >1
+        If Not ucrReceiverColourBy.IsEmpty Then
+            clsGeomLine.RemoveParameterByName("colour")
+        Else
+            clsGeomLine.AddParameter("colour", Chr(34) & "blue" & Chr(34))
+        End If
+    End Sub
+
+    Private Sub ucrReceiverX_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverX.ControlValueChanged
+        XAxisDataTypeCheck()
+    End Sub
+
+    Private Sub XAxisDataTypeCheck()
+        If Not ucrReceiverX.IsEmpty AndAlso ucrReceiverX.strCurrDataType.Contains("factor") Then
+            clsGeomLine.AddParameter("group", 1)
+            clsRaesFunction.AddParameter("x", ucrReceiverX.GetVariableNames(bWithQuotes:=False), iPosition:=2)
+            clsBaseOperator.RemoveParameterByName("scale_x_continuous")
+        Else
+            clsGeomLine.RemoveParameterByName("group")
+        End If
+    End Sub
+
+    Private Sub YAxisDataTypeCheckPISCATemp()
+        If Not ucrReceiverPICSA.IsEmpty Then
+            clsBaseOperator.RemoveParameterByName("geom_segment")
+            clsBaseOperator.RemoveParameterByName("geom_point2")
+            clsGeomLine.AddParameter("group", 0)
+        Else
+            clsGeomLine.RemoveParameterByName("group")
+        End If
+    End Sub
+
+    Private Sub ucrReceiverFacetBy_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverFacetBy.ControlValueChanged, ucrReceiverColourBy.ControlValueChanged, ucrReceiverX.ControlValueChanged
+        AddRemoveFacets()
+        AddRemoveGroupBy()
+    End Sub
+
+    Private Sub AutoFacetStation()
+        Dim ucrCurrentReceiver As ucrReceiver = Nothing
+
+        If ucrSelectorPICSATemperature.CurrentReceiver IsNot Nothing Then
+            ucrCurrentReceiver = ucrSelectorPICSATemperature.CurrentReceiver
+        End If
+        ucrReceiverFacetBy.AddItemsWithMetadataProperty(ucrSelectorPICSATemperature.ucrAvailableDataFrames.cboAvailableDataFrames.Text, "Climatic_Type", {"station_label"})
+        If ucrCurrentReceiver IsNot Nothing Then
+            ucrCurrentReceiver.SetMeAsReceiver()
+        End If
+        AddRemoveGroupBy()
+    End Sub
+
+    Private Sub ucrReceiverPICSA_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverPICSA.ControlValueChanged
+        YAxisDataTypeCheckPISCATemp()
+    End Sub
+
+    Private Sub ucrSelectorPICSATemperature_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrSelectorPICSATemperature.ControlValueChanged
+        AutoFacetStation()
+        SetPipeAssignTo()
+    End Sub
+
+    Private Sub AddRemoveGroupBy()
+
+        If clsPipeOperator.ContainsParameter("mutate") Then
+            clsGroupByFunction.ClearParameters()
+            If clsBaseOperator.ContainsParameter("facets") Then
+                '' Feb 07 2026
+                ''This should be figured out, when we have mutate in the clsPipeOperator for the all Cases
+                Select Case ucrInputStation.GetText()
+                    Case strFacetWrap
+                        'GetParameterValue(clsFacetVariablesOperator)
+                End Select
+            End If
+            If clsRaesFunction.ContainsParameter("colour") Then
+                clsGroupByFunction.AddParameter("colour",
+                                            ucrReceiverColourBy.GetVariableNames(bWithQuotes:=False),
+                                            bIncludeArgumentName:=False,
+                                            iPosition:=0)
+            End If
+            If clsGroupByFunction.iParameterCount > 0 Then
+                clsPipeOperator.AddParameter("group_by",
+                                         clsRFunctionParameter:=clsGroupByFunction,
+                                         iPosition:=1)
+            Else
+                clsPipeOperator.RemoveParameterByName("group_by")
+            End If
+        Else
+            clsPipeOperator.RemoveParameterByName("group_by")
+        End If
+        SetPipeAssignTo()
+    End Sub
+
+    Private Sub SetPipeAssignTo()
+        If ucrSelectorPICSATemperature.ucrAvailableDataFrames.cboAvailableDataFrames.Text <> "" AndAlso clsPipeOperator.clsParameters.Count > 1 Then
+            clsPipeOperator.SetAssignTo(ucrSelectorPICSATemperature.ucrAvailableDataFrames.cboAvailableDataFrames.Text)
+        Else
+            clsPipeOperator.RemoveAssignTo()
+        End If
+    End Sub
+
+    Private Sub toolStripMenuItemLineOptions_Click(sender As Object, e As EventArgs) Handles toolStripMenuItemLineOptions.Click
+        openSdgLayerOptions(clsGeomLine)
+    End Sub
+
+    Private Sub openSdgLayerOptions(clsNewGeomFunc As RFunction)
+        sdgLayerOptions.SetupLayer(clsNewGgPlot:=clsRggplotFunction, clsNewGeomFunc:=clsNewGeomFunc,
+                                   clsNewGlobalAesFunc:=clsRaesFunction, clsNewLocalAes:=clsLocalRaesFunction,
+                                   bFixGeom:=True, ucrNewBaseSelector:=ucrSelectorPICSATemperature,
+                                   bApplyAesGlobally:=True, bReset:=bResetLineLayerSubdialog)
+        sdgLayerOptions.ShowDialog()
+        bResetLineLayerSubdialog = False
+        'Coming from the sdgLayerOptions, clsRaesFunction and others have been modified. 
+        '  One then needs to display these modifications on the dlgScatteredPlot.
+
+        'The aesthetics parameters on the main dialog are repopulated as required.
+        For Each clsParam In clsRaesFunction.clsParameters
+            If clsParam.strArgumentName = "x" Then
+                If clsParam.strArgumentValue = Chr(34) & Chr(34) Then
+                    ucrReceiverX.Clear()
+                Else
+                    ucrReceiverX.Add(clsParam.strArgumentValue)
+                End If
+                'In the y case, the value stored in the clsReasFunction in the multiple variables 
+                '  case is "value", however that one shouldn't be written in the multiple 
+                '  variables receiver (otherwise it would stack all variables and the stack 
+                '  ("value") itself!).
+                'Warning: what if someone used the name value for one of it's variables 
+                '  independently from the multiple variables method? Here if the receiver is 
+                '  actually in single mode, the variable "value" will still be given back, which 
+                '  throws the problem back to the creation of "value" in the multiple receiver case.
+            ElseIf clsParam.strArgumentName = "y" AndAlso (clsParam.strArgumentValue <> "value") Then
+                'Still might be in the case of bSingleVariable with mapping y="".
+                If clsParam.strArgumentValue = (Chr(34) & Chr(34)) Then
+                    ucrReceiverPICSA.Clear()
+                Else
+                    ucrReceiverPICSA.Add(clsParam.strArgumentValue)
+                End If
+            ElseIf clsParam.strArgumentName = "colour" Then
+                ucrReceiverColourBy.Add(clsParam.strArgumentValue)
+            End If
+        Next
+        TestOkEnabled()
+    End Sub
+
+    Private Sub UpdatingFacetOptions()
+        bNotSubdialogue = False
+        If clsFacetFunction.strRCommand = "facet_grid" Then
+            If clsFacetFunction.ContainsParameter("rows") AndAlso clsFacetFunction.ContainsParameter("cols") Then
+                If clsFacetFunction.ContainsParameter("margins") Then
+                    ucrInputStation.SetName(strFacetRowAndColAll)
+                Else
+                    ucrInputStation.SetName(strFacetRowAndCol)
+                End If
+            ElseIf clsFacetFunction.ContainsParameter("rows") Then
+                If clsFacetFunction.ContainsParameter("margins") Then
+                    ucrInputStation.SetName(strFacetRowAll)
+                Else
+                    ucrInputStation.SetName(strFacetRow)
+                End If
+            ElseIf clsFacetFunction.ContainsParameter("cols") Then
+                If clsFacetFunction.ContainsParameter("margins") Then
+                    ucrInputStation.SetName(strFacetColAll)
+                Else
+                    ucrInputStation.SetName(strFacetCol)
+                End If
+            End If
+        Else
+            ucrInputStation.SetName(strFacetWrap)
+        End If
+        bNotSubdialogue = True
+    End Sub
+
+    Private Sub cmdOptions_Click(sender As Object, e As EventArgs) Handles cmdOptions.Click
+        sdgPlots.SetRCode(clsNewOperator:=ucrBase.clsRsyntax.clsBaseOperator, clsNewCoordPolarFunction:=clsCoordPolarFunction, clsNewCoordPolarStartOperator:=clsCoordPolarStartOperator, clsNewXScaleDateFunction:=clsXScaleDateFunction, clsNewYScaleDateFunction:=clsYScaleDateFunction,
+                          clsNewYScalecontinuousFunction:=clsYScalecontinuousFunction, clsNewXScalecontinuousFunction:=clsXScalecontinuousFunction, clsNewXLabsTitleFunction:=clsXLabsFunction, clsNewYLabTitleFunction:=clsYLabsFunction, clsNewLabsFunction:=clsLabsFunction,
+                          clsNewFacetFunction:=clsFacetFunction, clsNewThemeFunction:=clsThemeFunction, clsNewScaleFillViridisFunction:=clsScaleFillViridisFunction, clsNewScaleColourViridisFunction:=clsScaleColourViridisFunction, dctNewThemeFunctions:=dctThemeFunctions,
+                          clsNewAnnotateFunction:=clsAnnotateFunction, clsNewGlobalAesFunction:=clsRaesFunction, ucrNewBaseSelector:=ucrSelectorPICSATemperature, clsNewRowVarsFunction:=clsRowVarsFunction, clsNewColVarsFunction:=clsColVarsFunction, bReset:=bResetSubdialog)
+        sdgPlots.ShowDialog()
+        UpdatingFacetOptions()
+        bResetSubdialog = False
+        'AddRemoveGroupByAndHlines()
+    End Sub
+
+
+    Private Sub PlotOptionsToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles PlotOptionsToolStripMenuItem.Click
+        sdgPlots.SetRCode(clsNewOperator:=ucrBase.clsRsyntax.clsBaseOperator, clsNewCoordPolarFunction:=clsCoordPolarFunction, clsNewCoordPolarStartOperator:=clsCoordPolarStartOperator, clsNewXScaleDateFunction:=clsXScaleDateFunction, clsNewYScaleDateFunction:=clsYScaleDateFunction,
+                          clsNewYScalecontinuousFunction:=clsYScalecontinuousFunction, clsNewXScalecontinuousFunction:=clsXScalecontinuousFunction, clsNewXLabsTitleFunction:=clsXLabsFunction, clsNewYLabTitleFunction:=clsYLabsFunction, clsNewLabsFunction:=clsLabsFunction,
+                          clsNewFacetFunction:=clsFacetFunction, clsNewThemeFunction:=clsThemeFunction, clsNewScaleFillViridisFunction:=clsScaleFillViridisFunction, clsNewScaleColourViridisFunction:=clsScaleColourViridisFunction, dctNewThemeFunctions:=dctThemeFunctions,
+                          clsNewAnnotateFunction:=clsAnnotateFunction, clsNewGlobalAesFunction:=clsRaesFunction, clsNewRowVarsFunction:=clsRowVarsFunction, clsNewColVarsFunction:=clsColVarsFunction, ucrNewBaseSelector:=ucrSelectorPICSATemperature, bReset:=bResetSubdialog)
+        sdgPlots.ShowDialog()
+        UpdatingFacetOptions()
+        bResetSubdialog = False
+        'AddRemoveGroupByAndHlines()
+    End Sub
+
+    Private Sub ucrChkLineofBestFit_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrChkLineofBestFit.ControlValueChanged
+        If ucrChkLineofBestFit.Checked Then
+            clsBaseOperator.AddParameter("geom_smooth", clsRFunctionParameter:=clsGeomSmoothFunction, iPosition:=5)
+        Else
+            clsBaseOperator.RemoveParameterByName("geom_smooth")
+        End If
+    End Sub
+
+    Private Sub ucrChkPoints_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrChkPoints.ControlValueChanged
+        If ucrChkPoints.Checked Then
+            clsBaseOperator.AddParameter("geom_point", clsRFunctionParameter:=clsPointsFunc, iPosition:=4)
+        Else
+            clsBaseOperator.RemoveParameterByName("geom_point")
+        End If
+    End Sub
+
+    Private Sub toolStripMenuItemPointOption_Click(sender As Object, e As EventArgs) Handles toolStripMenuItemPointOption.Click
+        openSdgLayerOptions(clsPointsFunc)
+    End Sub
+
 End Class

--- a/instat/dlgPICSATemperature.vb
+++ b/instat/dlgPICSATemperature.vb
@@ -198,12 +198,13 @@ Public Class dlgPICSATemperature
         ucrInputStation.SetItems({strFacetWrap, strFacetRow, strFacetCol, strFacetRowAll, strFacetColAll, strFacetRowAndCol, strFacetRowAndColAll, strNone})
         ucrInputStation.SetDropDownStyleAsNonEditable()
 
-        ucrSave.SetPrefix("picsa_temperature_graph")
+        ucrSave.SetPrefix("last_graph")
         ucrSave.SetIsComboBox()
         ucrSave.SetSaveTypeAsGraph()
         ucrSave.SetCheckBoxText("Store Graph")
         ucrSave.SetDataFrameSelector(ucrSelectorPICSATemperature.ucrAvailableDataFrames)
         ucrSave.SetAssignToIfUncheckedValue("last_graph")
+
     End Sub
 
     Private Sub SetDefaults()
@@ -877,7 +878,7 @@ Public Class dlgPICSATemperature
         bResetSubdialog = False
     End Sub
 
-    Private Sub AllControl_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrSave.ControlContentsChanged, ucrReceiverX.ControlContentsChanged
+    Private Sub AllControl_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrSave.ControlContentsChanged, ucrReceiverX.ControlContentsChanged, ucrReceiverPICSA.ControlContentsChanged
         TestOkEnabled()
     End Sub
 

--- a/instat/frmMain.vb
+++ b/instat/frmMain.vb
@@ -1561,8 +1561,8 @@ Public Class frmMain
     End Sub
 
     Private Sub mnuClimaticPICSATemperature_Click(sender As Object, e As EventArgs) Handles mnuClimaticPICSATemperatureGraph.Click
-        dlgPICSARainfall.enumPICSAMode = dlgPICSARainfall.PICSAMode.Temperature
-        dlgPICSARainfall.ShowDialog()
+        'dlgPICSARainfall.enumPICSAMode = dlgPICSARainfall.PICSAMode.Temperature
+        dlgPICSATemperature.ShowDialog()
     End Sub
 
     Private Sub mnuClimaticPICSACrops_Click(sender As Object, e As EventArgs) Handles mnuClimaticPICSACrops.Click


### PR DESCRIPTION
Fixes #10197
I have fixed the regression found when using the the PICSA Temperature Graph when using it multiple receiver
@berylwaswa and @AmsaleEjigu this PR is ready for Review 
Thanks 
**Developer Testing Checklist**
- [x] Runs without errors  
- [x] OK disabled when dialog is incomplete or invalid  
- [x] OK enabled only when required inputs are valid
- [x] Reset returns dialog to its default/sensible state
- [x] Invalid inputs are handled cleanly (e.g. negative, too-large, empty, impossible combos)
- [x] Running twice with different settings behaves consistently (e.g., open → run → close → reopen → change options checked → run again)
- [x] All AI/bot comments addressed (fixed, intentionally ignored with explanation, or queried)
