### PR TITLE
Fix "Import from Library" bug when importing RDS-backed DataBook data…

### DIFF
--- a/instat/dlgFromLibrary.vb
+++ b/instat/dlgFromLibrary.vb
@@ -285,12 +285,10 @@ Public Class dlgFromLibrary
             strRClass = Mid(strVecOutput(0), 5).Replace("""", "").ToLower
         End If
 
-        ' If the loaded object has a get_data_frame method (e.g. DataBook R6 objects),
-        ' treat it as "databook" regardless of what class() returned
-        Dim strHasGetDataFrame As CharacterVector = frmMain.clsRLink.RunInternalScriptGetOutput(
+        Dim expHasGetDataFrame As SymbolicExpression = frmMain.clsRLink.RunInternalScriptGetValue(
             "is.function(try(" & strSelectedDataName & "$get_data_frame, silent=TRUE))", bSilent:=True)
-        If strHasGetDataFrame IsNot Nothing AndAlso strHasGetDataFrame.Length > 0 AndAlso
-           strHasGetDataFrame(0).Contains("TRUE") Then
+        If expHasGetDataFrame IsNot Nothing AndAlso
+           expHasGetDataFrame.AsLogical()(0) Then
             strRClass = "databook"
         End If
 
@@ -303,8 +301,8 @@ Public Class dlgFromLibrary
             clsLApplyFunction.AddParameter("FUN", strParameterValue:="data.frame", iPosition:=1)
             clsImportFunction.AddParameter("data_tables", clsRFunctionParameter:=clsLApplyFunction, iPosition:=0)
         Else
-            Dim clsListFunction As New RFunction
-            Dim clsListParameterFunction As New RFunction
+            Dim clsListFunction As New RFunction 'defines the list function. list(x=x)
+            Dim clsListParameterFunction As New RFunction 'defines the function that act as list parameters e.g list(y=fortify.zoo(x))
             clsListFunction.SetRCommand("list")
             Select Case strRClass
                 Case "zoo"

--- a/instat/dlgFromLibrary.vb
+++ b/instat/dlgFromLibrary.vb
@@ -285,6 +285,15 @@ Public Class dlgFromLibrary
             strRClass = Mid(strVecOutput(0), 5).Replace("""", "").ToLower
         End If
 
+        ' If the loaded object has a get_data_frame method (e.g. DataBook R6 objects),
+        ' treat it as "databook" regardless of what class() returned
+        Dim strHasGetDataFrame As CharacterVector = frmMain.clsRLink.RunInternalScriptGetOutput(
+            "is.function(try(" & strSelectedDataName & "$get_data_frame, silent=TRUE))", bSilent:=True)
+        If strHasGetDataFrame IsNot Nothing AndAlso strHasGetDataFrame.Length > 0 AndAlso
+           strHasGetDataFrame(0).Contains("TRUE") Then
+            strRClass = "databook"
+        End If
+
         If strRClass = "list" Then
             'some lists could be supplied in formats that R-Instat doesn't directly recognise as data frames
             'so always explicitly coerce the supplied list of data to type data.frame
@@ -294,13 +303,13 @@ Public Class dlgFromLibrary
             clsLApplyFunction.AddParameter("FUN", strParameterValue:="data.frame", iPosition:=1)
             clsImportFunction.AddParameter("data_tables", clsRFunctionParameter:=clsLApplyFunction, iPosition:=0)
         Else
-            Dim clsListFunction As New RFunction 'defines the list function. list(x=x)
-            Dim clsListParameterFunction As New RFunction 'defines the function that act as list parameters e.g list(y=fortify.zoo(x))
+            Dim clsListFunction As New RFunction
+            Dim clsListParameterFunction As New RFunction
             clsListFunction.SetRCommand("list")
             Select Case strRClass
                 Case "zoo"
                     'this is the recommended command for converting zoo object types to data frames.
-                    'In R-Instat the data.frame doesn't convert this object type well. See issue #5649
+                    'In R-Instat the data.frame doesn't convert this object type well. See issue #5649        
                     clsListParameterFunction.SetPackageName("zoo")
                     clsListParameterFunction.SetRCommand("fortify.zoo")
                     clsListParameterFunction.AddParameter("model", strParameterValue:=strSelectedDataName)
@@ -325,6 +334,11 @@ Public Class dlgFromLibrary
                     'currently this command loses data(some columns) of the matrix once it's coerced. See issue #5649
                     clsListParameterFunction.SetRCommand("data.frame")
                     clsListParameterFunction.AddParameter("x", strParameterValue:=strSelectedDataName)
+                    clsListFunction.AddParameter(ucrNewDataFrameName.GetText, clsRFunctionParameter:=clsListParameterFunction)
+                Case "databook"
+                    ' R6/DataBook objects must call $get_data_frame() to extract the underlying data.frame
+                    clsListParameterFunction.SetRCommand(strSelectedDataName & "$get_data_frame")
+                    clsListParameterFunction.AddParameter("data_name", Chr(34) & strSelectedDataName & Chr(34), iPosition:=0)
                     clsListFunction.AddParameter(ucrNewDataFrameName.GetText, clsRFunctionParameter:=clsListParameterFunction)
                 Case Else
                     clsListFunction.AddParameter(ucrNewDataFrameName.GetText, strParameterValue:=strSelectedDataName)


### PR DESCRIPTION
@berylwaswa @lilyclements @rdstern Kindly Check

Fixes  #10242

The root cause was that **datasets in the databook package (dodoma, ghana) are stored as R6/DataBook objects, not plain data.frames.** The dialog was passing the raw object directly to import_data() which requires a data.frame, hence the "Data set must be of type: data.frame" error.

The fix adds a check in SetParameterValues() after loading the object via utils::data(), we test whether it has a get_data_frame method. If it does, we call $get_data_frame(data_name=...) to extract the actual data.frame before importing. 

<img width="525" height="475" alt="Dialogue" src="https://github.com/user-attachments/assets/5457f1ad-bcd7-4f5d-b04b-7685becd4dab" />
<img width="1920" height="1020" alt="Script and output" src="https://github.com/user-attachments/assets/add007a8-c8d4-4d80-9c4f-ade381f59e43" />

this is how the script looks like 
````
# Dialog: Import From Library

utils::data(package="databook", X=dodoma)
data_book$import_data(data_tables=list(dodoma=dodoma$get_data_frame("dodoma")))
rm(dodoma)
````
