### PR TITLE
Minor Fixes to Import from ClimSoft dialog

### DIFF
--- a/instat/clsInstatOptionsDefaults.vb
+++ b/instat/clsInstatOptionsDefaults.vb
@@ -54,10 +54,10 @@ Public Class clsInstatOptionsDefaults
     Public Shared ReadOnly DEFAULTbShowWaitDialog As Boolean = True
     Public Shared ReadOnly DEFAULTiWaitTimeDelaySeconds As Integer = 2
     Public Shared ReadOnly DEFAULTiToolbarHeight As Integer = 30
-    Public Shared ReadOnly DEFAULTstrClimsoftDatabaseName As String = "mariadb_climsoft_db_v4"
-    Public Shared ReadOnly DEFAULTstrClimsoftHost As String = "127.0.0.1"
-    Public Shared ReadOnly DEFAULTstrClimsoftPort As String = "3308"
-    Public Shared ReadOnly DEFAULTstrClimsoftUsername As String = "root"
+    Public Shared ReadOnly DEFAULTstrClimsoftDatabaseName As String = "mariadb_climsoft_db_v4_zambia"
+    Public Shared ReadOnly DEFAULTstrClimsoftHost As String = "35.210.141.130"
+    Public Shared ReadOnly DEFAULTstrClimsoftPort As String = "3306"
+    Public Shared ReadOnly DEFAULTstrClimsoftUsername As String = "readonly"
     Public Shared ReadOnly DEFAULTiMaxOutputsHeight As Integer = 500
     Public Shared ReadOnly DEFAULTiMaxWidth As Integer = 80
     Public Shared ReadOnly DEFAULTbRemindLaterOption As Boolean = False

--- a/instat/dlgClimSoft.vb
+++ b/instat/dlgClimSoft.vb
@@ -132,11 +132,11 @@ Public Class dlgClimSoft
 
         'metadata controls
         '---------------------------------------
-        ucrChkImportStationsMetadata.SetText("Import All Stations Metadata")
+        ucrChkImportStationsMetadata.SetText("Import All Station Metadata")
         ucrChkImportStationsMetadata.SetParameter(New RParameter("import_stations", 0))
         ucrChkImportStationsMetadata.SetRDefault("FALSE")
 
-        ucrChkImportElementsMetadata.SetText("Import All Elements Metadata")
+        ucrChkImportElementsMetadata.SetText("Import All Element Metadata")
         ucrChkImportElementsMetadata.SetParameter(New RParameter("import_elements", 2))
         ucrChkImportElementsMetadata.SetRDefault("FALSE")
 

--- a/instat/dlgOptions.vb
+++ b/instat/dlgOptions.vb
@@ -149,6 +149,10 @@ Public Class dlgOptions
         ucrInputPort.SetName(frmMain.clsInstatOptions.strClimsoftPort)
         ucrInputUserName.SetName(frmMain.clsInstatOptions.strClimsoftUsername)
 
+        ucrInputUserName.SetRDefault("readonly")
+        ucrInputPort.SetRDefault("3306")
+        ucrInputHost.SetRDefault("35.210.141.130")
+        ucrInputDatabaseName.SetRDefault("mariadb_climsoft_db_v4_zambia")
         'maximum heights for output
         ucrChkMaxOutputsHeight.Checked = frmMain.clsInstatOptions.iMaxOutputsHeight > -1
         ucrNudMaxOutputsHeight.Value = If(frmMain.clsInstatOptions.iMaxOutputsHeight > -1, frmMain.clsInstatOptions.iMaxOutputsHeight, clsInstatOptionsDefaults.DEFAULTiMaxOutputsHeight)

--- a/instat/sdgImportFromClimSoft.Designer.vb
+++ b/instat/sdgImportFromClimSoft.Designer.vb
@@ -46,12 +46,12 @@ Partial Class sdgImportFromClimSoft
         Me.chkRememberCredentials = New System.Windows.Forms.CheckBox()
         Me.btnConnect = New System.Windows.Forms.Button()
         Me.ucrComboBoxPort = New instat.ucrInputComboBox()
-        Me.ucrTxtHost = New instat.ucrInputTextBox()
         Me.ucrComboBoxDatabaseName = New instat.ucrInputComboBox()
         Me.ucrBaseSdgClimSoft = New instat.ucrButtonsSubdialogue()
         Me.ucrTxtUserName = New instat.ucrInputTextBox()
         Me.ucrInputDrv = New instat.ucrInputComboBox()
         Me.lblDrv = New System.Windows.Forms.Label()
+        Me.ucrInputHost = New instat.ucrInputComboBox()
         Me.SuspendLayout()
         '
         'lblDatabaseName
@@ -147,18 +147,6 @@ Partial Class sdgImportFromClimSoft
         Me.ucrComboBoxPort.Size = New System.Drawing.Size(230, 32)
         Me.ucrComboBoxPort.TabIndex = 3
         '
-        'ucrTxtHost
-        '
-        Me.ucrTxtHost.AddQuotesIfUnrecognised = True
-        Me.ucrTxtHost.AutoSize = True
-        Me.ucrTxtHost.IsMultiline = False
-        Me.ucrTxtHost.IsReadOnly = False
-        Me.ucrTxtHost.Location = New System.Drawing.Point(154, 100)
-        Me.ucrTxtHost.Margin = New System.Windows.Forms.Padding(14)
-        Me.ucrTxtHost.Name = "ucrTxtHost"
-        Me.ucrTxtHost.Size = New System.Drawing.Size(230, 32)
-        Me.ucrTxtHost.TabIndex = 2
-        '
         'ucrComboBoxDatabaseName
         '
         Me.ucrComboBoxDatabaseName.AddQuotesIfUnrecognised = True
@@ -215,16 +203,28 @@ Partial Class sdgImportFromClimSoft
         Me.lblDrv.TabIndex = 10
         Me.lblDrv.Text = "drv:"
         '
+        'ucrInputHost
+        '
+        Me.ucrInputHost.AddQuotesIfUnrecognised = True
+        Me.ucrInputHost.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrInputHost.GetSetSelectedIndex = -1
+        Me.ucrInputHost.IsReadOnly = False
+        Me.ucrInputHost.Location = New System.Drawing.Point(154, 100)
+        Me.ucrInputHost.Margin = New System.Windows.Forms.Padding(14)
+        Me.ucrInputHost.Name = "ucrInputHost"
+        Me.ucrInputHost.Size = New System.Drawing.Size(230, 32)
+        Me.ucrInputHost.TabIndex = 11
+        '
         'sdgImportFromClimSoft
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(144.0!, 144.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
         Me.AutoSize = True
         Me.ClientSize = New System.Drawing.Size(402, 365)
+        Me.Controls.Add(Me.ucrInputHost)
         Me.Controls.Add(Me.lblDrv)
         Me.Controls.Add(Me.ucrInputDrv)
         Me.Controls.Add(Me.ucrComboBoxPort)
-        Me.Controls.Add(Me.ucrTxtHost)
         Me.Controls.Add(Me.ucrComboBoxDatabaseName)
         Me.Controls.Add(Me.btnConnect)
         Me.Controls.Add(Me.chkRememberCredentials)
@@ -256,8 +256,8 @@ Partial Class sdgImportFromClimSoft
     Friend WithEvents chkRememberCredentials As CheckBox
     Friend WithEvents btnConnect As Button
     Friend WithEvents ucrComboBoxDatabaseName As ucrInputComboBox
-    Friend WithEvents ucrTxtHost As ucrInputTextBox
     Friend WithEvents ucrComboBoxPort As ucrInputComboBox
     Friend WithEvents ucrInputDrv As ucrInputComboBox
     Friend WithEvents lblDrv As Label
+    Friend WithEvents ucrInputHost As ucrInputComboBox
 End Class

--- a/instat/sdgImportFromClimSoft.vb
+++ b/instat/sdgImportFromClimSoft.vb
@@ -43,9 +43,11 @@ Public Class sdgImportFromClimSoft
         Dim dctDatabaseNames As New Dictionary(Of String, String)
         Dim dctPorts As New Dictionary(Of String, String)
         Dim dctDrv As New Dictionary(Of String, String)
+        Dim dctHost As New Dictionary(Of String, String)
 
 
         'database names
+        dctDatabaseNames.Add("mariadb_climsoft_db_v4_zambia", Chr(34) & "mariadb_climsoft_db_v4_zambia" & Chr(34))
         dctDatabaseNames.Add("mariadb_climsoft_db_v4", Chr(34) & "mariadb_climsoft_db_v4" & Chr(34))
         dctDatabaseNames.Add("mariadb_climsoft_test_db_v4", Chr(34) & "mariadb_climsoft_test_db_v4" & Chr(34))
         ucrComboBoxDatabaseName.SetParameter(New RParameter("dbname", 0))
@@ -53,19 +55,28 @@ Public Class sdgImportFromClimSoft
         ucrComboBoxDatabaseName.bAllowNonConditionValues = True
 
         'host e.g 127.0.0.1
-        ucrTxtHost.SetParameter(New RParameter("host", 1))
+        dctHost.Add("35.210.141.130", "35.210.141.130")
+        dctHost.Add("127.0.0.1", "127.0.0.1")
+        ucrInputHost.SetParameter(New RParameter("host", 1))
+        ucrInputHost.SetItems(dctHost)
+        ucrInputHost.SetRDefault("35.210.141.130")
+        ucrInputHost.AddQuotesIfUnrecognised = False
+        ucrInputHost.bAllowNonConditionValues = True
+
 
         'ports
-        dctPorts.Add("3308", "3308")
         dctPorts.Add("3306", "3306")
+        dctPorts.Add("3308", "3308")
         ucrComboBoxPort.SetParameter(New RParameter("port", 2))
         ucrComboBoxPort.SetItems(dctPorts)
+        ucrComboBoxPort.SetRDefault("3306")
         ucrComboBoxPort.AddQuotesIfUnrecognised = False
         ucrComboBoxPort.bAllowNonConditionValues = True
         ucrComboBoxPort.SetValidationTypeAsNumeric(dcmMin:=0)
 
         'user name
         ucrTxtUserName.SetParameter(New RParameter("user", 3))
+        ucrTxtUserName.SetRDefault("readonly")
 
         ucrInputDrv.SetParameter(New RParameter("drv", 4))
         dctDrv.Add("RMySQL::MySQL()", "RMySQL::MySQL()")
@@ -98,7 +109,7 @@ Public Class sdgImportFromClimSoft
 
     Private Sub SetRCodeForControls(bReset As Boolean)
         ucrComboBoxDatabaseName.SetRCode(clsRDatabaseConnect, bReset)
-        ucrTxtHost.SetRCode(clsRDatabaseConnect, bReset)
+        ucrInputHost.SetRCode(clsRDatabaseConnect, bReset)
         ucrComboBoxPort.SetRCode(clsRDatabaseConnect, bReset)
         ucrTxtUserName.SetRCode(clsRDatabaseConnect, bReset)
         ucrInputDrv.SetRCode(clsRDatabaseConnect, bReset)
@@ -123,7 +134,7 @@ Public Class sdgImportFromClimSoft
         'enable/disable all other controls to allow entry of connection details
         ucrComboBoxDatabaseName.Enabled = bEnableControls
         ucrComboBoxPort.Enabled = bEnableControls
-        ucrTxtHost.Enabled = bEnableControls
+        ucrInputHost.Enabled = bEnableControls
         ucrTxtUserName.Enabled = bEnableControls
         chkRememberCredentials.Enabled = bEnableControls
         ucrInputDrv.Enabled = bEnableControls
@@ -178,19 +189,19 @@ Public Class sdgImportFromClimSoft
         If chkRememberCredentials.Checked AndAlso bConnected Then
             'save credentials
             frmMain.clsInstatOptions.SetClimsoftDatabaseName(ucrComboBoxDatabaseName.GetText())
-            frmMain.clsInstatOptions.SetClimsoftHost(ucrTxtHost.GetText())
+            frmMain.clsInstatOptions.SetClimsoftHost(ucrInputHost.GetText())
             frmMain.clsInstatOptions.SetClimsoftPort(ucrComboBoxPort.GetText())
             frmMain.clsInstatOptions.SetClimsoftUsername(ucrTxtUserName.GetText())
             clsRDatabaseConnect.AddParameter("drv", ucrInputDrv.GetText, iPosition:=4)
         End If
     End Sub
 
-    Private Sub ucrControlsContents_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrComboBoxDatabaseName.ControlContentsChanged, ucrTxtHost.ControlContentsChanged, ucrComboBoxPort.ControlContentsChanged, ucrTxtUserName.ControlContentsChanged, ucrInputDrv.ControlContentsChanged
+    Private Sub ucrControlsContents_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrComboBoxDatabaseName.ControlContentsChanged, ucrComboBoxPort.ControlContentsChanged, ucrTxtUserName.ControlContentsChanged, ucrInputDrv.ControlContentsChanged
         'if not already connected, check if it's valid to attempt connecting to database
         If bConnected Then
             btnConnect.Enabled = True
         Else
-            btnConnect.Enabled = Not ucrTxtHost.IsEmpty AndAlso Not ucrTxtUserName.IsEmpty AndAlso Not ucrComboBoxPort.IsEmpty AndAlso Not ucrComboBoxDatabaseName.IsEmpty AndAlso Not ucrInputDrv.IsEmpty
+            btnConnect.Enabled = Not ucrInputHost.IsEmpty AndAlso Not ucrTxtUserName.IsEmpty AndAlso Not ucrComboBoxPort.IsEmpty AndAlso Not ucrComboBoxDatabaseName.IsEmpty AndAlso Not ucrInputDrv.IsEmpty
         End If
     End Sub
 


### PR DESCRIPTION
Fixes #10287 


**Developer Testing Checklist**
- [x] Runs without errors  
- [x] OK disabled when dialog is incomplete or invalid  
- [x] OK enabled only when required inputs are valid
- [x] Reset returns dialog to its default/sensible state
- [x] Invalid inputs are handled cleanly (e.g. negative, too-large, empty, impossible combos)
- [x] Running twice with different settings behaves consistently (e.g., open → run → close → reopen → change options checked → run again)
- [x] All AI/bot comments addressed (fixed, intentionally ignored with explanation, or queried)
